### PR TITLE
Add serialize methods for members that aren't serialized yet

### DIFF
--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -96,6 +96,10 @@ namespace cryptonote
       KV_SERIALIZE(m_fee_too_low)
       KV_SERIALIZE(m_not_rct)
       KV_SERIALIZE(m_invalid_version)
+      KV_SERIALIZE(m_invalid_type);
+      KV_SERIALIZE(m_key_image_locked_by_snode);
+      KV_SERIALIZE(m_key_image_blacklisted);
+
       KV_SERIALIZE(m_vote_ctx)
     END_KV_SERIALIZE_MAP()
   };


### PR DESCRIPTION
This causes uninitialised bug when deserializing a tx verification context causing the wallet to report all failed transactions as being service node locked or invalid.