### PR TITLE
Refactor register service node into wallet2 to facilitate RPC call

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -140,7 +140,6 @@ enum TransferType {
 
 namespace
 {
-  const std::array<const char* const, 5> allowed_priority_strings = {{"default", "unimportant", "normal", "elevated", "priority"}};
   const auto arg_wallet_file = wallet_args::arg_wallet_file();
   const command_line::arg_descriptor<std::string> arg_generate_new_wallet = {"generate-new-wallet", sw::tr("Generate new wallet and save it to <arg>"), ""};
   const command_line::arg_descriptor<std::string> arg_generate_from_device = {"generate-from-device", sw::tr("Generate new wallet from device and save it to <arg>"), ""};
@@ -502,30 +501,6 @@ namespace
     return addresses[0];
   }
 
-  bool parse_subaddress_indices(const std::string& arg, std::set<uint32_t>& subaddr_indices)
-  {
-    subaddr_indices.clear();
-
-    if (arg.substr(0, 6) != "index=")
-      return false;
-    std::string subaddr_indices_str_unsplit = arg.substr(6, arg.size() - 6);
-    std::vector<std::string> subaddr_indices_str;
-    boost::split(subaddr_indices_str, subaddr_indices_str_unsplit, boost::is_any_of(","));
-
-    for (const auto& subaddr_index_str : subaddr_indices_str)
-    {
-      uint32_t subaddr_index;
-      if(!epee::string_tools::get_xtype_from_string(subaddr_index, subaddr_index_str))
-      {
-        fail_msg_writer() << sw::tr("failed to parse index: ") << subaddr_index_str;
-        subaddr_indices.clear();
-        return false;
-      }
-      subaddr_indices.insert(subaddr_index);
-    }
-    return true;
-  }
-
   boost::optional<std::pair<uint32_t, uint32_t>> parse_subaddress_lookahead(const std::string& str)
   {
     auto r = tools::parse_subaddress_lookahead(str);
@@ -675,27 +650,14 @@ namespace
   }
 }
 
-bool parse_priority(const std::string& arg, uint32_t& priority)
-{
-  auto priority_pos = std::find(
-    allowed_priority_strings.begin(),
-    allowed_priority_strings.end(),
-    arg);
-  if(priority_pos != allowed_priority_strings.end()) {
-    priority = std::distance(allowed_priority_strings.begin(), priority_pos);
-    return true;
-  }
-  return false;
-}
-
 std::string join_priority_strings(const char *delimiter)
 {
   std::string s;
-  for (size_t n = 0; n < allowed_priority_strings.size(); ++n)
+  for (size_t n = 0; n < tools::allowed_priority_strings.size(); ++n)
   {
     if (!s.empty())
       s += delimiter;
-    s += allowed_priority_strings[n];
+    s += tools::allowed_priority_strings[n];
   }
   return s;
 }
