### PR TITLE
Fix PRIu64 macro for mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ if(SANITIZE)
 endif()
 
 # Set default blockchain storage location:
-# memory was the default in Cryptonote before monero implemented LMDB, it still works but is unnecessary.
+# memory was the default in Cryptonote before Monero implemented LMDB, it still works but is unnecessary.
 # set(DATABASE memory)
 set(DATABASE lmdb)
 

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -27,6 +27,10 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#ifdef _WIN32
+ #define __STDC_FORMAT_MACROS // NOTE(loki): Explicitly define the PRIu64 macro on Mingw
+#endif
+
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/archive/portable_binary_iarchive.hpp>

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -157,7 +157,6 @@ int main(int argc, char* argv[])
   BlockchainObjects *blockchain_objects = new BlockchainObjects();
   Blockchain *core_storage = &blockchain_objects->m_blockchain;
   BlockchainDB *db = new_db(db_type);
-
   if (db == NULL)
   {
     LOG_ERROR("Attempted to use non-existent database type: " << db_type);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -35,8 +35,8 @@ using namespace epee;
 #include <atomic>
 #include <boost/algorithm/string.hpp>
 #include "wipeable_string.h"
-#include "common/i18n.h"
 #include "string_tools.h"
+#include "common/i18n.h"
 #include "serialization/string.h"
 #include "cryptonote_format_utils.h"
 #include "cryptonote_config.h"

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -34,7 +34,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <vector>
-#include <boost/math/special_functions/round.hpp>
 
 #include "common/int-util.h"
 #include "common/round.h"

--- a/src/cryptonote_basic/difficulty.h
+++ b/src/cryptonote_basic/difficulty.h
@@ -52,6 +52,5 @@ namespace cryptonote
      * @return true if valid, else false
      */
     bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
-    difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
     difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -45,8 +45,6 @@
 #define CURRENT_TRANSACTION_VERSION                     3
 #define CURRENT_BLOCK_MAJOR_VERSION                     7
 #define CURRENT_BLOCK_MINOR_VERSION                     7
-#define CURRENT_BLOCK_MAJOR_VERSION_TESTNET             7
-#define CURRENT_BLOCK_MINOR_VERSION_TESTNET             7
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           60*10
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -237,7 +237,7 @@ bool Blockchain::scan_outputkeys_for_indexes(size_t tx_version, const txin_to_ke
   }
 
   size_t count = 0;
-    for (const uint64_t& i : absolute_offsets)
+  for (const uint64_t& i : absolute_offsets)
   {
     try
     {
@@ -1020,10 +1020,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   LOG_PRINT_L3("Blockchain::" << __func__);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> cumulative_difficulties;
-  uint8_t version = get_current_hard_fork_version();
-  size_t difficulty_blocks_count;
-
-  difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
+  size_t difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
 
   // if the alt chain isn't long enough to calculate the difficulty target
   // based on its blocks alone, need to get more blocks from the main chain
@@ -1081,7 +1078,6 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // calculate the difficulty target for the block and return it
   return next_difficulty_v2(timestamps, cumulative_difficulties, target);
 }
-
 //------------------------------------------------------------------
 // This function does a sanity check on basic things that all miner
 // transactions have in common, such as:
@@ -1284,7 +1280,6 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   b.major_version = m_hardfork->get_current_version();
   b.minor_version = m_hardfork->get_ideal_version();
   b.prev_id = get_tail_id();
-
   b.timestamp = time(NULL);
 
   uint64_t median_ts;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -81,7 +81,6 @@ namespace cryptonote
   class Blockchain
   {
   public:
-
     enum version
     {
       version_7 = 7,

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1004,6 +1004,7 @@ namespace cryptonote
     st_inf.top_block_id_str = epee::string_tools::pod_to_hex(m_blockchain_storage.get_tail_id());
     return true;
   }
+
   //-----------------------------------------------------------------------------------------------
   bool core::check_tx_semantic(const transaction& tx, bool keeped_by_block) const
   {
@@ -1279,7 +1280,6 @@ namespace cryptonote
       LOG_ERROR("Failed to parse relayed transaction");
       return;
     }
-
     txs.push_back(std::make_pair(tx_hash, std::move(tx_blob)));
     m_mempool.set_relayed(txs);
   }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -641,7 +641,7 @@ namespace cryptonote
     {
       std::string keystr;
       bool r = epee::file_io_utils::load_file_to_string(keypath, keystr);
-      memcpy(&unwrap(m_service_node_key), keystr.data(), sizeof(m_service_node_key));
+      memcpy(&unwrap(unwrap(m_service_node_key)), keystr.data(), sizeof(m_service_node_key));
       wipeable_string wipe(keystr);
       CHECK_AND_ASSERT_MES(r, false, "failed to load service node key from file");
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -594,7 +594,6 @@ namespace cryptonote
         hwdev.derivation_to_scalar(derivation, output_index, scalar1);
         amount_keys.push_back(rct::sk2rct(scalar1));
       }
-
       r = hwdev.derive_public_key(derivation, output_index, dst_entr.addr.m_spend_public_key, out_eph_public_key);
       CHECK_AND_ASSERT_MES(r, false, "at creation outs: failed to derive_public_key(" << derivation << ", " << output_index << ", "<< dst_entr.addr.m_spend_public_key << ")");
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -720,7 +720,6 @@ namespace cryptonote
       }
       return true;
     }, false);
