### PR TITLE
In core_rpc_server don't cache nettype

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -76,18 +76,15 @@ public:
     protocol.set_p2p_endpoint(p2p.get());
     core.set_protocol(protocol.get());
 
-    const auto testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
-    const auto stagenet = command_line::get_arg(vm, cryptonote::arg_stagenet_on);
-    const auto regtest = command_line::get_arg(vm, cryptonote::arg_regtest_on);
     const auto restricted = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_restricted_rpc);
     const auto main_rpc_port = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_rpc_bind_port);
-    rpcs.emplace_back(new t_rpc{vm, core, p2p, restricted, testnet ? cryptonote::TESTNET : stagenet ? cryptonote::STAGENET : regtest ? cryptonote::FAKECHAIN : cryptonote::MAINNET, main_rpc_port, "core"});
+    rpcs.emplace_back(new t_rpc{vm, core, p2p, restricted, main_rpc_port, "core"});
 
     auto restricted_rpc_port_arg = cryptonote::core_rpc_server::arg_rpc_restricted_bind_port;
     if(!command_line::is_arg_defaulted(vm, restricted_rpc_port_arg))
     {
       auto restricted_rpc_port = command_line::get_arg(vm, restricted_rpc_port_arg);
-      rpcs.emplace_back(new t_rpc{vm, core, p2p, true, testnet ? cryptonote::TESTNET : stagenet ? cryptonote::STAGENET : cryptonote::MAINNET, restricted_rpc_port, "restricted"});
+      rpcs.emplace_back(new t_rpc{vm, core, p2p, true, restricted_rpc_port, "restricted"});
     }
   }
 };

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -55,7 +55,6 @@ public:
     , t_core & core
     , t_p2p & p2p
     , const bool restricted
-    , const cryptonote::network_type nettype
     , const std::string & port
     , const std::string & description
     )
@@ -63,7 +62,7 @@ public:
   {
     MGINFO("Initializing " << m_description << " RPC server...");
 
-    if (!m_server.init(vm, restricted, nettype, port))
+    if (!m_server.init(vm, restricted, port))
     {
       throw std::runtime_error("Failed to initialize " + m_description + " RPC server.");
     }

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -70,10 +70,10 @@ namespace cryptonote
     bool init(
         const boost::program_options::variables_map& vm,
         const bool restricted,
-        const network_type nettype,
         const std::string& port
       );
-    network_type nettype() const { return m_nettype; }
+
+    network_type nettype() const { return m_core.get_nettype(); }
 
     CHAIN_HTTP_TO_MAP2(connection_context); //forward http requests to uri map
 


### PR DESCRIPTION
Don't need to cache when we can get from core and in rare edge case of entering fakechain chain mode by specifying regtest causes this to go out of sync with core's nettype.