### PR TITLE
Service nodes restore only 1 rollback bug

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -106,11 +106,6 @@ namespace service_nodes
         block_added_generic(block, txs);
       }
     }
-
-    if (!m_rollback_events.empty())
-    {
-      m_rollback_events.push_front(std::unique_ptr<rollback_event>(new prevent_rollback(m_rollback_events.front()->m_block_height)));
-    }
   }
 
   std::vector<crypto::public_key> service_node_list::get_service_nodes_pubkeys() const

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -107,7 +107,10 @@ namespace service_nodes
       }
     }
 
-    m_rollback_events.push_back(std::unique_ptr<rollback_event>(new prevent_rollback(current_height)));
+    if (!m_rollback_events.empty())
+    {
+      m_rollback_events.push_front(std::unique_ptr<rollback_event>(new prevent_rollback(m_rollback_events.front()->m_block_height)));
+    }
   }
 
   std::vector<crypto::public_key> service_node_list::get_service_nodes_pubkeys() const
@@ -505,6 +508,7 @@ namespace service_nodes
       {
         m_rollback_events.pop_front();
       }
+      m_rollback_events.push_front(std::unique_ptr<rollback_event>(new prevent_rollback(cull_height)));
     }
 
     for (const crypto::public_key& pubkey : get_expired_nodes(block_height))
@@ -956,7 +960,6 @@ namespace service_nodes
         i->m_info = from.m_info;
         i->type = rollback_event::change_type;
         m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
-        break;
       }
       else if (event.type() == typeid(rollback_new))
       {
@@ -966,7 +969,6 @@ namespace service_nodes
         i->m_key = from.m_key;
         i->type = rollback_event::new_type;
         m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
-        break;
       }
       else if (event.type() == typeid(prevent_rollback))
       {
@@ -975,10 +977,10 @@ namespace service_nodes
         i->m_block_height = from.m_block_height;
         i->type = rollback_event::prevent_type;
         m_rollback_events.push_back(std::unique_ptr<rollback_event>(i));
-        break;
       }
       else
       {
+        MERROR("Unhandled rollback event type in restoring data to service node list.");
         return false;
       }
     }


### PR DESCRIPTION
Early break in the for loop causes only 1 event to be loaded. Seems like the prevent_rollback should be push_front onto the rollback list and all the rollback events are loaded after it. 

Also ensure that the prevent rollback is present when culling the event list.