@@ -2162,9 +2124,9 @@ bool simple_wallet::set_default_priority(const std::vector<std::string> &args/* 
     else
     {
       bool found = false;
-      for (size_t n = 0; n < allowed_priority_strings.size(); ++n)
+      for (size_t n = 0; n < tools::allowed_priority_strings.size(); ++n)
       {
-        if (allowed_priority_strings[n] == args[1])
+        if (tools::allowed_priority_strings[n] == args[1])
         {
           found = true;
           priority = n;
@@ -3046,8 +3008,8 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
       seed_language = crypto::ElectrumWords::get_english_name_for(seed_language);
     std::string priority_string = "invalid";
     uint32_t priority = m_wallet->get_default_priority();
-    if (priority < allowed_priority_strings.size())
-      priority_string = allowed_priority_strings[priority];
+    if (priority < tools::allowed_priority_strings.size())
+      priority_string = tools::allowed_priority_strings[priority];
     std::string ask_password_string = "invalid";
     switch (m_wallet->ask_password())
     {
@@ -4941,8 +4903,12 @@ bool simple_wallet::show_incoming_transfers(const std::vector<std::string>& args
   std::set<uint32_t> subaddr_indices;
   if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
+    std::string parse_subaddr_err;
+    if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
+    {
+      fail_msg_writer() << parse_subaddr_err;
       return true;
+    }
     local_args.erase(local_args.begin());
   }
 
@@ -5307,13 +5273,17 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
   std::set<uint32_t> subaddr_indices;
   if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
-      return false;
+    std::string parse_subaddr_err;
+    if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
+    {
+      fail_msg_writer() << parse_subaddr_err;
+      return true;
+    }
     local_args.erase(local_args.begin());
   }
 
   uint32_t priority = 0;
-  if (local_args.size() > 0 && parse_priority(local_args[0], priority))
+  if (local_args.size() > 0 && tools::parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
   priority = m_wallet->adjust_priority(priority);
@@ -5739,72 +5709,37 @@ bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
   return sweep_main(0, true, args_);
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::register_service_node_main(
-    const std::vector<std::string>& service_node_key_as_str,
-    const cryptonote::account_public_address& address,
-    uint32_t priority,
-    const std::vector<uint64_t>& portions,
-    const std::vector<uint8_t>& extra,
-    std::set<uint32_t>& subaddr_indices,
-    uint64_t bc_height,
-    uint64_t staking_requirement)
+bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
 {
-  m_wallet->refresh(false);
+  if (!try_connect_to_daemon())
+    return true;
 
-  uint64_t staking_requirement_lock_blocks = service_nodes::staking_num_lock_blocks(m_wallet->nettype());
-  uint64_t locked_blocks                   = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
-  uint64_t unlock_block                    = bc_height + locked_blocks;
+  SCOPED_WALLET_UNLOCK()
+  tools::wallet2::register_service_node_result result = m_wallet->create_register_service_node_tx(args_, m_current_subaddress_account);
+  if (result.status != tools::wallet2::register_service_node_result_status::success)
   {
-    boost::optional<std::string> failed;
-    const std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> response = m_wallet->get_service_nodes({service_node_key_as_str}, failed);
-    if (failed)
+    fail_msg_writer() << result.msg;
+    if (result.status == tools::wallet2::register_service_node_result_status::insufficient_num_args ||
+        result.status == tools::wallet2::register_service_node_result_status::service_node_key_parse_fail ||
+        result.status == tools::wallet2::register_service_node_result_status::service_node_signature_parse_fail ||
+        result.status == tools::wallet2::register_service_node_result_status::subaddr_indices_parse_fail ||
+        result.status == tools::wallet2::register_service_node_result_status::convert_registration_args_failed)
     {
-      fail_msg_writer() << *failed;
-      return true;
+      fail_msg_writer() << USAGE_REGISTER_SERVICE_NODE;
     }
-
-    if (response.size() >= 1)
-    {
-      bool can_reregister = false;
-      if (m_wallet->use_fork_rules(cryptonote::network_version_11_infinite_staking, 1))
-        unlock_block = 0; // Infinite staking, no time lock
-      else if (m_wallet->use_fork_rules(cryptonote::network_version_10_bulletproofs, 0))
-      {
-        cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info = response[0];
-        uint64_t expiry_height = node_info.registration_height + staking_requirement_lock_blocks;
-        if (bc_height >= expiry_height)
-          can_reregister = true;
-      }
-
-      if (!can_reregister)
-      {
-        fail_msg_writer() << tr("This service node is already registered");
-        return true;
-      }
-    }
-  }
-
-  if (portions.size() < 1)
-  {
-    fail_msg_writer() << tr("There must be at least 1 service node portion to create a registration transaction");
     return true;
   }
 
-  vector<cryptonote::tx_destination_entry> dsts;
-  cryptonote::tx_destination_entry de;
-  de.addr = address;
-  de.is_subaddress = false;
-  de.amount = service_nodes::portions_to_amount(portions[0], staking_requirement);
-  dsts.push_back(de);
-
+  address_parse_info info = {};
+  info.address            = m_wallet->get_address();
   try
   {
-    // NOTE(loki): We know the address should always be a primary address and has no payment id, so we can ignore the subaddress/payment id field here
-    cryptonote::address_parse_info dest = {};
-    dest.address                        = address;
-
-    auto ptx_vector = m_wallet->create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices, true);
-    sweep_main_internal(sweep_type_t::register_stake, ptx_vector, dest);
+    std::vector<tools::wallet2::pending_tx> ptx_vector = {result.ptx};
+    if (!sweep_main_internal(sweep_type_t::register_stake, ptx_vector, info))
+    {
+      fail_msg_writer() << tr("Sending register transaction failed");
+      return true;
+    }
   }
   catch (const std::exception& e)
   {
@@ -5816,132 +5751,6 @@ bool simple_wallet::register_service_node_main(
     fail_msg_writer() << tr("unknown error");
   }
 
-
-  return true;
-}
-
-bool simple_wallet::register_service_node(const std::vector<std::string> &args_)
-{
-  if (!try_connect_to_daemon())
-    return true;
-
-  std::vector<std::string> local_args = args_;
-  std::set<uint32_t> subaddr_indices;
-  if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
-  {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
-      return true;
-    local_args.erase(local_args.begin());
-  }
-
-  uint32_t priority = 0;
-  if (local_args.size() > 0 && parse_priority(local_args[0], priority))
-    local_args.erase(local_args.begin());
-
-  priority = m_wallet->adjust_priority(priority);
-
-  if (local_args.size() < 6)
-  {
-    fail_msg_writer() << tr(USAGE_REGISTER_SERVICE_NODE);
-    fail_msg_writer() << tr("");
-    fail_msg_writer() << tr("Prepare this command in the daemon with the prepare_registration command");
-    fail_msg_writer() << tr("");
-    fail_msg_writer() << tr("This command must be run from the daemon that will be acting as a service node");
-    return true;
-  }
-
-  uint64_t staking_requirement = 0, bc_height = 0;
-  service_nodes::converted_registration_args converted_args = {};
-  {
-    std::string err, err2;
-    bc_height = std::max(m_wallet->get_daemon_blockchain_height(err),
-                         m_wallet->get_daemon_blockchain_target_height(err2));
-    {
-      if (!err.empty() || !err2.empty())
-      {
-        fail_msg_writer() << tr("unable to get network blockchain height from daemon: ") << (err.empty() ? err2 : err);
-        return true;
-      }
-
-      if (!m_wallet->is_synced())
-      {
-        fail_msg_writer() << tr("Wallet not synced. Please synchronise your wallet to the blockchain");
-        return true;
-      }
-    }
-
-    staking_requirement = service_nodes::get_staking_requirement(m_wallet->nettype(), bc_height);
-    boost::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version)
-    {
-      fail_msg_writer() << tr("Could not query current hardfork version");
-      return true;
-    }
-
-    std::vector<std::string> const registration_args(local_args.begin(), local_args.begin() + local_args.size() - 3);
-    converted_args = service_nodes::convert_registration_args(m_wallet->nettype(), registration_args, staking_requirement, *hf_version);
-  }
-
-  if (!converted_args.success)
-  {
-    fail_msg_writer() << tr("Could not convert registration args, reason: ") << converted_args.err_msg << "\n" << tr(USAGE_REGISTER_SERVICE_NODE);
-    return true;
-  }
-
-  SCOPED_WALLET_UNLOCK();
-  size_t const key_index        = local_args.size() - 2;
-  size_t const signature_index  = local_args.size() - 1;
-  size_t const timestamp_index  = local_args.size() - 3;
-  uint64_t expiration_timestamp = 0;
-
-  try
-  {
-    expiration_timestamp = boost::lexical_cast<uint64_t>(local_args[timestamp_index]);
-    if (expiration_timestamp <= (uint64_t)time(nullptr) + 600 /* 10 minutes */)
-    {
-      fail_msg_writer() << tr("This registration has expired.");
-      return false;
-    }
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Invalid timestamp");
-    return true;
-  }
-
-  crypto::public_key service_node_key;
-  const std::vector<std::string> service_node_key_as_str = {local_args[key_index]};
-  if (!epee::string_tools::hex_to_pod(local_args[key_index], service_node_key))
-  {
-    fail_msg_writer() << tr("failed to parse service node pubkey");
-    return true;
-  }
-
-  crypto::signature signature;
-  if (!epee::string_tools::hex_to_pod(local_args[signature_index], signature))
-  {
-    fail_msg_writer() << tr("failed to parse service node signature");
-    return true;
-  }
-
-  std::vector<uint8_t> extra;
-  add_service_node_pubkey_to_tx_extra(extra, service_node_key);
-  if (!add_service_node_register_to_tx_extra(extra, converted_args.addresses, converted_args.portions_for_operator, converted_args.portions, expiration_timestamp, signature))
-  {
-    fail_msg_writer() << tr("failed to serialize service node registration tx extra");
-    return true;
-  }
-
-  cryptonote::account_public_address address = converted_args.addresses[0];
-  if (!m_wallet->contains_address(address))
-  {
-    fail_msg_writer() << tr("The first reserved address for this registration does not belong to this wallet.");
-    fail_msg_writer() << tr("Service node operator must specify an address owned by this wallet for service node registration.");
-    return true;
-  }
-
-  add_service_node_contributor_to_tx_extra(extra, address);
-  register_service_node_main(service_node_key_as_str, address, priority, converted_args.portions, extra, subaddr_indices, bc_height, staking_requirement);
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -5962,12 +5771,16 @@ bool simple_wallet::stake(const std::vector<std::string> &args_)
     std::vector<std::string> local_args = args_;
     if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
     {
-      if (!parse_subaddress_indices(local_args[0], subaddr_indices))
+      std::string parse_subaddr_err;
+      if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
+      {
+        fail_msg_writer() << parse_subaddr_err;
         return true;
+      }
       local_args.erase(local_args.begin());
     }
 
