### PR TITLE
allow less than 25% staking with large existing contributions

### DIFF
--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -103,8 +103,6 @@ namespace service_nodes
     cryptonote::account_public_address operator_address;
 
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
-    // the minimum contribution to start a new contributor
-    uint64_t get_min_contribution() const;
 
     service_node_info() = default;
 

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -32,17 +32,41 @@ uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement)
     return resultlo;
 }
 
-bool check_service_node_portions(const std::vector<uint64_t>& portions)
+bool check_service_node_portions(uint8_t hf_version, const std::vector<uint64_t>& portions)
 {
-    uint64_t portions_left = STAKING_PORTIONS;
+    if (portions.size() > MAX_NUMBER_OF_CONTRIBUTORS) return false;
 
-    for (const auto portion : portions) {
-        const uint64_t min_portions = std::min(portions_left, MIN_PORTIONS);
-        if (portion < min_portions || portion > portions_left) return false;
-        portions_left -= portion;
+    uint64_t reserved = 0;
+    for (auto i = 0u; i < portions.size(); ++i) {
+        const uint64_t min_portions = get_min_node_contribution(hf_version, STAKING_PORTIONS, reserved, i);
+        if (portions[i] < min_portions) return false;
+        reserved += portions[i];
     }
 
-    return true;
+    return reserved <= STAKING_PORTIONS;
+}
+
+
+static uint64_t get_min_node_contribution_pre_v11(uint64_t staking_requirement, uint64_t total_reserved)
+{
+    return std::min(staking_requirement - total_reserved, staking_requirement / MAX_NUMBER_OF_CONTRIBUTORS);
+}
+
+uint64_t get_min_node_contribution(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t contrib_count)
+{
+    if (version < cryptonote::network_version_11_swarms) {
+        return get_min_node_contribution_pre_v11(staking_requirement, total_reserved);
+    }
+
+    const uint64_t needed = staking_requirement - total_reserved;
+    const size_t vacant = MAX_NUMBER_OF_CONTRIBUTORS - contrib_count;
+
+    /// This function is not called when the node is full, but if
+    /// it does in the future, at least we don't cause undefined behaviour
+    if (vacant == 0) return 0;
+    assert(vacant > 0); /// sanity, should never happen
+
+    return std::min(needed, needed / vacant);
 }
 
 }

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -15,16 +15,14 @@ switch(nettype) {
 }
 }
 
-inline uint64_t get_min_node_contribution(uint64_t staking_requirement, uint64_t total_reserved)
-{
-  return std::min(staking_requirement - total_reserved, staking_requirement / MAX_NUMBER_OF_CONTRIBUTORS);
-}
+uint64_t get_min_node_contribution(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t contrib_count);
 
 uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height);
 
 uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
 
-/// Check if portions are sufficiently large (except for the last) and add up to the required amount
-bool check_service_node_portions(const std::vector<uint64_t>& portions);
+/// Check if portions are sufficiently large (provided the contributions
+/// are made in the specified order) and add up to the required amount
+bool check_service_node_portions(uint8_t version, const std::vector<uint64_t>& portions);
 
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5664,16 +5664,7 @@ bool simple_wallet::stake_main(
       return true;
   }
 
-  // sanity check address is not subaddress incase this gets called somewhere else that assumes it can be
-  if (parse_info.is_subaddress)
-  {
-    fail_msg_writer() << tr("Cannot stake from a subaddress");
-    return false;
-  }
-
   m_wallet->refresh(false);
-  uint64_t staking_requirement_lock_blocks = service_nodes::get_staking_requirement_lock_blocks(m_wallet->nettype());
-  uint64_t locked_blocks = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
 
   time_t begin_construct_time = time(nullptr);
   std::string err, err2;
@@ -5714,97 +5705,19 @@ bool simple_wallet::stake_main(
     }
   }
 
+  uint64_t staking_requirement_lock_blocks = service_nodes::get_staking_requirement_lock_blocks(m_wallet->nettype());
+  uint64_t locked_blocks = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
   uint64_t unlock_block = bc_height + locked_blocks;
 
