### PR TITLE
get registration command rpc using human readable input (#343)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ option(STATIC "Link libraries statically" ${DEFAULT_STATIC})
 
 # This is a CMake built-in switch that concerns internal libraries
 if (NOT DEFINED BUILD_SHARED_LIBS AND NOT STATIC AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
-    set(BUILD_SHARED_LIBS ON)
+  set(BUILD_SHARED_LIBS ON)
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1342,7 +1342,13 @@ namespace service_nodes
     m_height = hardfork_9_from_height;
   }
 
-  bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake)
+  bool convert_registration_args(cryptonote::network_type nettype,
+                                 std::vector<std::string> args,
+                                 std::vector<cryptonote::account_public_address>& addresses,
+                                 std::vector<uint64_t>& portions,
+                                 uint64_t& portions_for_operator,
+                                 bool& autostake,
+                                 boost::optional<std::string&> err_msg)
   {
     autostake = false;
     if (!args.empty() && args[0] == "auto")
@@ -1358,6 +1364,8 @@ namespace service_nodes
     }
     if ((args.size()-1)/ 2 > MAX_NUMBER_OF_CONTRIBUTORS)
     {
+      std::string msg = tr("Exceeds the maximum number of contributors, which is ") + std::to_string(MAX_NUMBER_OF_CONTRIBUTORS);
+      if (err_msg) *err_msg = msg;
       MERROR(tr("Exceeds the maximum number of contributors, which is ") << MAX_NUMBER_OF_CONTRIBUTORS);
       return false;
     }
@@ -1383,7 +1391,9 @@ namespace service_nodes
       cryptonote::address_parse_info info;
       if (!cryptonote::get_account_address_from_str(info, nettype, args[i]))
       {
-        MERROR(tr("failed to parse address"));
+        std::string msg = tr("failed to parse address: ") + args[i];
+        if (err_msg) *err_msg = msg;
+        MERROR(msg);
         return false;
       }
 
@@ -1395,7 +1405,9 @@ namespace service_nodes
 
       if (info.is_subaddress)
       {
-        MERROR(tr("can't use a subaddress for staking tx"));
+        std::string msg = tr("can't use a subaddress for staking tx");
+        if (err_msg) *err_msg = msg;
+        MERROR(msg);
         return false;
       }
 
@@ -1407,6 +1419,7 @@ namespace service_nodes
         uint64_t min_portions = std::min(portions_left, MIN_PORTIONS);
         if (num_portions < min_portions || num_portions > portions_left)
         {
+          if (err_msg) *err_msg = "invalid amount for contributor " + args[i];
           MERROR(tr("Invalid portion amount: ") << args[i+1] << tr(". ") << tr("The contributors must each have at least 25%, except for the last contributor which may have the remaining amount"));
           return false;
         }
@@ -1415,6 +1428,7 @@ namespace service_nodes
       }
       catch (const std::exception &e)
       {
+        if (err_msg) *err_msg = "invalid amount for contributor " + args[i];
         MERROR(tr("Invalid portion amount: ") << args[i+1] << tr(". ") << tr("The contributors must each have at least 25%, except for the last contributor which may have the remaining amount"));
         return false;
       }
@@ -1423,14 +1437,14 @@ namespace service_nodes
   }
 
   bool make_registration_cmd(cryptonote::network_type nettype, const std::vector<std::string> args, const crypto::public_key& service_node_pubkey,
-                             const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly)
+                             const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly, boost::optional<std::string&> err_msg)
   {
 
     std::vector<cryptonote::account_public_address> addresses;
     std::vector<uint64_t> portions;
     uint64_t operator_portions;
     bool autostake;
-    if (!convert_registration_args(nettype, args, addresses, portions, operator_portions, autostake))
+    if (!convert_registration_args(nettype, args, addresses, portions, operator_portions, autostake, err_msg))
     {
       MERROR(tr("Could not convert registration args"));
       return false;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -309,9 +309,9 @@ namespace service_nodes
   uint64_t get_reg_tx_staking_output_contribution(const cryptonote::transaction& tx, int i, crypto::key_derivation derivation, hw::device& hwdev);
   bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);
 
-  bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake);
+  bool convert_registration_args(cryptonote::network_type nettype, std::vector<std::string> args, std::vector<cryptonote::account_public_address>& addresses, std::vector<uint64_t>& portions, uint64_t& portions_for_operator, bool& autostake, boost::optional<std::string&> err_msg);
   bool make_registration_cmd(cryptonote::network_type nettype, const std::vector<std::string> args, const crypto::public_key& service_node_pubkey,
-                             const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly);
+                             const crypto::secret_key service_node_key, std::string &cmd, bool make_friendly, boost::optional<std::string&> err_msg);
 
   const static cryptonote::account_public_address null_address{ crypto::null_pkey, crypto::null_pkey };
   const static std::vector<std::pair<cryptonote::account_public_address, uint64_t>> null_winner =

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -2,6 +2,7 @@
 #include "common/exp2.h"
 #include "common/int-util.h"
 #include <vector>
+#include <boost/lexical_cast.hpp>
 
 #include "service_node_rules.h"
 
@@ -43,6 +44,54 @@ bool check_service_node_portions(const std::vector<uint64_t>& portions)
     }
 
     return true;