-
     return true;
   }
   //---------------------------------------------------------------------------------
@@ -1149,7 +1148,6 @@ namespace cryptonote
         }
       }
     }
-
     //if we here, transaction seems valid, but, anyway, check for key_images collisions with blockchain, just to be sure
     if(m_blockchain.have_tx_keyimges_as_spent(lazy_tx()))
     {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -36,7 +36,7 @@
  */
 
 #ifdef _WIN32
- #define __STDC_FORMAT_MACROS
+ #define __STDC_FORMAT_MACROS // NOTE(loki): Explicitly define the PRIu64 macro on Mingw
 #endif
 
 #include <thread>

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -34,6 +34,11 @@
  * 
  * \brief Source file that defines simple_wallet class.
  */
+
+#ifdef _WIN32
+ #define __STDC_FORMAT_MACROS
+#endif
+
 #include <thread>
 #include <iostream>
 #include <sstream>
@@ -2283,10 +2288,6 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("bc_height",
                            boost::bind(&simple_wallet::show_blockchain_height, this, _1),
                            tr("Show the blockchain height."));
-  m_cmd_binder.set_handler("transfer_original",
-                           boost::bind(&simple_wallet::transfer, this, _1),
-                           tr("transfer_original [index=<N1>[,<N2>,...]] [<priority>] (<URI> | <address> <amount>) [<payment_id>]"),
-                           tr("Transfer <amount> to <address> using an older transaction building algorithm. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
   m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::transfer, this, _1),
                            tr("transfer [index=<N1>[,<N2>,...]] [<priority>] (<URI> | <address> <amount>) [<payment_id>]"),
                            tr("Transfer <amount> to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. Multiple payments can be made at once by adding <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -44,7 +44,6 @@
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
-#include "cryptonote_core/service_node_deregister.h"
 #include "net/http_client.h"
 #include "storages/http_abstract_invoke.h"
 #include "rpc/core_rpc_server_commands_defs.h"
@@ -241,6 +240,7 @@ namespace tools
       uint64_t unlock_time;
       bool error;
       boost::optional<cryptonote::subaddress_receive_info> received;
+
       tx_scan_info_t(): money_transfered(0), error(true) {}
     };
 
@@ -753,7 +753,6 @@ namespace tools
       std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs,
       uint64_t unlock_time, uint64_t fee, const std::vector<uint8_t>& extra, cryptonote::transaction& tx, pending_tx &ptx, rct::RangeProofType range_proof_type, bool is_staking_tx=false);
 
-    void commit_deregister_vote(loki::service_node_deregister::vote& vote);
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
     bool save_tx(const std::vector<pending_tx>& ptx_vector, const std::string &filename) const;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -79,7 +79,6 @@ namespace tools
     //         tx_not_possible
     //         not_enough_outs_to_mix
     //         tx_not_constructed
-    //         vote_rejected
     //         tx_rejected
     //         tx_sum_overflow
     //         tx_too_big
@@ -641,34 +640,6 @@ namespace tools
 
     private:
       cryptonote::transaction m_tx;
-      std::string m_status;
-      std::string m_reason;
-    };
-    //----------------------------------------------------------------------------------------------------
-    struct vote_rejected : public transfer_error
-    {
-      explicit vote_rejected(std::string&& loc, const std::string& status, const std::string& reason)
-        : transfer_error(std::move(loc), "vote was rejected by daemon")
-        , m_status(status)
-        , m_reason(reason)
-      {
-      }
-
-      const std::string& status() const { return m_status; }
-      const std::string& reason() const { return m_reason; }
-
-      std::string to_string() const
-      {
-        std::ostringstream ss;
-        ss << transfer_error::to_string() << ", status = " << m_status;
-        if (!m_reason.empty())
-        {
-          ss << " (" << m_reason << ")";
-        }
-        return ss.str();
-      }
-
-    private:
       std::string m_status;
       std::string m_reason;
     };


### PR DESCRIPTION
Explicitly defines PRIu64 macro using __STDC_FORMAT_MACROS on _WIN32 targets, otherwise doesn't compile on mingw. 

Whitespace changes and deleted code come in after I did a complete diff between Monero and Loki to clean up and sanity check the changes between our codebase and theirs, so some of the whitespace changes make the diffs less noisy.

Lastly, fix build warning on mingw now that a keys are wrapped in mlocked, so keys must be unwrapped twice, the service node key was not using this yet when I merged in mlocked changes.