### PR TITLE
Change IP protocol resolution order

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -198,8 +198,8 @@ namespace net_utils
     std::map<std::string, t_connection_type> server_type_map;
     void create_server_type_map();
 
-    bool init_server(uint32_t port, const std::string address = "0.0.0.0", uint32_t port_ipv6 = 0, const std::string address_v6 = "::", bool no_ipv6 = false);
-    bool init_server(const std::string port,  const std::string& address = "0.0.0.0", const std::string& port_ipv6 = "", const std::string address_v6 = "::", bool no_ipv6 = false);
+    bool init_server(uint32_t port, const std::string address = "0.0.0.0", uint32_t port_ipv6 = 0, const std::string address_v6 = "::", bool use_ipv6 = false);
+    bool init_server(const std::string port,  const std::string& address = "0.0.0.0", const std::string& port_ipv6 = "", const std::string address_v6 = "::", bool use_ipv6 = false);
 
     /// Run the server's io_service loop.
     bool run_server(size_t threads_count, bool wait = true, const boost::thread::attributes& attrs = boost::thread::attributes());

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -844,7 +844,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::init_server(uint32_t port, const std::string address, uint32_t port_ipv6, const std::string address_v6, bool no_ipv6)
+  bool boosted_tcp_server<t_protocol_handler>::init_server(uint32_t port, const std::string address, uint32_t port_ipv6, const std::string address_v6, bool use_ipv6)
   {
     TRY_ENTRY();
     m_stop_signal_sent = false;
@@ -877,7 +877,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 	    boost::asio::placeholders::error));
     }
 
