### PR TITLE
QCop autonomously sends deregisters

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -58,6 +58,9 @@
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               11
 
+#define SECONDS_UPTIME_PROOF_BUFFER                     (5*60)
+#define SECONDS_UPTIME_PROOF_FREQUENCY                  (60*60)
+
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)(-1))
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
@@ -84,7 +87,6 @@
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)2000000000 * (uint64_t)CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2 / CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5)
 
 #define ORPHANED_BLOCKS_MAX_COUNT                       100
-
 
 #define DIFFICULTY_TARGET_V2                            120  // seconds
 #define DIFFICULTY_WINDOW_V2                            60

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -58,8 +58,9 @@
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               11
 
-#define SECONDS_UPTIME_PROOF_BUFFER                     (5*60)
-#define SECONDS_UPTIME_PROOF_FREQUENCY                  (60*60)
+#define UPTIME_PROOF_BUFFER_IN_SECONDS                  (5*60)
+#define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (60*60)
+#define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_FREQUENCY_IN_SECONDS + (2 * UPTIME_PROOF_BUFFER_IN_SECONDS))
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)(-1))

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(cryptonote_core_sources
   cryptonote_core.cpp
   service_node_list.cpp
   service_node_deregister.cpp
+  quorum_cop.cpp
   tx_pool.cpp
   cryptonote_tx_utils.cpp)
 