-    if (local_args.size() > 0 && parse_priority(local_args[0], priority))
+    if (local_args.size() > 0 && tools::parse_priority(local_args[0], priority))
       local_args.erase(local_args.begin());
     priority = m_wallet->adjust_priority(priority);
 
@@ -6025,9 +5838,8 @@ bool simple_wallet::stake(const std::vector<std::string> &args_)
       info.address            = m_wallet->get_address();
 
       time_t begin_construct_time = time(nullptr);
-      std::vector<tools::wallet2::pending_tx> ptx_vector;
 
-      tools::wallet2::stake_result stake_result = m_wallet->create_stake_tx(ptx_vector, service_node_key, info, amount, amount_fraction, priority, m_current_subaddress_account, subaddr_indices);
+      tools::wallet2::stake_result stake_result = m_wallet->create_stake_tx(service_node_key, info, amount, amount_fraction, priority, m_current_subaddress_account, subaddr_indices);
       if (stake_result.status != tools::wallet2::stake_result_status::success)
       {
         fail_msg_writer() << stake_result.msg;
@@ -6037,6 +5849,7 @@ bool simple_wallet::stake(const std::vector<std::string> &args_)
       if (!stake_result.msg.empty()) // i.e. warnings
         tools::msg_writer() << stake_result.msg;
 
+      std::vector<tools::wallet2::pending_tx> ptx_vector = {stake_result.ptx};
       if (!sweep_main_internal(sweep_type_t::stake, ptx_vector, info))
       {
         fail_msg_writer() << tr("Sending stake transaction failed");
@@ -6688,8 +6501,10 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
   std::set<uint32_t> subaddr_indices;
   if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
+    std::string parse_subaddr_err;
+    if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
     {
+      fail_msg_writer() << parse_subaddr_err;
       print_usage();
       return true;
     }
@@ -6697,7 +6512,7 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
   }
 
   uint32_t priority = 0;
-  if (local_args.size() > 0 && parse_priority(local_args[0], priority))
+  if (local_args.size() > 0 && tools::parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
   priority = m_wallet->adjust_priority(priority);
@@ -6851,7 +6666,7 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   std::vector<std::string> local_args = args_;
 
   uint32_t priority = 0;
-  if (local_args.size() > 0 && parse_priority(local_args[0], priority))
+  if (local_args.size() > 0 && tools::parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
   priority = m_wallet->adjust_priority(priority);
@@ -7804,8 +7619,12 @@ bool simple_wallet::get_transfers(std::vector<std::string>& local_args, std::vec
   std::set<uint32_t> subaddr_indices;
   if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
-      return false;
+    std::string parse_subaddr_err;
+    if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
+    {
+      fail_msg_writer() << parse_subaddr_err;
+      return true;
+    }
     local_args.erase(local_args.begin());
   }
 
@@ -8220,8 +8039,12 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
   std::set<uint32_t> subaddr_indices;
   if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
-    if (!parse_subaddress_indices(local_args[0], subaddr_indices))
+    std::string parse_subaddr_err;
+    if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices, &parse_subaddr_err))
+    {
+      fail_msg_writer() << parse_subaddr_err;
       return true;
+    }
     local_args.erase(local_args.begin());
   }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -78,6 +78,7 @@ using namespace epee;
 #include "device/device_cold.hpp"
 #include "device_trezor/device_trezor.hpp"
 
