### PR TITLE
IPV6 constexpr build breakage

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -100,11 +100,11 @@ namespace net_utils
 
 		bool equal(const ipv6_network_address& other) const noexcept;
 		bool less(const ipv6_network_address& other) const noexcept;
-		constexpr bool is_same_host(const ipv6_network_address& other) const noexcept
+		bool is_same_host(const ipv6_network_address& other) const noexcept
 		{ return ip() == other.ip(); }
 
-		constexpr std::string ip() const noexcept { return m_ip; }
-		constexpr uint16_t port() const noexcept { return m_port; }
+		std::string ip() const noexcept { return m_ip; }
+		uint16_t port() const noexcept { return m_port; }
 		std::string str() const;
 		std::string host_str() const;
 		bool is_loopback() const;


### PR DESCRIPTION
I'm not extremely familiar with this and I don't know why this compiles locally with my build using GCC 7.3.0. CompileExplorer fails to build on 7.3.0 as well so _shrug_ something somewhere not compiling this.

But ipv6 class can't have constexpr functions because std::string's destructor is typically a deallocation which can't be done at compile time, i.e.

```
/builds/lokiproject/loki/contrib/epee/include/net/net_utils_base.h:103:18: error: enclosing class of constexpr non-static member function 'bool epee::net_utils::ipv6_network_address::is_same_host(const epee::net_utils::ipv6_network_address&) const' is not a literal type
   constexpr bool is_same_host(const ipv6_network_address& other) const noexcept
                  ^
/builds/lokiproject/loki/contrib/epee/include/net/net_utils_base.h:92:8: note: 'epee::net_utils::ipv6_network_address' is not literal because:
  class ipv6_network_address
        ^
/builds/lokiproject/loki/contrib/epee/include/net/net_utils_base.h:92:8: note:   'epee::net_utils::ipv6_network_address' has a non-trivial destructor
/builds/lokiproject/loki/contrib/epee/include/net/net_utils_base.h:106:25: error: enclosing class of constexpr non-static member function 'std::__cxx11::string epee::net_utils::ipv6_network_address::ip() const' is not a literal type
   constexpr std::string ip() const noexcept { return m_ip; }
```