@@ -41,6 +42,7 @@ set(cryptonote_core_private_headers
   blockchain_storage_boost_serialization.h
   blockchain.h
   service_node_list.h
+  quorum_cop.h
   cryptonote_core.h
   service_node_deregister.h
   tx_pool.h

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1459,8 +1459,12 @@ namespace cryptonote
     m_deregisters_auto_relayer.do_call(boost::bind(&core::relay_deregister_votes, this));
     m_check_updates_interval.do_call(boost::bind(&core::check_updates, this));
     m_check_disk_space_interval.do_call(boost::bind(&core::check_disk_space, this));
-    if (m_service_node)
+    if (m_service_node && m_service_node_list.is_service_node(m_service_node_pubkey))
+    {
       m_submit_uptime_proof_interval.do_call(boost::bind(&core::submit_uptime_proof, this));
+      m_uptime_proof_pruner.do_call(boost::bind(&service_nodes::quorum_cop::prune_uptime_proof, &m_quorum_cop));
+    }
+
     m_miner.on_idle();
     m_mempool.on_idle();
     return true;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -172,6 +172,7 @@ namespace cryptonote
               m_mempool(m_blockchain_storage),
               m_service_node_list(m_blockchain_storage),
               m_blockchain_storage(m_mempool, m_service_node_list, m_deregister_vote_pool),
+              m_quorum_cop(m_blockchain_storage, m_service_node_list),
               m_miner(this),
               m_miner_address(boost::value_initialized<account_public_address>()),
               m_starter_message_showed(false),
@@ -1090,6 +1091,20 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  bool core::submit_uptime_proof()
+  {
+    cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+    NOTIFY_UPTIME_PROOF::request r;
+    m_quorum_cop.generate_uptime_proof_request(m_service_node_pubkey, m_service_node_key, r);
+    get_protocol()->relay_uptime_proof(r, fake_context);
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig)
+  {
+    return m_quorum_cop.handle_uptime_proof(timestamp, pubkey, sig);
+  }
+  //-----------------------------------------------------------------------------------------------
   void core::on_transaction_relayed(const cryptonote::blobdata& tx_blob)
   {
     std::list<std::pair<crypto::hash, cryptonote::blobdata>> txs;
@@ -1439,6 +1454,8 @@ namespace cryptonote
     m_deregisters_auto_relayer.do_call(boost::bind(&core::relay_deregister_votes, this));
     m_check_updates_interval.do_call(boost::bind(&core::check_updates, this));
     m_check_disk_space_interval.do_call(boost::bind(&core::check_disk_space, this));
+    if (m_service_node)
+      m_submit_uptime_proof_interval.do_call(boost::bind(&core::submit_uptime_proof, this));
     m_miner.on_idle();
     m_mempool.on_idle();
     return true;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1055,6 +1055,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
      epee::math_helper::once_a_time_seconds<UPTIME_PROOF_FREQUENCY_IN_SECONDS, true> m_submit_uptime_proof_interval; //!< interval for submitting uptime proof
+     epee::math_helper::once_a_time_seconds<30, true> m_uptime_proof_pruner;
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -45,6 +45,7 @@
 #include "tx_pool.h"
 #include "blockchain.h"
 #include "service_node_list.h"
+#include "quorum_cop.h"
 #include "cryptonote_basic/miner.h"
 #include "cryptonote_basic/connection_context.h"
 #include "cryptonote_basic/cryptonote_stat_info.h"
@@ -105,6 +106,15 @@ namespace cryptonote
       * @return true
       */
      bool on_idle();
+
+     /**
+      * @brief handles an incoming uptime proof
+      *
+      * Parses an incoming uptime proof
+      *
+      * @return true if we haven't seen it before and thus need to relay.
+      */
+     bool handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig);
 
      /**
       * @brief handles an incoming transaction
@@ -968,6 +978,13 @@ namespace cryptonote
      bool relay_deregister_votes();
 
      /**
+      * @brief attempts to submit an uptime proof to the network, if this is running in service node mode
+      *
+      * @return true
+      */
+     bool submit_uptime_proof();
+
+     /**
       * @brief checks DNS versions
       *
       * @return true on success, false otherwise
@@ -1006,6 +1023,7 @@ namespace cryptonote
      tx_memory_pool m_mempool; //!< transaction pool instance
      Blockchain m_blockchain_storage; //!< Blockchain instance
      service_nodes::service_node_list m_service_node_list;
+     service_nodes::quorum_cop m_quorum_cop;
 
      i_cryptonote_protocol* m_pprotocol; //!< cryptonote protocol instance
 
@@ -1025,6 +1043,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer; //!< interval for checking re-relaying deregister votes
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
+     epee::math_helper::once_a_time_seconds<60*60, true> m_submit_uptime_proof_interval; //!< interval for submitting uptime proof
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -818,6 +818,24 @@ namespace cryptonote
       */
      bool cmd_prepare_registration(const boost::program_options::variables_map& vm, const std::vector<std::string>& args);
 
+     /**
+      * @brief Return the account associated to this service node.
+
+      * @param pub_key The public key for the service node, unmodified if not a service node
+
+      * @param sec_key The secret key for the service node, unmodified if not a service node
+
+      * @return True if we are a service node
+      */
+     bool get_service_node_keys(crypto::public_key &pub_key, crypto::secret_key &sec_key) const;
+
+     /**
+      * @brief attempts to submit an uptime proof to the network, if this is running in service node mode
+      *
+      * @return true
+      */
+     bool submit_uptime_proof();
+
    private:
 
      /**
@@ -978,13 +996,6 @@ namespace cryptonote
      bool relay_deregister_votes();
 
      /**
-      * @brief attempts to submit an uptime proof to the network, if this is running in service node mode
-      *
-      * @return true
-      */
-     bool submit_uptime_proof();
-
-     /**
       * @brief checks DNS versions
       *
       * @return true on success, false otherwise
@@ -1043,7 +1054,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer; //!< interval for checking re-relaying deregister votes
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
-     epee::math_helper::once_a_time_seconds<60*60, true> m_submit_uptime_proof_interval; //!< interval for submitting uptime proof
+     epee::math_helper::once_a_time_seconds<UPTIME_PROOF_FREQUENCY_IN_SECONDS, true> m_submit_uptime_proof_interval; //!< interval for submitting uptime proof
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -152,7 +152,7 @@ namespace service_nodes
       return false;
 
     CRITICAL_REGION_LOCAL(m_lock);
-    if (m_uptime_proof_seen[pubkey] > now - UPTIME_PROOF_MAX_TIME_IN_SECONDS)
+    if (m_uptime_proof_seen[pubkey] >= now - (UPTIME_PROOF_FREQUENCY_IN_SECONDS / 2))
       return false; // already received one uptime proof for this node recently.
 
     crypto::hash hash = make_hash(pubkey, timestamp);

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -1,0 +1,117 @@
+// Copyright (c)      2018, The Loki Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "cryptonote_config.h"
+
+#include "quorum_cop.h"
+
+// TODO: rebase on top of doyle's changes and use the other constant.
+const uint64_t VOTE_LIFETIME_BY_HEIGHT = (60 * 60 * 2) / DIFFICULTY_TARGET_V2;
+
+namespace service_nodes
+{
+  quorum_cop::quorum_cop(cryptonote::Blockchain& blockchain, service_nodes::service_node_list& service_node_list)
+    : m_service_node_list(service_node_list), m_last_height(0)
+  {
+    blockchain.hook_block_added(*this);
+    blockchain.hook_blockchain_detached(*this);
+  }
+
+  void quorum_cop::blockchain_detached(uint64_t height)
+  {
+    // TODO: check for big reorg and if too big panic.
+  }
+
+  void quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
+  {
+    uint64_t height = cryptonote::get_block_height(block);
+
+    if (height < REORG_SAFETY_BUFFER_IN_BLOCKS)
+      return;
+
+    if (height >= VOTE_LIFETIME_BY_HEIGHT)
+      m_last_height = std::max(m_last_height, height - VOTE_LIFETIME_BY_HEIGHT);
+
+    while (m_last_height < height - REORG_SAFETY_BUFFER_IN_BLOCKS)
+    {
+      std::cout << "Processing quorum cop stuff for height = " << m_last_height << std::endl;
+      // XXX IN HERE, go through the quorum for m_last_height and for each of
+      // the pubkeys, check if the uptime proof was seen in the last hour and
+      // five minutes. If not, submit a vote to the vote pool.
+
+      m_last_height++;
+    }
+  }
+
+  bool quorum_cop::handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig)
+  {
+    uint64_t now = time(nullptr);
+
+    if (timestamp < now - SECONDS_UPTIME_PROOF_BUFFER || timestamp > now + SECONDS_UPTIME_PROOF_BUFFER)
+      return false;
+
+    if (!m_service_node_list.is_service_node(pubkey))
+      return false; // this pubkey is not a service node
+
+    if (m_uptime_proof_seen[pubkey] > now - SECONDS_UPTIME_PROOF_FREQUENCY + 2 * SECONDS_UPTIME_PROOF_BUFFER)
+    {
+      return false; // already received one uptime proof for this node recently.
+    }
+
+    char buf[44] = "SUP"; // Meaningless magic bytes
+    crypto::hash hash;
+    memcpy(buf + 4, reinterpret_cast<const void *>(&pubkey), 32);
+    memcpy(buf + 4 + 32, reinterpret_cast<const void *>(&timestamp), 8);
+    crypto::cn_fast_hash(buf, 40, hash);
+
+    if (!crypto::check_signature(hash, pubkey, sig))
+      return false;
+
+    // TODO: remove old/expired nodes (memleak)
+    // TODO: make thread safe
+
+    m_uptime_proof_seen[pubkey] = timestamp;
+
+    return true;
+  }
+
+  void quorum_cop::generate_uptime_proof_request(const crypto::public_key& pubkey, const crypto::secret_key& seckey, cryptonote::NOTIFY_UPTIME_PROOF::request& req) const
+  {
+    uint64_t timestamp = time(nullptr);
+
+    char buf[44] = "SUP"; // Meaningless magic bytes
+    crypto::hash hash;
+    memcpy(buf + 4, reinterpret_cast<const void *>(&pubkey), 32);
+    memcpy(buf + 4 + 32, reinterpret_cast<const void *>(&timestamp), 8);
+    crypto::cn_fast_hash(buf, 40, hash);
+
+    req.timestamp = timestamp;
+    req.pubkey = pubkey;
+    crypto::generate_signature(hash, pubkey, seckey, req.sig);
+  }
+}

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -41,11 +41,18 @@ namespace service_nodes
 
   void quorum_cop::blockchain_detached(uint64_t height)
   {
-    uint64_t delta_height = m_last_height - height;
-    if (delta_height > REORG_SAFETY_BUFFER_IN_BLOCKS)
+    if (m_last_height >= height)
     {
-      LOG_ERROR("The blockchain was detached, quorum cop has processed votes for: " << delta_height <<
-                " blocks which is greater than the recommended REORG_SAFETY_BUFFER_IN_BLOCKS: " << REORG_SAFETY_BUFFER_IN_BLOCKS);
+      uint64_t delta_height = m_last_height - height;
+      if (delta_height > REORG_SAFETY_BUFFER_IN_BLOCKS)
+      {
+        LOG_ERROR("The blockchain was detached to height: " << height << ", quorum cop has already processed votes for: " << delta_height <<
+                  " blocks which is greater than the recommended REORG_SAFETY_BUFFER_IN_BLOCKS: " << REORG_SAFETY_BUFFER_IN_BLOCKS);
+      }
+      else
+      {
+        LOG_WARNING("The blockchain was detached to height: " << height << ", quorum cop has already processed votes for: " << delta_height << " blocks";
+      }
       m_last_height = height;
     }
   }
@@ -187,7 +194,7 @@ namespace service_nodes
     for (auto it = m_uptime_proof_seen.begin(); it != m_uptime_proof_seen.end();)
     {
       if (it->second < prune_from_timestamp)
-        m_uptime_proof_seen.erase(it);
+        it = m_uptime_proof_seen.erase(it);
       else
         it++;
     }

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -57,9 +57,9 @@ namespace service_nodes
     static const uint64_t REORG_SAFETY_BUFFER_IN_BLOCKS = 20;
     static_assert(REORG_SAFETY_BUFFER_IN_BLOCKS < loki::service_node_deregister::VOTE_LIFETIME_BY_HEIGHT,
                   "Safety buffer should always be less than the vote lifetime");
+    bool prune_uptime_proof();
 
   private:
-    void prune_uptime_proof_below(uint64_t height);
 
     cryptonote::core& m_core;
     service_node_list& m_service_node_list;

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -1,0 +1,56 @@
+// Copyright (c)      2018, The Loki Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "blockchain.h"
+#include "service_node_list.h"
+#include "cryptonote_protocol/cryptonote_protocol_handler_common.h"
+
+namespace service_nodes
+{
+  class quorum_cop
+    : public cryptonote::Blockchain::BlockAddedHook,
+      public cryptonote::Blockchain::BlockchainDetachedHook
+  {
+  public:
+    quorum_cop(cryptonote::Blockchain& blockchain, service_nodes::service_node_list& service_node_list);
+    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
+    void blockchain_detached(uint64_t height);
+    bool handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig);
+    void generate_uptime_proof_request(const crypto::public_key& pubkey, const crypto::secret_key& seckey, cryptonote::NOTIFY_UPTIME_PROOF::request& req) const;
+
+    static const uint64_t REORG_SAFETY_BUFFER_IN_BLOCKS = 20;
+
+  private:
+    uint64_t m_last_height;
+    service_nodes::service_node_list& m_service_node_list;
+
+    std::unordered_map<crypto::public_key, uint64_t> m_uptime_proof_seen;
+  };
+}

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -67,11 +67,10 @@ namespace service_nodes
     }
 
     uint64_t current_height = m_blockchain.get_current_blockchain_height();
+
     uint64_t start_height = 0;
     if (current_height >= STAKING_REQUIREMENT_LOCK_BLOCKS + STAKING_RELOCK_WINDOW_BLOCKS)
-    {
       start_height = current_height - STAKING_REQUIREMENT_LOCK_BLOCKS - STAKING_RELOCK_WINDOW_BLOCKS;
-    }
 
     for (uint64_t height = start_height; height <= current_height; height += 1000)
     {
@@ -100,7 +99,7 @@ namespace service_nodes
     m_rollback_events.push_back(std::unique_ptr<rollback_event>(new prevent_rollback(current_height)));
   }
 
-  std::vector<crypto::public_key> service_node_list::get_service_node_pubkeys() const
+  std::vector<crypto::public_key> service_node_list::get_service_nodes_pubkeys() const
   {
     std::vector<crypto::public_key> result;
     for (const auto& iter : m_service_nodes_infos)
@@ -543,7 +542,7 @@ namespace service_nodes
       return;
     }
 
-    std::vector<crypto::public_key> full_node_list = get_service_node_pubkeys();
+    std::vector<crypto::public_key> full_node_list = get_service_nodes_pubkeys();
     std::vector<size_t>                              pub_keys_indexes(full_node_list.size());
     {
       size_t index = 0;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <random>
 
+
 #include "ringct/rctSigs.h"
 #include "wallet/wallet2.h"
 #include "cryptonote_tx_utils.h"
@@ -36,6 +37,7 @@
 #include "common/int-util.h"
 #include "common/scoped_message_writer.h"
 #include "common/i18n.h"
+#include "quorum_cop.h"
 
 #include "service_node_list.h"
 
@@ -46,12 +48,24 @@ namespace service_nodes
 {
 
   service_node_list::service_node_list(cryptonote::Blockchain& blockchain)
-    : m_blockchain(blockchain)
+    : m_blockchain(blockchain), m_hooks_registered(false)
   {
-    blockchain.hook_block_added(*this);
-    blockchain.hook_blockchain_detached(*this);
-    blockchain.hook_init(*this);
-    blockchain.hook_validate_miner_tx(*this);
+  }
+
+  void service_node_list::register_hooks(service_nodes::quorum_cop &quorum_cop)
+  {
+    if (m_hooks_registered)
+    {
+      m_hooks_registered = true;
+      m_blockchain.hook_block_added(*this);
+      m_blockchain.hook_blockchain_detached(*this);
+      m_blockchain.hook_init(*this);
+      m_blockchain.hook_validate_miner_tx(*this);
+
+      // NOTE: There is an implicit dependency on service node lists hooks
+      m_blockchain.hook_block_added(quorum_cop);
+      m_blockchain.hook_blockchain_detached(quorum_cop);
+    }
   }
 
   void service_node_list::init()

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -87,7 +87,7 @@ namespace service_nodes
     bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, int index, crypto::public_key& key, service_node_info& info) const;
     bool is_deregistration_tx(const cryptonote::transaction& tx, crypto::public_key& address) const;
 
-    std::vector<crypto::public_key> get_service_node_pubkeys() const;
+    std::vector<crypto::public_key> get_service_nodes_pubkeys() const;
 
     template<typename T>
     void block_added_generic(const cryptonote::block& block, const T& txs);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -34,10 +34,12 @@
 
 namespace service_nodes
 {
-  const size_t QUORUM_SIZE                    = 3;
-  const size_t MIN_VOTES_TO_KICK_SERVICE_NODE = 3;
+  const size_t QUORUM_SIZE                    = 10;
+  const size_t MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
   const size_t NTH_OF_THE_NETWORK_TO_TEST     = 100;
   const size_t MIN_NODES_TO_TEST              = 50;
+
+  class quorum_cop;
 
   struct quorum_state
   {
@@ -56,6 +58,7 @@ namespace service_nodes
     service_node_list(cryptonote::Blockchain& blockchain);
     void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
     void blockchain_detached(uint64_t height);
+    void register_hooks(service_nodes::quorum_cop &quorum_cop);
     void init();
     bool validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward);
 
@@ -138,6 +141,7 @@ namespace service_nodes
     std::unordered_map<crypto::public_key, service_node_info> m_service_nodes_infos;
     std::list<std::unique_ptr<rollback_event>> m_rollback_events;
     cryptonote::Blockchain& m_blockchain;
+    bool m_hooks_registered;
 
     using block_height = uint64_t;
     std::map<block_height, std::shared_ptr<quorum_state>> m_quorum_states;

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -299,4 +299,24 @@ namespace cryptonote
     };
   };
     
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_UPTIME_PROOF
+  {
+    const static int ID = BC_COMMANDS_POOL_BASE + 10;
+
+    struct request
+    {
+      uint64_t timestamp;
+      crypto::public_key pubkey;
+      crypto::signature sig;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(timestamp)
+        KV_SERIALIZE_VAL_POD_AS_BLOB(pubkey)
+        KV_SERIALIZE_VAL_POD_AS_BLOB(sig)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -304,7 +304,7 @@ namespace cryptonote
   /************************************************************************/
   struct NOTIFY_UPTIME_PROOF
   {
-    const static int ID = BC_COMMANDS_POOL_BASE + 10;
+    const static int ID = BC_COMMANDS_POOL_BASE + 11;
 
     struct request
     {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -56,24 +56,24 @@ DISABLE_VS_WARNINGS(4355)
 namespace cryptonote
 {
 
-	class cryptonote_protocol_handler_base_pimpl;
-	class cryptonote_protocol_handler_base {
-		private:
-			std::unique_ptr<cryptonote_protocol_handler_base_pimpl> mI;
+  class cryptonote_protocol_handler_base_pimpl;
+  class cryptonote_protocol_handler_base {
+    private:
+      std::unique_ptr<cryptonote_protocol_handler_base_pimpl> mI;
 
-		public:
-			cryptonote_protocol_handler_base();
-			virtual ~cryptonote_protocol_handler_base();
-			void handler_request_blocks_history(std::list<crypto::hash>& ids); // before asking for list of objects, we can change the list still
-			void handler_response_blocks_now(size_t packet_size);
-			
-			virtual double get_avg_block_size() = 0;
-			virtual double estimate_one_block_size() noexcept; // for estimating size of blocks to download
-	};
+    public:
+      cryptonote_protocol_handler_base();
+      virtual ~cryptonote_protocol_handler_base();
+      void handler_request_blocks_history(std::list<crypto::hash>& ids); // before asking for list of objects, we can change the list still
+      void handler_response_blocks_now(size_t packet_size);
+
+      virtual double get_avg_block_size() = 0;
+      virtual double estimate_one_block_size() noexcept; // for estimating size of blocks to download
+  };
 
   template<class t_core>
   class t_cryptonote_protocol_handler:  public i_cryptonote_protocol, cryptonote_protocol_handler_base
-  { 
+  {
   public:
     typedef cryptonote_connection_context connection_context;
     typedef core_stat_info stat_info;
@@ -89,9 +89,10 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_GET_OBJECTS, &cryptonote_protocol_handler::handle_response_get_objects)
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_CHAIN, &cryptonote_protocol_handler::handle_request_chain)
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_CHAIN_ENTRY, &cryptonote_protocol_handler::handle_response_chain_entry)
-      HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)			
-      HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)						
-      HANDLE_NOTIFY_T2(NOTIFY_NEW_DEREGISTER_VOTE, &cryptonote_protocol_handler::handle_notify_new_deregister_vote)						
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)
+      HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_DEREGISTER_VOTE, &cryptonote_protocol_handler::handle_notify_new_deregister_vote)
+      HANDLE_NOTIFY_T2(NOTIFY_UPTIME_PROOF, &cryptonote_protocol_handler::handle_uptime_proof);
     END_INVOKE_MAP2()
 
     bool on_idle();
