### PR TITLE
Making service node list thread-safe

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3069,7 +3069,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       return false;
     }
 
-    std::shared_ptr<service_nodes::quorum_state> quorum_state = m_service_node_list.get_quorum_state(deregister.block_height);
+    const auto quorum_state = m_service_node_list.get_quorum_state(deregister.block_height);
     if (!quorum_state)
     {
       MERROR_VER("TX version 3 deregister_tx could not get quorum for height: " << deregister.block_height);
@@ -3136,9 +3136,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
           continue;
         }
 
-        std::shared_ptr<service_nodes::quorum_state> existing_deregister_quorum_state
-          = m_service_node_list.get_quorum_state(existing_deregister.block_height);
-
+        const auto existing_deregister_quorum_state = m_service_node_list.get_quorum_state(existing_deregister.block_height);
         if (!existing_deregister_quorum_state)
         {
           MERROR_VER("could not get quorum state for recent deregister tx");

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -131,7 +131,7 @@ namespace cryptonote
     class ValidateMinerTxHook
     {
     public:
-      virtual bool validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward) = 0;
+      virtual bool validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward) const = 0;
     };
 
     /**

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1704,10 +1704,9 @@ namespace cryptonote
     return si.available;
   }
   //-----------------------------------------------------------------------------------------------
-  const std::shared_ptr<service_nodes::quorum_state> core::get_quorum_state(uint64_t height) const
+  const std::shared_ptr<const service_nodes::quorum_state> core::get_quorum_state(uint64_t height) const
   {
-    const std::shared_ptr<service_nodes::quorum_state> result = m_service_node_list.get_quorum_state(height);
-    return result;
+    return m_service_node_list.get_quorum_state(height);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::is_service_node(const crypto::public_key& pubkey) const
@@ -1749,7 +1748,7 @@ namespace cryptonote
       return false;
     }
 
-    const std::shared_ptr<service_nodes::quorum_state> quorum_state = m_service_node_list.get_quorum_state(vote.block_height);
+    const auto quorum_state = m_service_node_list.get_quorum_state(vote.block_height);
     if (!quorum_state)
     {
       vvc.m_verification_failed  = true;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -172,7 +172,7 @@ namespace cryptonote
               m_mempool(m_blockchain_storage),
               m_service_node_list(m_blockchain_storage),
               m_blockchain_storage(m_mempool, m_service_node_list, m_deregister_vote_pool),
-              m_quorum_cop(*this, m_service_node_list),
+              m_quorum_cop(*this),
               m_miner(this),
               m_miner_address(boost::value_initialized<account_public_address>()),
               m_starter_message_showed(false),
@@ -1708,6 +1708,11 @@ namespace cryptonote
   {
     const std::shared_ptr<service_nodes::quorum_state> result = m_service_node_list.get_quorum_state(height);
     return result;
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::is_service_node(const crypto::public_key& pubkey) const
+  {
+    return m_service_node_list.is_service_node(pubkey);
   }
   //-----------------------------------------------------------------------------------------------
   std::vector<service_nodes::service_node_pubkey_info> core::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -807,6 +807,14 @@ namespace cryptonote
       */
      std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
 
+    /**
+      * @brief get whether `pubkey` is known as a service node
+      *
+      * @param pubkey the public key to test
+      *
+      * @return whether `pubkey` is known as a service node
+      */
+    bool is_service_node(const crypto::public_key& pubkey) const;
      /**
       * @brief Add a vote to deregister a service node from network
       *

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -796,7 +796,7 @@ namespace cryptonote
 
       * @return Null shared ptr if quorum has not been determined yet for height
       */
