### PR TITLE
wallet-rpc: added IPs to error logging in simple_http_connection_handler

### DIFF
--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -69,7 +69,7 @@ namespace net_utils
 			typedef t_connection_context connection_context;//t_connection_context net_utils::connection_context_base connection_context;
 			typedef http_server_config config_type;
 
-			simple_http_connection_handler(i_service_endpoint* psnd_hndlr, config_type& config);
+			simple_http_connection_handler(i_service_endpoint* psnd_hndlr, config_type& config, t_connection_context& conn_context);
 			virtual ~simple_http_connection_handler(){}
 
 			bool release_protocol()
@@ -143,6 +143,7 @@ namespace net_utils
 			bool m_want_close;
 		protected:
 			i_service_endpoint* m_psnd_hndlr; 
+			t_connection_context& m_conn_context;
 		};
 
 		template<class t_connection_context>
@@ -174,9 +175,8 @@ namespace net_utils
 			typedef custum_handler_config<t_connection_context> config_type;
 			
 			http_custom_handler(i_service_endpoint* psnd_hndlr, config_type& config, t_connection_context& conn_context)
-				: simple_http_connection_handler<t_connection_context>(psnd_hndlr, config),
+				: simple_http_connection_handler<t_connection_context>(psnd_hndlr, config, conn_context),
 					m_config(config),
-					m_conn_context(conn_context),
 					m_auth(m_config.m_user ? http_server_auth{*m_config.m_user, config.rng} : http_server_auth{})
 			{}
 			inline bool handle_request(const http_request_info& query_info, http_response_info& response)
@@ -196,7 +196,7 @@ namespace net_utils
 				response.m_response_comment = "OK";
 				response.m_body.clear();
 
-				return m_config.m_phandler->handle_http_request(query_info, response, m_conn_context);
+				return m_config.m_phandler->handle_http_request(query_info, response, this->m_conn_context);
 			}
 
 			virtual bool thread_init()
@@ -218,7 +218,6 @@ namespace net_utils
 		private:
 			//simple_http_connection_handler::config_type m_stub_config;
 			config_type& m_config;
-			t_connection_context& m_conn_context;
 			http_server_auth m_auth;
 		};
 	}

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -195,15 +195,16 @@ namespace net_utils
 
 		//--------------------------------------------------------------------------------------------
 		template<class t_connection_context>
-		simple_http_connection_handler<t_connection_context>::simple_http_connection_handler(i_service_endpoint* psnd_hndlr, config_type& config):
+		simple_http_connection_handler<t_connection_context>::simple_http_connection_handler(i_service_endpoint* psnd_hndlr, config_type& config, t_connection_context& conn_context):
 		m_state(http_state_retriving_comand_line),
 		m_body_transfer_type(http_body_transfer_undefined),
-        m_is_stop_handling(false),
+		m_is_stop_handling(false),
 		m_len_summary(0),
 		m_len_remain(0),
-		m_config(config), 
+		m_config(config),
 		m_want_close(false),
-        m_psnd_hndlr(psnd_hndlr)
+		m_psnd_hndlr(psnd_hndlr),
+		m_conn_context(conn_context)
 	{
 
 	}
@@ -268,7 +269,7 @@ namespace net_utils
 					m_is_stop_handling = true;
 					if(m_cache.size() > HTTP_MAX_URI_LEN)
 					{
-						LOG_ERROR("simple_http_connection_handler::handle_buff_out: Too long URI line");
+						LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler::handle_buff_out: Too long URI line");
 						m_state = http_state_error;
 						return false;
 					}
@@ -282,7 +283,7 @@ namespace net_utils
 						m_is_stop_handling = true;
 						if(m_cache.size() > HTTP_MAX_HEADER_LEN)
 						{
-							LOG_ERROR("simple_http_connection_handler::handle_buff_in: Too long header area");
+							LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler::handle_buff_in: Too long header area");
 							m_state = http_state_error;
 							return false;
 						}	