-  // Check if client can stake into this service node, if so, how much.
-  try
-  {
-    const auto& response = m_wallet->get_service_nodes({ epee::string_tools::pod_to_hex(service_node_key) });
-    if (response.service_node_states.size() != 1)
-    {
-      fail_msg_writer() << tr("Could not find service node in service node list, please make sure it is registered first.");
+  /// Can this really throw?
+  try {
+    const tools::stake_check_result res = m_wallet->check_stake_allowed(service_node_key, parse_info, amount, amount_fraction);
+    if (res == tools::stake_check_result::try_later) {
       return true;
+    } else if (res == tools::stake_check_result::not_allowed) {
+      return false;
     }
-
-    const auto& snode_info = response.service_node_states.front();
-    const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
-
-    if (amount == 0)
-      amount = snode_info.staking_requirement * amount_fraction;
-
-    const bool full = snode_info.contributors.size() >= MAX_NUMBER_OF_CONTRIBUTORS;
-    uint64_t can_contrib_total = 0;
-    uint64_t must_contrib_total = 0;
-    if (!full)
-    {
-      can_contrib_total = snode_info.staking_requirement - snode_info.total_reserved;
-      must_contrib_total = service_nodes::get_min_node_contribution(snode_info.staking_requirement, snode_info.total_reserved);
-    }
-
-    bool is_preexisting_contributor = false;
-    for (const auto& contributor : snode_info.contributors)
-    {
-      address_parse_info info;
-      if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), contributor.address))
-        info.address = service_nodes::null_address;
-
-      if (info.address == parse_info.address)
-      {
-        uint64_t max_increase_reserve = snode_info.staking_requirement - snode_info.total_reserved;
-        uint64_t max_increase_amount_to = contributor.reserved + max_increase_reserve;
-        can_contrib_total = max_increase_amount_to - contributor.amount;
-        must_contrib_total = contributor.reserved - contributor.amount;
-        is_preexisting_contributor = true;
-      }
-    }
-
-    if (full && !is_preexisting_contributor)
-    {
-      fail_msg_writer() << tr("This service node already has the maximum number of participants, and the specified address is not one of them");
-      return true;
-    }
-
-    if (can_contrib_total == 0)
-    {
-      if (!autostake)
-        fail_msg_writer() << tr("You may not contribute any more to this service node");
-      return true;
-    }
-    if (amount > can_contrib_total)
-    {
-      success_msg_writer() << tr("You may only contribute up to ") << print_money(can_contrib_total) << tr(" more loki to this service node");
-      success_msg_writer() << tr("Reducing your stake from ") << print_money(amount) << tr(" to ") << print_money(can_contrib_total);
-      amount = can_contrib_total;
-    }
-    if (amount < must_contrib_total)
-    {
-      if (is_preexisting_contributor)
-          success_msg_writer() << tr("Warning: You must contribute ") << print_money(must_contrib_total) << tr(" loki to meet your registration requirements for this service node");
-
-      if (amount == 0)
-      {
-        amount = must_contrib_total;
-      }
-      else
-      {
-        success_msg_writer() << tr("You have only specified ") << print_money(amount);
-        if (must_contrib_total - amount <= DUST)
-        {
-          amount = must_contrib_total;
-          success_msg_writer() << tr("Seeing as this is insufficient by dust amounts, amount was increased automatically to ") << print_money(must_contrib_total);
-        }
-        else if (!is_preexisting_contributor || autostake)
-        {
-          if (!is_preexisting_contributor)
-            fail_msg_writer() << tr("You must contribute atleast ") << print_money(must_contrib_total) << tr(" loki to become a contributor for this service node");
-
-          return true;
-        }
-      }
-    }
-  }
-  catch(const std::exception &e)
-  {
+  } catch (const std::exception& e) {
     fail_msg_writer() << e.what();
     return true;
   }
@@ -6051,18 +5964,6 @@ bool simple_wallet::stake(const std::vector<std::string> &args_)
     fail_msg_writer() << tr("Service nodes do not support rewards to subaddresses, cannot stake for address: ")
                       << local_args[1]
                       << tr("Please use index=[...] if you want to stake funds from particular subaddresses.");
-    return true;
-  }
-
-  if (info.has_payment_id)
-  {
-    fail_msg_writer() << tr("Do not use payment ids for staking");
-    return true;
-  }
-
-  if (!m_wallet->contains_address(info.address))
-  {
-    fail_msg_writer() << tr("The specified address is not owned by this wallet.");
     return true;
   }
 

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -154,6 +154,21 @@ boost::optional<std::string> NodeRPCProxy::get_earliest_height(uint8_t version, 
   return boost::optional<std::string>();
 }
 