+}
+
+uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount)
+{
+  uint64_t lo, hi, resulthi, resultlo;
+  lo = mul128(amount, STAKING_PORTIONS, &hi);
+  if (lo > UINT64_MAX - (staking_requirement - 1))
+    hi++;
+  lo += staking_requirement-1;
+  div128_64(hi, lo, staking_requirement, &resulthi, &resultlo);
+  return resultlo;
+}
+
+static bool get_portions_from_percent(double cur_percent, uint64_t& portions) {
+
+  if(cur_percent < 0.0 || cur_percent > 100.0) return false;
+
+  // Fix for truncation issue when operator cut = 100 for a pool Service Node.
+  if (cur_percent == 100.0)
+  {
+    portions = STAKING_PORTIONS;
+  }
+  else
+  {
+    portions = (cur_percent / 100.0) * STAKING_PORTIONS;
+  }
+
+  return true;
+}
+
+bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions) {
+
+    if(!cut_str.empty() && cut_str.back() == '%')
+    {
+      cut_str.pop_back();
+    }
+
+    double cut_percent;
+    try
+    {
+      cut_percent = boost::lexical_cast<double>(cut_str);
+    }
+    catch(...)
+    {
+      return false;
+    }
+
+    return get_portions_from_percent(cut_percent, portions);
 }
 
 }

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -27,4 +27,9 @@ uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
 /// Check if portions are sufficiently large (except for the last) and add up to the required amount
 bool check_service_node_portions(const std::vector<uint64_t>& portions);
 
+// Returns lowest x such that (staking_requirement * x/STAKING_PORTIONS) >= amount
+uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount);
+
+bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions);
+
 }

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -117,7 +117,7 @@ t_command_server::t_command_server(
       "prepare_registration"
     , std::bind(&t_command_parser_executor::prepare_registration, &m_parser)
     , "prepare_registration"
-    , "Interactive prompt to prepare the registration. The resulting registration data is saved to disk."
+    , "Interactive prompt to prepare a service node registration command. The resulting registration command can be run in the command-line wallet to send the registration to the blockchain."
     );
   m_command_lookup.set_handler(
       "print_sn"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -156,8 +156,6 @@ public:
 
   bool sync_info();
 
-  bool get_service_node_registration_cmd(const std::vector<std::string> &args);
-
   bool print_sn_key();
 
   bool print_sn_status();

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -153,6 +153,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_txpool_backlog",     on_get_txpool_backlog,         COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG)
         MAP_JON_RPC_WE("get_output_distribution", on_get_output_distribution, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
         MAP_JON_RPC_WE("get_quorum_state",        on_get_quorum_state,     COMMAND_RPC_GET_QUORUM_STATE)
+        MAP_JON_RPC_WE("get_service_node_registration_cmd_raw", on_get_service_node_registration_cmd_raw, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW)
         MAP_JON_RPC_WE("get_service_node_registration_cmd", on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD)
         MAP_JON_RPC_WE("get_service_node_key",   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY)
         MAP_JON_RPC_WE("get_service_nodes", on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
@@ -220,6 +221,7 @@ namespace cryptonote
     bool on_get_txpool_backlog(const COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response& res, epee::json_rpc::error& error_resp);
     bool on_get_output_distribution(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, epee::json_rpc::error& error_resp);
     bool on_get_quorum_state(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_service_node_registration_cmd_raw(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2307,7 +2307,8 @@ namespace cryptonote
     };
   };
 
-  struct COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD
+
+  struct COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW
   {
     struct request
     {
@@ -2316,6 +2317,43 @@ namespace cryptonote
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(args)
         KV_SERIALIZE(make_friendly)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      std::string registration_cmd;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(registration_cmd)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
+  struct COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD
+  { 
+    struct contribution_t {
+      std::string address;
+      uint64_t amount;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(address)
+        KV_SERIALIZE(amount)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct request
+    {
+      bool autostake;
+      std::string operator_cut;
+      std::vector<contribution_t> contributions;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(autostake)
+        KV_SERIALIZE(operator_cut)
+        KV_SERIALIZE(contributions)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5549,9 +5549,11 @@ bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
   std::vector<uint64_t> portions;
   uint64_t portions_for_operator;
   bool autostake;
-  if (!service_nodes::convert_registration_args(m_wallet->nettype(), address_portions_args, addresses, portions, portions_for_operator, autostake))
+  std::string err_msg;
+  if (!service_nodes::convert_registration_args(m_wallet->nettype(), address_portions_args, addresses, portions, portions_for_operator, autostake, err_msg))
   {
     fail_msg_writer() << tr("Could not convert registration args");
+    if (err_msg != "") fail_msg_writer() << err_msg;
     fail_msg_writer() << tr("Usage: register_service_node [index=<N1>[,<N2>,...]] [priority] [auto] <operator cut> <address1> <fraction1> [<address2> <fraction2> [...]] <expiration timestamp> <service node pubkey> <signature>");
     return true;
   }


### PR DESCRIPTION
* Allow `prepare_registration` to work on command-line

This allows you to use `lokid prepare_registration` to generate a
registration command via RPC commands to the lokid, which is
particularly useful when the lokid is running non-interactively as a
system service.

Whithout this it is necessary to stop the lokid service, start it
manually, run the prepare_registration, then stop lokid and restart it
via the system service.

This also rewrites the description of the prepare_registration command to
remove the reference to saving to disk.

* make getting registration command more user-friendly via rpc

* better error message for get registration command rpc

* move get_service_node_registration_cmd into prepare_registration

* show error message on unsuccessful registration in simplewallet as well