### PR TITLE
Service Node Get Registration Command RPC/Daemon Call

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1738,47 +1738,17 @@ namespace cryptonote
     return m_service_node;
   }
   //-----------------------------------------------------------------------------------------------
-  std::string core::prepare_registration(const std::vector<std::string>& args)
-  {
-    std::vector<cryptonote::account_public_address> addresses;
-    std::vector<uint32_t> portions;
-    bool r = service_nodes::convert_registration_args(m_nettype, args, addresses, portions);
-    CHECK_AND_ASSERT_MES(r, "", tr("Failed to convert registration args"));
-    assert(addresses.size() == portions.size());
-    uint64_t exp_timestamp = time(nullptr) + STAKING_AUTHORIZATION_EXPIRATION_WINDOW;
-    crypto::hash hash;
-    r = cryptonote::get_registration_hash(addresses, portions, exp_timestamp, hash);
-    CHECK_AND_ASSERT_MES(r, "", tr("Failed to get the registration hash"));
-    crypto::signature signature;
-    crypto::generate_signature(hash, m_service_node_pubkey, m_service_node_key, signature);
-    std::stringstream ss;
-    ss << tr("Run this command in the wallet that will fund this registration:\n\n");
-    ss << "register_service_node ";
-    ss << std::setprecision(17);
-    for (size_t i = 0; i < addresses.size(); i++)
-      ss << get_account_address_as_str(m_nettype, false, addresses[i]) << " " << (portions[i]/(double)STAKING_PORTIONS) << " ";
-    ss << exp_timestamp << " " << epee::string_tools::pod_to_hex(m_service_node_pubkey) << " " << epee::string_tools::pod_to_hex(signature) << "\n\n";
-    time_t tt = exp_timestamp;
-    struct tm tm;
-#ifdef WIN32
-    gmtime_s(&tm, &tt);
-#else
-    gmtime_r(&tt, &tm);
-#endif
-    char buffer[128];
-    strftime(buffer, sizeof(buffer), "%Y-%m-%d %I:%M:%S %p", &tm);
-    ss << tr("This registration expires at ") << buffer << tr(". This should be in about 2 weeks. If it isn't, check this computer's clock") << std::endl;
-    ss << tr("Please submit your registration into the blockchain before this time or it will be invalid.");
-    return ss.str();
-  }
-  //-----------------------------------------------------------------------------------------------
   bool core::cmd_prepare_registration(const boost::program_options::variables_map& vm, const std::vector<std::string>& args)
   {
     bool r = handle_command_line(vm);
     CHECK_AND_ASSERT_MES(r, false, "Unable to parse command line arguments");
+
     r = init_service_node_key();
     CHECK_AND_ASSERT_MES(r, false, "Failed to create or load service node key");
-    std::string registration = prepare_registration(args);
+
+    std::string registration;
+    r = service_nodes::make_registration_cmd(get_nettype(), args, m_service_node_pubkey, m_service_node_key, registration, true /*make_friendly*/);
+    CHECK_AND_ASSERT_MES(r, "", tr("Failed to make registration command"));
     std::cout << registration << std::endl;
     return true;
   }

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -753,12 +753,12 @@ namespace cryptonote
       * @return the number of blocks to sync in one go
       */
      std::pair<uint64_t, uint64_t> get_coinbase_tx_sum(const uint64_t start_offset, const size_t count);
-     
+
      /**
       * @brief get the network type we're on
       *
       * @return which network are we on?
-      */     
+      */
      network_type get_nettype() const { return m_nettype; };
 
      /**
@@ -1015,16 +1015,6 @@ namespace cryptonote
       * @return true on success, false otherwise
       */
      bool init_service_node_key();
