### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -49,7 +49,7 @@ namespace service_nodes
 {
 
   service_node_list::service_node_list(cryptonote::Blockchain& blockchain)
-    : m_blockchain(blockchain), m_hooks_registered(false), m_height(0)
+    : m_blockchain(blockchain), m_hooks_registered(false), m_height(0), m_db(nullptr)
   {
   }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2037,8 +2037,7 @@ static void print_service_node_list_state(cryptonote::network_type nettype, uint
     // Print Expiry Info
     {
       uint64_t expiry_height = entry.registration_height;
-      if (is_registered) expiry_height += (nettype == cryptonote::TESTNET) ? STAKING_REQUIREMENT_LOCK_BLOCKS_TESTNET : STAKING_REQUIREMENT_LOCK_BLOCKS;
-      else               expiry_height += (STAKING_AUTHORIZATION_EXPIRATION_WINDOW / DIFFICULTY_TARGET_V2);
+      expiry_height += (nettype == cryptonote::TESTNET) ? STAKING_REQUIREMENT_LOCK_BLOCKS_TESTNET : STAKING_REQUIREMENT_LOCK_BLOCKS;
 
       if (curr_height)
       {
@@ -2046,20 +2045,8 @@ static void print_service_node_list_state(cryptonote::network_type nettype, uint
         uint64_t delta_height = expiry_height - *curr_height;
         uint64_t expiry_epoch_time = now + (delta_height * DIFFICULTY_TARGET_V2);
 
-        tools::msg_writer() << indent2 << "Registration Height/Expiry Height: " << entry.registration_height << "/" << expiry_height
-                            << " (in " << delta_height << " blocks) or UTC: " << get_date_time(expiry_epoch_time) << " (" << get_human_time_ago(expiry_epoch_time, now) << ")";
-
-        if (!is_registered)
-        {
-          uint64_t open_for_contrib_until_height = entry.registration_height + (STAKING_AUTHORIZATION_EXPIRATION_WINDOW / DIFFICULTY_TARGET_V2);
-          uint64_t open_for_contrib_height_delta = open_for_contrib_until_height - *curr_height;
-          uint64_t open_for_contrib_expiry_time = now + (open_for_contrib_height_delta * DIFFICULTY_TARGET_V2);
-
-          tools::msg_writer() << indent2 << "Open For Contribution Until: " << open_for_contrib_until_height << "/"
-                              << " (in " << open_for_contrib_height_delta << " blocks) or UTC: "
-                              << get_date_time(open_for_contrib_expiry_time) << " (" << get_human_time_ago(open_for_contrib_expiry_time, now) << ")";
-        }
-
+        tools::msg_writer() << indent2 << "Registration Height/Expiry Height: " << entry.registration_height << "/" << expiry_height << " (in " << delta_height << " blocks)";
+        tools::msg_writer() << indent2 << "Expiry Date (Estimated UTC): " << get_date_time(expiry_epoch_time) << " (" << get_human_time_ago(expiry_epoch_time, now) << ")";
       }
       else
       {


### PR DESCRIPTION
I removed displaying of the auto-staking period in print_sn because it's confusing. Instead just list one expiry date when the node is to expire off the network and if you're unregistered, then that date + the date that the node is accepting contribution before the registration expires (authorization window).

Even if they're autostaking, they can't be registered after the 30 days, so displaying 2 years is confusing? 

service_node_list::get_expired_nodes() will always kick off a service node that is < staking requirement lock blocks (30 days). Autostake is authorized for 2 years, so the registration tx is always not considered after 30 days?

and 1 extra ezy commit to appease valgrind.