@@ -122,11 +123,14 @@ namespace cryptonote
     int handle_notify_new_fluffy_block(int command, NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& context);
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_deregister_vote(int command, NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& context);
-		
+    int handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context);
+
     //----------------- i_bc_protocol_layout ---------------------------------------
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context);
+    //----------------- uptime proof ---------------------------------------
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool request_missing_objects(cryptonote_connection_context& context, bool check_having_blocks, bool force_next_span = false);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -822,8 +822,6 @@ namespace cryptonote
     if(context.m_state != cryptonote_connection_context::state_normal)
       return 1;
 
-    std::cout << " RECEIVED NOTIFY NEW TRANSACTIONS! " << std::endl;
-
     // while syncing, core will lock for a long time, so we ignore
     // those txes as they aren't really needed anyway, and avoid a
     // long block before replying

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -685,6 +685,17 @@ namespace cryptonote
   }  
   //------------------------------------------------------------------------------------------------------------------------  
   template<class t_core>
+  int t_cryptonote_protocol_handler<t_core>::handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context)
+  {
+    MLOG_P2P_MESSAGE("Received NOTIFY_UPTIME_PROOF");
+    if(context.m_state != cryptonote_connection_context::state_normal)
+      return 1;
+    if (m_core.handle_uptime_proof(arg.timestamp, arg.pubkey, arg.sig))
+      relay_uptime_proof(arg, context);
+    return 1;
+  }
+  //------------------------------------------------------------------------------------------------------------------------  
+  template<class t_core>
   int t_cryptonote_protocol_handler<t_core>::handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context)
   {
     MLOG_P2P_MESSAGE("Received NOTIFY_REQUEST_FLUFFY_MISSING_TX (" << arg.missing_tx_indices.size() << " txes), block hash " << arg.block_hash);
@@ -810,6 +821,8 @@ namespace cryptonote
     MLOG_P2P_MESSAGE("Received NOTIFY_NEW_TRANSACTIONS (" << arg.txs.size() << " txes)");
     if(context.m_state != cryptonote_connection_context::state_normal)
       return 1;
+
+    std::cout << " RECEIVED NOTIFY NEW TRANSACTIONS! " << std::endl;
 
     // while syncing, core will lock for a long time, so we ignore
     // those txes as they aren't really needed anyway, and avoid a
@@ -1761,6 +1774,12 @@ skip:
     for(auto tx_blob_it = arg.txs.begin(); tx_blob_it!=arg.txs.end(); ++tx_blob_it)
       m_core.on_transaction_relayed(*tx_blob_it);
     return relay_post_notify<NOTIFY_NEW_TRANSACTIONS>(arg, exclude_context);
+  }
+  //------------------------------------------------------------------------------------------------------------------------
+  template<class t_core>
+  bool t_cryptonote_protocol_handler<t_core>::relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)
+  {
+    return relay_post_notify<NOTIFY_UPTIME_PROOF>(arg, exclude_context);
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -42,6 +42,7 @@ namespace cryptonote
   {
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context)=0;
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)=0;
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
@@ -60,6 +61,10 @@ namespace cryptonote
       return false;
     }
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)
+    {
+      return false;
+    }
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)
     {
       return false;
     }

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -450,7 +450,7 @@ namespace nodetool
     };
   };
   
