### PR TITLE
Prepare registration dust failure minimal fix

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1758,9 +1758,14 @@ namespace service_nodes
       return result;
     }
 
+    struct addr_to_portion_t
+    {
+      cryptonote::address_parse_info info;
+      uint64_t portions;
+    };
+
+    std::vector<addr_to_portion_t> addr_to_portions;
     size_t const OPERATOR_ARG_INDEX     = 1;
-    uint64_t portions_left              = STAKING_PORTIONS;
-    uint64_t total_reserved             = 0;
     for (size_t i = OPERATOR_ARG_INDEX, num_contributions = 0;
          i < args.size();
          i += 2, ++num_contributions)
@@ -1787,30 +1792,93 @@ namespace service_nodes
       try
       {
         uint64_t num_portions = boost::lexical_cast<uint64_t>(args[i+1]);
-        uint64_t min_portions = get_min_node_contribution_in_portions(hf_version, staking_requirement, total_reserved, num_contributions);
-        if (num_portions < min_portions || num_portions > portions_left)
-        {
-          result.err_msg = tr("Invalid amount for contributor: ") + args[i] + tr(", with portion amount: ") + args[i+1] + tr(". The contributors must each have at least 25%, except for the last contributor which may have the remaining amount");
-          return result;
-        }
-
-        if (min_portions == UINT64_MAX)
-        {
-          result.err_msg = tr("Too many contributors specified, you can only split a node with up to: ") + std::to_string(MAX_NUMBER_OF_CONTRIBUTORS) + tr(" people.");
-          return result;
-        }
-
-        portions_left -= num_portions;
-        result.addresses.push_back(info.address);
-        result.portions.push_back(num_portions);
-        uint64_t loki_amount = service_nodes::portions_to_amount(num_portions, staking_requirement);
-        total_reserved      += loki_amount;
+        addr_to_portions.push_back({info, num_portions});
       }
       catch (const std::exception &e)
       {
         result.err_msg = tr("Invalid amount for contributor: ") + args[i] + tr(", with portion amount that could not be converted to a number: ") + args[i+1];
         return result;
       }
+    }
+
+    //
+    // FIXME(doyle): FIXME(loki) !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    //
+    std::array<uint64_t, MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR> excess_portions;
+    std::array<uint64_t, MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR> min_contributions;
+    {
+      uint64_t loki_reserved = 0;
+      for (size_t index = 0; index < addr_to_portions.size(); ++index)
+      {
+        addr_to_portion_t const &addr_to_portion = addr_to_portions[index];
+        uint64_t min_contribution_portions       = service_nodes::get_min_node_contribution_in_portions(hf_version, staking_requirement, loki_reserved, index);
+        uint64_t loki_amount                     = service_nodes::portions_to_amount(staking_requirement, addr_to_portion.portions);
+        loki_reserved                           += loki_amount;
+
+        uint64_t excess = 0;
+        if (addr_to_portion.portions > min_contribution_portions)
+          excess = addr_to_portion.portions - min_contribution_portions;
+
+        min_contributions[index] = min_contribution_portions;
+        excess_portions[index]   = excess;
+      }
+    }
+
+    uint64_t portions_left  = STAKING_PORTIONS;
+    uint64_t total_reserved = 0;
+    for (size_t i = 0; i < addr_to_portions.size(); ++i)
+    {
+      addr_to_portion_t &addr_to_portion = addr_to_portions[i];
+      uint64_t min_portions = get_min_node_contribution_in_portions(hf_version, staking_requirement, total_reserved, i);
+
+      if (addr_to_portion.portions < min_portions)
+      {
+          uint64_t needed = min_portions - addr_to_portion.portions;
+          const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
+          if (needed > DUST)
+            continue;
+
+          for (size_t sub_index = 0; sub_index < addr_to_portions.size(); sub_index++)
+          {
+            if (i == sub_index) continue;
+            uint64_t &contributor_excess = excess_portions[sub_index];
+            if (contributor_excess > 0)
+            {
+              uint64_t portions_to_steal = std::min(needed, contributor_excess);
+              addr_to_portion.portions += portions_to_steal;
+              contributor_excess -= portions_to_steal;
+              needed -= portions_to_steal;
+              result.portions[sub_index] -= portions_to_steal;
+              portions_left += portions_to_steal;
+
+              if (needed == 0)
+                break;
+            }
+          }
+
+          if (needed > 0 && addr_to_portions.size() < MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR)
+          {
+            addr_to_portion.portions += needed;
+          }
+      }
+
+      if (addr_to_portion.portions < min_portions || addr_to_portion.portions > portions_left)
+      {
+        result.err_msg = tr("Invalid amount for contributor: ") + args[i] + tr(", with portion amount: ") + args[i+1] + tr(". The contributors must each have at least 25%, except for the last contributor which may have the remaining amount");
+        return result;
+      }
+
+      if (min_portions == UINT64_MAX)
+      {
+        result.err_msg = tr("Too many contributors specified, you can only split a node with up to: ") + std::to_string(MAX_NUMBER_OF_CONTRIBUTORS) + tr(" people.");
+        return result;
+      }
+
+      portions_left -= addr_to_portion.portions;
+      result.addresses.push_back(addr_to_portion.info.address);
+      result.portions.push_back(addr_to_portion.portions);
+      uint64_t loki_amount = service_nodes::portions_to_amount(addr_to_portion.portions, staking_requirement);
+      total_reserved      += loki_amount;
     }
 
     result.success = true;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1803,10 +1803,13 @@ namespace service_nodes
 
     //
     // FIXME(doyle): FIXME(loki) !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // This is temporary code to redistribute the insufficient portion dust
