### PR TITLE
service nodes: changed portions to 64 bits

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -552,8 +552,8 @@ namespace cryptonote
   bool add_service_node_register_to_tx_extra(
       std::vector<uint8_t>& tx_extra,
       const std::vector<cryptonote::account_public_address>& addresses,
-      uint32_t portions_for_operator,
-      const std::vector<uint32_t>& portions,
+      uint64_t portions_for_operator,
+      const std::vector<uint64_t>& portions,
       uint64_t expiration_timestamp,
       const crypto::signature& service_node_signature)
   {
@@ -1041,22 +1041,24 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool get_registration_hash(const std::vector<cryptonote::account_public_address>& addresses, uint32_t operator_portions, const std::vector<uint32_t>& portions, uint64_t expiration_timestamp, crypto::hash& hash)
+  bool get_registration_hash(const std::vector<cryptonote::account_public_address>& addresses, uint64_t operator_portions, const std::vector<uint64_t>& portions, uint64_t expiration_timestamp, crypto::hash& hash)
   {
     if (addresses.size() != portions.size())
     {
       LOG_ERROR("get_registration_hash addresses.size() != portions.size()");
       return false;
     }
-    uint64_t total_portions = 0;
-    for (uint32_t portion : portions)
-      total_portions += portion;
-    if (total_portions > STAKING_PORTIONS)
+    uint64_t portions_left = STAKING_PORTIONS;
+    for (uint64_t portion : portions)
     {
-      LOG_ERROR(tr("Your registration has more than ") << STAKING_PORTIONS << tr(" portions, this registration is invalid!"));
-      return false;
+      if (portion > portions_left)
+      {
+        LOG_ERROR(tr("Your registration has more than ") << STAKING_PORTIONS << tr(" portions, this registration is invalid!"));
+        return false;
+      }
+      portions_left -= portion;
     }
-    size_t size = addresses.size() * (sizeof(cryptonote::account_public_address) + sizeof(uint32_t)) + sizeof(uint32_t) + sizeof(uint64_t);
+    size_t size = addresses.size() * (sizeof(cryptonote::account_public_address) + sizeof(uint64_t)) + sizeof(uint64_t) + sizeof(uint64_t);
     char* buffer = new char[size];
     char* buffer_iter = buffer;
     memcpy(buffer_iter, &operator_portions, sizeof(operator_portions));
@@ -1065,8 +1067,8 @@ namespace cryptonote
     {
       memcpy(buffer_iter, &addresses[i], sizeof(cryptonote::account_public_address));
       buffer_iter += sizeof(cryptonote::account_public_address);
-      memcpy(buffer_iter, &portions[i], sizeof(uint32_t));
-      buffer_iter += sizeof(uint32_t);
+      memcpy(buffer_iter, &portions[i], sizeof(uint64_t));
+      buffer_iter += sizeof(uint64_t);
     }
     memcpy(buffer_iter, &expiration_timestamp, sizeof(expiration_timestamp));
     buffer_iter += sizeof(expiration_timestamp);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -75,7 +75,7 @@ namespace cryptonote
   bool get_service_node_deregister_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_deregister& deregistration);
   bool get_service_node_pubkey_from_tx_extra(const std::vector<uint8_t>& tx_extra, crypto::public_key& pubkey);
   bool get_service_node_contributor_from_tx_extra(const std::vector<uint8_t>& tx_extra, cryptonote::account_public_address& address);
-  bool add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const std::vector<cryptonote::account_public_address>& addresses, uint32_t portions_for_operator, const std::vector<uint32_t>& portions, uint64_t expiration_timestamp, const crypto::signature& signature);
+  bool add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const std::vector<cryptonote::account_public_address>& addresses, uint64_t portions_for_operator, const std::vector<uint64_t>& portions, uint64_t expiration_timestamp, const crypto::signature& signature);
   bool get_tx_secret_key_from_tx_extra(const std::vector<uint8_t>& tx_extra, crypto::secret_key& key);
   void add_tx_secret_key_to_tx_extra(std::vector<uint8_t>& tx_extra, const crypto::secret_key& key);
   void add_service_node_winner_to_tx_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& winner);
@@ -110,7 +110,7 @@ namespace cryptonote
   crypto::hash get_blob_hash(const blobdata& blob);
   std::string short_hash_str(const crypto::hash& h);
 
