### PR TITLE
[DO NOT MERGE] Calculate based off portions and incorporate dust

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -112,6 +112,7 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
+  { network_version_12,                  6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -112,7 +112,6 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
-  { network_version_12,                  6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1759,7 +1759,11 @@ namespace service_nodes
     }
 
     size_t const OPERATOR_ARG_INDEX = 1;
-    uint64_t portions_left          = STAKING_PORTIONS;
+    uint64_t maximum_contribution   = STAKING_PORTIONS;
+    if (hf_version <= cryptonote::network_version_11_infinite_staking)
+      maximum_contribution          = staking_requirement;
+
+    uint64_t contribution_remaining = maximum_contribution;
     for (size_t i = OPERATOR_ARG_INDEX, num_contributions = 0;
          i < args.size();
          i += 2, ++num_contributions)
@@ -1785,9 +1789,9 @@ namespace service_nodes
 
       try
       {
-        uint64_t total_portions_reserved = STAKING_PORTIONS - portions_left;
         uint64_t num_portions = boost::lexical_cast<uint64_t>(args[i+1]);
-        uint64_t min_portions = get_min_node_contribution(hf_version, STAKING_PORTIONS, total_portions_reserved, num_contributions);
+        uint64_t const total_reserved = maximum_contribution - portions_left;
+        uint64_t const min_portions   = get_min_node_contribution(hf_version, maximum_contribution, total_reserved, num_contributions);
         if (num_portions < min_portions || num_portions > portions_left)
         {
           result.err_msg = tr("Invalid amount for contributor: ") + args[i] + tr(", with portion amount: ") + args[i+1] + tr(". The contributors must each have at least 25%, except for the last contributor which may have the remaining amount");

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1763,6 +1763,7 @@ namespace service_nodes
     if (hf_version <= cryptonote::network_version_11_infinite_staking)
       maximum_contribution          = staking_requirement;
 
+    uint64_t portions_left          = STAKING_PORTIONS;
     uint64_t contribution_remaining = maximum_contribution;
     for (size_t i = OPERATOR_ARG_INDEX, num_contributions = 0;
          i < args.size();

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -22,7 +22,6 @@ namespace service_nodes {
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
 
-
 inline uint64_t staking_num_lock_blocks(cryptonote::network_type nettype)
 {
   switch(nettype)
@@ -34,18 +33,17 @@ inline uint64_t staking_num_lock_blocks(cryptonote::network_type nettype)
 }
 
 static_assert(STAKING_PORTIONS != UINT64_MAX, "UINT64_MAX is used as the invalid value for failing to calculate the min_node_contribution");
-// return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount in loki atomic units
-uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
-uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t total_reserved, size_t num_contributions);
+// NOTE: The units of maximum and total_reserved must match, i.e. both expressed in Loki or both expressed in portions
+// return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount
+uint64_t get_min_node_contribution(uint8_t version, uint64_t maximum, uint64_t total_reserved, size_t num_contributions);
 
 uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, int hf_version);
 
 // Convert portions to amount but round up to include dust, i.e.
 // Returns lowest x such that (STAKING_PORTIONS * x/amount) >= portions
 uint64_t portions_to_amount_incl_dust(uint64_t portions, uint64_t staking_requirement);
-
-// Convert portions to amount but don't include dust
 uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
+uint64_t amount_to_portions_incl_dust(uint64_t amount, uint64_t portions);
 
 /// Check if portions are sufficiently large (provided the contributions
 /// are made in the specified order) and don't exceed the required amount
@@ -53,9 +51,6 @@ bool check_service_node_portions(uint8_t version, const std::vector<uint64_t>& p
 
 crypto::hash generate_request_stake_unlock_hash(uint32_t nonce);
 uint64_t     get_locked_key_image_unlock_height(cryptonote::network_type nettype, uint64_t node_register_height, uint64_t curr_height);
-
-// Returns lowest x such that (staking_requirement * x/STAKING_PORTIONS) >= amount
-uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount);
 
 bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions);
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -36,10 +36,15 @@ inline uint64_t staking_num_lock_blocks(cryptonote::network_type nettype)
 static_assert(STAKING_PORTIONS != UINT64_MAX, "UINT64_MAX is used as the invalid value for failing to calculate the min_node_contribution");
 // return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount in loki atomic units
 uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
-uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
+uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t total_reserved, size_t num_contributions);
 
 uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, int hf_version);
 
+// Convert portions to amount but round up to include dust, i.e.
+// Returns lowest x such that (STAKING_PORTIONS * x/amount) >= portions
+uint64_t portions_to_amount_incl_dust(uint64_t portions, uint64_t staking_requirement);
+
+// Convert portions to amount but don't include dust
 uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
 
 /// Check if portions are sufficiently large (provided the contributions

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2805,7 +2805,7 @@ bool t_rpc_command_executor::prepare_registration()
         state.addresses.push_back(address_str); // the addresses will be validated later down the line
         state.contributions.push_back(STAKING_PORTIONS);
         state.portions_remaining = 0;
