### PR TITLE
Service Nodes Safe Guard

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -73,7 +73,6 @@ namespace service_nodes
   void service_node_list::init()
   {
     uint64_t current_height = m_blockchain.get_current_blockchain_height();
-
     bool loaded = load();
 
     if (loaded && m_height == current_height) return;
@@ -1000,7 +999,14 @@ namespace service_nodes
     }
 
     m_quorum_states.clear();
-    m_height = 0;
+
+    uint64_t hardfork_9_height = 0;
+    {
+      uint32_t window, votes, threshold;
+      uint8_t voting;
+      m_blockchain.get_hard_fork_voting_info(9, window, votes, threshold, hardfork_9_height, voting);
+    }
+    m_height = hardfork_9_height;
   }
 
   bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4837,10 +4837,11 @@ bool simple_wallet::register_service_node_main(
       return true;
     }
 
-    // give user total and fee, and prompt to confirm
+    // give user total and fee, and prompt to confirm, and always set to atleast v3 to safeguard users against fork
     uint64_t total_fee = 0, total_sent = 0;
     for (size_t n = 0; n < ptx_vector.size(); ++n)
     {
+      ptx_vector[n].tx.version = std::max((size_t)transaction::version_3_per_output_unlock_times, ptx_vector[n].tx.version);
       total_fee += ptx_vector[n].fee;
       for (auto i: ptx_vector[n].selected_transfers)
         total_sent += m_wallet->get_transfer_details(i).amount();
@@ -5249,10 +5250,11 @@ bool simple_wallet::stake_main(
       return true;
     }
 
-    // give user total and fee, and prompt to confirm
+    // give user total and fee, and prompt to confirm, and always set to atleast v3 to safeguard users against fork
     uint64_t total_fee = 0, total_sent = 0;
     for (size_t n = 0; n < ptx_vector.size(); ++n)
     {
+      ptx_vector[n].tx.version = std::max((size_t)transaction::version_3_per_output_unlock_times, ptx_vector[n].tx.version);
       total_fee += ptx_vector[n].fee;
       for (auto i: ptx_vector[n].selected_transfers)
         total_sent += m_wallet->get_transfer_details(i).amount();


### PR DESCRIPTION
Prevent users from making mistakes by making it impossible to register a service node before the hardfork height. It makes sure that the minimum version that a stake/registration tx that can be made is a V3. With the checks in check_tx_inputs will bar these from being accepted into the mempool until their daemon is at hardfork 9 or higher.

This also adds in scanning service node lists starting from the fork height. I think this should go into master, and then PR master to dev to backport it into the dev branch because I think it should go in the final release.