+#include "cryptonote_core/service_node_list.h"
 #include "cryptonote_core/service_node_rules.h"
 #include "common/loki_integration_test_hooks.h"
 
@@ -7085,6 +7086,12 @@ bool wallet2::is_output_blackballed(const std::pair<uint64_t, uint64_t> &output)
   catch (const std::exception &e) { return false; }
 }
 
+static const char *ERR_MSG_NETWORK_VERSION_QUERY_FAILED = tr("Could not query the current network version, try later");
+static const char *ERR_MSG_NETWORK_HEIGHT_QUERY_FAILED = tr("Could not query the current network block height, try later: ");
+static const char *ERR_MSG_SERVICE_NODE_LIST_QUERY_FAILED = tr("Failed to query daemon for service node list");
+static const char *ERR_MSG_TOO_MANY_TXS_CONSTRUCTED = tr("Constructed too many transations, please sweep_all first");
+static const char *ERR_MSG_EXCEPTION_THROWN = tr("Exception thrown, staking process could not be completed");
+
 wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction)
 {
   wallet2::stake_result result = {};
@@ -7119,14 +7126,14 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
   {
     result.status = stake_result_status::service_node_list_query_failed;
     result.msg.reserve(failed->size() + 128);
-    result.msg    = tr("Failed to query daemon for service node list");
+    result.msg    = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
     result.msg    += *failed;
   }
 
   if (response.size() != 1)
   {
     result.status = stake_result_status::service_node_not_registered;
-    result.msg = tr("Could not find service node in service node list, please make sure it is registered first.");
+    result.msg    = tr("Could not find service node in service node list, please make sure it is registered first.");
     return result;
   }
 
@@ -7134,7 +7141,7 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
   if (!res)
   {
     result.status = stake_result_status::network_version_query_failed;
-    result.msg    = tr("Could not query the current network version, try later");
+    result.msg    = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
     return result;
   }
 
@@ -7222,10 +7229,9 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
   return result;
 }
 
