### PR TITLE
Store Service Node State to DB as Blob

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -2341,4 +2341,17 @@ void BlockchainBDB::fixup()
   BlockchainDB::fixup();
 }
 
+void BlockchainBDB::set_service_node_data(const std::string& data)
+{
+}
+
+bool BlockchainBDB::get_service_node_data(std::string& data)
+{
+  return false;
+}
+
+void BlockchainBDB::clear_service_node_data()
+{
+}
+
 }  // namespace cryptonote

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -426,6 +426,10 @@ private:
   // fix up anything that may be wrong due to past bugs
   virtual void fixup();
 
+  virtual void set_service_node_data(const std::string& data);
+  virtual bool get_service_node_data(std::string& data);
+  virtual void clear_service_node_data();
+
   bool m_run_checkpoint;
   std::unique_ptr<boost::thread> m_checkpoint_thread;
   typedef bdb_safe_buffer<void *> bdb_safe_buffer_t;

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1559,6 +1559,10 @@ public:
    */
   virtual void fixup();
 
+  virtual void set_service_node_data(const std::string& data) = 0;
+  virtual bool get_service_node_data(std::string& data) = 0;
+  virtual void clear_service_node_data() = 0;
+
   /**
    * @brief set whether or not to automatically remove logs
    *

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -62,6 +62,8 @@ typedef struct mdb_txn_cursors
   MDB_cursor *m_txc_txpool_blob;
 
   MDB_cursor *m_txc_hf_versions;
+
+  MDB_cursor *m_txc_service_node_data;
 } mdb_txn_cursors;
 
 #define m_cur_blocks	m_cursors->m_txc_blocks
@@ -79,6 +81,7 @@ typedef struct mdb_txn_cursors
 #define m_cur_txpool_meta	m_cursors->m_txc_txpool_meta
 #define m_cur_txpool_blob	m_cursors->m_txc_txpool_blob
 #define m_cur_hf_versions	m_cursors->m_txc_hf_versions
+#define m_cur_service_node_data	m_cursors->m_txc_service_node_data
 
 typedef struct mdb_rflags
 {
@@ -98,6 +101,7 @@ typedef struct mdb_rflags
   bool m_rf_txpool_meta;
   bool m_rf_txpool_blob;
   bool m_rf_hf_versions;
+  bool m_rf_service_node_data;
 } mdb_rflags;
 
 typedef struct mdb_threadinfo
@@ -389,6 +393,11 @@ private:
 
   void cleanup_batch();
 
+
+  virtual void set_service_node_data(const std::string& data);
+  virtual bool get_service_node_data(std::string& data);
+  virtual void clear_service_node_data();
+
 private:
   MDB_env* m_env;
 
@@ -413,6 +422,8 @@ private:
 
   MDB_dbi m_hf_starting_heights;
   MDB_dbi m_hf_versions;
+
+  MDB_dbi m_service_node_data;
 
   MDB_dbi m_properties;
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -516,6 +516,9 @@ bool Blockchain::deinit()
 
   MTRACE("Stopping blockchain read/write activity");
 
+  m_service_node_list.store();
+  m_service_node_list.set_db_pointer(nullptr);
+
  // stop async service
   m_async_work_idle.reset();
   m_async_pool.join_all();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -528,9 +528,10 @@ namespace cryptonote
     m_blockchain_storage.set_user_options(blocks_threads,
         blocks_per_sync, sync_mode, fast_sync);
 
-    // NOTE: Hooks must be registered before blockchain is initialised for the blockchain init hook to occur.
+    BlockchainDB *initialized_db = db.release();
+    m_service_node_list.set_db_pointer(initialized_db);
     m_service_node_list.register_hooks(m_quorum_cop);
-    r = m_blockchain_storage.init(db.release(), m_nettype, m_offline, test_options);
+    r = m_blockchain_storage.init(initialized_db, m_nettype, m_offline, test_options);
 
     r = m_mempool.init(max_txpool_size);
     CHECK_AND_ASSERT_MES(r, false, "Failed to initialize memory pool");

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -73,12 +73,8 @@ namespace service_nodes
     // TODO: Save this calculation, only do it if it's not here.
     LOG_PRINT_L0("Recalculating service nodes list, scanning last 30 days");
 
-    m_service_nodes_infos.clear();
-
-    while (!m_rollback_events.empty())
-    {
-      m_rollback_events.pop_front();
-    }
+    if (load()) return;
+    clear(true);
 
     uint64_t current_height = m_blockchain.get_current_blockchain_height();
 
@@ -448,6 +444,7 @@ namespace service_nodes
   void service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
     block_added_generic(block, txs);
+    store();
   }
 
 
@@ -516,9 +513,6 @@ namespace service_nodes
         m_quorum_states.erase(m_quorum_states.begin());
       }
     }
-
-
-    // store in the db service node state for height block_height;
   }
 
   void service_node_list::blockchain_detached(uint64_t height)
@@ -537,6 +531,7 @@ namespace service_nodes
     {
       m_quorum_states.erase(--m_quorum_states.end());
     }
+    store();
   }
 
   std::vector<crypto::public_key> service_node_list::get_expired_nodes(uint64_t block_height) const
@@ -785,6 +780,144 @@ namespace service_nodes
     return false;
   }
 
+  bool service_node_list::store()
+  {
+    if (!m_db)
+    {
+      return false;
+    }
+    data_members_for_serialization data_to_store;
+
+    node_info_for_serialization info;
+    for (const auto& kv_pair : m_service_nodes_infos)
+    {
+      info.key = kv_pair.first;
+      info.info = kv_pair.second;
+      data_to_store.infos.push_back(info);
+    }
+
+    rollback_event_variant event;
+    for (const auto& event_ptr : m_rollback_events)
+    {
+      switch (event_ptr->type)
+      {
+        case rollback_event::change_type:
+          event = *reinterpret_cast<rollback_change *>(event_ptr.get());
+          data_to_store.events.push_back(*reinterpret_cast<rollback_change *>(event_ptr.get()));
+          break;
+        case rollback_event::new_type:
+          event = *reinterpret_cast<rollback_new *>(event_ptr.get());
+          data_to_store.events.push_back(*reinterpret_cast<rollback_new *>(event_ptr.get()));
+          break;
+        case rollback_event::prevent_type:
+          event = *reinterpret_cast<prevent_rollback *>(event_ptr.get());
+          data_to_store.events.push_back(*reinterpret_cast<prevent_rollback *>(event_ptr.get()));
+          break;
+        default:
+          return false;
+      }
+    }
+
+    std::stringstream ss;
+    binary_archive<true> ba(ss);
+    bool r = ::serialization::serialize(ba, data_to_store);
+    if (!r) return false;
+
+    std::string blob = ss.str();
+    m_db->block_txn_start(false/*readonly*/);
+    m_db->set_service_node_data(blob);
+    m_db->block_txn_stop();
+
+    return true;
+  }
+
+  bool service_node_list::load()
+  {
+    clear(false);
+    if (!m_db)
+    {
+      return false;
+    }
+    std::stringstream ss;
+
+    data_members_for_serialization data_in;
+    std::string blob;
+
+    m_db->block_txn_start(true/*readonly*/);
+    if (!m_db->get_service_node_data(blob))
+    {
+      m_db->block_txn_stop();
+      return false;
+    }
+    m_db->block_txn_stop();
+
+    ss << blob;
+    binary_archive<false> ba(ss);
+    bool r = ::serialization::serialize(ba, data_in);
+    CHECK_AND_ASSERT_MES(r, false, "Failed to parse service node data from blob");
+
+    for (const auto& info : data_in.infos)
+    {
+      m_service_nodes_infos[info.key] = info.info;
+    }
+
+    for (const auto& event : data_in.events)
+    {
+      if (event.type() == typeid(rollback_change))
+      {
+        rollback_change *i = new rollback_change();
+        const rollback_change& from = boost::get<rollback_change>(event);
+        i->m_block_height = from.m_block_height;
+        i->m_key = from.m_key;
+        i->m_info = from.m_info;
+        i->type = rollback_event::change_type;
+        m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
+        break;
+      }
+      else if (event.type() == typeid(rollback_new))
+      {
+        rollback_new *i = new rollback_new();
+        const rollback_new& from = boost::get<rollback_new>(event);
+        i->m_block_height = from.m_block_height;
+        i->m_key = from.m_key;
+        i->type = rollback_event::change_type;
+        m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
+        break;
+      }
+      else if (event.type() == typeid(prevent_rollback))
+      {
+        prevent_rollback *i = new prevent_rollback();
+        const prevent_rollback& from = boost::get<prevent_rollback>(event);
+        i->m_block_height = from.m_block_height;
+        i->type = rollback_event::change_type;
+        m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
+        break;
+      }
+      else
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void service_node_list::clear(bool delete_db_entry)
+  {
+    m_service_nodes_infos.clear();
+    m_rollback_events.clear();
+
+    if (m_db && delete_db_entry)
+    {
+      m_db->block_txn_start(false/*readonly*/);
+      m_db->clear_service_node_data();
+      m_db->block_txn_stop();
+    }
+
+    // not currently done in init(), so maybe don't?
+    m_quorum_states.clear();
+  }
+
   bool convert_registration_args(cryptonote::network_type nettype, const std::vector<std::string>& args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint32_t>& portions, uint32_t& portions_for_operator, uint64_t& initial_contribution)
   {
     if (args.size() % 2 == 1)
@@ -941,5 +1074,6 @@ namespace service_nodes
     cmd = stream.str();
     return true;
   }
+
 }
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -29,6 +29,8 @@
 #pragma once
 
 #include "blockchain.h"
+#include <boost/variant.hpp>
+#include "serialization/serialization.h"
 
 #define ROLLBACK_EVENT_EXPIRATION_BLOCKS 30
 
@@ -70,7 +72,8 @@ namespace service_nodes
     bool is_service_node(const crypto::public_key& pubkey) const;
     const std::shared_ptr<quorum_state> get_quorum_state(uint64_t height) const;
 
-  private:
+    void set_db_pointer(cryptonote::BlockchainDB* db) { m_db = db; }
+    bool store();
 
     struct service_node_info
     {
@@ -79,8 +82,15 @@ namespace service_nodes
         uint64_t amount;
         uint64_t reserved;
         cryptonote::account_public_address address;
+        contribution() = default;
         contribution(uint64_t _reserved, const cryptonote::account_public_address& _address)
           : amount(0), reserved(_reserved), address(_address) { }
+
+        BEGIN_SERIALIZE()
+          VARINT_FIELD(amount)
+          VARINT_FIELD(reserved)
+          FIELD(address)
+        END_SERIALIZE()
       };
 
       // block_height and transaction_index are to record when the service node
@@ -89,7 +99,7 @@ namespace service_nodes
       // set the winning service node as though it was re-registering at the
       // block height it wins on, with transaction index=-1
       // (hence transaction_index is signed)
-
+      uint64_t version;
       uint64_t last_reward_block_height;
       uint32_t last_reward_transaction_index;
 
@@ -103,6 +113,18 @@ namespace service_nodes
       bool is_fully_funded() const { return total_contributed >= staking_requirement; }
       // the minimum contribution to start a new contributor
       uint64_t get_min_contribution() const { return std::min(staking_requirement - total_reserved, staking_requirement / MAX_NUMBER_OF_CONTRIBUTORS); }
+
+      BEGIN_SERIALIZE()
+        VARINT_FIELD(version)
+        VARINT_FIELD(last_reward_block_height)
+        VARINT_FIELD(last_reward_transaction_index)
+        FIELD(contributors)
+        VARINT_FIELD(total_contributed)
+        VARINT_FIELD(total_reserved)
+        VARINT_FIELD(staking_requirement)
+        VARINT_FIELD(portions_for_operator)
+        FIELD(operator_address)
+      END_SERIALIZE()
     };
 
     bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;