-  bool get_registration_hash(const std::vector<cryptonote::account_public_address>& addresses, uint32_t operator_portions, const std::vector<uint32_t>& portions, uint64_t expiration_timestamp, crypto::hash& hash);
+  bool get_registration_hash(const std::vector<cryptonote::account_public_address>& addresses, uint64_t operator_portions, const std::vector<uint64_t>& portions, uint64_t expiration_timestamp, crypto::hash& hash);
 
   crypto::hash get_transaction_hash(const transaction& t);
   bool get_transaction_hash(const transaction& t, crypto::hash& res);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -207,8 +207,8 @@ namespace cryptonote
   {
     std::vector<crypto::public_key> m_public_spend_keys;
     std::vector<crypto::public_key> m_public_view_keys;
-    uint32_t m_portions_for_operator;
-    std::vector<uint32_t> m_portions;
+    uint64_t m_portions_for_operator;
+    std::vector<uint64_t> m_portions;
     uint64_t m_expiration_timestamp;
     crypto::signature m_service_node_signature;
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -52,7 +52,7 @@
 #define STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS          20
 #define STAKING_REQUIREMENT_LOCK_BLOCKS                 (30*24*30)
 #define STAKING_REQUIREMENT_LOCK_BLOCKS_TESTNET         (30*24*2)
-#define STAKING_PORTIONS                                0xfffffffc
+#define STAKING_PORTIONS                                UINT64_C(0xfffffffffffffffc)
 #define MAX_NUMBER_OF_CONTRIBUTORS                      4
 #define MIN_PORTIONS                                    (STAKING_PORTIONS / MAX_NUMBER_OF_CONTRIBUTORS)
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1329,7 +1329,7 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   uint8_t hf_version = m_hardfork->get_current_version();
 
   crypto::public_key winner = m_service_node_list.select_winner(b.prev_id);
-  std::vector<std::pair<account_public_address, uint32_t>> service_node_addresses = m_service_node_list.get_winner_addresses_and_portions(b.prev_id);
+  std::vector<std::pair<account_public_address, uint64_t>> service_node_addresses = m_service_node_list.get_winner_addresses_and_portions(b.prev_id);
 
   bool r = construct_miner_tx(height, median_size, already_generated_coins, txs_size, fee, miner_address, b.miner_tx, ex_nonce, hf_version, m_nettype, winner, service_node_addresses);
   CHECK_AND_ASSERT_MES(r, false, "Failed to construct miner tx, first chance");

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -111,15 +111,15 @@ namespace cryptonote
     return hard_fork_version >= 9 ? base_reward / 2 : 0;
   }
 
-  uint64_t get_portion_of_reward(uint32_t portions, uint64_t total_service_node_reward)
+  uint64_t get_portion_of_reward(uint64_t portions, uint64_t total_service_node_reward)
   {
     uint64_t hi, lo, rewardhi, rewardlo;
     lo = mul128(total_service_node_reward, portions, &hi);
-    div128_32(hi, lo, STAKING_PORTIONS, &rewardhi, &rewardlo);
+    div128_64(hi, lo, STAKING_PORTIONS, &rewardhi, &rewardlo);
     return rewardlo;
   }
 
-  static uint64_t calculate_sum_of_portions(const std::vector<std::pair<cryptonote::account_public_address, uint32_t>>& portions, uint64_t total_service_node_reward)
+  static uint64_t calculate_sum_of_portions(const std::vector<std::pair<cryptonote::account_public_address, uint64_t>>& portions, uint64_t total_service_node_reward)
   {
     uint64_t reward = 0;
     for (size_t i = 0; i < portions.size(); i++)
@@ -184,7 +184,7 @@ namespace cryptonote
       uint8_t hard_fork_version,
       network_type nettype,
       const crypto::public_key& service_node_key,
-      const std::vector<std::pair<account_public_address, uint32_t>>& service_node_info)
+      const std::vector<std::pair<account_public_address, uint64_t>>& service_node_info)
   {
     tx.vin.clear();
     tx.vout.clear();

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -49,12 +49,12 @@ namespace cryptonote
       uint8_t hard_fork_version = 1,
       network_type nettype = MAINNET,
       const crypto::public_key& service_node_key = crypto::null_pkey,
-      const std::vector<std::pair<account_public_address, uint32_t>>& service_node_info={ std::pair<account_public_address, uint32_t>({ crypto::null_pkey, crypto::null_pkey }, STAKING_PORTIONS) }
+      const std::vector<std::pair<account_public_address, uint64_t>>& service_node_info={ std::pair<account_public_address, uint64_t>({ crypto::null_pkey, crypto::null_pkey }, STAKING_PORTIONS) }
   );
 
   keypair get_deterministic_keypair_from_height(uint64_t height);
 
