### PR TITLE
Abstract TCP Server2 fixes from Monero

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -158,6 +158,7 @@ namespace net_utils
     std::list<boost::shared_ptr<connection<t_protocol_handler> > > m_self_refs; // add_ref/release support
     critical_section m_self_refs_lock;
     critical_section m_chunking_lock; // held while we add small chunks of the big do_send() to small do_send_chunk()
+    critical_section m_shutdown_lock; // held while shutting down
     
     t_connection_type m_connection_type;
     

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -653,13 +653,13 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     m_timer.cancel();
     boost::system::error_code ignored_ec;
     socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
-    m_was_shutdown = true;
-    m_protocol_handler.release_protocol();
     if (!m_host.empty())
     {
       try { host_count(m_host, -1); } catch (...) { /* ignore */ }
       m_host = "";
     }
+    m_was_shutdown = true;
+    m_protocol_handler.release_protocol();
     return true;
   }
   //---------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes race condition and intermittent crashes during P2P communication.