### PR TITLE
More wallet performance by caching contributed SNs

### DIFF
--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -56,6 +56,7 @@ public:
 
   std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry>             get_service_nodes(std::vector<std::string> const &pubkeys, boost::optional<std::string> &failed) const;
   std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry>             get_all_service_nodes(boost::optional<std::string> &failed) const;
+  std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry>             get_contributed_service_nodes(const std::string &contributor, boost::optional<std::string> &failed) const;
   std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::entry> get_service_node_blacklisted_key_images(boost::optional<std::string> &failed) const;
 
 private:
@@ -67,8 +68,14 @@ private:
   mutable uint64_t m_service_node_blacklisted_key_images_cached_height;
   mutable std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::entry> m_service_node_blacklisted_key_images;
 
+  bool update_all_service_nodes_cache(uint64_t height, boost::optional<std::string> &failed) const;
+
   mutable uint64_t m_all_service_nodes_cached_height;
   mutable std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> m_all_service_nodes;
+
+  mutable uint64_t m_contributed_service_nodes_cached_height;
+  mutable std::string m_contributed_service_nodes_cached_address;
+  mutable std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> m_contributed_service_nodes;
 
   mutable uint64_t m_height;
   mutable uint64_t m_earliest_height[256];

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5619,15 +5619,15 @@ bool wallet2::is_transfer_unlocked(uint64_t unlock_time, uint64_t block_height, 
   }
 
   {
+    const std::string primary_address = get_address_as_str();
     boost::optional<std::string> failed;
-    std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> service_nodes_states = m_node_rpc_proxy.get_all_service_nodes(failed);
+    std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> service_nodes_states = m_node_rpc_proxy.get_contributed_service_nodes(primary_address, failed);
     if (failed)
     {
       LOG_PRINT_L1("Failed to query service node for locked transfers, assuming transfer not locked, reason: " << *failed);
       return true;
     }
 
-    const std::string primary_address = get_address_as_str();
     for (cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry const &entry : service_nodes_states)
     {
       for (cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : entry.contributors)


### PR DESCRIPTION
This caches a filtered-by-contributor list of service nodes in the
node_rpc_proxy so that when the wallet balance requests it the vast
majority of nodes will be only checked (and not included) for the first
input checked, massively speeding up following inputs which only need to
check the service nodes where the account has actually contributed.

This makes the `balance` command on my Raspberry Pi wallet return the
result essentially instantly (I can perceive no delay at all), while
before this it was around half a second (and before #536 around 10s on
the same mainnet wallet on the Pi).