-
-     /**
-      * @brief Prepare a registration tx using the service node keys for this
-      * daemon.
-      *
-      * @param args The arguments, as a string. <address1> <fraction1> [<address2> <fraction2> [...]]
-      *
-      * @return whether or not the command was able to prepare the registration.
-      */
-     std::string prepare_registration(const std::vector<std::string>& args);
 
      bool m_test_drop_download = true; //!< whether or not to drop incoming blocks (for testing)
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -163,6 +163,8 @@ namespace service_nodes
   };
 
   bool convert_registration_args(cryptonote::network_type nettype, const std::vector<std::string>& args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint32_t>& portions);
+  bool make_registration_cmd(cryptonote::network_type nettype, const std::vector<std::string> args, const crypto::public_key& service_node_pubkey,
+                             const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly);
 
   const static cryptonote::account_public_address null_address{ crypto::null_pkey, crypto::null_pkey };
 }

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -143,6 +143,17 @@ bool t_command_parser_executor::print_quorum_state(const std::vector<std::string
   return m_executor.print_quorum_state(height);
 }
 
+bool t_command_parser_executor::get_service_node_registration_cmd(const std::vector<std::string>& args)
+{
+  if (args.empty() || args.size() % 2 != 0)
+  {
+    std::cout << "Invalid number of arguments received, expected an even number of arguments and > 0, received: " << args.size() << std::endl;
+    return false;
+  }
+
+  bool result = m_executor.get_service_node_registration_cmd(args);
+  return result;
+}
 
 bool t_command_parser_executor::set_log_level(const std::vector<std::string>& args)
 {

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -77,6 +77,8 @@ public:
 
   bool print_quorum_state(const std::vector<std::string>& args);
 
+  bool get_service_node_registration_cmd(const std::vector<std::string>& args);
+
   bool set_log_level(const std::vector<std::string>& args);
 
   bool set_log_categories(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -102,6 +102,12 @@ t_command_server::t_command_server(
     , "Print the quorum state for the block height."
     );
   m_command_lookup.set_handler(
+      "get_service_node_registration_cmd"
+    , std::bind(&t_command_parser_executor::get_service_node_registration_cmd, &m_parser, p::_1)
+    , "get_service_node_registration_cmd <address1> <shares1> [<address2> <shares2> [...]]"
+    , "Generate the required registration command"
+    );
+  m_command_lookup.set_handler(
       "is_key_image_spent"
     , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
     , "is_key_image_spent <key_image>"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1963,4 +1963,33 @@ bool t_rpc_command_executor::sync_info()
     return true;
 }
 
+bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector<std::string> &args)
+{
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request req;
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response res;
+    std::string fail_message = "Unsuccessful";
+    epee::json_rpc::error error_resp;
+
+    req.args = args;
+    req.make_friendly = !m_is_rpc;
+    if (m_is_rpc)
+    {
+        if (!m_rpc_client->json_rpc_request(req, res, "get_service_node_registration_cmd", fail_message.c_str()))
+        {
+            tools::fail_msg_writer() << make_error(fail_message, res.status);
+            return true;
+        }
+    }
+    else
+    {
+        if (!m_rpc_server->on_get_service_node_registration_cmd(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
+        {
+            tools::fail_msg_writer() << make_error(fail_message, error_resp.message);
+            return true;
+        }
+    }
+
+    tools::success_msg_writer() << res.registration_cmd;
+    return true;
+}
 }// namespace daemonize

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -155,6 +155,8 @@ public:
   bool relay_tx(const std::string &txid);
 
   bool sync_info();
+
+  bool get_service_node_registration_cmd(const std::vector<std::string> &args);
 };
 
 } // namespace daemonize

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -121,7 +121,6 @@ namespace cryptonote
       MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)      
       MAP_URI_AUTO_JON2_IF("/update", on_update, COMMAND_RPC_UPDATE, !m_restricted)
       MAP_URI_AUTO_JON2("/get_quorum_state", on_get_quorum_state, COMMAND_RPC_GET_QUORUM_STATE)
