### PR TITLE
Blockchain pop_blocks command

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1114,6 +1114,18 @@ namespace cryptonote
     return result;
   }
   //-----------------------------------------------------------------------------------------------
+  void core::pop_blocks(size_t num_blocks_to_pop)
+  {
+    m_blockchain_storage.get_db().batch_start();
+    for (size_t i = 0; i < num_blocks_to_pop; i++)
+    {
+      block blk;
+      std::vector<transaction> txs;
+      m_blockchain_storage.get_db().pop_block(blk, txs);
+    }
+    m_blockchain_storage.get_db().batch_stop();
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::handle_uptime_proof(uint64_t timestamp, const crypto::public_key& pubkey, const crypto::signature& sig)
   {
     return m_quorum_cop.handle_uptime_proof(timestamp, pubkey, sig);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -843,6 +843,14 @@ namespace cryptonote
       */
      uint64_t get_uptime_proof(const crypto::public_key &key) const;
 
+     /**
+      * @brief Pop 'n' block(s) from the chain
+      *
+      * @param num_blocks_to_pop The number of blocks to pop
+      *
+      */
+     void pop_blocks(uint64_t num_blocks_to_pop);
+
    private:
 
      /**

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -729,4 +729,25 @@ bool t_command_parser_executor::version(const std::vector<std::string>& args)
   return true;
 }
 
+bool t_command_parser_executor::pop_blocks(const std::vector<std::string>& args)
+{
+  if (args.size() != 1)
+    return false;
+
+  size_t num_blocks_to_pop;
+  if(!epee::string_tools::get_xtype_from_string(num_blocks_to_pop, args[0]))
+  {
+    std::cout << "wrong starter block index parameter" << std::endl;
+    return false;
+  }
+
+  bool result = m_executor.pop_blocks(num_blocks_to_pop);
+  if (result)
+  {
+    raise(SIGTERM);
+  }
+
+  return result;
+}
+
 } // namespace daemonize

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -152,6 +152,8 @@ public:
   bool sync_info(const std::vector<std::string>& args);
 
   bool version(const std::vector<std::string>& args);
+
+  bool pop_blocks(const std::vector<std::string>& args);
 };
 
 } // namespace daemonize

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -322,6 +322,12 @@ t_command_server::t_command_server(
     , std::bind(&t_command_parser_executor::version, &m_parser, p::_1)
     , "Print version information."
     );
+    m_command_lookup.set_handler(
+        "pop_blocks"
+      , std::bind(&t_command_parser_executor::pop_blocks, &m_parser, p::_1)
+      , "pop_blocks <num_blocks_to_pop>"
+      , "Remove a number of blocks from the top of the chain"
+    );
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -167,6 +167,8 @@ public:
   bool prepare_registration();
 
   bool print_sn(const std::vector<std::string> &args);
+
+  bool pop_blocks(size_t num_blocks_to_pop);
 };
 
 } // namespace daemonize

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2004,6 +2004,30 @@ namespace cryptonote
     return r;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_pop_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res)
+  {
+    PERF_TIMER(on_pop_blocks);
+
+    // TODO(loki): It'd be nice not to need to be offline, but it makes
+    // implementation much easier to not handle any race conditions right now.
+    // And this is a really handy feature for debugging chains.
+
+    // TODO(loki): This doesn't activate service node lists rollbacks. But will
+    // trigger a rescan from scratch. Again simpler to not handle right now.
+    // Putting the Blockchaindetached hook in the pop blocks call may work, but
+    // haven't investigated the repercussions of that.
+    if (!m_core.offline())
+    {
+      res.status = "Daemon must be running in offline mode to pop blocks.";
+      return false;
+    }
+
+    m_core.pop_blocks(req.num_blocks_to_pop);
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp)
   {
     PERF_TIMER(on_get_service_node_key);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -197,6 +197,7 @@ namespace cryptonote
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res);
     bool on_get_quorum_state(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res);
+    bool on_pop_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res);
 
     //json_rpc
     bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2433,4 +2433,23 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+
+  struct COMMAND_RPC_POP_BLOCKS
+  {
+    struct request
+    {
+      size_t num_blocks_to_pop;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(num_blocks_to_pop)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 }


### PR DESCRIPTION
The ability to pop arbitrary number of blocks from the head of the chain, this is just useful in general for debugging, and getting users past stuck chains. The pre-requisites is that the daemon must be launched in offline mode and cannot be done over RPC. The command shuts down the daemon after it is done to be extra safe and trigger all the necessary updates to state on 2nd startup.

The command is pop_blocks <num_blocks_to_pop>.

This pull request should  probably **not be merged into the service node release** binaries but after it, but I had the implementation sitting around that was handy for unsticking the testnet chain.