### PR TITLE
Simplify deregister vote API by inlining set_relayed call

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1324,11 +1324,6 @@ namespace cryptonote
     m_mempool.set_relayed(txs);
   }
   //-----------------------------------------------------------------------------------------------
-  void core::set_deregister_votes_relayed(const std::vector<service_nodes::deregister_vote>& votes)
-  {
-    m_deregister_vote_pool.set_relayed(votes);
-  }
-  //-----------------------------------------------------------------------------------------------
   bool core::relay_deregister_votes()
   {
     NOTIFY_NEW_DEREGISTER_VOTE::request req;
@@ -1336,7 +1331,8 @@ namespace cryptonote
     if (!req.votes.empty())
     {
       cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
-      get_protocol()->relay_deregister_votes(req, fake_context);
+      if (get_protocol()->relay_deregister_votes(req, fake_context))
+        m_deregister_vote_pool.set_relayed(req.votes);
     }
 
     return true;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -223,11 +223,6 @@ namespace cryptonote
      virtual void on_transaction_relayed(const cryptonote::blobdata& tx);
 
      /**
-      * @brief mark the deregister vote as having been relayed in the vote pool
-      */
-     virtual void set_deregister_votes_relayed(const std::vector<service_nodes::deregister_vote>& votes);
-
-     /**
       * @brief gets the miner instance
       *
       * @return a reference to the miner instance

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2152,7 +2152,6 @@ skip:
   bool t_cryptonote_protocol_handler<t_core>::relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)
   {
     bool result = relay_post_notify<NOTIFY_NEW_DEREGISTER_VOTE>(arg, exclude_context);
-    m_core.set_deregister_votes_relayed(arg.votes);
     return result;
   }
   //------------------------------------------------------------------------------------------------------------------------

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -108,7 +108,6 @@ namespace tests
     uint64_t prevalidate_block_hashes(uint64_t height, const std::list<crypto::hash> &hashes) { return 0; }
     uint64_t prevalidate_block_hashes(uint64_t height, const std::vector<crypto::hash> &hashes) { return 0; }
     // TODO(loki): Write tests
-    virtual void set_deregister_votes_relayed(const std::vector<service_nodes::deregister_vote>& votes) {}
     bool add_deregister_vote(const service_nodes::deregister_vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
     bool pad_transactions() const { return false; }
     uint32_t get_blockchain_pruning_seed() const { return 0; }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -91,7 +91,6 @@ public:
 
   // TODO(loki): Write tests
   bool add_deregister_vote(const service_nodes::deregister_vote& vote, cryptonote::vote_verification_context &vvc) { return true; }
-  virtual void set_deregister_votes_relayed(const std::vector<service_nodes::deregister_vote>& votes) {}
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;


### PR DESCRIPTION
Noticed this when working on relaying checkpoint votes. No need to do a round-trip just to call set relayed on votes. Also makes it more robust by actually checking that we were able to relay the vote before declaring it as relayed.

