### PR TITLE
Service Nodes States Endpoint

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1679,9 +1679,9 @@ namespace cryptonote
     return result;
   }
   //-----------------------------------------------------------------------------------------------
-  std::vector<service_nodes::service_node_pubkey_info> core::get_service_node_list_state() const
+  std::vector<service_nodes::service_node_pubkey_info> core::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
-    std::vector<service_nodes::service_node_pubkey_info> result = m_service_node_list.get_service_node_list_state();
+    std::vector<service_nodes::service_node_pubkey_info> result = m_service_node_list.get_service_node_list_state(service_node_pubkeys);
     return result;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1106,6 +1106,12 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  uint64_t core::get_uptime_proof(const crypto::public_key &key) const
+  {
+    uint64_t result = m_quorum_cop.get_uptime_proof(key);
+    return result;
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig)
   {
     return m_quorum_cop.handle_uptime_proof(timestamp, pubkey, sig);
@@ -1670,6 +1676,12 @@ namespace cryptonote
   const std::shared_ptr<service_nodes::quorum_state> core::get_quorum_state(uint64_t height) const
   {
     const std::shared_ptr<service_nodes::quorum_state> result = m_service_node_list.get_quorum_state(height);
+    return result;
+  }
+  //-----------------------------------------------------------------------------------------------
+  std::vector<service_nodes::service_node_pubkey_info> core::get_service_node_list_state() const
+  {
+    std::vector<service_nodes::service_node_pubkey_info> result = m_service_node_list.get_service_node_list_state();
     return result;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -801,9 +801,11 @@ namespace cryptonote
      /**
       * @brief Get a snapshot of the service node list state at the time of the call.
       *
-      * @return All current service nodes that are in the process of registration or registered.
+      * @param service_node_pubkeys pubkeys to search, if empty this indicates get all the pubkeys
+      *
+      * @return All the service nodes that can be matched from pubkeys in param
       */
-     std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state() const;
+     std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
 
      /**
       * @brief Add a vote to deregister a service node from network

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -799,6 +799,13 @@ namespace cryptonote
      const std::shared_ptr<service_nodes::quorum_state> get_quorum_state(uint64_t height) const;
 
      /**
+      * @brief Get a snapshot of the service node list state at the time of the call.
+      *
+      * @return All current service nodes that are in the process of registration or registered.
+      */
+     std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state() const;
+
+     /**
       * @brief Add a vote to deregister a service node from network
       *
       * @param vote The vote for deregistering a service node.
@@ -835,6 +842,15 @@ namespace cryptonote
       * @return true
       */
      bool submit_uptime_proof();
+
+     /**
+      * @brief Try find the uptime proof from the service node.
+      *
+      * @param key The public key of the service node
+      *
+      * @return 0 if no uptime proof found, otherwise the timestamp it last received in epoch time
+      */
+     uint64_t get_uptime_proof(const crypto::public_key &key) const;
 
    private:
 

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -198,4 +198,15 @@ namespace service_nodes
 
     return true;
   }
+
+  uint64_t quorum_cop::get_uptime_proof(const crypto::public_key &pubkey) const
+  {
+    const auto& it = m_uptime_proof_seen.find(pubkey);
+    if (it == m_uptime_proof_seen.end())
+    {
+      return 0;
+    }
+
+    return (*it).second;
+  }
 }

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -63,13 +63,22 @@ namespace service_nodes
                   "Safety buffer should always be less than the vote lifetime");
     bool prune_uptime_proof();
 
+    using timestamp = uint64_t;
+
+    struct pubkey_timestamp
+    {
+      crypto::public_key pubkey;
+      timestamp          last_uptime_proof;
+    };
+
+    uint64_t get_uptime_proof(const crypto::public_key &pubkey) const;
+
   private:
 
     cryptonote::core& m_core;
     service_node_list& m_service_node_list;
     uint64_t m_last_height;
 
-    using timestamp = uint64_t;
     std::unordered_map<crypto::public_key, timestamp> m_uptime_proof_seen;
     epee::critical_section m_lock;
   };

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -63,14 +63,6 @@ namespace service_nodes
                   "Safety buffer should always be less than the vote lifetime");
     bool prune_uptime_proof();
 
