### PR TITLE
Revert "mlocker: fix dtor ordering problem"

### DIFF
--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -84,8 +84,8 @@ namespace epee
 
   boost::mutex &mlocker::mutex()
   {
-    static boost::mutex *vmutex = new boost::mutex();
-    return *vmutex;
+    static boost::mutex vmutex;
+    return vmutex;
   }
   std::map<size_t, unsigned int> &mlocker::map()
   {


### PR DESCRIPTION
This reverts commit 6e7f21a90ded6f29b58bfc184b2359d9df135b0b.

Causes a new crash on exit, that I can't tell if it has undesired side effects and risky to put into Festive Freya, whereas the old crash I know is harmless.