### PR TITLE
Added block of expiration to print_sn command

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -356,6 +356,7 @@ namespace service_nodes
     info.total_contributed = 0;
     info.total_reserved = 0;
     info.contributors.clear();
+    info.lock_blocks = get_staking_requirement_lock_blocks();
 
     for (size_t i = 0; i < service_node_addresses.size(); i++)
     {

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -85,6 +85,7 @@ namespace service_nodes
     uint64_t total_contributed;
     uint64_t total_reserved;
     uint64_t staking_requirement;
+    uint64_t lock_blocks;
     uint32_t portions_for_operator;
     cryptonote::account_public_address operator_address;
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2013,6 +2013,7 @@ static void print_service_node_list_state(std::vector<cryptonote::COMMAND_RPC_GE
 
     tools::msg_writer(color) << indent1 << "[" << i << "] Service Node: "              << entry.service_node_pubkey;
     tools::msg_writer(color) << indent2 << "Total Contributed / Staking Requirement: " << cryptonote::print_money(entry.total_contributed) << " / " << cryptonote::print_money(entry.staking_requirement);
+    tools::msg_writer() << indent2 << "Node expires at block height " << entry.expiration_block;
 
     tools::msg_writer() << indent2 << "Total Reserved    / Staking Requirement: " << cryptonote::print_money(entry.total_reserved) << " / " << cryptonote::print_money(entry.staking_requirement);
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2332,6 +2332,7 @@ namespace cryptonote
       entry.staking_requirement           = pubkey_info.info.staking_requirement;
       entry.portions_for_operator         = pubkey_info.info.portions_for_operator;
       entry.operator_address              = string_tools::pod_to_hex(pubkey_info.info.operator_address);
+      entry.expiration_block              = pubkey_info.info.lock_blocks + pubkey_info.info.registration_height;
 
       res.service_node_states.push_back(entry);
     }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2385,6 +2385,7 @@ namespace cryptonote
         uint64_t                           staking_requirement;
         uint32_t                           portions_for_operator;
         std::string                        operator_address;
+        uint64_t                           expiration_block;
 
         BEGIN_KV_SERIALIZE_MAP()
             KV_SERIALIZE(service_node_pubkey)
@@ -2397,6 +2398,7 @@ namespace cryptonote
             KV_SERIALIZE(staking_requirement)
             KV_SERIALIZE(portions_for_operator)
             KV_SERIALIZE(operator_address)
+            KV_SERIALIZE(expiration_block)
         END_KV_SERIALIZE_MAP()
       };
 


### PR DESCRIPTION
print_sn now adds when a user's node expires by saying the block height at which it expires. 

I added another field, lock_blocks, to the service_node_info struct to know how many blocks to add to the registration_height that was recently added. This will vary whether it's testnet or mainnet. 

If someone knows if there is a better way to determine from rpc_command_executor.cpp whether it's testnet or mainnet rather than passing in another field to the struct, i will take that alternative.