-    if (!no_ipv6)
+    if (use_ipv6)
     {
       if (port_ipv6 == 0) port_ipv6 = m_port; // default arg means bind to same port as ipv4
 
@@ -920,7 +920,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 PUSH_WARNINGS
 DISABLE_GCC_WARNING(maybe-uninitialized)
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::init_server(const std::string port,  const std::string& address, const std::string& port_ipv6, const std::string address_v6, bool no_ipv6)
+  bool boosted_tcp_server<t_protocol_handler>::init_server(const std::string port,  const std::string& address, const std::string& port_ipv6, const std::string address_v6, bool use_ipv6)
   {
     uint32_t p = 0;
     uint32_t p6 = 0;
@@ -938,7 +938,7 @@ DISABLE_GCC_WARNING(maybe-uninitialized)
     {
       p6 = p;
     }
-    return this->init_server(p, address, p6, address_v6, no_ipv6);
+    return this->init_server(p, address, p6, address_v6, use_ipv6);
   }
 POP_WARNINGS
   //---------------------------------------------------------------------------------

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -57,7 +57,7 @@ namespace epee
 
     bool init(std::function<void(size_t, uint8_t*)> rng, const std::string& bind_port = "0",
       const std::string& bind_ip = "0.0.0.0",
-      const std::string& bind_ipv6_address = "::", bool no_ipv6 = false,
+      const std::string& bind_ipv6_address = "::", bool use_ipv6 = false,
       std::vector<std::string> access_control_origins = std::vector<std::string>(),
       boost::optional<net_utils::http::login> user = boost::none)
     {
@@ -76,7 +76,7 @@ namespace epee
       m_net_server.get_config_object().m_user = std::move(user);
 
       MGINFO("Binding on " << bind_ip << ":" << bind_port);
-      bool res = m_net_server.init_server(bind_port, bind_ip, bind_port, bind_ipv6_address, no_ipv6);
+      bool res = m_net_server.init_server(bind_port, bind_ip, bind_port, bind_ipv6_address, use_ipv6);
       if(!res)
       {
         LOG_ERROR("Failed to bind server");

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -140,7 +140,7 @@ namespace net_utils
 				boost::asio::ip::tcp::resolver::iterator iterator;
 				boost::asio::ip::tcp::resolver::iterator end;
 
-				boost::asio::ip::tcp::resolver::query query6(boost::asio::ip::tcp::v6(), addr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
+				boost::asio::ip::tcp::resolver::query query6(boost::asio::ip::tcp::v4(), addr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
 
 				boost::system::error_code resolve_error;
 
@@ -162,73 +162,105 @@ namespace net_utils
 				  throw;
 				}
 
-				if(iterator == end)
+				boost::system::error_code ec = boost::asio::error::would_block;
+
+				if (iterator != end)
 				{
-				  boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), addr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
+				  boost::asio::ip::tcp::endpoint remote_endpoint(*iterator);
+				  m_ssl_socket.next_layer().open(remote_endpoint.protocol());
+
+				  if(bind_ip != "0.0.0.0" && bind_ip != "0" && bind_ip != "" )
+				  {
+				    boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::address::from_string(addr.c_str()), 0);
+				    m_ssl_socket.next_layer().bind(local_endpoint);
+				  }
+
+				  m_deadline.expires_from_now(timeout);
+				  m_ssl_socket.next_layer().async_connect(remote_endpoint, boost::lambda::var(ec) = boost::lambda::_1);
+				  while (ec == boost::asio::error::would_block)
+				  {	
+				    m_io_service.run_one(); 
+				  }
+				  
+				  if (!ec && m_ssl_socket.next_layer().is_open())
+				  {
+				    m_connected = true;
+				    m_deadline.expires_at(std::chrono::steady_clock::time_point::max());
+				  }
+				  else
+				  {
+				    MWARNING("Some problems at connect, message: " << ec.message());
+				  }
+				}
+				else
+				{
+				  MWARNING("Failed to resolve (IPv4) " << addr);
+				}
+
+				if (!m_connected)
+				{
+				  if (m_ssl_socket.next_layer().is_open())
+				  {
+				    m_ssl_socket.next_layer().close();
+				  }
+
+				  boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v6(), addr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
 				  iterator = resolver.resolve(query);
 
-				  if (iterator == end)
+				  if (iterator != end)
 				  {
-				    LOG_ERROR("Failed to resolve " << addr);
-				    return false;
+
+				    boost::asio::ip::tcp::endpoint remote_endpoint(*iterator);
+				    m_ssl_socket.next_layer().open(remote_endpoint.protocol());
+
+				    m_ssl_socket.next_layer().async_connect(remote_endpoint, boost::lambda::var(ec) = boost::lambda::_1);
+				    while (ec == boost::asio::error::would_block)
+				    {	
+				      m_io_service.run_one(); 
+				    }
+
+				    if (!ec && m_ssl_socket.next_layer().is_open())
+				    {
+				      m_connected = true;
+				      m_deadline.expires_at(std::chrono::steady_clock::time_point::max());
+				    }
+				    else
+				    {
+				      MWARNING("Some problems at connect, message: " << ec.message());
+				    }
+				  }
+				  else
+				  {
+				    MWARNING("Failed to resolve (IPv6) " << addr);
 				  }
 				}
 
-
-				//////////////////////////////////////////////////////////////////////////
-
-
-				//boost::asio::ip::tcp::endpoint remote_endpoint(boost::asio::ip::address::from_string(addr.c_str()), port);
-				boost::asio::ip::tcp::endpoint remote_endpoint(*iterator);
-
-
-				m_ssl_socket.next_layer().open(remote_endpoint.protocol());
-				if(bind_ip != "0.0.0.0" && bind_ip != "0" && bind_ip != "" )
+				if (m_connected)
 				{
-					boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::address::from_string(addr.c_str()), 0);
-					m_ssl_socket.next_layer().bind(local_endpoint);
+				  // SSL Options
+				  if(m_ssl) {
+				    // Disable verification of host certificate
+				    m_ssl_socket.set_verify_mode(boost::asio::ssl::verify_peer);
+				    // Handshake
+				    m_ssl_socket.next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
+				    m_ssl_socket.handshake(boost::asio::ssl::stream_base::client);
+				  }
+				  return true;
 				}
-
-				
-				m_deadline.expires_from_now(timeout);
-
-
-				boost::system::error_code ec = boost::asio::error::would_block;
-
-				m_ssl_socket.next_layer().async_connect(remote_endpoint, boost::lambda::var(ec) = boost::lambda::_1);
-				while (ec == boost::asio::error::would_block)
-				{	
-					m_io_service.run_one(); 
-				}
-				
-				if (!ec && m_ssl_socket.next_layer().is_open())
+				else
 				{
-					m_connected = true;
-					m_deadline.expires_at(std::chrono::steady_clock::time_point::max());
-					// SSL Options
-					if(m_ssl) {
-						// Disable verification of host certificate
-						m_ssl_socket.set_verify_mode(boost::asio::ssl::verify_peer);
-						// Handshake
-						m_ssl_socket.next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
-						m_ssl_socket.handshake(boost::asio::ssl::stream_base::client);
-					}
-					return true;
-				}else
-				{
-					MWARNING("Some problems at connect, message: " << ec.message());
-					return false;
+				  return false;
 				}
 
 			}
 			catch(const boost::system::system_error& er)
 			{
-				MDEBUG("Some problems at connect, message: " << er.what());
+				MERROR("Some problems at connect, message: " << er.what());
 				return false;
 			}
 			catch(...)
 			{
-				MDEBUG("Some fatal problems.");
+				MERROR("Some fatal problems.");
 				return false;
 			}
 

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -73,7 +73,7 @@ namespace nodetool
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
 
     const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