-    using timestamp = uint64_t;
-
-    struct pubkey_timestamp
-    {
-      crypto::public_key pubkey;
-      timestamp          last_uptime_proof;
-    };
-
     uint64_t get_uptime_proof(const crypto::public_key &pubkey) const;
 
   private:
@@ -79,6 +71,7 @@ namespace service_nodes
     service_node_list& m_service_node_list;
     uint64_t m_last_height;
 
+    using timestamp = uint64_t;
     std::unordered_map<crypto::public_key, timestamp> m_uptime_proof_seen;
     epee::critical_section m_lock;
   };

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -142,18 +142,37 @@ namespace service_nodes
     return result;
   }
 
-  std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state() const
+  std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
     // TODO(doyle): Is order important here?
     std::vector<service_node_pubkey_info> result;
-    result.reserve(m_service_nodes_infos.size());
 
-    for (const auto &it : m_service_nodes_infos)
+    if (service_node_pubkeys.empty())
     {
-      service_node_pubkey_info entry = {};
-      entry.pubkey                   = it.first;
-      entry.info                     = it.second;
-      result.push_back(entry);
+      result.reserve(m_service_nodes_infos.size());
+
+      for (const auto &it : m_service_nodes_infos)
+      {
+        service_node_pubkey_info entry = {};
+        entry.pubkey                   = it.first;
+        entry.info                     = it.second;
+        result.push_back(entry);
+      }
+    }
+    else
+    {
+      result.reserve(service_node_pubkeys.size());
+      for (const auto &it : service_node_pubkeys)
+      {
+        const auto &find_it = m_service_nodes_infos.find(it);
+        if (find_it == m_service_nodes_infos.end())
+          continue;
+
+        service_node_pubkey_info entry = {};
+        entry.pubkey                   = (*find_it).first;
+        entry.info                     = (*find_it).second;
+        result.push_back(entry);
+      }
     }
 
     return result;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -144,7 +144,6 @@ namespace service_nodes
 
   std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
-    // TODO(doyle): Is order important here?
     std::vector<service_node_pubkey_info> result;
 
     if (service_node_pubkeys.empty())

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -142,6 +142,23 @@ namespace service_nodes
     return result;
   }
 
+  std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state() const
+  {
+    // TODO(doyle): Is order important here?
+    std::vector<service_node_pubkey_info> result;
+    result.reserve(m_service_nodes_infos.size());
+
+    for (const auto &it : m_service_nodes_infos)
+    {
+      service_node_pubkey_info entry = {};
+      entry.pubkey                   = it.first;
+      entry.info                     = it.second;
+      result.push_back(entry);
+    }
+
+    return result;
+  }
+
   bool service_node_list::is_service_node(const crypto::public_key& pubkey) const
   {
     return m_service_nodes_infos.find(pubkey) != m_service_nodes_infos.end();

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -48,6 +48,39 @@ namespace service_nodes
     std::vector<crypto::public_key> nodes_to_test;
   };
 
+  struct service_node_info // registration information
+  {
+    struct contribution
+    {
+      uint64_t amount;
+      uint64_t reserved;
+      cryptonote::account_public_address address;
+      contribution(uint64_t _reserved, const cryptonote::account_public_address& _address)
+        : amount(0), reserved(_reserved), address(_address) { }
+    };
+
+    // block_height and transaction_index are to record when the service node is registered or when it last received a reward.
+    uint64_t last_reward_block_height;
+    uint32_t last_reward_transaction_index;
+
+    std::vector<contribution> contributors;
+    uint64_t total_contributed;
+    uint64_t total_reserved;
+    uint64_t staking_requirement;
+    uint32_t portions_for_operator;
+    cryptonote::account_public_address operator_address;
+
+    bool is_fully_funded() const { return total_contributed >= staking_requirement; }
+    // the minimum contribution to start a new contributor
+    uint64_t get_min_contribution() const { return std::min(staking_requirement - total_reserved, staking_requirement / MAX_NUMBER_OF_CONTRIBUTORS); }
+  };
+
+  struct service_node_pubkey_info
+  {
+    crypto::public_key pubkey;
+    service_node_info  info;
+  };
+
   class service_node_list
     : public cryptonote::Blockchain::BlockAddedHook,
       public cryptonote::Blockchain::BlockchainDetachedHook,
