### PR TITLE
Fix layout putting prompt yes/no on new line

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -271,7 +271,7 @@ namespace
 #endif
     std::cout << prompt;
     if (yesno)
-      std::cout << "  (Y/Yes/N/No)";
+      std::cout << " (Y/Yes/N/No)";
     std::cout << ": " << std::flush;
 
     std::string buf;
@@ -3226,8 +3226,9 @@ bool simple_wallet::ask_wallet_create_if_needed()
           bool ok = true;
           if (!m_restoring)
           {
-            message_writer() << tr("No wallet found with that name. Confirm creation of new wallet named: ") << wallet_path;
-            confirm_creation = input_line("", true);
+            std::string prompt = tr("No wallet found with that name. Confirm creation of new wallet named: ");
+            prompt += "\"" + wallet_path + "\"";
+            confirm_creation = input_line(prompt, true);
             if(std::cin.eof())
             {
               LOG_ERROR("Unexpected std::cin.eof() - Exited simple_wallet::ask_wallet_create_if_needed()");


### PR DESCRIPTION
Removes the new line and tab on the prompt
```
Wallet file name (or Ctrl-C to quit): deleteme1
No wallet found with that name. Confirm creation of new wallet named: deleteme1
  (Y/Yes/N/No): 
```
to

```
Wallet file name (or Ctrl-C to quit): deleteme1
No wallet found with that name. Confirm creation of new wallet named: "deleteme1" (Y/Yes/N/No): 
```