### PR TITLE
Store last announced supernode version and expose in RPC

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1367,10 +1367,9 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  uint64_t core::get_uptime_proof(const crypto::public_key &key) const
+  service_nodes::proof_info core::get_uptime_proof(const crypto::public_key &key) const
   {
-    uint64_t result = m_quorum_cop.get_uptime_proof(key);
-    return result;
+    return m_quorum_cop.get_uptime_proof(key);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof)
@@ -1704,7 +1703,7 @@ namespace cryptonote
     {
       // Code snippet from Github @Jagerman
       m_check_uptime_proof_interval.do_call([&states, this](){
-        uint64_t last_uptime = m_quorum_cop.get_uptime_proof(states[0].pubkey);
+        uint64_t last_uptime = m_quorum_cop.get_uptime_proof(states[0].pubkey).timestamp;
         if (last_uptime <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS))
           this->submit_uptime_proof();
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -876,9 +876,9 @@ namespace cryptonote
       *
       * @param key The public key of the service node
       *
-      * @return 0 if no uptime proof found, otherwise the timestamp it last received in epoch time
+      * @return proof_info struct containing the uptime proof epoch timestamp and version if proof found, otherwise all 0s.
       */
-     uint64_t get_uptime_proof(const crypto::public_key &key) const;
+     service_nodes::proof_info get_uptime_proof(const crypto::public_key &key) const;
 
      /*
       * @brief get the blockchain pruning seed

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -38,6 +38,12 @@ namespace cryptonote
 
 namespace service_nodes
 {
+  struct proof_info
+  {
+      uint64_t timestamp;
+      uint16_t version_major, version_minor, version_patch;
+  };
+
   class quorum_cop
     : public cryptonote::Blockchain::BlockAddedHook,
       public cryptonote::Blockchain::BlockchainDetachedHook,
@@ -57,7 +63,7 @@ namespace service_nodes
                   "Safety buffer should always be less than the vote lifetime");
     bool prune_uptime_proof();
 
-    uint64_t get_uptime_proof(const crypto::public_key &pubkey) const;
+    proof_info get_uptime_proof(const crypto::public_key &pubkey) const;
 
     void generate_uptime_proof_request(cryptonote::NOTIFY_UPTIME_PROOF::request& req) const;
 
@@ -66,8 +72,7 @@ namespace service_nodes
     cryptonote::core& m_core;
     uint64_t m_last_height;
 
-    using timestamp = uint64_t;
-    std::unordered_map<crypto::public_key, timestamp> m_uptime_proof_seen;
+    std::unordered_map<crypto::public_key, proof_info> m_uptime_proof_seen;
     mutable epee::critical_section m_lock;
   };
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2599,12 +2599,15 @@ namespace cryptonote
     {
       COMMAND_RPC_GET_SERVICE_NODES::response::entry entry = {};
 
+      const auto proof = m_core.get_uptime_proof(pubkey_info.pubkey);
+
       entry.service_node_pubkey           = string_tools::pod_to_hex(pubkey_info.pubkey);
       entry.registration_height           = pubkey_info.info.registration_height;
       entry.requested_unlock_height       = pubkey_info.info.requested_unlock_height;
       entry.last_reward_block_height      = pubkey_info.info.last_reward_block_height;
       entry.last_reward_transaction_index = pubkey_info.info.last_reward_transaction_index;
-      entry.last_uptime_proof             = m_core.get_uptime_proof(pubkey_info.pubkey);
+      entry.last_uptime_proof             = proof.timestamp;
+      entry.service_node_version          = {proof.version_major, proof.version_minor, proof.version_patch};
 
       entry.contributors.reserve(pubkey_info.info.contributors.size());
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2604,6 +2604,7 @@ namespace cryptonote
         uint64_t                  last_reward_block_height;
         uint32_t                  last_reward_transaction_index;
         uint64_t                  last_uptime_proof;
+        std::vector<uint16_t>     service_node_version;
         std::vector<contributor>  contributors;
         uint64_t                  total_contributed;
         uint64_t                  total_reserved;
@@ -2618,6 +2619,7 @@ namespace cryptonote
             KV_SERIALIZE(last_reward_block_height)
             KV_SERIALIZE(last_reward_transaction_index)
             KV_SERIALIZE(last_uptime_proof)
+            KV_SERIALIZE(service_node_version)
             KV_SERIALIZE(contributors)
             KV_SERIALIZE(total_contributed)
             KV_SERIALIZE(total_reserved)


### PR DESCRIPTION
(@KeeJef requested I PR this for discussion of whether or not it belongs in core.)

This stores the last major/minor/patch versions that were included in the last uptime proof for each SN and exposes it as "service_node_version" in the get_service_nodes RPC call.