### PR TITLE
Service Nodes underflow popping all rollback events

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -497,9 +497,14 @@ namespace service_nodes
     if (hard_fork_version < 9)
       return;
 
-    while (!m_rollback_events.empty() && m_rollback_events.front()->m_block_height < block_height - ROLLBACK_EVENT_EXPIRATION_BLOCKS)
     {
-      m_rollback_events.pop_front();
+      const size_t ROLLBACK_EVENT_EXPIRATION_BLOCKS = 30;
+      uint64_t cull_height = (block_height < ROLLBACK_EVENT_EXPIRATION_BLOCKS) ? block_height : block_height - ROLLBACK_EVENT_EXPIRATION_BLOCKS;
+
+      while (!m_rollback_events.empty() && m_rollback_events.front()->m_block_height < cull_height)
+      {
+        m_rollback_events.pop_front();
+      }
     }
 
     for (const crypto::public_key& pubkey : get_expired_nodes(block_height))

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -32,8 +32,6 @@
 #include <boost/variant.hpp>
 #include "serialization/serialization.h"
 
-#define ROLLBACK_EVENT_EXPIRATION_BLOCKS 30
-
 namespace service_nodes
 {
   const size_t QUORUM_SIZE                    = 10;


### PR DESCRIPTION
In synthetic environments (i.e. our core tests) where we can create rollback events in the first 30 blocks we could underflow and pop back all the events early and cause unusual behaviour.

In reality, with setting up the hardforks at heights not 0, the probability of making service node events within the first 30 blocks is probably never going to happen and this will never trigger.

@msgmaxim Sanity check please. I usually misunderstand these types of bugs a lot.