### PR TITLE
increase precision of get_human_time_ago

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -96,13 +96,13 @@ namespace {
     time_t dt = t > now ? t - now : now - t;
     std::string s;
     if (dt < 90)
-      s = boost::lexical_cast<std::string>(dt) + " seconds";
+      s = boost::lexical_cast<std::string>(dt) + (dt == 1 ? " second" : " seconds");
     else if (dt < 90 * 60)
-      s = boost::lexical_cast<std::string>(dt/60) + " minutes";
+      s = (boost::format("%.1f minutes") % ((float)dt/60)).str();
     else if (dt < 36 * 3600)
-      s = boost::lexical_cast<std::string>(dt/3600) + " hours";
+      s = (boost::format("%.1f hours") % ((float)dt/3600)).str();
     else
-      s = boost::lexical_cast<std::string>(dt/(3600*24)) + " days";
+      s = (boost::format("%.1f days") % ((float)dt/(3600*24))).str();
     return s + " " + (t > now ? "in the future" : "ago");
   }
 


### PR DESCRIPTION
The `get_human_time_ago` string can be misleading because the units are always rounded down. This PR adds one decimal point of precision.

(This is a replacement for #413. This PR is based on dev whereas #413 was based on master.)