### PR TITLE
Broken Fees Pre v10

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8553,7 +8553,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   uint64_t needed_fee, available_for_fee = 0;
   uint64_t upper_transaction_weight_limit = get_upper_transaction_weight_limit();
   const bool use_per_byte_fee = use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0);
-  const bool use_rct = use_fork_rules(4, 0);
+  const bool use_rct = true;
   const bool bulletproof = use_fork_rules(get_bulletproof_fork(), 0);
   const rct::RangeProofType range_proof_type = bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean;
 
@@ -8590,7 +8590,9 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // early out if we know we can't make it anyway
   // we could also check for being within FEE_PER_KB, but if the fee calculation
   // ever changes, this might be missed, so let this go through
-  const uint64_t min_fee = (fee_multiplier * base_fee * estimate_tx_size(use_rct, 1, fake_outs_count, 2, extra.size(), bulletproof));
+  uint64_t min_fee = (fee_multiplier * base_fee * estimate_tx_size(use_rct, 1, fake_outs_count, 2, extra.size(), bulletproof));
+  if (!use_per_byte_fee) min_fee /= 1024;
+
   uint64_t balance_subtotal = 0;
   uint64_t unlocked_balance_subtotal = 0;
   for (uint32_t index_minor : subaddr_indices)


### PR DESCRIPTION
I only had a cursory look at fixing this. I have a hunch that this is probably the necessary fix to get sensible fees again for pre v10 fork. @msgmaxim it appears this might be the culprit, https://github.com/monero-project/monero/pull/4702

Further look into it is warranted as to why this 1024 div is considered obsolete and removed. But, it produces sensible fees as I'd expect on a pre v10 chain. It's possible that the divide by 1024 was removed in Monero after their bulletproof fork- since they'd never need that divide again once they entered bulletproofs, and would be the first thing I'd investigate.