+boost::optional<uint8_t> NodeRPCProxy::get_network_version() const
+{
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req = AUTO_VAL_INIT(req);
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::response resp = AUTO_VAL_INIT(resp);
+
+  m_daemon_rpc_mutex.lock();
+  bool r = net_utils::invoke_http_json_rpc("/json_rpc", "hard_fork_info", req, resp, m_http_client, rpc_timeout);
+  m_daemon_rpc_mutex.unlock();
+  CHECK_AND_ASSERT_MES(r, {}, "Failed to connect to daemon");
+  CHECK_AND_ASSERT_MES(resp.status != CORE_RPC_STATUS_BUSY, {}, "Failed to connect to daemon");
+  CHECK_AND_ASSERT_MES(resp.status == CORE_RPC_STATUS_OK, {}, "Failed to get hard fork status");
+
+  return resp.version;
+}
+
 boost::optional<std::string> NodeRPCProxy::get_dynamic_base_fee_estimate(uint64_t grace_blocks, uint64_t &fee) const
 {
   uint64_t height;

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -51,6 +51,7 @@ public:
   boost::optional<std::string> get_earliest_height(uint8_t version, uint64_t &earliest_height) const;
   boost::optional<std::string> get_dynamic_base_fee_estimate(uint64_t grace_blocks, uint64_t &fee) const;
   boost::optional<std::string> get_fee_quantization_mask(uint64_t &fee_quantization_mask) const;
+  boost::optional<uint8_t> get_network_version() const;
 
 private:
   boost::optional<std::string> get_info() const;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -63,6 +63,7 @@ using namespace epee;
 #include "common/i18n.h"
 #include "common/util.h"
 #include "common/apply_permutation.h"
+#include "common/scoped_message_writer.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
@@ -6587,41 +6588,54 @@ bool wallet2::is_output_blackballed(const std::pair<uint64_t, uint64_t> &output)
   catch (const std::exception &e) { return false; }
 }
 