-wallet2::stake_result wallet2::create_stake_tx(std::vector<pending_tx> &ptx, const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount, double amount_fraction, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+wallet2::stake_result wallet2::create_stake_tx(const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount, double amount_fraction, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
   wallet2::stake_result result = {};
-  ptx.clear();
 
   try
   {
@@ -7236,7 +7242,7 @@ wallet2::stake_result wallet2::create_stake_tx(std::vector<pending_tx> &ptx, con
   catch (const std::exception& e)
   {
     result.status = stake_result_status::exception_thrown;
-    result.msg = tr("Exception thrown, staking process could not be completed");
+    result.msg = ERR_MSG_EXCEPTION_THROWN;
     result.msg += e.what();
     return result;
   }
@@ -7260,7 +7266,7 @@ wallet2::stake_result wallet2::create_stake_tx(std::vector<pending_tx> &ptx, con
 
   if (!err.empty() || !err2.empty())
   {
-    result.msg = tr("Could not query the current network block height, try later: ");
+    result.msg = ERR_MSG_NETWORK_HEIGHT_QUERY_FAILED;
     result.msg += (err.empty() ? err2 : err);
     result.status = stake_result_status::network_height_query_failed;
     return result;
@@ -7283,25 +7289,260 @@ wallet2::stake_result wallet2::create_stake_tx(std::vector<pending_tx> &ptx, con
   try
   {
     priority = adjust_priority(priority);
-    ptx = create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_at_block, priority, extra, subaddr_account, subaddr_indices, true);
+    auto ptx_vector  = create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_at_block, priority, extra, subaddr_account, subaddr_indices, true);
+    if (ptx_vector.size() == 1)
+    {
+      result.status = stake_result_status::success;
+      result.ptx    = ptx_vector[0];
+    }
+    else
+    {
+      result.status = stake_result_status::too_many_transactions_constructed;
+      result.msg    = ERR_MSG_TOO_MANY_TXS_CONSTRUCTED;
+    }
   }
   catch (const std::exception& e)
   {
-    result.msg = tr("Exception thrown on create tx: ");
+    result.status = stake_result_status::exception_thrown;
+    result.msg = ERR_MSG_EXCEPTION_THROWN;
     result.msg += e.what();
-    result.status = stake_result_status::network_height_query_failed;
     return result;
   }
 
-  if (ptx.size() == 1) result.status = stake_result_status::success;
-  else
+  return result;
+}
+
+wallet2::register_service_node_result wallet2::create_register_service_node_tx(const std::vector<std::string> &args_, uint32_t subaddr_account)
+{
+  std::vector<std::string> local_args = args_;
+  register_service_node_result result = {};
+
+  //
+  // Parse Tx Args
+  //
+  std::set<uint32_t> subaddr_indices;
+  uint32_t priority = 0;
   {
-    result.status = stake_result_status::too_many_transactions_constructed;
-    result.msg    = tr("Constructed too many transations, please sweep_all first");
-    ptx.clear();
+    if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
+    {
+      if (!tools::parse_subaddress_indices(local_args[0], subaddr_indices))
+      {
+        result.status = register_service_node_result_status::subaddr_indices_parse_fail;
+        result.msg = tr("Could not parse subaddress indices argument: ") + local_args[0];
+        return result;
+      }
+
+      local_args.erase(local_args.begin());
+    }
+
+    uint32_t priority = 0;
+    if (local_args.size() > 0 && parse_priority(local_args[0], priority))
+      local_args.erase(local_args.begin());
+
+    priority = adjust_priority(priority);
+    if (local_args.size() < 6)
+    {
+      result.status = register_service_node_result_status::insufficient_num_args;
+      result.msg += tr("\nPrepare this command in the daemon with the prepare_registration command");
+      result.msg += tr("\nThis command must be run from the daemon that will be acting as a service node");
+      return result;
+    }
   }
 
-  return result;
+  //
+  // Parse Registration Contributor Args
+  //
+  uint64_t staking_requirement = 0, bc_height = 0;
+  service_nodes::converted_registration_args converted_args = {};
+  {
+    std::string err, err2;
+    bc_height = std::max(get_daemon_blockchain_height(err),
+                         get_daemon_blockchain_target_height(err2));
+    {
+      if (!err.empty() || !err2.empty())
+      {
+        result.msg = ERR_MSG_NETWORK_HEIGHT_QUERY_FAILED;
+        result.msg += (err.empty() ? err2 : err);
+        result.status = register_service_node_result_status::network_height_query_failed;
+        return result;
+      }
+
+      if (!is_synced())
+      {
+        result.status = register_service_node_result_status::wallet_not_synced;
+        result.msg    = tr("Wallet is not synced. Please synchronise your wallet to the blockchain");
+        return result;
+      }
+    }
+
+    staking_requirement = service_nodes::get_staking_requirement(nettype(), bc_height);
+    boost::optional<uint8_t> hf_version = get_hard_fork_version();
+    if (!hf_version)
+    {
+      result.status = register_service_node_result_status::network_version_query_failed;
+      result.msg    = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+    }
+
+    std::vector<std::string> const registration_args(local_args.begin(), local_args.begin() + local_args.size() - 3);
+    converted_args = service_nodes::convert_registration_args(nettype(), registration_args, staking_requirement, *hf_version);
+
+    if (!converted_args.success)
+    {
+      result.status = register_service_node_result_status::convert_registration_args_failed;
+      result.msg = tr("Could not convert registration args, reason: ") + converted_args.err_msg;
+      return result;
+    }
+  }
+
+  cryptonote::account_public_address address = converted_args.addresses[0];
+  if (!contains_address(address))
+  {
+    result.status = register_service_node_result_status::first_address_must_be_primary_address;
+    result.msg = tr(
+                    "The first reserved address for this registration does not belong to this wallet.\n"
+                    "Service node operator must specify an address owned by this wallet for service node registration."
+                   );
+    return result;
+  }
+
+
+  //
+  // Parse Registration Metadata Args
+  //
+  size_t const timestamp_index  = local_args.size() - 3;
+  size_t const key_index        = local_args.size() - 2;
+  size_t const signature_index  = local_args.size() - 1;
+  const std::string &service_node_key_as_str = local_args[key_index];
+
+  crypto::public_key service_node_key;
+  crypto::signature signature;
+  uint64_t expiration_timestamp = 0;
+  {
+    try
+    {
+      expiration_timestamp = boost::lexical_cast<uint64_t>(local_args[timestamp_index]);
+      if (expiration_timestamp <= (uint64_t)time(nullptr) + 600 /* 10 minutes */)
+      {
+        result.status = register_service_node_result_status::registration_timestamp_expired;
+        result.msg    = tr("The registration timestamp has expired.");
+        return result;
+      }
+    }
+    catch (const std::exception &e)
+    {
+      result.status = register_service_node_result_status::registration_timestamp_expired;
+      result.msg = tr("The registration timestamp failed to parse: ") + local_args[timestamp_index];
+      return result;
+    }
+
+    if (!epee::string_tools::hex_to_pod(local_args[key_index], service_node_key))
+    {
+      result.status = register_service_node_result_status::service_node_key_parse_fail;
+      result.msg = tr("Failed to parse service node pubkey");
+      return result;
+    }
+
+    if (!epee::string_tools::hex_to_pod(local_args[signature_index], signature))
+    {
+      result.status = register_service_node_result_status::service_node_signature_parse_fail;
+      result.msg = tr("Failed to parse service node signature");
+      return result;
+    }
+
+  }
+
+  std::vector<uint8_t> extra;
+  add_service_node_contributor_to_tx_extra(extra, address);
+  add_service_node_pubkey_to_tx_extra(extra, service_node_key);
+  if (!add_service_node_register_to_tx_extra(extra, converted_args.addresses, converted_args.portions_for_operator, converted_args.portions, expiration_timestamp, signature))
+  {
+    result.status = register_service_node_result_status::service_node_register_serialize_to_tx_extra_fail;
+    result.msg    = tr("Failed to serialize service node registration tx extra");
+    return result;
+  }
+
+  //
+  // Check service is able to be registered and calculate unlock blocks
+  //
+  refresh(false);
+  uint64_t unlock_block = 0;
+  {
+    uint64_t staking_requirement_lock_blocks = service_nodes::staking_num_lock_blocks(nettype());
+    uint64_t locked_blocks                   = staking_requirement_lock_blocks + STAKING_REQUIREMENT_LOCK_BLOCKS_EXCESS;
+    unlock_block                             = bc_height + locked_blocks;
+    {
+      boost::optional<std::string> failed;
+      const std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> response = get_service_nodes({service_node_key_as_str}, failed);
+      if (failed)
+      {
+        result.status = register_service_node_result_status::service_node_list_query_failed;
+        result.msg    = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+        return result;
+      }
+
+      if (response.size() >= 1)
+      {
+        bool can_reregister = false;
+        if (use_fork_rules(cryptonote::network_version_11_infinite_staking, 1))
+          unlock_block = 0; // Infinite staking, no time lock
+        else if (use_fork_rules(cryptonote::network_version_10_bulletproofs, 0))
+        {
+          cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info = response[0];
+          uint64_t expiry_height = node_info.registration_height + staking_requirement_lock_blocks;
+          if (bc_height >= expiry_height)
+            can_reregister = true;
+        }
+
+        if (!can_reregister)
+        {
+          result.status = register_service_node_result_status::service_node_cannot_reregister;
+          result.msg    = tr("This service node is already registered");
+          return result;
+        }
+      }
+    }
+  }
+
+  //
+  // Create Register Transaction
+  //
+  {
+    vector<cryptonote::tx_destination_entry> dsts;
+    cryptonote::tx_destination_entry de;
+    de.addr = address;
+    de.is_subaddress = false;
+    de.amount = service_nodes::portions_to_amount(converted_args.portions[0], staking_requirement);
+    dsts.push_back(de);
+
+    try
+    {
+      // NOTE(loki): We know the address should always be a primary address and has no payment id, so we can ignore the subaddress/payment id field here
+      cryptonote::address_parse_info dest = {};
+      dest.address                        = address;
+
+      auto ptx_vector = create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, subaddr_account, subaddr_indices, true);
+      if (ptx_vector.size() == 1)
+      {
+        result.status = register_service_node_result_status::success;
+        result.ptx    = ptx_vector[0];
+      }
+      else
+      {
+        result.status = register_service_node_result_status::too_many_transactions_constructed;
+        result.msg    = ERR_MSG_TOO_MANY_TXS_CONSTRUCTED;
+      }
+    }
+    catch (const std::exception& e)
+    {
+      result.status = register_service_node_result_status::exception_thrown;
+      result.msg = ERR_MSG_EXCEPTION_THROWN;
+      result.msg += e.what();
+      return result;
+    }
+
+    result.status = register_service_node_result_status::success;
+    return result;
+  }
 }
 
 bool wallet2::lock_keys_file()
@@ -12910,6 +13151,44 @@ void wallet2::throw_on_rpc_response_error(const boost::optional<std::string> &st
 
   THROW_WALLET_EXCEPTION_IF(*status == CORE_RPC_STATUS_BUSY, tools::error::daemon_busy, method);
   THROW_WALLET_EXCEPTION_IF(*status != CORE_RPC_STATUS_OK, tools::error::wallet_generic_rpc_error, method, m_trusted_daemon ? *status : "daemon error");
+}
+
+const std::array<const char* const, 5> allowed_priority_strings = {{"default", "unimportant", "normal", "elevated", "priority"}};
+bool parse_subaddress_indices(const std::string& arg, std::set<uint32_t>& subaddr_indices, std::string *err_msg)
+{
+  subaddr_indices.clear();
+
+  if (arg.substr(0, 6) != "index=")
+    return false;
+  std::string subaddr_indices_str_unsplit = arg.substr(6, arg.size() - 6);
+  std::vector<std::string> subaddr_indices_str;
+  boost::split(subaddr_indices_str, subaddr_indices_str_unsplit, boost::is_any_of(","));
+
+  for (const auto& subaddr_index_str : subaddr_indices_str)
+  {
+    uint32_t subaddr_index;
+    if(!epee::string_tools::get_xtype_from_string(subaddr_index, subaddr_index_str))
+    {
+      subaddr_indices.clear();
+      if (err_msg) *err_msg = tr("failed to parse index: ") + subaddr_index_str;
+      return false;
+    }
+    subaddr_indices.insert(subaddr_index);
+  }
+  return true;
+}
+
+bool parse_priority(const std::string& arg, uint32_t& priority)
+{
+  auto priority_pos = std::find(
+    allowed_priority_strings.begin(),
+    allowed_priority_strings.end(),
+    arg);
+  if(priority_pos != allowed_priority_strings.end()) {
+    priority = std::distance(allowed_priority_strings.begin(), priority_pos);
+    return true;
+  }
+  return false;
 }
 
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1306,13 +1306,44 @@ namespace tools
     {
       stake_result_status status;
       std::string         msg;
+      pending_tx          ptx;
     };
 
     /// Modifies the `amount` to maximum possible if too large, but rejects if insufficient.
     /// `fraction` is only used to determine the amount if specified zero.
     stake_result check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction = 0);
-    stake_result create_stake_tx    (std::vector<pending_tx> &ptx, const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount,
+    stake_result create_stake_tx    (const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount,
                                      double amount_fraction = 0, uint32_t priority = 0, uint32_t subaddr_account = 0, std::set<uint32_t> subaddr_indices = {});
+
+    enum struct register_service_node_result_status
+    {
+      success,
+      insufficient_num_args,
+      subaddr_indices_parse_fail,
+      network_height_query_failed,
+      network_version_query_failed,
+      convert_registration_args_failed,
+      registration_timestamp_expired,
+      registration_timestamp_parse_fail,
+      service_node_key_parse_fail,
+      service_node_signature_parse_fail,
+      service_node_register_serialize_to_tx_extra_fail,
+      first_address_must_be_primary_address,
+      service_node_list_query_failed,
+      service_node_cannot_reregister,
+      insufficient_portions,
+      wallet_not_synced,
+      too_many_transactions_constructed,
+      exception_thrown,
+    };
+
+    struct register_service_node_result
+    {
+      register_service_node_result_status status;
+      std::string                         msg;
+      pending_tx                          ptx;
+    };
+    register_service_node_result create_register_service_node_tx(const std::vector<std::string> &args_, uint32_t subaddr_account = 0);
 
     // MMS -------------------------------------------------------------------------------------------------
     mms::message_store& get_message_store() { return m_message_store; };
@@ -1544,6 +1575,19 @@ namespace tools
     std::shared_ptr<tools::Notify> m_tx_notify;
     std::unique_ptr<wallet_device_callback> m_device_callback;
   };
+
+  // TODO(loki): Hmm. We need this here because we make register_service_node do
+  // parsing on the wallet2 side instead of simplewallet. This is so that
+  // register_service_node RPC command doesn't make it the wallet_rpc's
+  // responsibility to parse out the string returned from the daemon. We're
+  // purposely abstracting that complexity out to just wallet2's responsibility.
+
+  // TODO(loki): The better question is if anyone is ever going to try use
+  // register service node funded by multiple subaddresses. This is unlikely.
+  extern const std::array<const char* const, 5> allowed_priority_strings;
+  bool parse_subaddress_indices(const std::string& arg, std::set<uint32_t>& subaddr_indices, std::string *err_msg = nullptr);
+  bool parse_priority          (const std::string& arg, uint32_t& priority);
+
 }
 BOOST_CLASS_VERSION(tools::wallet2, 28)
 BOOST_CLASS_VERSION(tools::wallet2::transfer_details, 11)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3831,8 +3831,7 @@ namespace tools
     }
 
     // NOTE(loki): Pre-emptively set subaddr_account to 0. We don't support onwards from Infinite Staking which is when this call was implemented.
