### PR TITLE
Don't ban peers for a bad vote, just drop their connection

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3796,7 +3796,14 @@ leave:
 
   // appears to be a NOP *and* is called elsewhere.  wat?
   m_tx_pool.on_blockchain_inc(new_height, id);
-  m_deregister_vote_pool.remove_expired_votes(new_height);
+
+  // New height is the height of the block we just mined. We want (new_height
+  // + 1) because our age checks for deregister votes is now (age >=
+  // DEREGISTER_VOTE_LIFETIME_BY_HEIGHT) where age is derived from
+  // get_current_blockchain_height() which gives you the height that you are
+  // currently mining for, i.e. (new_height + 1). Otherwise peers will silently
+  // drop connection from each other when they go around P2Ping votes.
+  m_deregister_vote_pool.remove_expired_votes(new_height + 1);
   m_deregister_vote_pool.remove_used_votes(txs);
 
   return true;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -790,7 +790,7 @@ namespace cryptonote
       if (vvc.m_verification_failed)
       {
         LOG_PRINT_CCONTEXT_L1("Deregister vote verification failed, dropping connection");
-        drop_connection(context, true /*add_fail*/, false /*flush_all_spans i.e. delete cached block data from this peer*/);
+        drop_connection(context, false /*add_fail*/, false /*flush_all_spans i.e. delete cached block data from this peer*/);
         return 1;
       }
 


### PR DESCRIPTION
Stop banning for too old votes, I reviewed the banning code, Monero only bans for bad blocks. Bad transactions, we just drop the connection, so I decided that was a better behaviour to follow suite.

Also the off-by-one for checking vote age had a knock-on effect to when we remove expired votes. The height returned in handling a new block to the chain was not the same as get_current_blockchain_height() which the other age checks use causing us to send old votes off by 1 height and then subsequently slowly ban everyone.