@@ -125,45 +147,104 @@ namespace service_nodes
 
     void store_quorum_state_from_rewards_list(uint64_t height);
 
-    class rollback_event
+  public:
+    struct rollback_event
     {
-    public:
+      enum rollback_type
+      {
+        change_type,
+        new_type,
+        prevent_type
+      };
+
+      rollback_event() = default;
       rollback_event(uint64_t block_height);
       virtual ~rollback_event() { }
       virtual bool apply(std::unordered_map<crypto::public_key, service_node_info>& service_nodes_infos) const = 0;
+
+      rollback_type type;
+
       uint64_t m_block_height;
+
+      BEGIN_SERIALIZE()
+        VARINT_FIELD(m_block_height)
+      END_SERIALIZE()
     };
 
-    class rollback_change : public rollback_event
+    struct rollback_change : public rollback_event
     {
-    public:
+      rollback_change() { type = change_type; }
       rollback_change(uint64_t block_height, const crypto::public_key& key, const service_node_info& info);
       bool apply(std::unordered_map<crypto::public_key, service_node_info>& service_nodes_infos) const;
-    private:
       crypto::public_key m_key;
       service_node_info m_info;
+
+      BEGIN_SERIALIZE()
+        FIELDS(*static_cast<rollback_event *>(this))
+        FIELD(m_key)
+        FIELD(m_info)
+      END_SERIALIZE()
     };
 
