### PR TITLE
Print SN Status

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -174,6 +174,13 @@ bool t_command_parser_executor::print_sn(const std::vector<std::string>& args)
   return result;
 }
 
+bool t_command_parser_executor::print_sn_status(const std::vector<std::string>& args)
+{
+  if (!args.empty()) return false;
+  bool result = m_executor.print_sn_status();
+  return result;
+}
+
 bool t_command_parser_executor::set_log_level(const std::vector<std::string>& args)
 {
   if(args.size() > 1)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -85,6 +85,8 @@ public:
 
   bool print_sn(const std::vector<std::string>& args);
 
+  bool print_sn_status(const std::vector<std::string>& args);
+
   bool set_log_level(const std::vector<std::string>& args);
 
   bool set_log_categories(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -126,6 +126,12 @@ t_command_server::t_command_server(
     , "Print service node registration info for the current height"
     );
   m_command_lookup.set_handler(
+      "print_sn_status"
+    , std::bind(&t_command_parser_executor::print_sn_status, &m_parser, p::_1)
+    , "print_sn_status"
+    , "Print service node registration info for this service node"
+    );
+  m_command_lookup.set_handler(
       "is_key_image_spent"
     , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
     , "is_key_image_spent <key_image>"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -160,6 +160,8 @@ public:
 
   bool print_sn_key();
 
+  bool print_sn_status();
+
   bool prepare_registration();
 
   bool print_sn(const std::vector<std::string> &args);


### PR DESCRIPTION
Convenience command print_sn_status which combines print_sn_key and print_sn to print out the running service node's status for you in one call.