### PR TITLE
Uptime proof transmission tweaks

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -64,8 +64,9 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               11
 
 #define UPTIME_PROOF_BUFFER_IN_SECONDS                  (5*60)
-#define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (60*60)
-#define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_FREQUENCY_IN_SECONDS * 2 + UPTIME_PROOF_BUFFER_IN_SECONDS)
+#define UPTIME_PROOF_MIN_TIME_IN_SECONDS                (30*60)
+#define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (UPTIME_PROOF_MIN_TIME_IN_SECONDS + 60)
+#define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_MIN_TIME_IN_SECONDS * 4 + UPTIME_PROOF_BUFFER_IN_SECONDS)
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)(-1))

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1449,7 +1449,10 @@ namespace cryptonote
     // wait one block before starting uptime proofs.
     if (!states.empty() && states[0].info.registration_height + 1 < get_current_blockchain_height())
     {
-      m_submit_uptime_proof_interval.do_call(boost::bind(&core::submit_uptime_proof, this));
+      time_t const now = time(nullptr);
+      if (now - get_start_time() >= 60) {
+        m_submit_uptime_proof_interval.do_call(boost::bind(&core::submit_uptime_proof, this));
+      }
     }
     else
     {

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -159,7 +159,7 @@ namespace service_nodes
       return false;
 
     CRITICAL_REGION_LOCAL(m_lock);
-    if (m_uptime_proof_seen[pubkey] >= now - (UPTIME_PROOF_FREQUENCY_IN_SECONDS / 2))
+    if (m_uptime_proof_seen[pubkey] >= now - UPTIME_PROOF_MIN_TIME_IN_SECONDS)
       return false; // already received one uptime proof for this node recently.
 
     crypto::hash hash = make_hash(pubkey, timestamp);


### PR DESCRIPTION
This pair of commits tweaks the uptime proof (as discussed in #259) transmission times of a service node (which keeping the uptime proof acceptance logic the same).  There are two main changes here:

- sending more frequent uptime proofs (every 31 minutes rather than every 60).  The minimum accepted time for a proof (30 minutes) is left unchanged (and so this doesn't change the deregistration logic and so should be perfectly usable on the network as-is without a fork).

- delaying the initial uptime proof transmission by 1 minute to work around the issue where the proof often doesn't make it to the network (this is the main issue in #259).

Fixes #259 