### PR TITLE
Begin fixing core tests

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -198,6 +198,10 @@ namespace cryptonote {
     // No limits should be employed, but this is correct way to employ a 20% symmetrical limit:
     // nextDifficulty=max(previous_Difficulty*0.8,min(previous_Difficulty/0.8, next_Difficulty));
     next_difficulty = static_cast<uint64_t>(nextDifficulty);
+
+    if (next_difficulty == 0)
+        next_difficulty = 1;
+
     return next_difficulty;
   }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -42,8 +42,8 @@
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW            30
 #define CURRENT_TRANSACTION_VERSION                     3
-#define CURRENT_BLOCK_MAJOR_VERSION                     6
-#define CURRENT_BLOCK_MINOR_VERSION                     6
+#define CURRENT_BLOCK_MAJOR_VERSION                     7
+#define CURRENT_BLOCK_MINOR_VERSION                     7
 #define CURRENT_BLOCK_MAJOR_VERSION_TESTNET             7
 #define CURRENT_BLOCK_MINOR_VERSION_TESTNET             7
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           60*10

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1141,7 +1141,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
       case TESTNET:
         governance_wallet_address_str = ::config::testnet::GOVERNANCE_WALLET_ADDRESS;
         break;
-      case MAINNET:
+      case FAKECHAIN: case MAINNET:
         governance_wallet_address_str = ::config::GOVERNANCE_WALLET_ADDRESS;
         break;
       default:

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -132,7 +132,7 @@ namespace cryptonote
       case TESTNET:
         cryptonote::get_account_address_from_str(governance_wallet_address, cryptonote::TESTNET, governance_wallet_address_str);
         break;
-      case MAINNET:
+      case FAKECHAIN: case MAINNET:
         cryptonote::get_account_address_from_str(governance_wallet_address, cryptonote::MAINNET, governance_wallet_address_str);
         break;
       default:

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -571,7 +571,7 @@ transaction construct_tx_with_fee(std::vector<test_event_entry>& events, const b
                                   const account_base& acc_from, const account_base& acc_to, uint64_t amount, uint64_t fee)
 {
   transaction tx;
-  construct_tx_to_key(events, tx, blk_head, acc_from, acc_to, amount, fee, 0);
+  construct_tx_to_key(events, tx, blk_head, acc_from, acc_to, amount, fee, 9);
   events.push_back(tx);
   return tx;
 }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -443,7 +443,7 @@ struct get_test_options {
   const cryptonote::test_options test_options = {
     hard_forks
   };
-  get_test_options():hard_forks{std::make_pair((uint8_t)1, (uint64_t)0), std::make_pair((uint8_t)0, (uint64_t)0)}{}
+  get_test_options():hard_forks{std::make_pair((uint8_t)7, (uint64_t)0), std::make_pair((uint8_t)0, (uint64_t)0)}{}
 };
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
- Difficulty fix to prevent 0 difficulty which is not considered valid.
- CURRENT_BLOCK_MAJOR/MINOR_VERSION is only used for tests it appears
- Core Tests generate a blockchain using the nettype FAKECHAIN, so some
  codepaths need to accept FAKECHAIN as a nettype. FAKECHAIN is essentially the
  mainnet.
- Core Tests uses their own hard-fork data that specifies the current hard-fork
  version and time it forked etc instead of using the data in blockchain.cpp at
  the top. We started from v7, so get_test_options() is updated accordingly.