### PR TITLE
Fix for RPC prepare registration

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2655,7 +2655,7 @@ bool t_rpc_command_executor::prepare_registration()
       if (!m_rpc_client->rpc_request(req, res, "/getinfo", info_fail_message.c_str()))
         return true;
 
-      if (!m_rpc_client->rpc_request(hf_req, hf_res, "hard_fork_info", info_fail_message.c_str()))
+      if (!m_rpc_client->json_rpc_request(hf_req, hf_res, "hard_fork_info", info_fail_message.c_str()))
         return true;
 
       if      (res.mainnet) nettype  = cryptonote::MAINNET;


### PR DESCRIPTION
hard_fork_info is a RPC post request, unlike /getinfo.

This was resulting in failure when attempting to prepare from the command-line:
```
$ ./lokid --testnet prepare_registration 
2019-03-11 16:33:52.924	    7f3738ac40c0	INFO	global	src/daemon/main.cpp:228	Loki 'Summer Sigyn' (v3.0.0-beta.1-release)
Error: Could not get current blockchain info-- rpc_request: 
```