@@ -69,42 +102,9 @@ namespace service_nodes
 
     bool is_service_node(const crypto::public_key& pubkey) const;
     const std::shared_ptr<quorum_state> get_quorum_state(uint64_t height) const;
+    std::vector<service_node_pubkey_info> get_service_node_list_state() const;
 
   private:
-
-    struct service_node_info
-    {
-      struct contribution
-      {
-        uint64_t amount;
-        uint64_t reserved;
-        cryptonote::account_public_address address;
-        contribution(uint64_t _reserved, const cryptonote::account_public_address& _address)
-          : amount(0), reserved(_reserved), address(_address) { }
-      };
-
-      // block_height and transaction_index are to record when the service node
-      // is registered or when it last received a reward.
-      //
-      // set the winning service node as though it was re-registering at the
-      // block height it wins on, with transaction index=-1
-      // (hence transaction_index is signed)
-
-      uint64_t last_reward_block_height;
-      uint32_t last_reward_transaction_index;
-
-      std::vector<contribution> contributors;
-      uint64_t total_contributed;
-      uint64_t total_reserved;
-      uint64_t staking_requirement;
-      uint32_t portions_for_operator;
-      cryptonote::account_public_address operator_address;
-
-      bool is_fully_funded() const { return total_contributed >= staking_requirement; }
-      // the minimum contribution to start a new contributor
-      uint64_t get_min_contribution() const { return std::min(staking_requirement - total_reserved, staking_requirement / MAX_NUMBER_OF_CONTRIBUTORS); }
-    };
-
     bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;
     bool get_contribution(const cryptonote::transaction& tx, uint64_t block_height, cryptonote::account_public_address& address, uint64_t& transferred) const;
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -102,7 +102,7 @@ namespace service_nodes
 
     bool is_service_node(const crypto::public_key& pubkey) const;
     const std::shared_ptr<quorum_state> get_quorum_state(uint64_t height) const;
-    std::vector<service_node_pubkey_info> get_service_node_list_state() const;
+    std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
 
   private:
     bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -168,6 +168,12 @@ bool t_command_parser_executor::prepare_registration()
   return result;
 }
 
+bool t_command_parser_executor::print_sn(const std::vector<std::string>& args)
+{
+  bool result = m_executor.print_sn(args);
+  return result;
+}
+
 bool t_command_parser_executor::set_log_level(const std::vector<std::string>& args)
 {
   if(args.size() > 1)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -83,6 +83,8 @@ public:
 
   bool prepare_registration();
 
+  bool print_sn(const std::vector<std::string>& args);
+
   bool set_log_level(const std::vector<std::string>& args);
 
   bool set_log_categories(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -120,6 +120,12 @@ t_command_server::t_command_server(
     , "Interactive prompt to prepare the registration. The resulting registration data is saved to disk."
     );
   m_command_lookup.set_handler(
+      "print_sn"
+    , std::bind(&t_command_parser_executor::print_sn, &m_parser, p::_1)
+    , "print_sn [<pubkey> [...]]"
+    , "Print service node registration info for the current height"
+    );
+  m_command_lookup.set_handler(
       "is_key_image_spent"
     , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
     , "is_key_image_spent <key_image>"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1998,7 +1998,7 @@ bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector
     return true;
 }
 
-static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> list)
+static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *> list)
 {
   const char indent1[] = "    ";
   const char indent2[] = "        ";
@@ -2006,7 +2006,7 @@ static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GE
 
   for (size_t i = 0; i < list.size(); ++i)
   {
-    const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry &entry = *list[i];
+    const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry &entry = *list[i];
 
     bool is_registered = entry.total_contributed >= entry.staking_requirement;
     epee::console_colors color = is_registered ? console_color_green : epee::console_color_yellow;
@@ -2037,7 +2037,7 @@ static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GE
     tools::msg_writer() << "";
     for (size_t j = 0; j < entry.contributors.size(); ++j)
     {
-      const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::contribution &contributor = entry.contributors[j];
+      const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::contribution &contributor = entry.contributors[j];
       tools::msg_writer() << indent2 << "[" << j << "] Contributor: " << contributor.address;
       tools::msg_writer() << indent3 << "Amount / Reserved: "         << cryptonote::print_money(contributor.amount) << " / " << cryptonote::print_money(contributor.reserved);
     }
@@ -2046,17 +2046,17 @@ static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GE
   }
 }
 
-bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::string> &args)
+bool t_rpc_command_executor::print_sn(const std::vector<std::string> &args)
 {
-    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request req = {};
-    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response res = {};
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE::request req = {};
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response res = {};
     std::string fail_message = "Unsuccessful";
     epee::json_rpc::error error_resp;
     req.service_node_pubkeys = args;
 
     if (m_is_rpc)
     {
-      if (!m_rpc_client->json_rpc_request(req, res, "get_service_node_list_state", fail_message.c_str()))
+      if (!m_rpc_client->json_rpc_request(req, res, "get_service_node", fail_message.c_str()))
       {
           tools::fail_msg_writer() << make_error(fail_message, res.status);
           return true;
@@ -2064,14 +2064,14 @@ bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::
     }
     else
     {
-      if (!m_rpc_server->on_get_service_node_list_state(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
+      if (!m_rpc_server->on_get_service_node(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
       {
           tools::fail_msg_writer() << make_error(fail_message, error_resp.message);
           return true;
       }
 
-      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> unregistered;
-      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> registered;
+      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *> unregistered;
+      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *> registered;
       registered.reserve  (res.service_node_states.size());
       unregistered.reserve(res.service_node_states.size() * 0.5f);
 
@@ -2088,7 +2088,7 @@ bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::
       }
 
       std::sort(unregistered.begin(), unregistered.end(),
-          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *b) {
+          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *b) {
           uint64_t a_remaining = a->staking_requirement - a->total_reserved;
           uint64_t b_remaining = b->staking_requirement - b->total_reserved;
 
@@ -2099,7 +2099,7 @@ bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::
       });
 
       std::stable_sort(registered.begin(), registered.end(),
-          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *b) {
+          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE::response::entry *b) {
           if (a->last_reward_block_height == b->last_reward_block_height)
             return a->last_reward_transaction_index < b->last_reward_transaction_index;
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2089,8 +2089,13 @@ bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::
 
       std::sort(unregistered.begin(), unregistered.end(),
           [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *b) {
-          bool result = a->contributors.size() < b->contributors.size();
-          return result;
+          uint64_t a_remaining = a->staking_requirement - a->total_reserved;
+          uint64_t b_remaining = b->staking_requirement - b->total_reserved;
+
+          if (b_remaining == a_remaining)
+            return b->portions_for_operator < a->portions_for_operator;
+
+          return b_remaining < a_remaining;
       });
 
       std::stable_sort(registered.begin(), registered.end(),

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1991,9 +1991,75 @@ bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector
           tools::fail_msg_writer() << make_error(fail_message, error_resp.message);
           return true;
       }
+
+      tools::success_msg_writer() << res.registration_cmd;
     }
 
-    tools::success_msg_writer() << res.registration_cmd;
+    return true;
+}
+
+bool t_rpc_command_executor::get_service_node_list_state()
+{
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request req;
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response res;
+    std::string fail_message = "Unsuccessful";
+    epee::json_rpc::error error_resp;
+
+    if (m_is_rpc)
+    {
+      if (!m_rpc_client->json_rpc_request(req, res, "get_service_node_list_state", fail_message.c_str()))
+      {
+          tools::fail_msg_writer() << make_error(fail_message, res.status);
+          return true;
+      }
+    }
+    else
+    {
+      if (!m_rpc_server->on_get_service_node_list_state(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
+      {
+          tools::fail_msg_writer() << make_error(fail_message, error_resp.message);
+          return true;
+      }
+
+      tools::msg_writer() << "Service Node Registration State[" << res.service_node_states.size() << "]";
+
+      const char indent1[] = "    ";
+      const char indent2[] = "        ";
+      const char indent3[] = "            ";
+      for (size_t i = 0; i < res.service_node_states.size(); ++i)
+      {
+        const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry &entry = res.service_node_states[i];
+
+        bool is_registered = entry.total_contributed >= entry.staking_requirement;
+        epee::console_colors color = is_registered ? console_color_green : epee::console_color_yellow;
+
+        tools::msg_writer(color) << indent1 << "[" << i << "] Service Node: "              << entry.service_node_pubkey;
+        tools::msg_writer(color) << indent2 << "Total Contributed / Staking Requirement: " << cryptonote::print_money(entry.total_contributed) << " / " << cryptonote::print_money(entry.staking_requirement);
+
+        tools::msg_writer() << indent2 << "Total Reserved    / Staking Requirement: " << cryptonote::print_money(entry.total_reserved) << " / " << cryptonote::print_money(entry.staking_requirement);
+        tools::msg_writer() << indent2 << "Last Reward At (Block Height/TX Index): "  << entry.last_reward_block_height << " / " << entry.last_reward_transaction_index;
+        tools::msg_writer() << indent2 << "Operator Cut (\% Of Reward): "             << ((entry.portions_for_operator / (double)STAKING_PORTIONS) * 100.0) << "%";
+        tools::msg_writer() << indent2 << "Operator Address: "                        << entry.operator_address;
+
+        epee::console_colors uptime_proof_color = (entry.last_uptime_proof == 0) ? epee::console_color_red : epee::console_color_green;
+
+        if (entry.last_uptime_proof == 0)
+          tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: Not Received Yet";
+        else
+          tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: "            << get_human_time_ago(entry.last_uptime_proof, time(nullptr));
+
+        tools::msg_writer() << "";
+        for (size_t j = 0; j < entry.contributors.size(); ++j)
+        {
+          const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::contribution &contributor = entry.contributors[j];
+          tools::msg_writer() << indent2 << "[" << j << "] Contributor: " << contributor.address;
+          tools::msg_writer() << indent3 << "Amount / Reserved: "         << cryptonote::print_money(contributor.amount) << " / " << cryptonote::print_money(contributor.reserved);
+        }
+
+        tools::msg_writer() << "";
+      }
+    }
+
     return true;
 }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1998,6 +1998,54 @@ bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector
     return true;
 }
 
+static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> list)
+{
+  const char indent1[] = "    ";
+  const char indent2[] = "        ";
+  const char indent3[] = "            ";
+
+  for (size_t i = 0; i < list.size(); ++i)
+  {
+    const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry &entry = *list[i];
+
+    bool is_registered = entry.total_contributed >= entry.staking_requirement;
+    epee::console_colors color = is_registered ? console_color_green : epee::console_color_yellow;
+
+    tools::msg_writer(color) << indent1 << "[" << i << "] Service Node: "              << entry.service_node_pubkey;
+    tools::msg_writer(color) << indent2 << "Total Contributed / Staking Requirement: " << cryptonote::print_money(entry.total_contributed) << " / " << cryptonote::print_money(entry.staking_requirement);
+
+    tools::msg_writer() << indent2 << "Total Reserved    / Staking Requirement: " << cryptonote::print_money(entry.total_reserved) << " / " << cryptonote::print_money(entry.staking_requirement);
+
+    if (is_registered)
+    {
+      tools::msg_writer() << indent2 << "Last Reward At (Block Height/TX Index): "  << entry.last_reward_block_height << " / " << entry.last_reward_transaction_index;
+    }
+
+    tools::msg_writer() << indent2 << "Operator Cut (\% Of Reward): "             << ((entry.portions_for_operator / (double)STAKING_PORTIONS) * 100.0) << "%";
+    tools::msg_writer() << indent2 << "Operator Address: "                        << entry.operator_address;
+
+    epee::console_colors uptime_proof_color = (entry.last_uptime_proof == 0) ? epee::console_color_red : epee::console_color_green;
+
+    if (is_registered)
+    {
+      if (entry.last_uptime_proof == 0)
+        tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: Not Received Yet";
+      else
+        tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: "            << get_human_time_ago(entry.last_uptime_proof, time(nullptr));
+    }
+
+    tools::msg_writer() << "";
+    for (size_t j = 0; j < entry.contributors.size(); ++j)
+    {
+      const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::contribution &contributor = entry.contributors[j];
+      tools::msg_writer() << indent2 << "[" << j << "] Contributor: " << contributor.address;
+      tools::msg_writer() << indent3 << "Amount / Reserved: "         << cryptonote::print_money(contributor.amount) << " / " << cryptonote::print_money(contributor.reserved);
+    }
+
+    tools::msg_writer() << "";
+  }
+}
+
 bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::string> &args)
 {
     cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request req = {};
@@ -2022,42 +2070,52 @@ bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::
           return true;
       }
 
-      tools::msg_writer() << "Service Node Registration State[" << res.service_node_states.size() << "]";
+      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> unregistered;
+      std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *> registered;
+      registered.reserve  (res.service_node_states.size());
+      unregistered.reserve(res.service_node_states.size() * 0.5f);
 
-      const char indent1[] = "    ";
-      const char indent2[] = "        ";
-      const char indent3[] = "            ";
-      for (size_t i = 0; i < res.service_node_states.size(); ++i)
+      for (auto &entry : res.service_node_states)
       {
-        const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry &entry = res.service_node_states[i];
-
-        bool is_registered = entry.total_contributed >= entry.staking_requirement;
-        epee::console_colors color = is_registered ? console_color_green : epee::console_color_yellow;
-
-        tools::msg_writer(color) << indent1 << "[" << i << "] Service Node: "              << entry.service_node_pubkey;
-        tools::msg_writer(color) << indent2 << "Total Contributed / Staking Requirement: " << cryptonote::print_money(entry.total_contributed) << " / " << cryptonote::print_money(entry.staking_requirement);
-
-        tools::msg_writer() << indent2 << "Total Reserved    / Staking Requirement: " << cryptonote::print_money(entry.total_reserved) << " / " << cryptonote::print_money(entry.staking_requirement);
-        tools::msg_writer() << indent2 << "Last Reward At (Block Height/TX Index): "  << entry.last_reward_block_height << " / " << entry.last_reward_transaction_index;
-        tools::msg_writer() << indent2 << "Operator Cut (\% Of Reward): "             << ((entry.portions_for_operator / (double)STAKING_PORTIONS) * 100.0) << "%";
-        tools::msg_writer() << indent2 << "Operator Address: "                        << entry.operator_address;
-
-        epee::console_colors uptime_proof_color = (entry.last_uptime_proof == 0) ? epee::console_color_red : epee::console_color_green;
-
-        if (entry.last_uptime_proof == 0)
-          tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: Not Received Yet";
-        else
-          tools::msg_writer(uptime_proof_color) << indent2 << "Last Uptime Proof Received: "            << get_human_time_ago(entry.last_uptime_proof, time(nullptr));
-
-        tools::msg_writer() << "";
-        for (size_t j = 0; j < entry.contributors.size(); ++j)
+        if (entry.total_contributed == entry.staking_requirement)
         {
-          const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::contribution &contributor = entry.contributors[j];
-          tools::msg_writer() << indent2 << "[" << j << "] Contributor: " << contributor.address;
-          tools::msg_writer() << indent3 << "Amount / Reserved: "         << cryptonote::print_money(contributor.amount) << " / " << cryptonote::print_money(contributor.reserved);
+          registered.push_back(&entry);
         }
+        else
+        {
+          unregistered.push_back(&entry);
+        }
+      }
 
-        tools::msg_writer() << "";
+      std::sort(unregistered.begin(), unregistered.end(),
+          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *b) {
+          bool result = a->contributors.size() < b->contributors.size();
+          return result;
+      });
+
+      std::stable_sort(registered.begin(), registered.end(),
+          [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry *b) {
+          if (a->last_reward_block_height == b->last_reward_block_height)
+            return a->last_reward_transaction_index < b->last_reward_transaction_index;
+
+          return a->last_reward_block_height < b->last_reward_block_height;
+      });
+
+      if (unregistered.size() > 0)
+      {
+        tools::msg_writer() << "Service Node Unregistered State[" << unregistered.size()<< "]";
+        print_service_node_list_state(unregistered);
+      }
+
+      if (registered.size() > 0)
+      {
+        tools::msg_writer() << "Service Node Registration State[" << registered.size()<< "]";
+        print_service_node_list_state(registered);
+      }
+
+      if (unregistered.size() == 0 && registered.size() == 0)
+      {
+        tools::msg_writer() << "No service node is currently known on the network";
       }
     }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1998,12 +1998,13 @@ bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector
     return true;
 }
 
