### PR TITLE
Explicitly define PRIu64 macro in api/wallet

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -29,6 +29,9 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#ifdef _WIN32
+ #define __STDC_FORMAT_MACROS // NOTE(loki): Explicitly define the PRIu64 macro on Mingw
+#endif
 
 #include "wallet.h"
 #include "pending_transaction.h"


### PR DESCRIPTION
Similar to: https://github.com/loki-project/loki/pull/300

This doesn't trigger until you try build libwallet_merged.a (i.e. the GUI).