### PR TITLE
don't use ncurses from apt-get

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,8 +34,6 @@ build:linux:
   tags:
     - ubuntu
   stage: build
-  before_script:
-    - apt-get update -qq && apt-get install -y libncurses5-dev libncursesw5-dev
   script:
     # print our runner distro
     - cat /proc/version


### PR DESCRIPTION
revert only the culprit
The docker image now has ncurses locally built with -fPIC.