### PR TITLE
Core Tests TX Builder Regression

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -973,9 +973,13 @@ namespace cryptonote
       const size_t weight = get_transaction_weight(results[i].tx, it->size());
       ok &= add_new_tx(results[i].tx, results[i].hash, results[i].prefix_hash, weight, tvc[i], keeped_by_block, relayed, do_not_relay);
       if(tvc[i].m_verifivation_failed)
-      {MERROR_VER("Transaction verification failed: " << results[i].hash);}
+      {
+        MERROR_VER("Transaction verification failed: " << results[i].hash);
+      }
       else if(tvc[i].m_verifivation_impossible)
-      {MERROR_VER("Transaction verification impossible: " << results[i].hash);}
+      {
+        MERROR_VER("Transaction verification impossible: " << results[i].hash);
+      }
 
       if(tvc[i].m_added_to_pool)
         MDEBUG("tx added: " << results[i].hash);

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -334,7 +334,7 @@ bool gen_block_miner_tx_has_2_in::generate(std::vector<test_event_entry>& events
 
   transaction tmp_tx;
 
-  if (!TxBuilder(events, tmp_tx, blk_0r, miner_account, miner_account, blk_0.miner_tx.vout[0].amount).build())
+  if (!TxBuilder(events, tmp_tx, blk_0r, miner_account, miner_account, blk_0.miner_tx.vout[0].amount, cryptonote::network_version_7).build())
     return false;
 
   MAKE_MINER_TX_MANUALLY(miner_tx, blk_0r);
@@ -361,7 +361,7 @@ bool gen_block_miner_tx_with_txin_to_key::generate(std::vector<test_event_entry>
   REWIND_BLOCKS(events, blk_1r, blk_1, miner_account);
 
   transaction tmp_tx;
-  if (!TxBuilder(events, tmp_tx, blk_1r, miner_account, miner_account, blk_1.miner_tx.vout[0].amount).build())
+  if (!TxBuilder(events, tmp_tx, blk_1r, miner_account, miner_account, blk_1.miner_tx.vout[0].amount, cryptonote::network_version_7).build())
     return false;
 
   MAKE_MINER_TX_MANUALLY(miner_tx, blk_1);

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -1110,7 +1110,7 @@ transaction construct_tx_with_fee(std::vector<test_event_entry>& events, const b
                                   const account_base& acc_from, const account_base& acc_to, uint64_t amount, uint64_t fee)
 {
   transaction tx;
-  TxBuilder(events, tx, blk_head, acc_from, acc_to, amount).with_fee(fee).build();
+  TxBuilder(events, tx, blk_head, acc_from, acc_to, amount, cryptonote::network_version_7).with_fee(fee).build();
   events.push_back(tx);
   return tx;
 }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -454,7 +454,7 @@ public:
             const cryptonote::account_base& from,
             const cryptonote::account_base& to,
             uint64_t amount,
-            uint8_t hf_version = cryptonote::network_version_9_service_nodes)
+            uint8_t hf_version)
     : m_events(events)
     , m_tx(tx)
     , m_head(head)
@@ -948,9 +948,10 @@ cryptonote::transaction make_deregistration_tx(const std::vector<test_event_entr
                                                const cryptonote::block& head,
                                                const cryptonote::tx_extra_service_node_deregister& deregister, uint8_t hf_version, uint64_t fee);
 
+// NOTE(loki): These macros assume hardfork version 7 and are from the old Monero testing code
 #define MAKE_TX_MIX(VEC_EVENTS, TX_NAME, FROM, TO, AMOUNT, NMIX, HEAD)                       \
   cryptonote::transaction TX_NAME;                                                           \
-  TxBuilder(VEC_EVENTS, TX_NAME, HEAD, FROM, TO, AMOUNT).build();                            \
+  TxBuilder(VEC_EVENTS, TX_NAME, HEAD, FROM, TO, AMOUNT, cryptonote::network_version_7).build();                            \
   VEC_EVENTS.push_back(TX_NAME);
 
 #define MAKE_TX(VEC_EVENTS, TX_NAME, FROM, TO, AMOUNT, HEAD) MAKE_TX_MIX(VEC_EVENTS, TX_NAME, FROM, TO, AMOUNT, 9, HEAD)
@@ -958,7 +959,7 @@ cryptonote::transaction make_deregistration_tx(const std::vector<test_event_entr
 #define MAKE_TX_MIX_LIST(VEC_EVENTS, SET_NAME, FROM, TO, AMOUNT, NMIX, HEAD)             \
   {                                                                                      \
     cryptonote::transaction t;                                                             \
-    TxBuilder(VEC_EVENTS, t, HEAD, FROM, TO, AMOUNT).build();                            \
+    TxBuilder(VEC_EVENTS, t, HEAD, FROM, TO, AMOUNT, cryptonote::network_version_7).build(); \
     SET_NAME.push_back(t);                                                               \
     VEC_EVENTS.push_back(t);                                                             \
   }

--- a/tests/core_tests/chaingen001.cpp
+++ b/tests/core_tests/chaingen001.cpp
@@ -103,16 +103,16 @@ gen_simple_chain_001::gen_simple_chain_001()
   REGISTER_CALLBACK("verify_callback_2", gen_simple_chain_001::verify_callback_2);
 }
 
-void make_rct_tx(eventV& events,
-                 std::vector<cryptonote::transaction>& txs,
-                 const cryptonote::block& blk_head,
-                 const cryptonote::account_base& from,
-                 const cryptonote::account_base& to,
-                 uint64_t amount)
+static void make_rct_tx(eventV& events,
+                        std::vector<cryptonote::transaction>& txs,
+                        const cryptonote::block& blk_head,
+                        const cryptonote::account_base& from,
+                        const cryptonote::account_base& to,
+                        uint64_t amount)
 {
     txs.emplace_back();
 
-    bool success = TxBuilder(events, txs.back(), blk_head, from, to, amount).build();
+    bool success = TxBuilder(events, txs.back(), blk_head, from, to, amount, cryptonote::network_version_7).build();
     /// TODO: beter error message
     if (!success) throw std::exception();
     events.push_back(txs.back());


### PR DESCRIPTION
Default value of cryptonote::network_version_9 causing tests working with pre hardfork 9 to generate invalid transactions.