### PR TITLE
core tests: update priority for service nodes selected as winners

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1389,8 +1389,10 @@ namespace service_nodes
     crypto::public_key winner = select_winner();
 
     crypto::public_key check_winner_pubkey = cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
-    if (check_winner_pubkey != winner)
+    if (check_winner_pubkey != winner) {
+      MERROR("Service node reward winner is incorrect");
       return false;
+    }
 
     const std::vector<std::pair<cryptonote::account_public_address, uint64_t>> addresses_and_portions = get_winner_addresses_and_portions();
     

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -585,8 +585,8 @@ bool deregister_too_old::generate(std::vector<test_event_entry>& events)
   const auto pk = gen.get_test_pk(0);
   const auto dereg_tx = gen.build_deregister(pk, false).build();
 
-  /// create enough block to make deregistrations invalid (60 - 1 blocks)
-  gen.rewind_blocks_n(service_nodes::deregister_vote::DEREGISTER_LIFETIME_BY_HEIGHT-1);
+  /// create enough blocks to make deregistrations invalid (60 blocks)
+  gen.rewind_blocks_n(service_nodes::deregister_vote::DEREGISTER_LIFETIME_BY_HEIGHT);
 
   /// In the real world, this transaction should not make it into a block, but in this case we do try to add it (as in
   /// tests we must add specify transactions manually), which should exercise the same validation code and reject the
@@ -771,7 +771,7 @@ bool test_swarms_basic::generate(std::vector<test_event_entry>& events)
   for (auto i = init_sn_count; i < SN_KEYS_COUNT; ++i) {
     const auto sn = get_static_keys(i);
     const auto tx = gen.create_registration_tx(gen.first_miner(), sn);
-    gen.create_block({tx}); 
+    gen.create_block({tx});
   }
 
   /// test that another swarm has been created


### PR DESCRIPTION
- update "priority" (aka transaction idx) to UINT32_MAX when SN is selected as winner
- use grace period for SNs registered during hardfork 10
- fix an off-by-one bug