+    // amounts between contributors. It should be removed in HF12.
     //
     std::array<uint64_t, MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR> excess_portions;
     std::array<uint64_t, MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR> min_contributions;
     {
+      // NOTE: Calculate excess portions from each contributor
       uint64_t loki_reserved = 0;
       for (size_t index = 0; index < addr_to_portions.size(); ++index)
       {
@@ -1833,6 +1836,8 @@ namespace service_nodes
 
       if (addr_to_portion.portions < min_portions)
       {
+          // NOTE: Steal dust portions from other contributor if we fall below
+          // the minimum by a dust amount.
           uint64_t needed = min_portions - addr_to_portion.portions;
           const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
           if (needed > DUST)
@@ -1856,10 +1861,10 @@ namespace service_nodes
             }
           }
 
+          // NOTE: Operator is sending in the minimum amount and it falls below
+          // the minimum by dust, just increase the portions so it passes
           if (needed > 0 && addr_to_portions.size() < MAX_NUMBER_OF_CONTRIBUTORS * service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR)
-          {
             addr_to_portion.portions += needed;
-          }
       }
 
       if (addr_to_portion.portions < min_portions || addr_to_portion.portions > portions_left)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1759,7 +1759,7 @@ namespace service_nodes
     }
 
     size_t const OPERATOR_ARG_INDEX     = 1;
-    uint64_t amount_payable_by_operator = 0;
+    uint64_t portions_left              = STAKING_PORTIONS;
     uint64_t total_reserved             = 0;
     for (size_t i = OPERATOR_ARG_INDEX, num_contributions = 0;
          i < args.size();
@@ -1788,7 +1788,7 @@ namespace service_nodes
       {
         uint64_t num_portions = boost::lexical_cast<uint64_t>(args[i+1]);
         uint64_t min_portions = get_min_node_contribution_in_portions(hf_version, staking_requirement, total_reserved, num_contributions);
-        if (num_portions < min_portions)
+        if (num_portions < min_portions || num_portions > portions_left)
         {
           result.err_msg = tr("Invalid amount for contributor: ") + args[i] + tr(", with portion amount: ") + args[i+1] + tr(". The contributors must each have at least 25%, except for the last contributor which may have the remaining amount");
           return result;
@@ -1800,6 +1800,7 @@ namespace service_nodes
           return result;
         }
 
+        portions_left -= num_portions;
         result.addresses.push_back(info.address);
         result.portions.push_back(num_portions);
         uint64_t loki_amount = service_nodes::portions_to_amount(num_portions, staking_requirement);
@@ -1811,11 +1812,6 @@ namespace service_nodes
         return result;
       }
     }
-
-    uint64_t amount_left = staking_requirement - total_reserved;
-    const uint64_t DUST  = MAX_NUMBER_OF_CONTRIBUTORS;
-    if (amount_left <= DUST)
-      result.portions[0] += amount_left;
 
     result.success = true;
     return result;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1834,6 +1834,7 @@ namespace service_nodes
       addr_to_portion_t &addr_to_portion = addr_to_portions[i];
       uint64_t min_portions = get_min_node_contribution_in_portions(hf_version, staking_requirement, total_reserved, i);
 
