### PR TITLE
Add an rpc call for getting batched quorum states

### DIFF
--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -55,6 +55,7 @@ namespace loki
   {
     const uint64_t VOTE_LIFETIME_BY_HEIGHT       = (60 * 60 * 2) / DIFFICULTY_TARGET_V2;
     const uint64_t DEREGISTER_LIFETIME_BY_HEIGHT = VOTE_LIFETIME_BY_HEIGHT;
+    const size_t    QUORUM_LIFETIME         = (6 * loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT);
 
     struct vote
     {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -153,16 +153,12 @@ namespace service_nodes
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
     const auto &it = m_quorum_states.find(height);
-    if (it == m_quorum_states.end())
-    {
-      // TODO(loki): Not being able to find the quorum is going to be a fatal error.
-    }
-    else
+    if (it != m_quorum_states.end())
     {
       return it->second;
     }
 
-    return std::make_shared<quorum_state>();
+    return nullptr;
   }
 
   std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
@@ -853,7 +849,8 @@ namespace service_nodes
       update_swarms(block_height);
     }
 
-    const size_t QUORUM_LIFETIME         = (6 * loki::service_node_deregister::DEREGISTER_LIFETIME_BY_HEIGHT);
+    const size_t QUORUM_LIFETIME = loki::service_node_deregister::QUORUM_LIFETIME;
+
     // save six times the quorum lifetime, to be sure. also to help with debugging.
     const size_t cache_state_from_height = (block_height < QUORUM_LIFETIME) ? 0 : block_height - QUORUM_LIFETIME;
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2323,6 +2323,13 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp)
+  {
+    auto req_all = req;
+    req_all.service_node_pubkeys.clear();
+    return on_get_service_nodes(req_all, res, error_resp);
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp)
   {
     PERF_TIMER(on_get_staking_requirement);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2040,6 +2040,62 @@ namespace cryptonote
     return r;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_quorum_state_batched(const COMMAND_RPC_GET_QUORUM_STATE_BATCHED::request& req, COMMAND_RPC_GET_QUORUM_STATE_BATCHED::response& res, epee::json_rpc::error& error_resp)
+  {
+    PERF_TIMER(on_get_quorum_state_batched);
+
+    const uint64_t cur_height = m_core.get_current_blockchain_height();
+
+    const uint64_t height_begin = std::max(req.height_begin, cur_height - loki::service_node_deregister::QUORUM_LIFETIME);
+    const uint64_t height_end = std::min(req.height_end, cur_height);
+
+    if (height_begin > height_end)
+    {
+      error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+      error_resp.message = "height_end cannot be smaller than height_begin";
+      return true;
+    }
+
+    boost::optional<uint64_t> failed_height = boost::none;
+
+    res.quorum_entries.reserve(height_end - height_begin + 1);
+    for (auto h = height_begin; h <= height_end; ++h)
+    {
+      const auto quorum_state = m_core.get_quorum_state(h);
+
+      if (!quorum_state) {
+        failed_height = h;
+        break;
+      }
+
+      res.quorum_entries.push_back({});
+
+      auto &entry = res.quorum_entries.back();
+
+      entry.height = h;
+      entry.quorum_nodes.reserve(quorum_state->quorum_nodes.size());
+      entry.nodes_to_test.reserve(quorum_state->nodes_to_test.size());
+
+      for (const auto &key : quorum_state->quorum_nodes)
+        entry.quorum_nodes.push_back(epee::string_tools::pod_to_hex(key));
+
+      for (const auto &key : quorum_state->nodes_to_test)
+        entry.nodes_to_test.push_back(epee::string_tools::pod_to_hex(key));
+
+    }
+
+    if (failed_height) {
+      error_resp.code     = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+      error_resp.message  = "Block height: ";
+      error_resp.message += std::to_string(*failed_height);
+      error_resp.message += ", returned null hash or failed to derive quorum list";
+    } else {
+      res.status = CORE_RPC_STATUS_OK;
+    }
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp)
   {
     PERF_TIMER(on_get_service_node_key);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -153,6 +153,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_txpool_backlog",     on_get_txpool_backlog,         COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG)
         MAP_JON_RPC_WE("get_output_distribution", on_get_output_distribution, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
         MAP_JON_RPC_WE("get_quorum_state",        on_get_quorum_state,     COMMAND_RPC_GET_QUORUM_STATE)
+        MAP_JON_RPC_WE("get_quorum_state_batched", on_get_quorum_state_batched, COMMAND_RPC_GET_QUORUM_STATE_BATCHED)
         MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
         MAP_JON_RPC_WE("get_service_node_key",   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY)
         MAP_JON_RPC_WE("get_service_nodes", on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
@@ -220,6 +221,7 @@ namespace cryptonote
     bool on_get_txpool_backlog(const COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response& res, epee::json_rpc::error& error_resp);
     bool on_get_output_distribution(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, epee::json_rpc::error& error_resp);
     bool on_get_quorum_state(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_quorum_state_batched(const COMMAND_RPC_GET_QUORUM_STATE_BATCHED::request& req, COMMAND_RPC_GET_QUORUM_STATE_BATCHED::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -157,6 +157,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
         MAP_JON_RPC_WE("get_service_node_key",   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY)
         MAP_JON_RPC_WE("get_service_nodes", on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
+        MAP_JON_RPC_WE("get_all_service_nodes", on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_staking_requirement", on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
@@ -225,6 +226,7 @@ namespace cryptonote
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp);
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp);
     //-----------------------
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2307,6 +2307,46 @@ namespace cryptonote
     };
   };
 
+  struct COMMAND_RPC_GET_QUORUM_STATE_BATCHED
+  {
+    struct request
+    {
+      /// both inclusive
+      uint64_t height_begin;
+      uint64_t height_end;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height_begin)
+        KV_SERIALIZE(height_end)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response_entry
+    {
+      uint64_t height;
+      std::vector<std::string> quorum_nodes;
+      std::vector<std::string> nodes_to_test;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height)
+        KV_SERIALIZE(quorum_nodes)
+        KV_SERIALIZE(nodes_to_test)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      std::vector<response_entry> quorum_entries;
+      bool untrusted;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(quorum_entries)
+        KV_SERIALIZE(untrusted)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD
   {
     struct request

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -686,6 +686,7 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     get_service_node_deregister_from_tx_extra(dereg_tx.extra, deregistration);
 
     const auto quorum_state = c.get_quorum_state(deregistration.block_height);
+    CHECK_TEST_CONDITION(quorum_state);
     const auto pk_a = quorum_state->nodes_to_test.at(deregistration.service_node_index);
 
     /// Check present


### PR DESCRIPTION
Addresses #257.
Additionally this reverts unintended change in `get_quorum_state` that made it never fail.