### PR TITLE
Remove nested shadowed variables

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -125,8 +125,6 @@ namespace service_nodes
         missed_txs.clear();
 
         const cryptonote::block& block = block_pair.second;
-        std::vector<cryptonote::transaction> txs;
-        std::vector<crypto::hash> missed_txs;
         if (!m_blockchain.get_transactions(block.tx_hashes, txs, missed_txs))
         {
           MERROR("Unable to get transactions for block " << block.hash);


### PR DESCRIPTION
If you expand the diff upwards you see the variable shadowing for `txs` and `missed_txs`:
```cpp
std::vector<cryptonote::transaction> txs;
std::vector<crypto::hash> missed_txs;
for (const auto& block_pair : blocks)
{
  ...
  std::vector<cryptonote::transaction> txs;
  std::vector<crypto::hash> missed_txs;
...
}
```