### PR TITLE
Add fixes for compile errors raised on the Android Wallet

### DIFF
--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -250,8 +250,6 @@ namespace cryptonote
     uint8_t default_threshold_percent;
 
     uint8_t original_version;
-    uint64_t original_version_till_height;
-
     std::vector<Params> heights;
 
     std::deque<uint8_t> versions; /* rolling window of the last N blocks' versions */

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -96,7 +96,7 @@ static reward_type from_pay_type(tools::pay_type ptype) {
     switch (ptype) {
         case tools::pay_type::service_node: return reward_type::service_node;
         case tools::pay_type::miner: return reward_type::miner;
-        default: reward_type::unspecified;
+        default: return reward_type::unspecified;
     }
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1675,7 +1675,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
           auto iter = std::find_if(
               tx_money_got_in_outs.begin(),
               tx_money_got_in_outs.end(),
-              [&tx_scan_info,&tx,&o](const tx_money_got_in_out& value)
+              [&tx_scan_info,&o](const tx_money_got_in_out& value)
               {
                 return value.index == tx_scan_info[o].received->index &&
                   value.amount == tx_scan_info[o].amount &&


### PR DESCRIPTION
- No return value in default case
- Unused lambda capture tx
- Unused private member variable