-    std::vector<tools::wallet2::pending_tx> ptx;
-    tools::wallet2::stake_result stake_result = m_wallet->create_stake_tx(ptx, snode_key, addr_info, req.amount, 0 /*amount_fraction*/, req.priority, 0 /*subaddr_account*/, req.subaddr_indices);
+    tools::wallet2::stake_result stake_result = m_wallet->create_stake_tx(snode_key, addr_info, req.amount, 0 /*amount_fraction*/, req.priority, 0 /*subaddr_account*/, req.subaddr_indices);
     if (stake_result.status != tools::wallet2::stake_result_status::success)
     {
       er.code    = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
@@ -3840,7 +3839,35 @@ namespace tools
       return false;
     }
 
-    return fill_response(ptx, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
+    std::vector<tools::wallet2::pending_tx> ptx_vector = {stake_result.ptx};
+    return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
+        res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, er);
+  }
+
+  bool wallet_rpc_server::on_register_service_node(const wallet_rpc::COMMAND_RPC_REGISTER_SERVICE_NODE::request& req, wallet_rpc::COMMAND_RPC_REGISTER_SERVICE_NODE::response& res, epee::json_rpc::error& er, const connection_context *ctx)
+  {
+    if (!m_wallet) return not_open(er);
+    if (m_restricted)
+    {
+      er.code    = WALLET_RPC_ERROR_CODE_DENIED;
+      er.message = "Register service node command is unavailable in restricted mode.";
+      return false;
+    }
+
+    std::vector<std::string> args;
+    boost::split(args, req.register_service_node_str, boost::is_any_of(" "));
+
+    // NOTE(loki): Pre-emptively set subaddr_account to 0. We don't support onwards from Infinite Staking which is when this call was implemented.
+    tools::wallet2::register_service_node_result register_result = m_wallet->create_register_service_node_tx(args, 0 /*subaddr_account*/);
+    if (register_result.status != tools::wallet2::register_service_node_result_status::success)
+    {
+      er.code    = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
+      er.message = register_result.msg;
+      return false;
+    }
+
+    std::vector<tools::wallet2::pending_tx> ptx_vector = {register_result.ptx};
+    return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
         res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, er);
   }
 }

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3857,6 +3857,12 @@ namespace tools
     std::vector<std::string> args;
     boost::split(args, req.register_service_node_str, boost::is_any_of(" "));
 