-    const command_line::arg_descriptor<bool>        arg_p2p_no_ipv6  = {"no-p2p-ipv6", "Disable IPv6 for p2p"};
+    const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
     const command_line::arg_descriptor<int64_t>     arg_in_peers = {"in-peers", "set max number of in peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -297,7 +297,7 @@ namespace nodetool
     bool m_hide_my_port;
     bool m_no_igd;
     bool m_offline;
-    bool m_no_ipv6;
+    bool m_use_ipv6;
     std::atomic<bool> m_save_graph;
     std::atomic<bool> is_closing;
     std::unique_ptr<boost::thread> mPeersLoggerThread;
@@ -348,7 +348,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ipv6_address;
     extern const command_line::arg_descriptor<std::string, false, true, 2> arg_p2p_bind_port;
     extern const command_line::arg_descriptor<std::string, false, true, 2> arg_p2p_bind_port_ipv6;
-    extern const command_line::arg_descriptor<bool>        arg_p2p_no_ipv6;
+    extern const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6;
     extern const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port;
     extern const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip;
     extern const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -72,7 +72,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_p2p_bind_ipv6_address);
     command_line::add_arg(desc, arg_p2p_bind_port, false);
     command_line::add_arg(desc, arg_p2p_bind_port_ipv6, false);
-    command_line::add_arg(desc, arg_p2p_no_ipv6);
+    command_line::add_arg(desc, arg_p2p_use_ipv6);
     command_line::add_arg(desc, arg_p2p_external_port);
     command_line::add_arg(desc, arg_p2p_allow_local_ip);
     command_line::add_arg(desc, arg_p2p_add_peer);
@@ -272,7 +272,7 @@ namespace nodetool
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
     m_no_igd = command_line::get_arg(vm, arg_no_igd);
     m_offline = command_line::get_arg(vm, cryptonote::arg_offline);