-#endif
+#endif /* ALLOW_DEBUG_COMMANDS */
 
 
   inline crypto::hash get_proof_of_trust_hash(const nodetool::proof_of_trust& pot)

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -223,6 +223,12 @@ bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_
     return true;
 }
 
+bool tests::proxy_core::handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig)
+{
+  // TODO: add tests for core uptime proof checking.
+  return false; // never relay these for tests.
+}
+
 bool tests::proxy_core::get_short_chain_history(std::list<crypto::hash>& ids) {
     build_short_history(ids, m_lastblk);
     return true;

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -79,6 +79,7 @@ namespace tests
     bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_txs(const std::list<cryptonote::blobdata>& tx_blobs, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_block(const cryptonote::blobdata& block_blob, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate = true);
+    bool handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig);
     void pause_mine(){}
     void resume_mine(){}
     bool on_idle(){return true;}

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -57,6 +57,7 @@ public:
   bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_txs(const std::list<cryptonote::blobdata>& tx_blob, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate = true) { return true; }
+  bool handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig) { return false; }
   void pause_mine(){}
   void resume_mine(){}
   bool on_idle(){return true;}


### PR DESCRIPTION
Quorum cop takes the core and service node list to query the quorum and begins voting off if it's participating in the quorum for nodes up to the (latest height - some safety buffer) if no ping has been seen since some threshold.

Nodes ping every 1 hour and also send out a ping on demand if they detect that they are included in the quorum for the latest block height.

There's an implicit dependency in Quorum Cop that it relies on Service Node Lists to have finished calculating the quorum state before Quorum Cop starts voting otherwise it receives an empty quorum.
I've chosen to enforce this by making it that the hooks for service node lists have to be registered explicitly and requires you to pass in the quorum cop.