### PR TITLE
Zero init rct_signatures member txnFee otherwise it has garbage values

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -350,6 +350,7 @@ namespace cryptonote
     vout.clear();
     extra.clear();
     signatures.clear();
+    rct_signatures = {};
     rct_signatures.type = rct::RCTTypeNull;
     set_hash_valid(false);
     set_blob_size_valid(false);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3024,6 +3024,14 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
 
   if (tx.is_deregister_tx())
   {
+    if (tx.rct_signatures.txnFee != 0)
+    {
+      tvc.m_invalid_input = true;
+      tvc.m_verifivation_failed = true;
+      MERROR_VER("TX version deregister should have 0 fee!");
+      return false;
+    }
+
     // Check the inputs (votes) of the transaction have not been already been
     // submitted to the blockchain under another transaction using a different
     // combination of votes.


### PR DESCRIPTION
rctSigBase has a member txnFee that is a ```typedef uint64_t xmr_amount``` and doesn't get initialised to 0 using the default constructor. Deregisters don't make use of fee and ignore most fee checks. Somehow, all of a sudden deregisters are being made with garbage fee values (when it wasn't before) and creating artificial Loki. So, make sure they are zero initialised and add a check in check_tx_inputs to reject any deregister with fees.

Normal transactions are fine because they most likely go through some initialisation steps after the fact, setting the txnFee to the correct value when RCT does its thing.