-        state.total_reserved_contributions += service_nodes::portions_to_amount(staking_requirement, STAKING_PORTIONS);
+        state.total_reserved_contributions = staking_requirement;
         state.prev_step = step;
         step            = register_step::final_summary;
         state_stack.push(state);
@@ -2916,7 +2916,7 @@ bool t_rpc_command_executor::prepare_registration()
 
       case register_step::is_open_stake__operator_amount_to_reserve:
       {
-        uint64_t min_contribution_portions = service_nodes::get_min_node_contribution_in_portions(hf_version, 0, 0);
+        uint64_t min_contribution_portions = service_nodes::get_min_node_contribution(hf_version, STAKING_PORTIONS, 0, 0);
         const uint64_t min_contribution    = service_nodes::portions_to_amount_incl_dust(staking_requirement, min_contribution_portions);
         std::cout << "Minimum amount that can be reserved: " << cryptonote::print_money(min_contribution) << " " << cryptonote::get_unit() << std::endl;
 
@@ -2938,7 +2938,7 @@ bool t_rpc_command_executor::prepare_registration()
           continue;
         }
 
-        uint64_t portions = service_nodes::get_portions_to_make_amount(staking_requirement, contribution);
+        uint64_t portions = service_nodes::amount_to_portions_incl_dust(contribution, staking_requirement);
         if(portions < min_contribution_portions)
         {
           std::cout << "The operator needs to contribute at least 25% of the stake requirement (" << cryptonote::print_money(min_contribution) << " " << cryptonote::get_unit() << "). Aborted." << std::endl;
@@ -2995,8 +2995,8 @@ bool t_rpc_command_executor::prepare_registration()
       case register_step::is_open_stake__contributor_amount_to_reserve:
       {
         const uint64_t total_portions_reserved   = STAKING_PORTIONS - state.portions_remaining;
-        const uint64_t min_contribution_portions = service_nodes::get_min_node_contribution_in_portions(hf_version, total_portions_reserved, state.contributions.size());
-        const uint64_t min_contribution          = service_nodes::portions_to_amount(staking_requirement, min_contribution_portions);
+        const uint64_t min_contribution_portions = service_nodes::get_min_node_contribution(hf_version, STAKING_PORTIONS, total_portions_reserved, state.contributions.size());
+        const uint64_t min_contribution          = service_nodes::portions_to_amount_incl_dust(staking_requirement, min_contribution_portions);
         const uint64_t amount_left               = staking_requirement - state.total_reserved_contributions;
 
         std::cout << "The minimum amount possible to contribute is " << cryptonote::print_money(min_contribution) << " " << cryptonote::get_unit() << std::endl;
@@ -3021,7 +3021,7 @@ bool t_rpc_command_executor::prepare_registration()
           continue;
         }
 
-        uint64_t portions = service_nodes::get_portions_to_make_amount(staking_requirement, contribution);
+        uint64_t portions = service_nodes::amount_to_portions_incl_dust(contribution, staking_requirement);
         if (portions < min_contribution_portions)
         {
           std::cout << "The amount is too small." << std::endl;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2489,7 +2489,7 @@ namespace cryptonote
 
     for (const auto contrib : req.contributions)
     {
-        uint64_t num_portions = service_nodes::get_portions_to_make_amount(staking_requirement, contrib.amount);
+        uint64_t num_portions = service_nodes::portions_to_amount_incl_dust(staking_requirement, contrib.amount);
         args.push_back(contrib.address);
         args.push_back(std::to_string(num_portions));
     }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7508,11 +7508,26 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
   // Create Register Transaction
   //
   {
+    uint64_t amount_payable_by_operator = 0;
+    {
+      const uint64_t DUST                 = MAX_NUMBER_OF_CONTRIBUTORS;
+      uint64_t amount_left                = staking_requirement;
+      for (size_t i = 0; i < converted_args.portions.size(); i++)
+      {
+        uint64_t amount = service_nodes::portions_to_amount(staking_requirement, converted_args.portions[i]);
+        if (i == 0) amount_payable_by_operator += amount;
+        amount_left -= amount;
+      }
+
+      if (amount_left <= DUST)
+        amount_payable_by_operator += amount_left;
+    }
+
     vector<cryptonote::tx_destination_entry> dsts;
     cryptonote::tx_destination_entry de;
     de.addr = address;
     de.is_subaddress = false;
-    de.amount = service_nodes::portions_to_amount(converted_args.portions[0], staking_requirement);
+    de.amount = amount_payable_by_operator;
     dsts.push_back(de);
 
     try


### PR DESCRIPTION
This is a regression introduced when we started calculating minimum contribution in Loki and not accounting for dust in the relaxed contribution rules.

Edit
Not to be merged until hard fork 12. Use this as a reference to fix up the problem at the source. The min portions for node calculation will switch to portions for hf12, hf11 should continue calculating off the loki amount to avoid any discrepancies.