### PR TITLE
Remove get_service_node_registration from the client commands

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -143,18 +143,6 @@ bool t_command_parser_executor::print_quorum_state(const std::vector<std::string
   return m_executor.print_quorum_state(height);
 }
 
-bool t_command_parser_executor::get_service_node_registration_cmd(const std::vector<std::string>& args)
-{
-  if (args.empty() || args.size() % 2 != 0)
-  {
-    std::cout << "Invalid number of arguments received, expected an even number of arguments and > 0, received: " << args.size() << std::endl;
-    return false;
-  }
-
-  bool result = m_executor.get_service_node_registration_cmd(args);
-  return result;
-}
-
 bool t_command_parser_executor::print_sn_key(const std::vector<std::string>& args)
 {
   if (!args.empty()) return false;

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -77,8 +77,6 @@ public:
 
   bool print_quorum_state(const std::vector<std::string>& args);
 
-  bool get_service_node_registration_cmd(const std::vector<std::string>& args);
-
   bool print_sn_key(const std::vector<std::string>& args);
 
   bool prepare_registration();

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -102,12 +102,6 @@ t_command_server::t_command_server(
     , "Print the quorum state for the block height."
     );
   m_command_lookup.set_handler(
-      "get_service_node_registration_cmd"
-    , std::bind(&t_command_parser_executor::get_service_node_registration_cmd, &m_parser, p::_1)
-    , "get_service_node_registration_cmd <address1> <shares1> [<address2> <shares2> [...]]"
-    , "Generate the required registration command"
-    );
-  m_command_lookup.set_handler(
       "print_sn_key"
     , std::bind(&t_command_parser_executor::print_sn_key, &m_parser, p::_1)
     , "print_sn_key"


### PR DESCRIPTION
get_service_node_registration_cmd is removed because it has been deprecated in favour of the interactive command prepare_registration and doesn't work anymore since it expects the old format for registrations.

Prepare registration without the prompt should be done with prepare_registration by detecting if there are supplied arguments to the call and they are correct and through RPC.