-    class rollback_new : public rollback_event
+    struct rollback_new : public rollback_event
     {
-    public:
+      rollback_new() { type = new_type; }
       rollback_new(uint64_t block_height, const crypto::public_key& key);
       bool apply(std::unordered_map<crypto::public_key, service_node_info>& service_nodes_infos) const;
-    private:
       crypto::public_key m_key;
+
+      BEGIN_SERIALIZE()
+        FIELDS(*static_cast<rollback_event *>(this))
+        FIELD(m_key)
+      END_SERIALIZE()
     };
 
-    class prevent_rollback : public rollback_event
+    struct prevent_rollback : public rollback_event
     {
-    public:
+      prevent_rollback() { type = prevent_type; }
       prevent_rollback(uint64_t block_height);
       bool apply(std::unordered_map<crypto::public_key, service_node_info>& service_nodes_infos) const;
+
+      BEGIN_SERIALIZE()
+        FIELDS(*static_cast<rollback_event *>(this))
+      END_SERIALIZE()
     };
+
+    typedef boost::variant<rollback_change, rollback_new, prevent_rollback> rollback_event_variant;
+
+    struct node_info_for_serialization
+    {
+      crypto::public_key key;
+      service_node_info info;
+
+      BEGIN_SERIALIZE()
+        FIELD(key)
+        FIELD(info)
+      END_SERIALIZE()
+    };
+
+    struct data_members_for_serialization
+    {
+      std::vector<node_info_for_serialization> infos;
+      std::vector<rollback_event_variant> events;
+
+      BEGIN_SERIALIZE()
+        FIELD(infos)
+        FIELD(events)
+      END_SERIALIZE()
+    };
+
+  private:
+
+    void clear(bool delete_db_entry = false);
+    bool load();
 
     std::unordered_map<crypto::public_key, service_node_info> m_service_nodes_infos;
     std::list<std::unique_ptr<rollback_event>> m_rollback_events;
     cryptonote::Blockchain& m_blockchain;
     bool m_hooks_registered;
