### PR TITLE
Service Nodes make miners reject expired deregistrations

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3040,6 +3040,33 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       return false;
     }
 
+    // Check if deregister is too old or too new to hold onto
+    {
+      const uint64_t curr_height = get_current_blockchain_height();
+      if (deregister.block_height >= curr_height)
+      {
+        LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
+                     << " and service node: "              << deregister.service_node_index
+                     << ", is newer than current height: " << curr_height
+                     << " blocks and has been rejected.");
+        tvc.m_vote_ctx.m_invalid_block_height = true;
+        tvc.m_verifivation_failed             = true;
+        return false;
+      }
+
+      uint64_t delta_height = curr_height - deregister.block_height;
+      if (delta_height > loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT)
+      {
+        LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
+                     << " and service node: "     << deregister.service_node_index
+                     << ", is older than: "       << loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT
+                     << " blocks and has been rejected. The current height is: " << curr_height);
+        tvc.m_vote_ctx.m_invalid_block_height = true;
+        tvc.m_verifivation_failed             = true;
+        return false;
+      }
+    }
+
     const uint64_t height            = deregister.block_height;
     const size_t num_blocks_to_check = loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT;
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -249,40 +249,6 @@ namespace cryptonote
       }
     }
 
-    if (tx.is_deregister_tx())
-    {
-      tx_extra_service_node_deregister deregister;
-      if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
-      {
-        LOG_PRINT_L1("Could not get service node deregister from tx v3, possibly corrupt tx in your blockchain");
-        return false;
-      }
-
-      const uint64_t curr_height = m_blockchain.get_current_blockchain_height();
-      if (deregister.block_height >= curr_height)
-      {
-        LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
-                     << " and service node: "              << deregister.service_node_index
-                     << ", is newer than current height: " << curr_height
-                     << " blocks and has been rejected.");
-        tvc.m_vote_ctx.m_invalid_block_height = true;
-        tvc.m_verifivation_failed             = true;
-        return false;
-      }
-
-      uint64_t delta_height = curr_height - deregister.block_height;
-      if (delta_height > loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT)
-      {
-        LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
-                     << " and service node: "     << deregister.service_node_index
-                     << ", is older than: "       << loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT
-                     << " blocks and has been rejected.");
-        tvc.m_vote_ctx.m_invalid_block_height = true;
-        tvc.m_verifivation_failed             = true;
-        return false;
-      }
-    }
-
     if (!m_blockchain.check_tx_outputs(tx, tvc))
     {
       LOG_PRINT_L1("Transaction with id= "<< id << " has at least one invalid output");
@@ -1100,35 +1066,6 @@ namespace cryptonote
     {
       txd.double_spend_seen = true;
       return false;
-    }
-
-    // Check that the deregister hasn't become too old to be included in the block, if so reject.
-    if (tx.is_deregister_tx())
-    {
-      uint64_t curr_height    = m_blockchain.get_current_blockchain_height();
-      bool failed_ready_check = true;
-
-      tx_extra_service_node_deregister deregister;
-      if (get_service_node_deregister_from_tx_extra(tx.extra, deregister))
-      {
-        uint64_t delta_height = curr_height - deregister.block_height;
-        if (delta_height <= loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT)
-        {
-          failed_ready_check = false;
-        }
-      }
-
-      if (failed_ready_check)
-      {
-        // NOTE: This deregistration is too old to be considered, but we can't delete it incase we
-        // pop blocks and they suddenly become valid again. Let them fail to get included in blocks
-        // until they expire.
-        txd.last_failed_height    = curr_height - 1;
-        txd.last_failed_id        = m_blockchain.get_block_id_by_height(txd.last_failed_height);
-        txd.max_used_block_height = txd.last_failed_height;
-        txd.max_used_block_id     = txd.last_failed_id;
-        return false;
-      }
     }
 
     //transaction is ok.


### PR DESCRIPTION
This fixes an edge case that triggered a chain split in testnet, whereby if there are service nodes in the oldest valid quorum who begin voting and are enough to to create deregistration TXs for that quorum, and will end up sitting in your pool for Daemon A.

If then Daemon B mines a block before receiving your deregistration TX's from your pool (from Daemon A) it'll create a block without those TX's. Now these deregistrations are too old and are sitting in Daemon A's TX pool. Now the next time Daemon A mines a block, it will populate the block with these old deregistrations.

Daemon A will attempt to propagate this new block. Every other daemon will take this block in and return all the transactions in to the tx pool, i.e. calling tx_memory_pool::add_tx() and fail validation at 

      uint64_t delta_height = curr_height - deregister.block_height;
      if (delta_height > loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT)
      {
        LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
                     << " and service node: "     << deregister.service_node_index
                     << ", is older than: "       << loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT
                     << " blocks and has been rejected.");
        tvc.m_vote_ctx.m_invalid_block_height = true;
        tvc.m_verifivation_failed             = true;
        return false;
      }

Causing all other daemons to reject the block. Daemon A that mined this block will include it in their chain and split off with the invalid block in their chain.

The fix to this is add a check in fill_block_template when it calls is_transaction_ready_to_go() to refuse to add any transaction that is a deregister and is older than the permitted lifetime of the deregister.

This also makes me think that pruning of deregisters in the TX pool should be done by block height and not timestamp as they have different pruning rules than normal transactions. But in interest of changing the minimum amount required to get it working before launch is more desirable.