+      uint64_t portions_to_steal = 0;
       if (addr_to_portion.portions < min_portions)
       {
           // NOTE: Steal dust portions from other contributor if we fall below
@@ -1851,12 +1852,11 @@ namespace service_nodes
             uint64_t &contributor_excess = excess_portions[sub_index];
             if (contributor_excess > 0)
             {
-              uint64_t portions_to_steal = std::min(needed, contributor_excess);
+              portions_to_steal = std::min(needed, contributor_excess);
               addr_to_portion.portions += portions_to_steal;
               contributor_excess -= portions_to_steal;
               needed -= portions_to_steal;
               result.portions[sub_index] -= portions_to_steal;
-              portions_left += portions_to_steal;
 
               if (needed == 0)
                 break;
@@ -1882,6 +1882,7 @@ namespace service_nodes
       }
 
       portions_left -= addr_to_portion.portions;
+      portions_left += portions_to_steal;
       result.addresses.push_back(addr_to_portion.info.address);
       result.portions.push_back(addr_to_portion.portions);
       uint64_t loki_amount = service_nodes::portions_to_amount(addr_to_portion.portions, staking_requirement);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1838,8 +1838,10 @@ namespace service_nodes
       {
           // NOTE: Steal dust portions from other contributor if we fall below
           // the minimum by a dust amount.
-          uint64_t needed = min_portions - addr_to_portion.portions;
-          const uint64_t DUST = MAX_NUMBER_OF_CONTRIBUTORS;
+          uint64_t needed             = min_portions - addr_to_portion.portions;
+          const uint64_t FUDGE_FACTOR = 10;
+          const uint64_t DUST_UNIT    = (STAKING_PORTIONS / staking_requirement);
+          const uint64_t DUST         = DUST_UNIT * FUDGE_FACTOR;
           if (needed > DUST)
             continue;
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2772,7 +2772,6 @@ bool t_rpc_command_executor::prepare_registration()
     uint64_t                 total_reserved_contributions = 0;
     std::vector<std::string> addresses;
     std::vector<uint64_t>    contributions;
-
   };
 
   prepare_registration_state state = {};
@@ -3115,9 +3114,7 @@ bool t_rpc_command_executor::prepare_registration()
           const std::string participant_name = (i==0) ? "Operator" : "Contributor " + std::to_string(i);
           uint64_t amount = get_actual_amount(staking_requirement, state.contributions[i]);
           if (amount_left <= DUST && i == 0)
-          {
             amount += amount_left; // add dust to the operator.
-          }
           printf("%-16s%-9s%-19s%-.9f\n", participant_name.c_str(), state.addresses[i].substr(0,6).c_str(), cryptonote::print_money(amount).c_str(), (double)state.contributions[i] * 100 / STAKING_PORTIONS);
         }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7508,11 +7508,26 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
   // Create Register Transaction
   //
   {
+    uint64_t amount_payable_by_operator = 0;
+    {
+      const uint64_t DUST                 = MAX_NUMBER_OF_CONTRIBUTORS;
+      uint64_t amount_left                = staking_requirement;
+      for (size_t i = 0; i < converted_args.portions.size(); i++)
+      {
+        uint64_t amount = service_nodes::portions_to_amount(staking_requirement, converted_args.portions[i]);
+        if (i == 0) amount_payable_by_operator += amount;
+        amount_left -= amount;
+      }
+
+      if (amount_left <= DUST)
+        amount_payable_by_operator += amount_left;
+    }
+
     vector<cryptonote::tx_destination_entry> dsts;
     cryptonote::tx_destination_entry de;
     de.addr = address;
     de.is_subaddress = false;
-    de.amount = service_nodes::portions_to_amount(converted_args.portions[0], staking_requirement);
+    de.amount = amount_payable_by_operator;
     dsts.push_back(de);
 
     try


### PR DESCRIPTION
This fixes prepare registration failing by dust, only on the client side. This is temporary code, the next hard fork should contain the canonical fix https://github.com/loki-project/loki/pull/519 Adding the canonical fix now will cause network problems.

The fix here is to redistribute the missing dust amounts from the contribution that falls below the minimum amount from predecessor contributors.