### PR TITLE
fix http connect address parsing

### DIFF
--- a/contrib/epee/include/net/net_parse_helpers.h
+++ b/contrib/epee/include/net/net_parse_helpers.h
@@ -172,7 +172,7 @@ namespace net_utils
 
     if (parse_url_ipv6(url_str, content)) return true;
 
-    STATIC_REGEXP_EXPR_1(rexp_match_uri, "^((.*?)://)?(([^/]*)(:(\\d+))?)(/?.*)?", boost::regex::icase | boost::regex::normal);
+    STATIC_REGEXP_EXPR_1(rexp_match_uri, "^((.*?)://)?(([^/:]*)(:(\\d+))?)(/?.*)?", boost::regex::icase | boost::regex::normal);
     //                                     12         34       5 6       7
 
     content.port = 0;


### PR DESCRIPTION
Modified the address parsing to work with IPv6 and inadvertently
messed up parsing IPv4 addresses a bit -- this should fix it.