-  uint64_t get_portion_of_reward(uint32_t portions, uint64_t total_service_node_reward);
+  uint64_t get_portion_of_reward(uint64_t portions, uint64_t total_service_node_reward);
 
   uint64_t get_governance_reward(uint64_t height, uint64_t base_reward);
   uint64_t get_service_node_reward(uint64_t height, uint64_t base_reward, int hard_fork_version);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -85,7 +85,7 @@ namespace service_nodes
     uint64_t total_contributed;
     uint64_t total_reserved;
     uint64_t staking_requirement;
-    uint32_t portions_for_operator;
+    uint64_t portions_for_operator;
     cryptonote::account_public_address operator_address;
 
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -130,7 +130,7 @@ namespace service_nodes
 
     std::vector<crypto::public_key> get_expired_nodes(uint64_t block_height) const;
 
-    std::vector<std::pair<cryptonote::account_public_address, uint32_t>> get_winner_addresses_and_portions(const crypto::hash& prev_id) const;
+    std::vector<std::pair<cryptonote::account_public_address, uint64_t>> get_winner_addresses_and_portions(const crypto::hash& prev_id) const;
     crypto::public_key select_winner(const crypto::hash& prev_id) const;
 
     bool is_service_node(const crypto::public_key& pubkey) const;
@@ -155,7 +155,7 @@ namespace service_nodes
     void block_added_generic(const cryptonote::block& block, const T& txs);
 
     bool contribution_tx_output_has_correct_unlock_time(const cryptonote::transaction& tx, size_t i, uint64_t block_height) const;
-    bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint32_t& portions_for_operator, std::vector<uint32_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key) const;
+    bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key) const;
     uint64_t get_reg_tx_staking_output_contribution(const cryptonote::transaction& tx, int i, crypto::key_derivation derivation, hw::device& hwdev) const;
 
     crypto::public_key find_service_node_from_miner_tx(const cryptonote::transaction& miner_tx, uint64_t block_height) const;
@@ -282,7 +282,7 @@ namespace service_nodes
     std::map<block_height, std::shared_ptr<quorum_state>> m_quorum_states;
   };
 
-  bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint32_t>& portions, uint32_t& portions_for_operator, bool& autostake);
+  bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake);
   bool make_registration_cmd(cryptonote::network_type nettype, const std::vector<std::string> args, const crypto::public_key& service_node_pubkey,
                              const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly);
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2383,7 +2383,7 @@ namespace cryptonote
         uint64_t                           total_contributed;
         uint64_t                           total_reserved;
         uint64_t                           staking_requirement;
-        uint32_t                           portions_for_operator;
+        uint64_t                           portions_for_operator;
         std::string                        operator_address;
 
         BEGIN_KV_SERIALIZE_MAP()

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4712,7 +4712,7 @@ bool simple_wallet::register_service_node_main(
     uint64_t expiration_timestamp,
     const cryptonote::account_public_address& address,
     uint32_t priority,
-    const std::vector<uint32_t>& portions,
+    const std::vector<uint64_t>& portions,
     const std::vector<uint8_t>& extra,
     std::set<uint32_t>& subaddr_indices,
     bool autostake)