-bool t_rpc_command_executor::get_service_node_list_state()
+bool t_rpc_command_executor::get_service_node_list_state(const std::vector<std::string> &args)
 {
-    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request req;
-    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response res;
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request req = {};
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response res = {};
     std::string fail_message = "Unsuccessful";
     epee::json_rpc::error error_resp;
+    req.service_node_pubkeys = args;
 
     if (m_is_rpc)
     {

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -161,6 +161,8 @@ public:
   bool get_service_node_key();
 
   bool prepare_registration();
+
+  bool print_sn(const std::vector<std::string> &args);
 };
 
 } // namespace daemonize

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2290,7 +2290,22 @@ namespace cryptonote
                                                              epee::json_rpc::error& error_resp)
   {
     PERF_TIMER(on_get_service_node_list_state);
-    std::vector<service_nodes::service_node_pubkey_info> pubkey_info_list = m_core.get_service_node_list_state();
+
+    std::vector<crypto::public_key> pubkeys(req.service_node_pubkeys.size());
+    for (size_t i = 0; i < req.service_node_pubkeys.size(); i++)
+    {
+      if (!string_tools::hex_to_pod(req.service_node_pubkeys[i], pubkeys[i]))
+      {
+        error_resp.code    = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+        error_resp.message = "Could not convert to a public key, arg: ";
+        error_resp.message += std::to_string(i);
+        error_resp.message += " which is pubkey: ";
+        error_resp.message += req.service_node_pubkeys[i];
+        return false;
+      }
+    }
+
+    std::vector<service_nodes::service_node_pubkey_info> pubkey_info_list = m_core.get_service_node_list_state(pubkeys);
 
     // TODO(doyle): Reassignment into agnostic structure, is it ideal?
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2307,7 +2307,6 @@ namespace cryptonote
 
     std::vector<service_nodes::service_node_pubkey_info> pubkey_info_list = m_core.get_service_node_list_state(pubkeys);
 
-    // TODO(doyle): Reassignment into agnostic structure, is it ideal?
     res.status = CORE_RPC_STATUS_OK;
     res.service_node_states.reserve(pubkey_info_list.size());
     for (const auto &pubkey_info : pubkey_info_list)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2285,11 +2285,9 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_service_node_list_state(const COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request& req,
-                                                             COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response& res,
-                                                             epee::json_rpc::error& error_resp)
+  bool core_rpc_server::on_get_service_node(const COMMAND_RPC_GET_SERVICE_NODE::request& req, COMMAND_RPC_GET_SERVICE_NODE::response& res, epee::json_rpc::error& error_resp)
   {
-    PERF_TIMER(on_get_service_node_list_state);
+    PERF_TIMER(on_get_sn);
 
     std::vector<crypto::public_key> pubkeys(req.service_node_pubkeys.size());
     for (size_t i = 0; i < req.service_node_pubkeys.size(); i++)
@@ -2311,7 +2309,7 @@ namespace cryptonote
     res.service_node_states.reserve(pubkey_info_list.size());
     for (const auto &pubkey_info : pubkey_info_list)
     {
-      COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::entry entry = {};
+      COMMAND_RPC_GET_SERVICE_NODE::response::entry entry = {};
       entry.service_node_pubkey           = string_tools::pod_to_hex(pubkey_info.pubkey);
       entry.last_reward_block_height      = pubkey_info.info.last_reward_block_height;
       entry.last_reward_transaction_index = pubkey_info.info.last_reward_transaction_index;
@@ -2320,7 +2318,7 @@ namespace cryptonote
       entry.contributors.reserve(pubkey_info.info.contributors.size());
       for (service_nodes::service_node_info::contribution const &contributor : pubkey_info.info.contributors)
       {
-        COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response::contribution new_contributor = {};
+        COMMAND_RPC_GET_SERVICE_NODE::response::contribution new_contributor = {};
         new_contributor.amount   = contributor.amount;
         new_contributor.reserved = contributor.reserved;
         new_contributor.address  = string_tools::pod_to_hex(contributor.address);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -158,7 +158,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_quorum_state",        on_get_quorum_state_json,     COMMAND_RPC_GET_QUORUM_STATE)
         MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
         MAP_JON_RPC_WE("get_service_node_key",   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY)
-        MAP_JON_RPC_WE("get_service_node_list_state", on_get_service_node_list_state, COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE)
+        MAP_JON_RPC_WE("get_service_node", on_get_service_node, COMMAND_RPC_GET_SERVICE_NODE)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -225,7 +225,7 @@ namespace cryptonote
     bool on_get_quorum_state_json(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp);
-    bool on_get_service_node_list_state(const COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request& req, COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_service_node(const COMMAND_RPC_GET_SERVICE_NODE::request& req, COMMAND_RPC_GET_SERVICE_NODE::response& res, epee::json_rpc::error& error_resp);
     //-----------------------
 
 private:

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -158,6 +158,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_quorum_state",        on_get_quorum_state_json,     COMMAND_RPC_GET_QUORUM_STATE)
         MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
         MAP_JON_RPC_WE("get_service_node_key",   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY)
+        MAP_JON_RPC_WE("get_service_node_list_state", on_get_service_node_list_state, COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -224,6 +225,7 @@ namespace cryptonote
     bool on_get_quorum_state_json(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp);
+    bool on_get_service_node_list_state(const COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::request& req, COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE::response& res, epee::json_rpc::error& error_resp);
     //-----------------------
 
 private:

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2350,7 +2350,9 @@ namespace cryptonote
   {
     struct request
     {
+      std::vector<std::string> service_node_pubkeys; // pass empty vector to get all the service nodes
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(service_node_pubkeys);
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2345,4 +2345,64 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+
+  struct COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE
+  {
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      struct contribution
+      {
+        uint64_t amount;
+        uint64_t reserved;
+        std::string address;
+
+        BEGIN_KV_SERIALIZE_MAP()
+          KV_SERIALIZE(amount)
+          KV_SERIALIZE(reserved)
+          KV_SERIALIZE(address)
+        END_KV_SERIALIZE_MAP()
+      };
+
+      struct entry
+      {
+        std::string                        service_node_pubkey;
+        uint64_t                           last_reward_block_height;
+        uint32_t                           last_reward_transaction_index;
+        uint64_t                           last_uptime_proof;
+        std::vector<contribution>          contributors;
+        uint64_t                           total_contributed;
+        uint64_t                           total_reserved;
+        uint64_t                           staking_requirement;
+        uint32_t                           portions_for_operator;
+        std::string                        operator_address;
+
+        BEGIN_KV_SERIALIZE_MAP()
+            KV_SERIALIZE(service_node_pubkey)
+            KV_SERIALIZE(last_reward_block_height)
+            KV_SERIALIZE(last_reward_transaction_index)
+            KV_SERIALIZE(last_uptime_proof)
+            KV_SERIALIZE(contributors)
+            KV_SERIALIZE(total_contributed)
+            KV_SERIALIZE(total_reserved)
+            KV_SERIALIZE(staking_requirement)
+            KV_SERIALIZE(portions_for_operator)
+            KV_SERIALIZE(operator_address)
+        END_KV_SERIALIZE_MAP()
+      };
+
+      std::vector<entry> service_node_states;
+      std::string        status;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(service_node_states)
+        KV_SERIALIZE(status)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2346,7 +2346,7 @@ namespace cryptonote
     };
   };
 
-  struct COMMAND_RPC_GET_SERVICE_NODE_LIST_STATE
+  struct COMMAND_RPC_GET_SERVICE_NODE
   {
     struct request
     {


### PR DESCRIPTION
Add an endpoint for retrieving service node network information and consequently a command in the daemon to display the network.

The command is `get_service_node_list_state [<pubkey>, ...]`. When given no pubkey, all service nodes are enumerated.