### PR TITLE
Provide --log-level for unit tests

### DIFF
--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -65,6 +65,8 @@ int main(int argc, char** argv)
   po::options_description desc_options("Command line options");
   const command_line::arg_descriptor<std::string> arg_data_dir = { "data-dir", "Data files directory", DEFAULT_DATA_DIR };
   command_line::add_arg(desc_options, arg_data_dir);
+  const command_line::arg_descriptor<int> arg_log_level = { "log-level", "Log level (0-4)", 1 };
+  command_line::add_arg(desc_options, arg_log_level);
 
   po::variables_map vm;
   bool r = command_line::handle_error_helper(desc_options, [&]()
@@ -77,6 +79,11 @@ int main(int argc, char** argv)
     return 1;
 
   unit_test::data_dir = command_line::get_arg(vm, arg_data_dir);
+  const int log_level = command_line::get_arg(vm, arg_log_level);
+  if (0 <= log_level && log_level <= 4)
+  {
+    mlog_set_log_level(log_level);
+  }
 
   CATCH_ENTRY_L0("main", 1);
 


### PR DESCRIPTION
Handy flag for running unit tests.
Could not get the same thing working for core tests, as the log level is overridden somewhere by the logic being tested.