@@ -4723,10 +4723,10 @@ bool simple_wallet::register_service_node_main(
   {
     if (!try_connect_to_daemon(true))
       return true;
-
-    uint64_t fetched_blocks;
-    m_wallet->refresh(0, fetched_blocks);
   }
+
+  uint64_t fetched_blocks;
+  m_wallet->refresh(0, fetched_blocks);
 
   if (expiration_timestamp <= (uint64_t)time(nullptr) + 600 /* 10 minutes */)
   {
@@ -4798,7 +4798,7 @@ bool simple_wallet::register_service_node_main(
       service_nodes::get_staking_requirement(m_wallet->nettype(), bc_height+STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS)
   );
 
-  const uint64_t DUST = (expected_staking_requirement / STAKING_PORTIONS + 1) * (MAX_NUMBER_OF_CONTRIBUTORS - 1);
+  const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
 
   uint64_t amount_left = expected_staking_requirement;
   uint64_t amount_payable_by_operator = 0;
@@ -4806,7 +4806,7 @@ bool simple_wallet::register_service_node_main(
   {
     uint64_t hi, lo, resulthi, resultlo;
     lo = mul128(expected_staking_requirement, portions[i], &hi);
-    div128_32(hi, lo, STAKING_PORTIONS, &resulthi, &resultlo);
+    div128_64(hi, lo, STAKING_PORTIONS, &resulthi, &resultlo);
     if (i == 0)
       amount_payable_by_operator += resultlo;
     amount_left -= resultlo;
@@ -4979,8 +4979,8 @@ bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
 
   std::vector<std::string> address_portions_args(local_args.begin(), local_args.begin() + local_args.size() - 3);
   std::vector<cryptonote::account_public_address> addresses;
-  std::vector<uint32_t> portions;
-  uint32_t portions_for_operator;
+  std::vector<uint64_t> portions;
+  uint64_t portions_for_operator;
   bool autostake;
   if (!service_nodes::convert_registration_args(m_wallet->nettype(), address_portions_args, addresses, portions, portions_for_operator, autostake))
   {
@@ -5090,10 +5090,10 @@ bool simple_wallet::stake_main(
   {
     if (!try_connect_to_daemon(true))
       return true;
-
-    uint64_t fetched_blocks;
-    m_wallet->refresh(0, fetched_blocks);
   }
+
+  uint64_t fetched_blocks;
+  m_wallet->refresh(0, fetched_blocks);
 
   uint64_t staking_requirement_lock_blocks = (m_wallet->nettype() == cryptonote::TESTNET ? STAKING_REQUIREMENT_LOCK_BLOCKS_TESTNET : STAKING_REQUIREMENT_LOCK_BLOCKS);
   uint64_t locked_blocks = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
@@ -5151,7 +5151,7 @@ bool simple_wallet::stake_main(
     const auto& snode_info = response.service_node_states.front();
     bool full = false;
 
-    const uint64_t DUST = (snode_info.staking_requirement / STAKING_PORTIONS + 1) * (MAX_NUMBER_OF_CONTRIBUTORS - 1);
+    const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
 
     if (amount == 0)
       amount = snode_info.staking_requirement * amount_fraction;
@@ -5196,18 +5196,22 @@ bool simple_wallet::stake_main(
     if (amount < must_contrib_total)
     {
       success_msg_writer() << tr("Warning: You must contribute ") << print_money(must_contrib_total) << tr(" loki to meet your registration requirements for this service node");
-      success_msg_writer() << tr("You have only specified ") << print_money(amount);
-      if (must_contrib_total - amount <= DUST)
+      if (amount == 0)
       {
-        success_msg_writer() << tr("Seeing as this is only a little bit, amount was increased automatically");
         amount = must_contrib_total;
       }
-      else if (autostake)
+      else
       {
-        if (amount == 0)
+        success_msg_writer() << tr("You have only specified ") << print_money(amount);
+        if (must_contrib_total - amount <= DUST)
+        {
+          success_msg_writer() << tr("Seeing as this is only a little bit, amount was increased automatically");
           amount = must_contrib_total;
-        else
+        }
+        else if (autostake)
+        {
           return true;
+        }
       }
     }
   }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -225,7 +225,7 @@ namespace cryptonote
     bool blackballed(const std::vector<std::string>& args);
     bool version(const std::vector<std::string>& args);
 
-    bool register_service_node_main(const std::vector<std::string>& service_node_key_as_str, uint64_t expiration_timestamp, const cryptonote::account_public_address& address, uint32_t priority, const std::vector<uint32_t>& portions, const std::vector<uint8_t>& extra, std::set<uint32_t>& subaddr_indices, bool autostake);
+    bool register_service_node_main(const std::vector<std::string>& service_node_key_as_str, uint64_t expiration_timestamp, const cryptonote::account_public_address& address, uint32_t priority, const std::vector<uint64_t>& portions, const std::vector<uint8_t>& extra, std::set<uint32_t>& subaddr_indices, bool autostake);
     bool stake_main(const crypto::public_key& service_node_key, const cryptonote::account_public_address& address, uint32_t priority, std::set<uint32_t>& subaddr_indices, uint64_t amount, double amount_fraction, bool autostake);
 
     uint64_t get_daemon_blockchain_height(std::string& err);


### PR DESCRIPTION
Basically just s/uint32_t/uint64_t/ around portions.

It's unlikely to compile without an error or a warning if I've missed anything.

Seems to be working fine locally.