### PR TITLE
Service Nodes Reregistration Grace Period

### DIFF
--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -87,6 +87,15 @@ namespace cryptonote
   class Blockchain
   {
   public:
+
+    enum version
+    {
+      version_7 = 7,
+      version_8,
+      version_9,
+      version_10_swarms,
+    };
+
     /**
      * @brief Now-defunct (TODO: remove) struct from in-memory blockchain
      */

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -414,13 +414,13 @@ namespace service_nodes
     // NOTE: A node doesn't expire until registration_height + lock blocks excess now which acts as the grace period
     // So it is possible to find the node still in our list.
     bool registered_during_grace_period = false;
-    auto iter = m_service_nodes_infos.find(key);
+    const auto iter = m_service_nodes_infos.find(key);
     if (iter != m_service_nodes_infos.end())
     {
       int hard_fork_version = m_blockchain.get_hard_fork_version(block_height);
       if (hard_fork_version >= cryptonote::Blockchain::version_10_swarms)
       {
-        service_node_info &old_info = iter->second;
+        service_node_info const &old_info = iter->second;
         uint64_t expiry_height = old_info.registration_height + get_staking_requirement_lock_blocks(m_blockchain.nettype());
         if (block_height < expiry_height)
           return;
@@ -676,7 +676,7 @@ namespace service_nodes
         service_node_info  const &info   = it.second;
 
         uint64_t node_expiry_height = info.registration_height + lock_blocks;
-        if (block_height >= node_expiry_height)
+        if (block_height > node_expiry_height)
         {
           expired_nodes.push_back(pubkey);
         }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -411,13 +411,34 @@ namespace service_nodes
     if (!is_registration_tx(tx, block_timestamp, block_height, index, key, info))
       return;
 
+    // NOTE: A node doesn't expire until registration_height + lock blocks excess now which acts as the grace period
+    // So it is possible to find the node still in our list.
+    bool registered_during_grace_period = false;
     auto iter = m_service_nodes_infos.find(key);
     if (iter != m_service_nodes_infos.end())
-      return;
+    {
+      service_node_info &old_info = iter->second;
+      uint64_t expiry_height = old_info.registration_height + get_staking_requirement_lock_blocks(m_blockchain.nettype());
+
+      if (block_height < expiry_height)
+        return;
+
+      // NOTE: Node preserves its position in list if it reregisters during grace period.
+      registered_during_grace_period = true;
+      info.last_reward_block_height = old_info.last_reward_block_height;
+      info.last_reward_transaction_index = old_info.last_reward_transaction_index;
+    }
 
     if (m_service_node_pubkey && *m_service_node_pubkey == key)
     {
-      MGINFO_GREEN("New service node registered (yours): " << key << " at block height: " << block_height);
+      if (registered_during_grace_period)
+      {
+        MGINFO_GREEN("Service node re-registered (yours): " << key << " at block height: " << block_height);
+      }
+      else
+      {
+        MGINFO_GREEN("Service node registered (yours): " << key << " at block height: " << block_height);
+      }
     }
     else
     {
@@ -552,6 +573,15 @@ namespace service_nodes
       auto i = m_service_nodes_infos.find(pubkey);
       if (i != m_service_nodes_infos.end())
       {
+        if (m_service_node_pubkey && *m_service_node_pubkey == pubkey)
+        {
+          MGINFO_GREEN("Service node expired (yours): " << pubkey << " at block height: " << block_height);
+        }
+        else
+        {
+          LOG_PRINT_L1("Service node expired: " << pubkey << " at block height: " << block_height);
+        }
+
         m_rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_change(block_height, pubkey, i->second)));
         m_service_nodes_infos.erase(i);
       }
@@ -623,39 +653,21 @@ namespace service_nodes
   {
     std::vector<crypto::public_key> expired_nodes;
 
-    const uint64_t lock_blocks = get_staking_requirement_lock_blocks(m_blockchain.nettype());
+    const uint64_t lock_blocks = get_staking_requirement_lock_blocks(m_blockchain.nettype()) + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
 
     if (block_height < lock_blocks)
       return expired_nodes;
 
-    const uint64_t expired_nodes_block_height = block_height - lock_blocks;
-
-    std::vector<std::pair<cryptonote::blobdata, cryptonote::block>> blocks;
-    if (!m_blockchain.get_blocks(expired_nodes_block_height, 1, blocks))
+    for (auto &it : m_service_nodes_infos)
     {
-      LOG_ERROR("Unable to get historical blocks");
-      return expired_nodes;
-    }
+      crypto::public_key const &pubkey = it.first;
+      service_node_info  const &info   = it.second;
 
-    const cryptonote::block& block = blocks.begin()->second;
-    std::vector<cryptonote::transaction> txs;
-    std::vector<crypto::hash> missed_txs;
-    if (!m_blockchain.get_transactions(block.tx_hashes, txs, missed_txs))
-    {
-      LOG_ERROR("Unable to get transactions for block " << block.hash);
-      return expired_nodes;
-    }
-
-    uint32_t index = 0;
-    for (const cryptonote::transaction& tx : txs)
-    {
-      crypto::public_key key;
-      service_node_info info;
-      if (is_registration_tx(tx, block.timestamp, expired_nodes_block_height, index, key, info))
+      uint64_t node_expiry_height = info.registration_height + lock_blocks;
+      if (block_height >= node_expiry_height)
       {
-        expired_nodes.push_back(key);
+        expired_nodes.push_back(pubkey);
       }
-      index++;
     }
 
     return expired_nodes;

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2014,7 +2014,7 @@ bool t_rpc_command_executor::get_service_node_registration_cmd(const std::vector
     return true;
 }
 
-static void print_service_node_list_state(cryptonote::network_type nettype, uint64_t *curr_height, std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *> list)
+static void print_service_node_list_state(cryptonote::network_type nettype, int hard_fork_version, uint64_t *curr_height, std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *> list)
 {
   const char indent1[] = "    ";
   const char indent2[] = "        ";
@@ -2036,8 +2036,9 @@ static void print_service_node_list_state(cryptonote::network_type nettype, uint
 
     // Print Expiry Info
     {
-      uint64_t expiry_height = entry.registration_height;
-      expiry_height += service_nodes::get_staking_requirement_lock_blocks(nettype) + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
+      uint64_t expiry_height = entry.registration_height + service_nodes::get_staking_requirement_lock_blocks(nettype);
+      if (hard_fork_version >= cryptonote::Blockchain::version_10_swarms)
+        expiry_height += STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
 
       if (curr_height)
       {
@@ -2102,12 +2103,25 @@ bool t_rpc_command_executor::print_sn(const std::vector<std::string> &args)
 
     cryptonote::network_type nettype = cryptonote::UNDEFINED;
     uint64_t *curr_height = nullptr;
+    int hard_fork_version = 7;
     if (m_is_rpc)
     {
       if (!m_rpc_client->rpc_request(get_info_req, get_info_res, "/getinfo", fail_message.c_str()))
       {
         tools::fail_msg_writer() << make_error(fail_message, get_info_res.status);
         return true;
+      }
+
+      {
+        cryptonote::COMMAND_RPC_HARD_FORK_INFO::request  hard_fork_info_req = {};
+        cryptonote::COMMAND_RPC_HARD_FORK_INFO::response hard_fork_info_res = {};
+        if (!m_rpc_client->json_rpc_request(hard_fork_info_req, hard_fork_info_res, "hard_fork_info", fail_message.c_str()))
+        {
+          tools::fail_msg_writer() << make_error(fail_message, hard_fork_info_res.status);
+          return true;
+        }
+
+        hard_fork_version = hard_fork_info_res.version;
       }
 
       if (!m_rpc_client->json_rpc_request(req, res, "get_service_nodes", fail_message.c_str()))
@@ -2125,6 +2139,17 @@ bool t_rpc_command_executor::print_sn(const std::vector<std::string> &args)
     {
       if (m_rpc_server->on_get_info(get_info_req, get_info_res) || get_info_res.status == CORE_RPC_STATUS_OK)
         curr_height = &get_info_res.height;
+
+      {
+        cryptonote::COMMAND_RPC_HARD_FORK_INFO::request  hard_fork_info_req = {};
+        cryptonote::COMMAND_RPC_HARD_FORK_INFO::response hard_fork_info_res = {};
+        if (!m_rpc_server->on_hard_fork_info(hard_fork_info_req, hard_fork_info_res, error_resp) || hard_fork_info_res.status != CORE_RPC_STATUS_OK)
+        {
+          tools::fail_msg_writer() << make_error(fail_message, error_resp.message);
+          return true;
+        }
+        hard_fork_version = hard_fork_info_res.version;
+      }
 
       if (!m_rpc_server->on_get_service_nodes(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
       {
@@ -2173,13 +2198,13 @@ bool t_rpc_command_executor::print_sn(const std::vector<std::string> &args)
     if (unregistered.size() > 0)
     {
       tools::msg_writer() << "Service Node Unregistered State[" << unregistered.size()<< "]";
-      print_service_node_list_state(nettype, curr_height, unregistered);
+      print_service_node_list_state(nettype, hard_fork_version, curr_height, unregistered);
     }
 
     if (registered.size() > 0)
     {
       tools::msg_writer() << "Service Node Registration State[" << registered.size()<< "]";
-      print_service_node_list_state(nettype, curr_height, registered);
+      print_service_node_list_state(nettype, hard_fork_version, curr_height, registered);
     }
 
     if (unregistered.size() == 0 && registered.size() == 0)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2037,7 +2037,7 @@ static void print_service_node_list_state(cryptonote::network_type nettype, uint
     // Print Expiry Info
     {
       uint64_t expiry_height = entry.registration_height;
-      expiry_height += service_nodes::get_staking_requirement_lock_blocks(nettype);
+      expiry_height += service_nodes::get_staking_requirement_lock_blocks(nettype) + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
 
       if (curr_height)
       {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4735,22 +4735,6 @@ bool simple_wallet::register_service_node_main(
     return false;
   }
 
-  try
-  {
-    const auto& response = m_wallet->get_service_nodes(service_node_key_as_str);
-    if (response.service_node_states.size() >= 1)
-    {
-      if (!autostake)
-        fail_msg_writer() << tr("This service node is already registered");
-      return true;
-    }
-  }
-  catch(const std::exception &e)
-  {
-    fail_msg_writer() << e.what();
-    return true;
-  }
-
   uint64_t staking_requirement_lock_blocks = service_nodes::get_staking_requirement_lock_blocks(m_wallet->nettype());
   uint64_t locked_blocks = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
 
@@ -4790,6 +4774,27 @@ bool simple_wallet::register_service_node_main(
       if (bc_height == 0)
         return true;
     }
+  }
+
+  try
+  {
+    const auto& response = m_wallet->get_service_nodes(service_node_key_as_str);
+    if (response.service_node_states.size() >= 1)
+    {
+      cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info = response.service_node_states[0];
+      uint64_t expiry_height = node_info.registration_height + staking_requirement_lock_blocks;
+
+      if (bc_height < expiry_height)
+      {
+        if (!autostake) fail_msg_writer() << tr("This service node is already registered");
+        return true;
+      }
+    }
+  }
+  catch(const std::exception &e)
+  {
+    fail_msg_writer() << e.what();
+    return true;
   }
 
   uint64_t unlock_block = bc_height + locked_blocks;
@@ -5062,10 +5067,6 @@ bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
 
   add_service_node_contributor_to_tx_extra(extra, address);
 
-  std::string please_wait_to_be_included_in_block_msg = std::string() +
-      tr("Wait for transaction to be included in a block before registration is complete.\n") +
-      tr("Use the print_sn command in the daemon to check the status.");
-
   if (autostake)
   {
     bool is_open_service_node = portions_for_operator != STAKING_PORTIONS;
@@ -5077,7 +5078,6 @@ bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
 
     stop();
     m_idle_thread.join();
-    success_msg_writer(false) << please_wait_to_be_included_in_block_msg;
 #ifndef WIN32
     success_msg_writer(true /*color*/) << tr("Successfully entered autostaking mode, this wallet is moving into the background to automatically renew your service node every period.");
     tools::threadpool::getInstance().stop();
@@ -5103,7 +5103,6 @@ bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
   {
     LOCK_IDLE_SCOPE();
     register_service_node_main(service_node_key_as_str, expiration_timestamp, address, priority, portions, extra, subaddr_indices, autostake);
-    success_msg_writer(false) << please_wait_to_be_included_in_block_msg;
   }
 
   return true;


### PR DESCRIPTION
This allows service nodes to re-register and renew their staking cycle before they formally expire and get removed from the service node list. This has the benefit of allowing the operator to preserve their position in the queue and sets us up for success for swarms :>

To summarise, the criteria for checking expired node changes to include the excess lock blocks. We no longer check 30 days back from the registration height to find expired nodes, we use the registration height parameter. 

Reason being, if we look 30 days back and we re-register within the grace period, we're gonna hit the initial registration in the blocks eventually and expire the node prematurely.

The grace period is currently set to STAKING_REQURIMENT_LOCK_BLOCKS_EXCESS which is 20 blocks (40mins).