### PR TITLE
Fix change in address format in RPC which broke parsing and pooling contributors

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4699,14 +4699,6 @@ bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
   return sweep_main(0, true, args_);
 }
 //----------------------------------------------------------------------------------------------------
-static cryptonote::account_public_address string_to_address(const std::string& s)
-{
-  cryptonote::account_public_address address;
-  if (!epee::string_tools::hex_to_pod(s, address))
-    return service_nodes::null_address;
-  return address;
-}
-//----------------------------------------------------------------------------------------------------
 bool simple_wallet::register_service_node_main(
     const std::vector<std::string>& service_node_key_as_str,
     uint64_t expiration_timestamp,
@@ -5168,7 +5160,11 @@ bool simple_wallet::stake_main(
 
     for (const auto& contributor : snode_info.contributors)
     {
-      if (string_to_address(contributor.address) == address)
+      address_parse_info info;
+      if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), contributor.address))
+        info.address = service_nodes::null_address;
+
+      if (info.address == address)
       {
         uint64_t max_increase_reserve = snode_info.staking_requirement - snode_info.total_reserved;
         uint64_t max_increase_amount_to = contributor.reserved + max_increase_reserve;
@@ -5192,7 +5188,7 @@ bool simple_wallet::stake_main(
     if (amount > can_contrib_total)
     {
       success_msg_writer() << tr("You may only contribute up to ") << print_money(can_contrib_total) << tr(" more loki to this service node");
-      success_msg_writer() << tr("Automatically staking ") << print_money(can_contrib_total);
+      success_msg_writer() << tr("Reducing your stake from ") << print_money(amount) << tr(" to ") << print_money(can_contrib_total);
       amount = can_contrib_total;
     }
     if (amount < must_contrib_total)


### PR DESCRIPTION
Before get_service_nodes RPC endpoint returns the address using hex_to_pod, that's been changed to use cryptonote address conversion which is more correct. The wallet was still trying to parse it as a hex string.