-     const std::shared_ptr<service_nodes::quorum_state> get_quorum_state(uint64_t height) const;
+     const std::shared_ptr<const service_nodes::quorum_state> get_quorum_state(uint64_t height) const;
 
      /**
       * @brief Get a snapshot of the service node list state at the time of the call.

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -97,7 +97,7 @@ namespace service_nodes
       if (m_core.get_hard_fork_version(m_last_height) < 9)
         continue;
 
-      const std::shared_ptr<quorum_state> state = m_core.get_quorum_state(m_last_height);
+      const std::shared_ptr<const quorum_state> state = m_core.get_quorum_state(m_last_height);
       if (!state)
       {
         // TODO(loki): Fatal error

--- a/src/cryptonote_core/quorum_cop.cpp
+++ b/src/cryptonote_core/quorum_cop.cpp
@@ -37,8 +37,8 @@
 
 namespace service_nodes
 {
-  quorum_cop::quorum_cop(cryptonote::core& core, service_nodes::service_node_list& service_node_list)
-    : m_core(core), m_service_node_list(service_node_list), m_last_height(0)
+  quorum_cop::quorum_cop(cryptonote::core& core)
+    : m_core(core), m_last_height(0)
   {
     init();
   }
@@ -153,9 +153,7 @@ namespace service_nodes
     if ((timestamp < now - UPTIME_PROOF_BUFFER_IN_SECONDS) || (timestamp > now + UPTIME_PROOF_BUFFER_IN_SECONDS))
       return false;
 
-    // TODO(doyle): the only dependency on m_service_node_lists which could be
-    // replaced by the lists stored in db when that is implemented - 2018-07-24
-    if (!m_service_node_list.is_service_node(pubkey))
+    if (!m_core.is_service_node(pubkey))
       return false;
 
     CRITICAL_REGION_LOCAL(m_lock);

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -49,7 +49,7 @@ namespace service_nodes
       public cryptonote::Blockchain::InitHook
   {
   public:
-    quorum_cop(cryptonote::core& core);
+    explicit quorum_cop(cryptonote::core& core);
 
     void init();
     void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);

--- a/src/cryptonote_core/quorum_cop.h
+++ b/src/cryptonote_core/quorum_cop.h
@@ -49,7 +49,7 @@ namespace service_nodes
       public cryptonote::Blockchain::InitHook
   {
   public:
-    quorum_cop(cryptonote::core& core, service_nodes::service_node_list& service_node_list);
+    quorum_cop(cryptonote::core& core);
 
     void init();
     void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
@@ -68,7 +68,6 @@ namespace service_nodes
   private:
 
     cryptonote::core& m_core;
-    service_node_list& m_service_node_list;
     uint64_t m_last_height;
 
     using timestamp = uint64_t;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -60,6 +60,7 @@ namespace service_nodes
 
   void service_node_list::register_hooks(service_nodes::quorum_cop &quorum_cop)
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     if (!m_hooks_registered)
     {
       m_hooks_registered = true;
@@ -77,6 +78,7 @@ namespace service_nodes
 
   void service_node_list::init()
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     uint64_t current_height = m_blockchain.get_current_blockchain_height();
     bool loaded = load();
 
@@ -126,9 +128,9 @@ namespace service_nodes
     return result;
   }
 
-  const std::shared_ptr<quorum_state> service_node_list::get_quorum_state(uint64_t height) const
+  const std::shared_ptr<const quorum_state> service_node_list::get_quorum_state(uint64_t height) const
   {
-    std::shared_ptr<service_nodes::quorum_state> result;
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     const auto &it = m_quorum_states.find(height);
     if (it == m_quorum_states.end())
     {
@@ -136,14 +138,15 @@ namespace service_nodes
     }
     else
     {
-      result = it->second;
+      return it->second;
     }
 
-    return result;
+    return std::make_shared<quorum_state>();
   }
 
   std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     std::vector<service_node_pubkey_info> result;
 
     if (service_node_pubkeys.empty())
@@ -177,8 +180,21 @@ namespace service_nodes
     return result;
   }
 
+  void service_node_list::set_db_pointer(cryptonote::BlockchainDB* db)
+  {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
+    m_db = db;
+  }
+
+  void service_node_list::set_my_service_node_keys(crypto::public_key const *pub_key)
+  {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
+    m_service_node_pubkey = pub_key;
+  }
+
   bool service_node_list::is_service_node(const crypto::public_key& pubkey) const
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     return m_service_nodes_infos.find(pubkey) != m_service_nodes_infos.end();
   }
 
@@ -192,7 +208,7 @@ namespace service_nodes
     return unlock_time < CRYPTONOTE_MAX_BLOCK_NUMBER && unlock_time >= block_height + get_staking_requirement_lock_blocks(m_blockchain.nettype());
   }
 
-  bool service_node_list::reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key) const
+  bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key)
   {
     cryptonote::tx_extra_service_node_register registration;
     if (!get_service_node_register_from_tx_extra(tx.extra, registration))
@@ -264,7 +280,7 @@ namespace service_nodes
       return;
     }
 
-    const std::shared_ptr<quorum_state> state = get_quorum_state(deregister.block_height);
+    const auto state = get_quorum_state(deregister.block_height);
 
     if (!state)
     {
@@ -502,6 +518,7 @@ namespace service_nodes
 
   void service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     block_added_generic(block, txs);
     store();
   }
@@ -581,6 +598,7 @@ namespace service_nodes
 
   void service_node_list::blockchain_detached(uint64_t height)
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     while (!m_rollback_events.empty() && m_rollback_events.back()->m_block_height >= height)
     {
       if (!m_rollback_events.back()->apply(m_service_nodes_infos))
@@ -645,6 +663,7 @@ namespace service_nodes
 
   std::vector<std::pair<cryptonote::account_public_address, uint64_t>> service_node_list::get_winner_addresses_and_portions(const crypto::hash& prev_id) const
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     crypto::public_key key = select_winner(prev_id);
     if (key == crypto::null_pkey)
       return { std::make_pair(null_address, STAKING_PORTIONS) };
@@ -672,6 +691,7 @@ namespace service_nodes
 
   crypto::public_key service_node_list::select_winner(const crypto::hash& prev_id) const
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     auto oldest_waiting = std::pair<uint64_t, uint32_t>(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint32_t>::max());
     crypto::public_key key = crypto::null_pkey;
     for (const auto& info : m_service_nodes_infos)
@@ -689,8 +709,9 @@ namespace service_nodes
 
   /// validates the miner TX for the next block
   //
-  bool service_node_list::validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward)
+  bool service_node_list::validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward) const
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     if (hard_fork_version < 9)
       return true;
 
@@ -787,15 +808,12 @@ namespace service_nodes
     }
 
     // Assign indexes from shuffled list into quorum and list of nodes to test
-    if (!m_quorum_states[height])
-      m_quorum_states[height] = std::shared_ptr<quorum_state>(new quorum_state());
 
-    std::shared_ptr<quorum_state> state = m_quorum_states[height];
-    state->clear();
+    auto new_state = std::make_shared<quorum_state>();
+
     {
-      std::vector<crypto::public_key>& quorum = state->quorum_nodes;
+      std::vector<crypto::public_key>& quorum = new_state->quorum_nodes;
       {
-        quorum.clear();
         quorum.resize(std::min(full_node_list.size(), QUORUM_SIZE));
         for (size_t i = 0; i < quorum.size(); i++)
         {
@@ -805,13 +823,12 @@ namespace service_nodes
         }
       }
 
-      std::vector<crypto::public_key>& nodes_to_test = state->nodes_to_test;
+      std::vector<crypto::public_key>& nodes_to_test = new_state->nodes_to_test;
       {
         size_t num_remaining_nodes = pub_keys_indexes.size() - quorum.size();
         size_t num_nodes_to_test   = std::max(num_remaining_nodes/NTH_OF_THE_NETWORK_TO_TEST,
                                               std::min(MIN_NODES_TO_TEST, num_remaining_nodes));
 
-        nodes_to_test.clear();
         nodes_to_test.resize(num_nodes_to_test);
 
         const int pub_keys_offset = quorum.size();
@@ -823,6 +840,8 @@ namespace service_nodes
         }
       }
     }
+
+    m_quorum_states[height] = new_state;
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -871,6 +890,7 @@ namespace service_nodes
 
   bool service_node_list::store()
   {
+    std::lock_guard<std::recursive_mutex> lock(sn_mutex_);
     CHECK_AND_ASSERT_MES(m_db != nullptr, false, "Failed to store service node info, m_db == nullptr");
     data_members_for_serialization data_to_store;
 
@@ -959,8 +979,7 @@ namespace service_nodes
 
     for (const auto& quorum : data_in.quorum_states)
     {
-      m_quorum_states[quorum.height] = std::shared_ptr<quorum_state>(new quorum_state());
-      *m_quorum_states[quorum.height] = quorum.state;
+      m_quorum_states[quorum.height] = std::make_shared<quorum_state>(quorum.state);
     }
 
     for (const auto& info : data_in.infos)

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -161,7 +161,6 @@ namespace service_nodes
 
     void store_quorum_state_from_rewards_list(uint64_t height);
 
-  public:
     struct rollback_event
     {
       enum rollback_type

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -43,7 +43,6 @@ namespace service_nodes
 
   struct quorum_state
   {
-    void clear() { quorum_nodes.clear(); nodes_to_test.clear(); }
     std::vector<crypto::public_key> quorum_nodes;
     std::vector<crypto::public_key> nodes_to_test;
 
@@ -122,44 +121,23 @@ namespace service_nodes
   {
   public:
     service_node_list(cryptonote::Blockchain& blockchain);
-    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
-    void blockchain_detached(uint64_t height);
+    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs) override;
+    void blockchain_detached(uint64_t height) override;
     void register_hooks(service_nodes::quorum_cop &quorum_cop);
-    void init();
-    bool validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward);
-
-    std::vector<crypto::public_key> get_expired_nodes(uint64_t block_height) const;
-
+    void init() override;
+    bool validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hard_fork_version, uint64_t base_reward) const override;
     std::vector<std::pair<cryptonote::account_public_address, uint64_t>> get_winner_addresses_and_portions(const crypto::hash& prev_id) const;
     crypto::public_key select_winner(const crypto::hash& prev_id) const;
 
     bool is_service_node(const crypto::public_key& pubkey) const;
-    const std::shared_ptr<quorum_state> get_quorum_state(uint64_t height) const;
+
+    /// Note(maxim): this should not affect thread-safety as the returned object is const
+    const std::shared_ptr<const quorum_state> get_quorum_state(uint64_t height) const;
     std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
 
-    void set_db_pointer(cryptonote::BlockchainDB* db) { m_db = db; }
-    void set_my_service_node_keys(crypto::public_key const *pub_key) { m_service_node_pubkey = pub_key; }
+    void set_db_pointer(cryptonote::BlockchainDB* db);
+    void set_my_service_node_keys(crypto::public_key const *pub_key);
     bool store();
-
-    bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;
-    bool get_contribution(const cryptonote::transaction& tx, uint64_t block_height, cryptonote::account_public_address& address, uint64_t& transferred) const;
-
-    void process_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index);
-    void process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index);
-    void process_deregistration_tx(const cryptonote::transaction& tx, uint64_t block_height);
-
-    std::vector<crypto::public_key> get_service_nodes_pubkeys() const;
-
-    template<typename T>
-    void block_added_generic(const cryptonote::block& block, const T& txs);
-
-    bool contribution_tx_output_has_correct_unlock_time(const cryptonote::transaction& tx, size_t i, uint64_t block_height) const;
-    bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key) const;
-    uint64_t get_reg_tx_staking_output_contribution(const cryptonote::transaction& tx, int i, crypto::key_derivation derivation, hw::device& hwdev) const;
-
-    crypto::public_key find_service_node_from_miner_tx(const cryptonote::transaction& miner_tx, uint64_t block_height) const;
-
-    void store_quorum_state_from_rewards_list(uint64_t height);
 
     struct rollback_event
     {
@@ -264,8 +242,30 @@ namespace service_nodes
 
   private:
 
+    // Note(maxim): private methods don't have to be protected the mutex
+    bool get_contribution(const cryptonote::transaction& tx, uint64_t block_height, cryptonote::account_public_address& address, uint64_t& transferred) const;
+
+    void process_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index);
+    void process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index);
+    void process_deregistration_tx(const cryptonote::transaction& tx, uint64_t block_height);
+
+    std::vector<crypto::public_key> get_service_nodes_pubkeys() const;
+
+    template<typename T>
+    void block_added_generic(const cryptonote::block& block, const T& txs);
+
+    bool contribution_tx_output_has_correct_unlock_time(const cryptonote::transaction& tx, size_t i, uint64_t block_height) const;
+    uint64_t get_reg_tx_staking_output_contribution(const cryptonote::transaction& tx, int i, crypto::key_derivation derivation, hw::device& hwdev) const;
+
+    void store_quorum_state_from_rewards_list(uint64_t height);
+
+    bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;
+    std::vector<crypto::public_key> get_expired_nodes(uint64_t block_height) const;
+
     void clear(bool delete_db_entry = false);
     bool load();
+
+    mutable std::recursive_mutex sn_mutex_;
 
     using block_height = uint64_t;
 
@@ -279,8 +279,10 @@ namespace service_nodes
 
     cryptonote::BlockchainDB* m_db;
 
-    std::map<block_height, std::shared_ptr<quorum_state>> m_quorum_states;
+    std::map<block_height, std::shared_ptr<const quorum_state>> m_quorum_states;
   };
+
+  bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);
 
   bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake);
   bool make_registration_cmd(cryptonote::network_type nettype, const std::vector<std::string> args, const crypto::public_key& service_node_pubkey,

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1980,7 +1980,7 @@ namespace cryptonote
     PERF_TIMER(on_get_quorum_state);
     bool r;
 
-    const std::shared_ptr<service_nodes::quorum_state> quorum_state = m_core.get_quorum_state(req.height);
+    const auto quorum_state = m_core.get_quorum_state(req.height);
     r = (quorum_state != nullptr);
     if (r)
     {


### PR DESCRIPTION
Most data in the service node list is accessed when `m_blockchain_lock` is held. Occasionally though some of its non-modifying methods (e.g. `is_service_node`, `get_service_node_list_state` etc.) are called without that lock, which opens an opportunity for a data race. This mostly seems to happen when `handle_uptime_proof` is called, but it is also possible to access the service node list concurrently via RPC calls.

Note that to find this, I had to modify all methods within service node list to take a long time (100ms) as to increase the chance of concurrent access. I'm not sure how often that happens in real code.  

This PR makes the service node list thread safe by making sure that a lock for sn_mutex_ is held whenever a public method is called. Additionally `get_quorum_state` used to return a reference to a non-const data (a `shared_ptr` in this case), so whoever held that reference would have to remember acquire the lock as well. Instead, I changed `get_quorum_state` to return a `shared_ptr` to a const data, so locking could be done entirely within the service node list class.