### PR TITLE
Fix switch fallthrough error after fixing export_transfers

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7994,7 +7994,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
           running_balance -= transfer.amount + transfer.fee;
           break;
         default:
-          assert(false); // NOTE(loki): Developer error, unhandled type
+          fail_msg_writer() << tr("Warning: Unhandled pay type, this is most likely a developer error, please report it to the Loki developers.");
           break;
       }
     }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7989,10 +7989,12 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
           break;
         case tools::pay_type::stake:
           running_balance -= transfer.fee;
+          break;
         case tools::pay_type::out:
           running_balance -= transfer.amount + transfer.fee;
+          break;
         default:
-          // do nothing
+          assert(false); // NOTE(loki): Developer error, unhandled type
           break;
       }
     }


### PR DESCRIPTION
@msgmaxim Can you check if this was the intended behaviour of https://github.com/loki-project/loki/pull/379

Looks ok to me after testing it out.