### PR TITLE
Remove assert for service node paid and total

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -410,9 +410,6 @@ namespace cryptonote
     if (loki_context.snode_winner_info.empty()) result.service_node_paid = calculate_sum_of_portions(service_nodes::null_winner,     result.service_node_total);
     else                                        result.service_node_paid = calculate_sum_of_portions(loki_context.snode_winner_info, result.service_node_total);
 
-   // TODO(loki): Having the snode total and paid was probably just a sanity check? If so we can remove the field ..
-    assert(result.service_node_total == result.service_node_paid);
-
     result.adjusted_base_reward = result.original_base_reward;
     if (hard_fork_version >= network_version_10_bulletproofs)
     {

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -77,10 +77,6 @@ namespace cryptonote
 
   struct block_reward_parts
   {
-    // TODO(loki): There can be a difference between the total reward and the
-    // reward paid out to the service node? This would mean that a user can
-    // specify less portions but still contribute the full amount?
-    // Or was this just a sanity check? I don't think the first case is possible
     uint64_t service_node_total;
     uint64_t service_node_paid;
 


### PR DESCRIPTION
Looks like they can differ by small amounts due to divisibility it seems of different portion amounts that are not nicely divisible. Removing assert just returns the code back to the original functionality from before the governance change.

Checked and confirmed in integration tests.