+
+    cryptonote::BlockchainDB* m_db;
 
     using block_height = uint64_t;
     std::map<block_height, std::shared_ptr<quorum_state>> m_quorum_states;
@@ -175,3 +256,8 @@ namespace service_nodes
 
   const static cryptonote::account_public_address null_address{ crypto::null_pkey, crypto::null_pkey };
 }
+
+VARIANT_TAG(binary_archive, service_nodes::service_node_list::data_members_for_serialization, 0xa0);
+VARIANT_TAG(binary_archive, service_nodes::service_node_list::rollback_change, 0xa1);
+VARIANT_TAG(binary_archive, service_nodes::service_node_list::rollback_new, 0xa2);
+VARIANT_TAG(binary_archive, service_nodes::service_node_list::prevent_rollback, 0xa3);

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -116,6 +116,10 @@ public:
   virtual std::map<uint64_t, std::tuple<uint64_t, uint64_t, uint64_t>> get_output_histogram(const std::vector<uint64_t> &amounts, bool unlocked, uint64_t recent_cutoff, uint64_t min_count) const { return std::map<uint64_t, std::tuple<uint64_t, uint64_t, uint64_t>>(); }
   virtual bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, std::vector<uint64_t> &distribution, uint64_t &base) const { return false; }
 
+  virtual void set_service_node_data(const std::string& data) {}
+  virtual bool get_service_node_data(std::string& data) { return false; }
+  virtual void clear_service_node_data() {}
+
   virtual void add_txpool_tx(const transaction &tx, const txpool_tx_meta_t& details) {}
   virtual void update_txpool_tx(const crypto::hash &txid, const txpool_tx_meta_t& details) {}
   virtual uint64_t get_txpool_tx_count(bool include_unrelayed_txes = true) const { return 0; }


### PR DESCRIPTION
Is ready for preliminary review, still needs to be tested abit before I'm satisfied. It's just I haven't got around to make dummy registrations and getting it onto the network as the commands keep changing and get more difficult to create with each iteration.

Of note, to get around the crashes on load/store and clear I just decided to create a transaction handle for read/writing into the DB at that point and make sure I close it before we exit the function.

Also, moved the store() command to blockchain.deinit(). Before, having it save to the DB in the destructor was occurring after the db had been de-initialised causing a null pointer deref, so I delegated service_node_list.store() call to the deinit function in blockchain itself.