-      MAP_URI_AUTO_JON2("/submit_deregister_vote", on_submit_deregister_vote, COMMAND_RPC_SEND_DEREGISTER_VOTE)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("get_block_count",           on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
         MAP_JON_RPC("getblockcount",             on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
@@ -157,6 +156,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_txpool_backlog",     on_get_txpool_backlog,         COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG)
         MAP_JON_RPC_WE("get_output_distribution", on_get_output_distribution, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
         MAP_JON_RPC_WE("get_quorum_state",        on_get_quorum_state_json,     COMMAND_RPC_GET_QUORUM_STATE)
+        MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -194,7 +194,6 @@ namespace cryptonote
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res);
     bool on_get_quorum_state(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res);
-    bool on_submit_deregister_vote(const COMMAND_RPC_SEND_DEREGISTER_VOTE::request& req, COMMAND_RPC_SEND_DEREGISTER_VOTE::response& resp);
 
     //json_rpc
     bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);
@@ -222,6 +221,7 @@ namespace cryptonote
     bool on_get_txpool_backlog(const COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response& res, epee::json_rpc::error& error_resp);
     bool on_get_output_distribution(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, epee::json_rpc::error& error_resp);
     bool on_get_quorum_state_json(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     //-----------------------
 
 private:

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2303,36 +2303,27 @@ namespace cryptonote
     };
   };
 
-  struct COMMAND_RPC_SEND_DEREGISTER_VOTE
+  struct COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD
   {
-      struct request
-      {
-        loki::service_node_deregister::vote vote;
+    struct request
+    {
+      std::vector<std::string> args;
+      bool make_friendly; // Provide information about how to use the command in the result
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(args)
+        KV_SERIALIZE(make_friendly)
+      END_KV_SERIALIZE_MAP()
+    };
 
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE_VAL_POD_AS_BLOB(vote)
-        END_KV_SERIALIZE_MAP()
-      };
+    struct response
+    {
+      std::string status;
+      std::string registration_cmd;
 
-      struct response
-      {
-        std::string status;
-        std::string reason;
-
-        bool invalid_block_height;
-        bool voters_quorum_index_out_of_bounds;
-        bool service_node_index_out_of_bounds;
-        bool signature_not_valid;
-
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(status)
-          KV_SERIALIZE(reason)
-          KV_SERIALIZE(invalid_block_height)
-          KV_SERIALIZE(voters_quorum_index_out_of_bounds)
-          KV_SERIALIZE(service_node_index_out_of_bounds)
-          KV_SERIALIZE(signature_not_valid)
-        END_KV_SERIALIZE_MAP()
-      };
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(registration_cmd)
+      END_KV_SERIALIZE_MAP()
+    };
   };
-
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4584,29 +4584,6 @@ crypto::hash wallet2::get_payment_id(const pending_tx &ptx) const
   return payment_id;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::commit_deregister_vote(loki::service_node_deregister::vote& vote)
-{
-  if (m_light_wallet)
-  {
-    LOG_PRINT_L1("Deregister vote can not be sent in a light wallet.");
-  }
-  else
-  {
-    COMMAND_RPC_SEND_DEREGISTER_VOTE::request req;
-    req.vote = vote;
-
-    COMMAND_RPC_SEND_DEREGISTER_VOTE::response resp;
-
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/submit_deregister_vote", req, resp, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "submit_deregister_vote");
-    THROW_WALLET_EXCEPTION_IF(resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "submit_deregister_vote");
-    THROW_WALLET_EXCEPTION_IF(resp.status != CORE_RPC_STATUS_OK, error::vote_rejected, resp.status, resp.reason);
-  }
-}
-//----------------------------------------------------------------------------------------------------
 // take a pending tx and actually send it to the daemon
 void wallet2::commit_tx(pending_tx& ptx)
 {


### PR DESCRIPTION
Allow a way to get the registration command for a particular service node from the daemon and using RPC calls. Also remove some dead RPC code belonging to deregister votes that are not relevant.