@@ -297,10 +298,10 @@ namespace net_utils
 			case http_state_connection_close:
 				return false;
 			default:
-				LOG_ERROR("simple_http_connection_handler::handle_char_out: Wrong state: " << m_state);
+				LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler::handle_char_out: Wrong state: " << m_state);
 				return false;
 			case http_state_error:
-				LOG_ERROR("simple_http_connection_handler::handle_char_out: Error state!!!");
+				LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler::handle_char_out: Error state!!!");
 				return false;
 			}
 
@@ -362,7 +363,7 @@ namespace net_utils
 		}else
 		{
 			m_state = http_state_error;
-			LOG_ERROR("simple_http_connection_handler<t_connection_context>::handle_invoke_query_line(): Failed to match first line: " << m_cache);
+			LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler<t_connection_context>::handle_invoke_query_line(): Failed to match first line: " << m_cache);
 			return false;
 		}
 
@@ -393,7 +394,7 @@ namespace net_utils
 
 		if(!parse_cached_header(m_query_info.m_header_info, m_cache, pos))
 		{
-			LOG_ERROR("simple_http_connection_handler<t_connection_context>::analize_cached_request_header_and_invoke_state(): failed to anilize request header: " << m_cache);
+			LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler<t_connection_context>::analize_cached_request_header_and_invoke_state(): failed to anilize request header: " << m_cache);
 			m_state = http_state_error;
 			return false;
 		}
@@ -409,7 +410,7 @@ namespace net_utils
 			m_body_transfer_type = http_body_transfer_measure;
 			if(!get_len_from_content_lenght(m_query_info.m_header_info.m_content_length, m_len_summary))
 			{
-				LOG_ERROR("simple_http_connection_handler<t_connection_context>::analize_cached_request_header_and_invoke_state(): Failed to get_len_from_content_lenght();, m_query_info.m_content_length="<<m_query_info.m_header_info.m_content_length);
+				LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler<t_connection_context>::analize_cached_request_header_and_invoke_state(): Failed to get_len_from_content_lenght();, m_query_info.m_content_length="<<m_query_info.m_header_info.m_content_length);
 				m_state = http_state_error;
 				return false;
 			}
@@ -442,7 +443,7 @@ namespace net_utils
 		case http_body_transfer_multipart:
 		case http_body_transfer_undefined:
 		default:
-			LOG_ERROR("simple_http_connection_handler<t_connection_context>::handle_retriving_query_body(): Unexpected m_body_query_type state:" << m_body_transfer_type);
+			LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler<t_connection_context>::handle_retriving_query_body(): Unexpected m_body_query_type state:" << m_body_transfer_type);
 			m_state = http_state_error;
 			return false;
 		}
@@ -523,7 +524,7 @@ namespace net_utils
 				body_info.m_etc_fields.push_back(std::pair<std::string, std::string>(result[field_etc_name], result[field_val]));
 			else
 			{
-				LOG_ERROR("simple_http_connection_handler<t_connection_context>::parse_cached_header() not matched last entry in:"<<m_cache_to_process);
+				LOG_ERROR_CC(m_conn_context, "simple_http_connection_handler<t_connection_context>::parse_cached_header() not matched last entry in:" << m_cache_to_process);
 			}
 
 			it_current_bound = result[(int)result.size()-1]. first;


### PR DESCRIPTION
This implements https://github.com/monero-project/monero/issues/3127

I've moved `m_conn_context` from the custom http handler into the base class so it can be referenced, then added the connection context to the errors referenced in the issue.

Some of the errors in `contrib/epee/include/net/http_protocol_handler.inl` are in helper functions and I wasn't able to easily access the context connection. However, these functions all seem to only be used by a helper function `parse_multipart_body`, which isn't called anywhere in the project. So I don't think they're actually being used and didn't bother implementing IP logging for errors in those functions.