-bool wallet2::check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount) {
+
+stake_check_result wallet2::check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction) {
 
   if (addr_info.has_payment_id) {
-    LOG_ERROR("Do not use payment ids for staking.");
-    return false;
+    fail_msg_writer() << tr("Do not use payment ids for staking.");
+    return stake_check_result::not_allowed;
   }
 
   if (!this->contains_address(addr_info.address)) {
-    LOG_ERROR("The specified address is not owned by this wallet.");
-    return false;
+    fail_msg_writer() << tr("The specified address is not owned by this wallet.");
+    return stake_check_result::not_allowed;
   }
 
   if (addr_info.is_subaddress)
   {
-    LOG_ERROR("Service nodes do not support subaddresses.");
-    return false;
+    fail_msg_writer() << tr("Service nodes do not support subaddresses.");
+    return stake_check_result::not_allowed;
   }
 
   /// check that the service node is registered
   const auto& response = this->get_service_nodes({ epee::string_tools::pod_to_hex(sn_key) });
   if (response.service_node_states.size() != 1)
   {
-    LOG_ERROR("Could not find service node in service node list, please make sure it is registered first.");
-    return false;
+    fail_msg_writer() << tr("Could not find service node in service node list, please make sure it is registered first.");
+    return stake_check_result::try_later;
   }
 
   const auto& snode_info = response.service_node_states.front();
+
+  if (amount == 0)
+      amount = snode_info.staking_requirement * fraction;
 
   const bool full = snode_info.contributors.size() >= MAX_NUMBER_OF_CONTRIBUTORS;
 
   /// maximum to contribute (unless we have some amount reserved for us)
   uint64_t max_contrib_total = snode_info.staking_requirement - snode_info.total_reserved;
 
-  /// decrease if some reserved for us
-  uint64_t min_contrib_total = service_nodes::get_min_node_contribution(snode_info.staking_requirement, snode_info.total_reserved);
+  uint64_t expected_to_contrib = 0;
+
+  if (max_contrib_total == 0) {
+    fail_msg_writer() << tr("You may not contribute any more loki to this service node");
+    return stake_check_result::not_allowed;
+  }
+
+  const boost::optional<uint8_t> res = m_node_rpc_proxy.get_network_version();
+  /// Use stricter rules when not sure what version we are on
+  const uint8_t hf_version = res ? *res : cryptonote::network_version_9_service_nodes;
+  uint64_t min_contrib_total = service_nodes::get_min_node_contribution(hf_version, snode_info.staking_requirement, snode_info.total_reserved, snode_info.contributors.size());
 
   bool is_preexisting_contributor = false;
   for (const auto& contributor : snode_info.contributors)
@@ -6634,6 +6648,7 @@ bool wallet2::check_stake_allowed(const crypto::public_key& sn_key, const crypto
     {
       /// reserved for us, so we can contribute some more
       max_contrib_total += contributor.reserved - contributor.amount;
+      expected_to_contrib += contributor.reserved - contributor.amount;
       /// in this case we can contribute as little as we want
       min_contrib_total = 0;
       is_preexisting_contributor = true;
@@ -6642,31 +6657,45 @@ bool wallet2::check_stake_allowed(const crypto::public_key& sn_key, const crypto
 
   /// a. Check if there is room for us
   if (full && !is_preexisting_contributor) {
-      LOG_ERROR("The service node is full.");
-      return false;
+      fail_msg_writer() << tr("This service node already has the maximum number of participants, and the specified address is not one of them.");
+      return stake_check_result::not_allowed;
   }
 
   /// b. Check if the amount is too small
   if (amount < min_contrib_total) {
-      LOG_ERROR("You must contribute at least " << print_money(min_contrib_total) << " loki to become a contributor for this service node.");
-      return false;
+
+      const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
+      if (min_contrib_total - amount <= DUST) {
+          amount = min_contrib_total;
+          success_msg_writer() << tr("Seeing as this is insufficient by dust amounts, amount was increased automatically to ") << print_money(min_contrib_total);
+      } else {
+          fail_msg_writer() << tr("You must contribute at least ") << print_money(min_contrib_total) << tr(" loki to become a contributor for this service node.");
+          return stake_check_result::try_later;
+      }
+
   }
 
   /// c. Check if the amount is too big
   if (amount > max_contrib_total)
   {
-    LOG_ERROR("You may only contribute up to ") << print_money(max_contrib_total) << tr(" more loki to this service node") << std::endl;
-    LOG_ERROR("Reducing your stake from ") << print_money(amount) << tr(" to ") << print_money(max_contrib_total) << std::endl;
+    success_msg_writer() << tr("You may only contribute up to ") << print_money(max_contrib_total) << tr(" more loki to this service node.") << std::endl;
+    success_msg_writer() << tr("Reducing your stake from ") << print_money(amount) << tr(" to ") << print_money(max_contrib_total) << std::endl;
     amount = max_contrib_total;
   }
 
-  return true;
+  /// Issue a warning if there is more loki reserved from this contributor
+  if (amount < expected_to_contrib) {
+    success_msg_writer() << tr("Warning: You must contribute ") << print_money(expected_to_contrib)
+                         << tr(" loki to meet your registration requirements for this service node");
+  }
+
+  return stake_check_result::allowed;
 }
 
 std::vector<wallet2::pending_tx> wallet2::create_stake_tx(const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount)
 {
   /// check stake parameters (this might adjust the amount)
-  if (!check_stake_allowed(service_node_key, addr_info, amount)) {
+  if (check_stake_allowed(service_node_key, addr_info, amount) != stake_check_result::allowed) {
     LOG_ERROR("Invalid stake parameters");
     return {};
   }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -187,6 +187,8 @@ namespace tools
     std::deque<crypto::hash> m_blockchain;
   };
 
+  enum class stake_check_result { allowed, not_allowed, try_later };
+
   class wallet_keys_unlocker;
   class wallet2
   {
@@ -1235,8 +1237,9 @@ namespace tools
     bool unblackball_output(const std::pair<uint64_t, uint64_t> &output);
     bool is_output_blackballed(const std::pair<uint64_t, uint64_t> &output) const;
 
-    /// Note that the amount will be modified to maximum possible if too large
-    bool check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount);
+    /// Checks arguments for staking. Modifies the amount to maximum possible if too large,
+    /// but rejects if insufficient. `fraction` is only used to determine the amount if specified zero. 
+    stake_check_result check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction = 0);
 
     std::vector<wallet2::pending_tx> create_stake_tx(const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount);
 

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -327,27 +327,30 @@ TEST(service_nodes, tx_extra_deregister_validation)
 
 TEST(service_nodes, min_portions)
 {
+
+  uint8_t hf_version = cryptonote::network_version_9_service_nodes;
   // Test new contributors can *NOT* stake to a registration with under 25% of the total stake if there is more than 25% available.
   {
-    ASSERT_FALSE(service_nodes::check_service_node_portions({0, STAKING_PORTIONS}));
+    ASSERT_FALSE(service_nodes::check_service_node_portions(hf_version, {0, STAKING_PORTIONS}));
   }
 
   {
     const auto small = MIN_PORTIONS - 1;
     const auto rest = STAKING_PORTIONS - small;
-    ASSERT_FALSE(service_nodes::check_service_node_portions({small, rest}));
+    ASSERT_FALSE(service_nodes::check_service_node_portions(hf_version, {small, rest}));
   }
 
   {
+    /// TODO: fix this test
     const auto small = MIN_PORTIONS - 1;
     const auto rest = STAKING_PORTIONS - small - STAKING_PORTIONS / 2;
-    ASSERT_FALSE(service_nodes::check_service_node_portions({STAKING_PORTIONS / 2, small, rest}));
+    ASSERT_FALSE(service_nodes::check_service_node_portions(hf_version, {STAKING_PORTIONS / 2, small, rest}));
   }
 
   {
     const auto small = MIN_PORTIONS - 1;
     const auto rest = STAKING_PORTIONS - small - 2 * MIN_PORTIONS;
-    ASSERT_FALSE(service_nodes::check_service_node_portions({MIN_PORTIONS, MIN_PORTIONS, small, rest}));
+    ASSERT_FALSE(service_nodes::check_service_node_portions(hf_version, {MIN_PORTIONS, MIN_PORTIONS, small, rest}));
   }
 
   // Test new contributors *CAN* stake as the last person with under 25% if there is less than 25% available.
@@ -356,7 +359,7 @@ TEST(service_nodes, min_portions)
   {
     const auto large = 4 * (STAKING_PORTIONS / 5);
     const auto rest = STAKING_PORTIONS - large;
-    bool result = service_nodes::check_service_node_portions({large, rest});
+    bool result = service_nodes::check_service_node_portions(hf_version, {large, rest});
     ASSERT_TRUE(result);
   }
 
@@ -364,7 +367,7 @@ TEST(service_nodes, min_portions)
   {
     const auto half = STAKING_PORTIONS / 2 - 1;
     const auto rest = STAKING_PORTIONS - 2 * half;
-    bool result = service_nodes::check_service_node_portions({half, half, rest});
+    bool result = service_nodes::check_service_node_portions(hf_version, {half, half, rest});
     ASSERT_TRUE(result);
   }
 
@@ -372,8 +375,61 @@ TEST(service_nodes, min_portions)
   {
     const auto third = STAKING_PORTIONS / 3 - 1;
     const auto rest = STAKING_PORTIONS - 3 * third;
-    bool result = service_nodes::check_service_node_portions({third, third, third, rest});
+    bool result = service_nodes::check_service_node_portions(hf_version, {third, third, third, rest});
     ASSERT_TRUE(result);
+  }
+
+  // ===== After hard fork v11 =====
+  hf_version = cryptonote::network_version_11_swarms;
+
+  // Allow less than 25% stake in the presence of large existing contributions
+  {
+    const auto large = STAKING_PORTIONS / 2;
+    const auto small_1 = STAKING_PORTIONS / 6;
+    const auto small_2 = STAKING_PORTIONS / 6;
+    const auto rest = STAKING_PORTIONS - large - small_1 - small_2;
+    bool result = service_nodes::check_service_node_portions(hf_version, {large, small_1, small_2, rest});
+    ASSERT_TRUE(result);
+  }
+
+}
+
+
+// Test minimum stake contributions (should test pre and post this change)
+TEST(service_nodes, min_stake_amount)
+{
+  uint64_t height = 101250;
+  const uint64_t stake_requirement = service_nodes::get_staking_requirement(cryptonote::MAINNET, height);
+
+  /// pre v11
+  uint8_t hf_version = cryptonote::network_version_9_service_nodes;
+
+  {
+    const uint64_t reserved = stake_requirement / 2;
+    const uint64_t min_stake = service_nodes::get_min_node_contribution(hf_version, stake_requirement, reserved, 1);
+    ASSERT_EQ(min_stake, stake_requirement / 4);
+  }
+
+  {
+    const uint64_t reserved = 5 * stake_requirement / 6;
+    const uint64_t min_stake = service_nodes::get_min_node_contribution(hf_version, stake_requirement, reserved, 5);
+    ASSERT_EQ(min_stake, stake_requirement / 6);
+  }
+
+  /// post v11
+  hf_version = cryptonote::network_version_11_swarms;
+  {
+    /// Should be able to contribute roughly one sixth of the total requirement, but not less
+    const uint64_t reserved = stake_requirement / 2;
+    const uint64_t min_stake = service_nodes::get_min_node_contribution(hf_version, stake_requirement, reserved, 1);
+    ASSERT_EQ(min_stake, stake_requirement / 6);
+  }
+
+  {
+    /// Cannot contribute less than 25% under normal circumstances
+    const uint64_t reserved = stake_requirement / 4;
+    const uint64_t min_stake = service_nodes::get_min_node_contribution(hf_version, stake_requirement, reserved, 1);
+    ASSERT_FALSE(min_stake <= stake_requirement / 6);
   }
 
 }


### PR DESCRIPTION
- relaxed rules for staking
- checking portions now uses the same code/rules as checking contributions
- cli now uses the same code as the GUI wallet to check staking rules (`wallet2::check_stake_allowed`)
- added some unit tests to accommodate new rules