-    m_no_ipv6 = command_line::get_arg(vm, arg_p2p_no_ipv6);
+    m_use_ipv6 = command_line::get_arg(vm, arg_p2p_use_ipv6);
 
     if (command_line::has_arg(vm, arg_p2p_add_peer))
     {
@@ -571,18 +571,18 @@ namespace nodetool
 
     //try to bind
     MINFO("Binding (IPv4) on " << m_bind_ip << ":" << m_port);
-    if (!m_no_ipv6)
+    if (m_use_ipv6)
     {
       MINFO("Binding (IPv6) on " << m_bind_ipv6_address << ":" << m_port_ipv6);
     }
 
-    res = m_net_server.init_server(m_port, m_bind_ip, m_port_ipv6, m_bind_ipv6_address, m_no_ipv6);
+    res = m_net_server.init_server(m_port, m_bind_ip, m_port_ipv6, m_bind_ipv6_address, m_use_ipv6);
     CHECK_AND_ASSERT_MES(res, false, "Failed to bind server");
 
     m_listening_port = m_net_server.get_binded_port();
     MLOG_GREEN(el::Level::Info, "Net service bound to " << m_bind_ip << ":" << m_listening_port);
 
-    if (!m_no_ipv6)
+    if (m_use_ipv6)
     {
       m_listening_port_ipv6 = m_net_server.get_binded_port_ipv6();
       MLOG_GREEN(el::Level::Info, "Net service bound to " << m_bind_ipv6_address << ":" << m_listening_port_ipv6);
@@ -595,7 +595,7 @@ namespace nodetool
     if(!m_no_igd)
     {
       add_upnp_port_mapping_v4(m_listening_port);
-      if (!m_no_ipv6)
+      if (m_use_ipv6)
       {
 	add_upnp_port_mapping_v6(m_listening_port);
       }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -124,7 +124,7 @@ namespace cryptonote
     auto rng = [](size_t len, uint8_t *ptr){ return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<core_rpc_server, connection_context>::init(
       rng, std::move(port), std::move(rpc_config->bind_ip),
-      std::move(rpc_config->bind_ipv6_address), std::move(rpc_config->no_ipv6),
+      std::move(rpc_config->bind_ipv6_address), std::move(rpc_config->use_ipv6),
       std::move(rpc_config->access_control_origins), std::move(http_login)
     );
   }

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -39,7 +39,7 @@ namespace cryptonote
   rpc_args::descriptors::descriptors()
      : rpc_bind_ip({"rpc-bind-ip", rpc_args::tr("Specify IPv4 address to bind RPC server"), "127.0.0.1"})
      , rpc_bind_ipv6_address({"rpc-bind-ipv6-address", rpc_args::tr("Specify IPv6 address to bind RPC server"), "::1"})
-     , rpc_no_ipv6({"rpc-no-ipv6", rpc_args::tr("Don't bind ipv6"), false})
+     , rpc_use_ipv6({"rpc-use-ipv6", rpc_args::tr("Allow IPv6 for RPC"), false})
      , rpc_login({"rpc-login", rpc_args::tr("Specify username[:password] required for RPC server"), "", true})
      , confirm_external_bind({"confirm-external-bind", rpc_args::tr("Confirm rpc-bind-ip value is NOT a loopback (local) IP")})
      , rpc_access_control_origins({"rpc-access-control-origins", rpc_args::tr("Specify a comma separated list of origins to allow cross origin resource sharing"), ""})
@@ -52,7 +52,7 @@ namespace cryptonote
     const descriptors arg{};
     command_line::add_arg(desc, arg.rpc_bind_ip);
     command_line::add_arg(desc, arg.rpc_bind_ipv6_address);
-    command_line::add_arg(desc, arg.rpc_no_ipv6);
+    command_line::add_arg(desc, arg.rpc_use_ipv6);
     command_line::add_arg(desc, arg.rpc_login);
     command_line::add_arg(desc, arg.confirm_external_bind);
     command_line::add_arg(desc, arg.rpc_access_control_origins);
@@ -65,7 +65,7 @@ namespace cryptonote
     
     config.bind_ip = command_line::get_arg(vm, arg.rpc_bind_ip);
     config.bind_ipv6_address = command_line::get_arg(vm, arg.rpc_bind_ipv6_address);
-    config.no_ipv6 = command_line::get_arg(vm, arg.rpc_no_ipv6);
+    config.use_ipv6 = command_line::get_arg(vm, arg.rpc_use_ipv6);
     if (!config.bind_ip.empty())
     {
       // always parse IP here for error consistency

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -52,7 +52,7 @@ namespace cryptonote
 
       const command_line::arg_descriptor<std::string> rpc_bind_ip;
       const command_line::arg_descriptor<std::string> rpc_bind_ipv6_address;
-      const command_line::arg_descriptor<bool> rpc_no_ipv6;
+      const command_line::arg_descriptor<bool> rpc_use_ipv6;
       const command_line::arg_descriptor<std::string> rpc_login;
       const command_line::arg_descriptor<bool> confirm_external_bind;
       const command_line::arg_descriptor<std::string> rpc_access_control_origins;
@@ -66,7 +66,7 @@ namespace cryptonote
 
     std::string bind_ip;
     std::string bind_ipv6_address;
-    bool no_ipv6;
+    bool use_ipv6;
     std::vector<std::string> access_control_origins;
     boost::optional<tools::login> login; // currently `boost::none` if unspecified by user
   };

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -238,7 +238,7 @@ namespace tools
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::init(
       rng, std::move(bind_port), std::move(rpc_config->bind_ip),
-      std::move(rpc_config->bind_ipv6_address), std::move(rpc_config->no_ipv6),
+      std::move(rpc_config->bind_ipv6_address), std::move(rpc_config->use_ipv6),
       std::move(rpc_config->access_control_origins), std::move(http_login)
     );
   }


### PR DESCRIPTION
This should address #353

Because the code would try to resolve a given host as IPv6 and
then fail if it resolved but couldn't connect, nodes which could
resolve IPv6 but did not have IPv6 connectivity to that host for
whatever reason could not connect at all.  This change both makes
IPv4 resolution and connection attempt come first, and also makes
the client attempt IPv6 resolution/connection if either fails for
IPv4.