### PR TITLE
Service Nodes improve integrity of list after block detachment

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -876,6 +876,10 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
     pop_block_from_blockchain();
   }
 
+  // Revert all changes from switching to the alt chain before adding the original chain back in
+  for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
+    hook->blockchain_detached(rollback_height);
+
   // make sure the hard fork object updates its current version
   m_hardfork->reorganize_from_chain_height(rollback_height);
 
@@ -944,7 +948,6 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<blocks_ext_by_hash::
     if(!r || !bvc.m_added_to_main_chain)
     {
       MERROR("Failed to switch to alternative blockchain");
-
       // rollback_blockchain_switching should be moved to two different
       // functions: rollback and apply_chain, but for now we pretend it is
       // just the latter (because the rollback was done above).

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -539,9 +539,9 @@ namespace service_nodes
       index++;
     }
 
-    const size_t QUORUM_LIFETIME         = loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT;
+    const size_t QUORUM_LIFETIME         = (6 * loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT);
     // save six times the quorum lifetime, to be sure. also to help with debugging.
-    const size_t cache_state_from_height = (block_height < 6 * QUORUM_LIFETIME) ? 0 : block_height - 6 * QUORUM_LIFETIME;
+    const size_t cache_state_from_height = (block_height < QUORUM_LIFETIME) ? 0 : block_height - QUORUM_LIFETIME;
 
     store_quorum_state_from_rewards_list(block_height);
 


### PR DESCRIPTION
Fix a case where if you fail to switch to an alternative chain at any point, you don't undo the changes made from the block_added hook, whilst the blockchain reverts back to the original chain causing anything relying on the blockchain_detached hook to have state relating to the alternative chain (currently only service node list state) and not re-derived from the original chain.

i.e. This fixes sometimes getting stuck at syncing the chain in some cases.