### PR TITLE
Interactive registration: part 1

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -155,6 +155,12 @@ bool t_command_parser_executor::get_service_node_registration_cmd(const std::vec
   return result;
 }
 
+bool t_command_parser_executor::prepare_registration()
+{
+  bool result = m_executor.prepare_registration();
+  return result;
+}
+
 bool t_command_parser_executor::set_log_level(const std::vector<std::string>& args)
 {
   if(args.size() > 1)

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -157,7 +157,13 @@ bool t_command_parser_executor::get_service_node_registration_cmd(const std::vec
 
 bool t_command_parser_executor::prepare_registration()
 {
+  // disable messages during interactive prompt
+  std::string categories = mlog_get_categories();
+  mlog_set_categories("");
+
   bool result = m_executor.prepare_registration();
+  // restore messages
+  mlog_set_categories(categories.c_str());
   return result;
 }
 

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -79,6 +79,8 @@ public:
 
   bool get_service_node_registration_cmd(const std::vector<std::string>& args);
 
+  bool prepare_registration();
+
   bool set_log_level(const std::vector<std::string>& args);
 
   bool set_log_categories(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -108,6 +108,12 @@ t_command_server::t_command_server(
     , "Generate the required registration command"
     );
   m_command_lookup.set_handler(
+      "prepare_registration"
+    , std::bind(&t_command_parser_executor::prepare_registration, &m_parser)
+    , "prepare_registration"
+    , "Interactive prompt to prepare the registration. The resulting registration data is saved to disk."
+    );
+  m_command_lookup.set_handler(
       "is_key_image_spent"
     , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
     , "is_key_image_spent <key_image>"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2204,7 +2204,6 @@ bool t_rpc_command_executor::prepare_registration()
     }
     else if(number_contribution_under_minimum == 1)
     {
-      std::cout << "one contribution under 25%" << std::endl;
       // make sure the only contribution <25% is last
       const auto it = std::find_if(
         contributions.begin(),
@@ -2213,7 +2212,6 @@ bool t_rpc_command_executor::prepare_registration()
       if(it != contributions.end())
       {
         size_t index = it - contributions.begin();
-        std::cout << "found at " << index << std::endl;
         if(index != (contributions.size() - 1) && index > 0)
         {
           // swap

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -157,6 +157,8 @@ public:
   bool sync_info();
 
   bool get_service_node_registration_cmd(const std::vector<std::string> &args);
+    
+  bool prepare_registration();
 };
 
 } // namespace daemonize


### PR DESCRIPTION
This PR will only add the interactive prompt and saving to disk of the registration parameters.
I will remove `get_service_node_registration_cmd` separately.
This is an early PR with the intention to get feedback.

A couple of open questions:
- Money is displayed with 9 digits of precision, overkill?
- I could use feedback on the actual phrasing of the prompts
- I am not sure if I am getting the correct block height
- I am not sure my logic is in the right file
- I assume we want to minimise overshooting the staking requirement, so at each participant iteration I display how much is left before the staking requirement is fulfilled.
- suggestion: I think it would be more user-friendly to prompt percentage as 0-100 instead of 0-1

Example of interactions:
Single participant (operator):
```
> prepare_registration
Current staking requirement: 100.000000000
Do you want to reserve portions of the stake for other participants? (Y/Yes/N/No):N
Enter the reward percentage reserved for operating costs [0.0-1.0]:0.5
Enter the loki address for the operator:abc
Reserved staking contribution: 100.000000000
Registration parameters saved.
```
Multiple participants, operator stakes the minimum:
```
prepare_registration 
Current staking requirement: 100.000000000
Do you want to reserve portions of the stake for other participants? (Y/Yes/N/No):Yes
Number of additional participants [1-3]:2
Enter the reward percentage reserved for operating costs [0.0-1.0]:0.5
Enter the loki address for the operator:a
Enter the total stake amount for the operator [25.000000000-100.000000000]:25
the operator will need to contribute 25.000000000.
Enter the loki address for participant 1:b
Enter the total stake amount for participant 1 [0.000000000-75.000000000]:20
Enter the loki address for participant 2:c
Enter the total stake amount for participant 2 [0.000000000-55.000000000]:20
Reserved staking contribution: 65.000000000
The remaining 35.000000000 will need to be filled by an external staker.
Registration parameters saved.
```
4 Participants, operator reserves more than minimum, but not enough amount reserved:
```
Current staking requirement: 100.000000000
Do you want to reserve portions of the stake for other participants? (Y/Yes/N/No):Yes
Number of additional participants [1-3]:3
Enter the reward percentage reserved for operating costs [0.0-1.0]:0.5
Enter the loki address for the operator:a
Enter the total stake amount for the operator [25.000000000-100.000000000]:50
Enter the amount that the operator will contribute initially [25.000000000-50.000000000]:30
Enter the loki address for participant 1:b
Enter the total stake amount for participant 1 [0.000000000-50.000000000]:21
Enter the loki address for participant 2:c
Enter the total stake amount for participant 2 [0.000000000-29.000000000]:17.54
Enter the loki address for participant 3:d
Enter the total stake amount for participant 3 [0.000000000-11.460000000]:10   
Reserved staking contribution: 98.540000000
Invalid parameters: the total contribution 98.540000000 does not meet the staking requirement of 100.000000000
```