### PR TITLE
wallet2: fix transfers between subaddresses hitting the sanity check

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1523,10 +1523,14 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   }
 
   // remove change sent to the spending subaddress account from the list of received funds
+  uint64_t sub_change = 0;
   for (auto i = tx_money_got_in_outs.begin(); i != tx_money_got_in_outs.end();)
   {
     if (subaddr_account && i->index.major == *subaddr_account)
+    {
+      sub_change += i->amount;
       i = tx_money_got_in_outs.erase(i);
+    }
     else
       ++i;
   }
@@ -1573,7 +1577,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       LOG_PRINT_L2("Found unencrypted payment ID: " << payment_id);
     }
 
-    uint64_t total_received_2 = 0;
+    uint64_t total_received_2 = sub_change;
     for (const auto& i : tx_money_got_in_outs)
       total_received_2 += i.amount;
 


### PR DESCRIPTION
Transfers between subaddresses are accounted for differently