+    if (args.size() > 0)
+    {
+      if (args[0] == "register_service_node")
+        args.erase(args.begin());
+    }
+
     // NOTE(loki): Pre-emptively set subaddr_account to 0. We don't support onwards from Infinite Staking which is when this call was implemented.
     tools::wallet2::register_service_node_result register_result = m_wallet->create_register_service_node_tx(args, 0 /*subaddr_account*/);
     if (register_result.status != tools::wallet2::register_service_node_result_status::success)

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -155,6 +155,7 @@ namespace tools
         // Loki
         //
         MAP_JON_RPC_WE("stake", on_stake, wallet_rpc::COMMAND_RPC_STAKE)
+        MAP_JON_RPC_WE("register_service_node", on_register_service_node, wallet_rpc::COMMAND_RPC_REGISTER_SERVICE_NODE)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -236,6 +237,7 @@ namespace tools
       bool on_validate_address(const wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_get_version(const wallet_rpc::COMMAND_RPC_GET_VERSION::request& req, wallet_rpc::COMMAND_RPC_GET_VERSION::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_stake(const wallet_rpc::COMMAND_RPC_STAKE::request& req, wallet_rpc::COMMAND_RPC_STAKE::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
+      bool on_register_service_node(const wallet_rpc::COMMAND_RPC_REGISTER_SERVICE_NODE::request& req, wallet_rpc::COMMAND_RPC_REGISTER_SERVICE_NODE::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
 
       //json rpc v2
       bool on_query_key(const wallet_rpc::COMMAND_RPC_QUERY_KEY::request& req, wallet_rpc::COMMAND_RPC_QUERY_KEY::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2240,6 +2240,48 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_REGISTER_SERVICE_NODE
+  {
+    struct request
+    {
+      std::string register_service_node_str;
+      bool        get_tx_key;
+      bool        do_not_relay;
+      bool        get_tx_hex;
+      bool        get_tx_metadata;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(register_service_node_str);
+        KV_SERIALIZE(get_tx_key)
+        KV_SERIALIZE_OPT(do_not_relay,    false)
+        KV_SERIALIZE_OPT(get_tx_hex,      false)
+        KV_SERIALIZE_OPT(get_tx_metadata, false)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string tx_hash;
+      std::string tx_key;
+      uint64_t amount;
+      uint64_t fee;
+      std::string tx_blob;
+      std::string tx_metadata;
+      std::string multisig_txset;
+      std::string unsigned_txset;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash)
+        KV_SERIALIZE(tx_key)
+        KV_SERIALIZE(amount)
+        KV_SERIALIZE(fee)
+        KV_SERIALIZE(tx_blob)
+        KV_SERIALIZE(tx_metadata)
+        KV_SERIALIZE(multisig_txset)
+        KV_SERIALIZE(unsigned_txset)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_VALIDATE_ADDRESS
   {
     struct request


### PR DESCRIPTION
Essentially moves register_service_node into wallet2. Fail messages has to be hoisted up so that it can be returned in wallet_rpc and simplewallet. The same process that staking has gone through when that was made rpc-able.