### PR TITLE
Comments for rpc-doc-generator.

### DIFF
--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -61,12 +61,14 @@ namespace wallet_rpc
 #define WALLET_RPC_STATUS_BUSY    "BUSY"
 
   LOKI_RPC_DOC_INTROSPECT
+  // Return the wallet's balance.
   struct COMMAND_RPC_GET_BALANCE
   {
     struct request
     {
-      uint32_t account_index;
-      std::set<uint32_t> address_indices;
+      uint32_t account_index;             // Return balance for this account.
+      std::set<uint32_t> address_indices; // (Optional) Return balance detail for those subaddresses.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(address_indices)
@@ -75,12 +77,12 @@ namespace wallet_rpc
 
     struct per_subaddress_info
     {
-      uint32_t address_index;
-      std::string address;
-      uint64_t balance;
-      uint64_t unlocked_balance;
-      std::string label;
-      uint64_t num_unspent_outputs;
+      uint32_t address_index;       // Index of the subaddress in the account.
+      std::string address;          // Address at this index. Base58 representation of the public keys.
+      uint64_t balance;             // Balance for the subaddress (locked or unlocked).
+      uint64_t unlocked_balance;    // Unlocked funds are those funds that are sufficiently deep enough in the loki blockchain to be considered safe to spend.
+      std::string label;            // Label for the subaddress.
+      uint64_t num_unspent_outputs; // Number of unspent outputs available for the subaddress.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address_index)
@@ -94,10 +96,10 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t 	 balance;
-      uint64_t 	 unlocked_balance;
-      bool       multisig_import_needed;
-      std::vector<per_subaddress_info> per_subaddress;
+      uint64_t 	 balance;                              // The total balance of the current loki-wallet-rpc in session.
+      uint64_t 	 unlocked_balance;                     // Unlocked funds are those funds that are sufficiently deep enough in the loki blockchain to be considered safe to spend.
+      bool       multisig_import_needed;               // True if importing multisig data is needed for returning a correct balance.
+      std::vector<per_subaddress_info> per_subaddress; // Balance information for each subaddress in an account.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(balance)
@@ -108,13 +110,15 @@ namespace wallet_rpc
     };
   };
 
-    LOKI_RPC_DOC_INTROSPECT
-    struct COMMAND_RPC_GET_ADDRESS
+  LOKI_RPC_DOC_INTROSPECT
+  // Return the wallet's addresses for an account. Optionally filter for specific set of subaddresses.
+  struct COMMAND_RPC_GET_ADDRESS
   {
     struct request
     {
-      uint32_t account_index;
-      std::vector<uint32_t> address_index;
+      uint32_t account_index;              // Return subaddresses for this account.
+      std::vector<uint32_t> address_index; // (Optional) List of subaddresses to return from an account.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(address_index)
@@ -123,10 +127,10 @@ namespace wallet_rpc
 
     struct address_info
     {
-      std::string address;
-      std::string label;
-      uint32_t address_index;
-      bool used;
+      std::string address;    // The 95-character hex (sub)address string.
+      std::string label;      // Label of the (sub)address.
+      uint32_t address_index; // Index of the subaddress
+      bool used;              // States if the (sub)address has already received funds.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -138,8 +142,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string address;                  // to remain compatible with older RPC format
-      std::vector<address_info> addresses;
+      std::string address;                  // The 95-character hex address string of the loki-wallet-rpc in session. To remain compatible with older RPC format
+      std::vector<address_info> addresses;  // Addresses informations.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -149,11 +153,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get account and address indexes from a specific (sub)address.
   struct COMMAND_RPC_GET_ADDRESS_INDEX
   {
     struct request
     {
-      std::string address;
+      std::string address; // (sub)address to look for.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
       END_KV_SERIALIZE_MAP()
@@ -161,7 +167,8 @@ namespace wallet_rpc
 
     struct response
     {
-      cryptonote::subaddress_index index;
+      cryptonote::subaddress_index index; // Account index.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index)
       END_KV_SERIALIZE_MAP()
@@ -169,12 +176,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Create a new address for an account. Optionally, label the new address.
   struct COMMAND_RPC_CREATE_ADDRESS
   {
     struct request
     {
-      uint32_t account_index;
-      std::string label;
+      uint32_t account_index; // Create a new address for this account.
+      std::string label;      // (Optional) Label for the new address.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
@@ -184,8 +192,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string   address;
-      uint32_t      address_index;
+      std::string   address;       // Newly created address. Base58 representation of the public keys.
+      uint32_t      address_index; // Index of the new address under the input account.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -195,12 +203,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Label an address.
   struct COMMAND_RPC_LABEL_ADDRESS
   {
     struct request
     {
-      cryptonote::subaddress_index index;
-      std::string label;
+      cryptonote::subaddress_index index; // JSON Object containing the major & minor address index.
+      std::string label;                  // Label for the address.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index)
@@ -216,11 +225,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get all accounts for a wallet. Optionally filter accounts by tag.
   struct COMMAND_RPC_GET_ACCOUNTS
   {
     struct request
     {
-      std::string tag;      // all accounts if empty, otherwise those accounts with this tag
+      std::string tag;      // (Optional) Tag for filtering accounts. All accounts if empty, otherwise those accounts with this tag
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tag)
@@ -229,12 +239,12 @@ namespace wallet_rpc
 
     struct subaddress_account_info
     {
-      uint32_t account_index;
-      std::string base_address;
-      uint64_t balance;
-      uint64_t unlocked_balance;
-      std::string label;
-      std::string tag;
+      uint32_t account_index;    // Index of the account.
+      std::string base_address;  // Base64 representation of the first subaddress in the account.
+      uint64_t balance;          // Balance of the account (locked or unlocked).
+      uint64_t unlocked_balance; // Unlocked balance for the account.
+      std::string label;         // (Optional) Label of the account.
+      std::string tag;           // (Optional) Tag for filtering accounts.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
@@ -248,9 +258,9 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t total_balance;
-      uint64_t total_unlocked_balance;
-      std::vector<subaddress_account_info> subaddress_accounts;
+      uint64_t total_balance;                                   // Total balance of the selected accounts (locked or unlocked).
+      uint64_t total_unlocked_balance;                          // Total unlocked balance of the selected accounts.
+      std::vector<subaddress_account_info> subaddress_accounts; // Account information.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(total_balance)
@@ -261,11 +271,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Create a new account with an optional label.
   struct COMMAND_RPC_CREATE_ACCOUNT
   {
     struct request
     {
-      std::string label;
+      std::string label; // (Optional) Label for the account.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(label)
       END_KV_SERIALIZE_MAP()
@@ -273,8 +285,9 @@ namespace wallet_rpc
 
     struct response
     {
-      uint32_t account_index;
-      std::string address;      // the 0-th address for convenience
+      uint32_t account_index;   // Index of the new account.
+      std::string address;      // Address for this account. Base58 representation of the public keys. The 0-th address for convenience
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(address)
@@ -283,12 +296,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Label an account.
   struct COMMAND_RPC_LABEL_ACCOUNT
   {
     struct request
     {
-      uint32_t account_index;
-      std::string label;
+      uint32_t account_index; // Apply label to account at this index.
+      std::string label;      // Label for the account.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
@@ -304,6 +318,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get a list of user-defined account tags.
   struct COMMAND_RPC_GET_ACCOUNT_TAGS
   {
     struct request
@@ -314,9 +329,9 @@ namespace wallet_rpc
 
     struct account_tag_info
     {
-      std::string tag;
-      std::string label;
-      std::vector<uint32_t> accounts;
+      std::string tag;                // Filter tag.
+      std::string label;              // Label for the tag.
+      std::vector<uint32_t> accounts; // List of tagged account indices.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tag);
@@ -327,7 +342,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::vector<account_tag_info> account_tags;
+      std::vector<account_tag_info> account_tags; // Account tag information:
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_tags)
@@ -336,12 +351,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Apply a filtering tag to a list of accounts.
   struct COMMAND_RPC_TAG_ACCOUNTS
   {
     struct request
     {
-      std::string tag;
-      std::set<uint32_t> accounts;
+      std::string tag;             // Tag for the accounts.
+      std::set<uint32_t> accounts; // Tag this list of accounts.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tag)
@@ -357,11 +373,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Remove filtering tag from a list of accounts.
   struct COMMAND_RPC_UNTAG_ACCOUNTS
   {
     struct request
     {
-      std::set<uint32_t> accounts;
+      std::set<uint32_t> accounts; // Remove tag from this list of accounts.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(accounts)
@@ -376,12 +393,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Set description for an account tag.
   struct COMMAND_RPC_SET_ACCOUNT_TAG_DESCRIPTION
   {
     struct request
     {
-      std::string tag;
-      std::string description;
+      std::string tag;         // Set a description for this tag.
+      std::string description; // Description for the tag.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tag)
@@ -396,28 +414,31 @@ namespace wallet_rpc
     };
   };
 
-    LOKI_RPC_DOC_INTROSPECT
-    struct COMMAND_RPC_GET_HEIGHT
+  LOKI_RPC_DOC_INTROSPECT
+  // Returns the wallet's current block height.
+  struct COMMAND_RPC_GET_HEIGHT
+  {
+    struct request
     {
-      struct request
-      {
-        BEGIN_KV_SERIALIZE_MAP()
-        END_KV_SERIALIZE_MAP()
-      };
-
-      struct response
-      {
-        uint64_t  height;
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(height)
-        END_KV_SERIALIZE_MAP()
-      };
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
     };
+
+    struct response
+    {
+      uint64_t  height; // The current loki-wallet-rpc's blockchain height. If the wallet has been offline for a long time, it may need to catch up with the daemon.
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 
   struct transfer_destination
   {
-    uint64_t amount;
-    std::string address;
+    uint64_t amount;     // Amount to send to each destination, in atomic units.
+    std::string address; // Destination public address.
+
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(amount)
       KV_SERIALIZE(address)
@@ -425,22 +446,23 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Send loki to a number of recipients.
   struct COMMAND_RPC_TRANSFER
   {
     struct request
     {
-      std::list<transfer_destination> destinations;
-      uint32_t account_index;
-      std::set<uint32_t> subaddr_indices;
-      uint32_t priority;
-      uint64_t mixin;
-      uint64_t ring_size;
-      uint64_t unlock_time;
-      std::string payment_id;
-      bool get_tx_key;
-      bool do_not_relay;
-      bool get_tx_hex;
-      bool get_tx_metadata;
+      std::list<transfer_destination> destinations; // Array of destinations to receive LOKI.
+      uint32_t account_index;                       // (Optional) Transfer from this account index. (Defaults to 0)
+      std::set<uint32_t> subaddr_indices;           // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
+      uint32_t priority;                            // Set a priority for the transaction. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
+      uint64_t mixin;                               // (Ignored) Number of outputs from the blockchain to mix with. Loki mixin statically set to 9.
+      uint64_t ring_size;                           // (Ignored) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
+      uint64_t unlock_time;                         // Number of blocks before the loki can be spent (0 to not add a lock).
+      std::string payment_id;                       // (Optional) Random 32-byte/64-character hex string to identify a transaction.
+      bool get_tx_key;                              // (Optional) Return the transaction key after sending.
+      bool do_not_relay;                            // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
+      bool get_tx_hex;                              // Return the transaction as hex string after sending. (Defaults to false)
+      bool get_tx_metadata;                         // Return the metadata needed to relay the transaction. (Defaults to false)
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -460,14 +482,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_hash;
-      std::string tx_key;
-      uint64_t amount;
-      uint64_t fee;
-      std::string tx_blob;
-      std::string tx_metadata;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::string tx_hash;        // Publically searchable transaction hash.
+      std::string tx_key;         // Transaction key if get_tx_key is true, otherwise, blank string.
+      uint64_t amount;            // Amount transferred for the transaction.
+      uint64_t fee;               // Fee charged for the txn.
+      std::string tx_blob;        // Raw transaction represented as hex string, if get_tx_hex is true.
+      std::string tx_metadata;    // Set of transaction metadata needed to relay this transfer later, if get_tx_metadata is true.
+      std::string multisig_txset; // Set of multisig transactions in the process of being signed (empty for non-multisig).
+      std::string unsigned_txset; // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -483,22 +505,23 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Same as transfer, but can split into more than one tx if necessary.
   struct COMMAND_RPC_TRANSFER_SPLIT
   {
     struct request
     {
-      std::list<transfer_destination> destinations;
-      uint32_t account_index;
-      std::set<uint32_t> subaddr_indices;
-      uint32_t priority;
-      uint64_t mixin;
-      uint64_t ring_size;
-      uint64_t unlock_time;
-      std::string payment_id;
-      bool get_tx_keys;
-      bool do_not_relay;
-      bool get_tx_hex;
-      bool get_tx_metadata;
+      std::list<transfer_destination> destinations; // Array of destinations to receive LOKI:
+      uint32_t account_index;                       // (Optional) Transfer from this account index. (Defaults to 0)
+      std::set<uint32_t> subaddr_indices;           // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
+      uint32_t priority;                            // Set a priority for the transactions. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
+      uint64_t mixin;                               // (Ignored) Number of outputs from the blockchain to mix with. Loki mixin statically set to 9.
+      uint64_t ring_size;                           // (Ignored) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
+      uint64_t unlock_time;                         // Number of blocks before the loki can be spent (0 to not add a lock).
+      std::string payment_id;                       // (Optional) Random 32-byte/64-character hex string to identify a transaction.
+      bool get_tx_keys;                             // (Optional) Return the transaction keys after sending.
+      bool do_not_relay;                            // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
+      bool get_tx_hex;                              // Return the transactions as hex string after sending.
+      bool get_tx_metadata;                         // Return list of transaction metadata needed to relay the transfer later.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -518,7 +541,7 @@ namespace wallet_rpc
 
     struct key_list
     {
-      std::list<std::string> keys;
+      std::list<std::string> keys; //
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(keys)
@@ -527,14 +550,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> tx_hash_list;
-      std::list<std::string> tx_key_list;
-      std::list<uint64_t> amount_list;
-      std::list<uint64_t> fee_list;
-      std::list<std::string> tx_blob_list;
-      std::list<std::string> tx_metadata_list;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::list<std::string> tx_hash_list;     // The tx hashes of every transaction.
+      std::list<std::string> tx_key_list;      // The transaction keys for every transaction.
+      std::list<uint64_t> amount_list;         // The amount transferred for every transaction.
+      std::list<uint64_t> fee_list;            // The amount of fees paid for every transaction.
+      std::list<std::string> tx_blob_list;     // The tx as hex string for every transaction.
+      std::list<std::string> tx_metadata_list; // List of transaction metadata needed to relay the transactions later.
+      std::string multisig_txset;              // The set of signing keys used in a multisig transaction (empty for non-multisig).
+      std::string unsigned_txset;              // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -550,12 +573,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+
   struct COMMAND_RPC_DESCRIBE_TRANSFER
   {
     struct recipient
     {
-      std::string address;
-      uint64_t amount;
+      std::string address; // Destination public address.
+      uint64_t amount;     // Amount in atomic units.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -565,17 +589,17 @@ namespace wallet_rpc
 
     struct transfer_description
     {
-      uint64_t amount_in;
-      uint64_t amount_out;
-      uint32_t ring_size;
-      uint64_t unlock_time;
-      std::list<recipient> recipients;
-      std::string payment_id;
-      uint64_t change_amount;
-      std::string change_address;
-      uint64_t fee;
-      uint32_t dummy_outputs;
-      std::string extra;
+      uint64_t amount_in;              // Amount in, in atomic units.
+      uint64_t amount_out;             // amount out, in atomic units.
+      uint32_t ring_size;              // Ring size of transfer.
+      uint64_t unlock_time;            // Number of blocks before the loki can be spent (0 to not add a lock).
+      std::list<recipient> recipients; // List of addresses and amounts.
+      std::string payment_id;          // Payment ID matching the input parameter.
+      uint64_t change_amount;          // Change received from transaction in atomic units.
+      std::string change_address;      // Address the change was sent to.
+      uint64_t fee;                    // Fee of the transaction in atomic units.
+      uint32_t dummy_outputs;          // 
+      std::string extra;               // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(amount_in)
@@ -594,7 +618,7 @@ namespace wallet_rpc
 
     struct request
     {
-      std::string unsigned_txset;
+      std::string unsigned_txset; // Set of unsigned tx returned by "transfer" or "transfer_split" methods.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(unsigned_txset)
@@ -603,7 +627,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<transfer_description> desc;
+      std::list<transfer_description> desc; // List of information of transfers.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(desc)
@@ -612,13 +636,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Sign a transaction created on a read-only wallet (in cold-signing process).
   struct COMMAND_RPC_SIGN_TRANSFER
   {
     struct request
     {
-      std::string unsigned_txset;
-      bool export_raw;
-      bool get_tx_keys;
+      std::string unsigned_txset; // Set of unsigned tx returned by "transfer" or "transfer_split" methods.
+      bool export_raw;            // (Optional) If true, return the raw transaction data. (Defaults to false)
+      bool get_tx_keys;           // (Optional) Return the transaction keys after sending.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(unsigned_txset)
@@ -629,10 +654,10 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string signed_txset;
-      std::list<std::string> tx_hash_list;
-      std::list<std::string> tx_raw_list;
-      std::list<std::string> tx_key_list;
+      std::string signed_txset;            // Set of signed tx to be used for submitting transfer.
+      std::list<std::string> tx_hash_list; // The tx hashes of every transaction.
+      std::list<std::string> tx_raw_list;  // The tx raw data of every transaction.
+      std::list<std::string> tx_key_list;  // The tx key data of every transaction.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signed_txset)
@@ -644,11 +669,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Submit a previously signed transaction on a read-only wallet (in cold-signing process).
   struct COMMAND_RPC_SUBMIT_TRANSFER
   {
     struct request
     {
-      std::string tx_data_hex;
+      std::string tx_data_hex; // Set of signed tx returned by "sign_transfer".
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_data_hex)
@@ -657,7 +683,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> tx_hash_list;
+      std::list<std::string> tx_hash_list; // The tx hashes of every transaction.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -666,14 +692,15 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Send all dust outputs back to the wallet's, to make them easier to spend (and mix).
   struct COMMAND_RPC_SWEEP_DUST
   {
     struct request
     {
-      bool get_tx_keys;
-      bool do_not_relay;
-      bool get_tx_hex;
-      bool get_tx_metadata;
+      bool get_tx_keys;     // (Optional) Return the transaction keys after sending.
+      bool do_not_relay;    // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
+      bool get_tx_hex;      // (Optional) Return the transactions as hex string after sending. (Defaults to false)
+      bool get_tx_metadata; // (Optional) Return list of transaction metadata needed to relay the transfer later. (Defaults to false)
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(get_tx_keys)
@@ -685,7 +712,7 @@ namespace wallet_rpc
 
     struct key_list
     {
-      std::list<std::string> keys;
+      std::list<std::string> keys; 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(keys)
@@ -694,14 +721,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> tx_hash_list;
-      std::list<std::string> tx_key_list;
-      std::list<uint64_t> amount_list;
-      std::list<uint64_t> fee_list;
-      std::list<std::string> tx_blob_list;
-      std::list<std::string> tx_metadata_list;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::list<std::string> tx_hash_list;     // The tx hashes of every transaction.
+      std::list<std::string> tx_key_list;      // The transaction keys for every transaction.
+      std::list<uint64_t> amount_list;         // The amount transferred for every transaction.
+      std::list<uint64_t> fee_list;            // The amount of fees paid for every transaction.
+      std::list<std::string> tx_blob_list;     // The tx as hex string for every transaction.
+      std::list<std::string> tx_metadata_list; // List of transaction metadata needed to relay the transactions later. 
+      std::string multisig_txset;              // The set of signing keys used in a multisig transaction (empty for non-multisig).
+      std::string unsigned_txset;              // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -717,24 +744,25 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Send all unlocked balance to an address.
   struct COMMAND_RPC_SWEEP_ALL
   {
     struct request
     {
-      std::string address;
-      uint32_t account_index;
-      std::set<uint32_t> subaddr_indices;
-      uint32_t priority;
-      uint64_t mixin;
-      uint64_t ring_size;
-      uint64_t outputs;
-      uint64_t unlock_time;
-      std::string payment_id;
-      bool get_tx_keys;
-      uint64_t below_amount;
-      bool do_not_relay;
-      bool get_tx_hex;
-      bool get_tx_metadata;
+      std::string address;                // Destination public address.
+      uint32_t account_index;             // Sweep transactions from this account.
+      std::set<uint32_t> subaddr_indices; // (Optional) Sweep from this set of subaddresses in the account.
+      uint32_t priority;                  // (Optional) Priority for sending the sweep transfer, partially determines fee. 
+      uint64_t mixin;                     // (Ignored) Number of outputs from the blockchain to mix with. Loki mixin statically set to 9.
+      uint64_t ring_size;                 // (Ignored) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
+      uint64_t outputs;                   // 
+      uint64_t unlock_time;               // Number of blocks before the loki can be spent (0 to not add a lock). 
+      std::string payment_id;             // (Optional) Random 32-byte/64-character hex string to identify a transaction.
+      bool get_tx_keys;                   // (Optional) Return the transaction keys after sending.
+      uint64_t below_amount;              // (Optional) Include outputs below this amount.
+      bool do_not_relay;                  // (Optional) If true, do not relay this sweep transfer. (Defaults to false)
+      bool get_tx_hex;                    // (Optional) return the transactions as hex encoded string. (Defaults to false)
+      bool get_tx_metadata;               // (Optional) return the transaction metadata as a string. (Defaults to false)
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -765,14 +793,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> tx_hash_list;
-      std::list<std::string> tx_key_list;
-      std::list<uint64_t> amount_list;
-      std::list<uint64_t> fee_list;
-      std::list<std::string> tx_blob_list;
-      std::list<std::string> tx_metadata_list;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::list<std::string> tx_hash_list;     // The tx hashes of every transaction.
+      std::list<std::string> tx_key_list;      // The transaction keys for every transaction.
+      std::list<uint64_t> amount_list;         // The amount transferred for every transaction.
+      std::list<uint64_t> fee_list;            // The amount of fees paid for every transaction.
+      std::list<std::string> tx_blob_list;     // The tx as hex string for every transaction.
+      std::list<std::string> tx_metadata_list; // List of transaction metadata needed to relay the transactions later.
+      std::string multisig_txset;              // The set of signing keys used in a multisig transaction (empty for non-multisig).
+      std::string unsigned_txset;              // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -788,22 +816,23 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Send all of a specific unlocked output to an address.
   struct COMMAND_RPC_SWEEP_SINGLE
   {
     struct request
     {
-      std::string address;
-      uint32_t priority;
-      uint64_t mixin;
-      uint64_t ring_size;
-      uint64_t outputs;
-      uint64_t unlock_time;
-      std::string payment_id;
-      bool get_tx_key;
-      std::string key_image;
-      bool do_not_relay;
-      bool get_tx_hex;
-      bool get_tx_metadata;
+      std::string address;    // Destination public address.
+      uint32_t priority;      // (Optional) Priority for sending the sweep transfer, partially determines fee.
+      uint64_t mixin;         // (Ignored) Number of outputs from the blockchain to mix with. Loki mixin statically set to 9.
+      uint64_t ring_size;     // (Ignored) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
+      uint64_t outputs;       // 
+      uint64_t unlock_time;   // Number of blocks before the loki can be spent (0 to not add a lock).
+      std::string payment_id; // (Optional) Random 32-byte/64-character hex string to identify a transaction.
+      bool get_tx_key;        // (Optional) Return the transaction keys after sending.
+      std::string key_image;  // Key image of specific output to sweep.
+      bool do_not_relay;      // (Optional) If true, do not relay this sweep transfer. (Defaults to false)
+      bool get_tx_hex;        // (Optional) return the transactions as hex encoded string. (Defaults to false)
+      bool get_tx_metadata;   // (Optional) return the transaction metadata as a string. (Defaults to false)
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -823,14 +852,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_hash;
-      std::string tx_key;
-      uint64_t amount;
-      uint64_t fee;
-      std::string tx_blob;
-      std::string tx_metadata;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::string tx_hash;        // The tx hashes of the transaction.
+      std::string tx_key;         // The tx key of the transaction.
+      uint64_t amount;            // The amount transfered in atomic units.
+      uint64_t fee;               // The fee paid in atomic units.
+      std::string tx_blob;        // The tx as hex string.
+      std::string tx_metadata;    // Transaction metadata needed to relay the transaction later.
+      std::string multisig_txset; // The set of signing keys used in a multisig transaction (empty for non-multisig).
+      std::string unsigned_txset; // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -846,11 +875,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Relay a transaction previously created with `"do_not_relay":true`.
   struct COMMAND_RPC_RELAY_TX
   {
     struct request
     {
-      std::string hex;
+      std::string hex; // Transaction metadata returned from a transfer method with get_tx_metadata set to true.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(hex)
@@ -859,7 +889,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_hash;
+      std::string tx_hash; // String for the publically searchable transaction hash.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -868,6 +898,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Save the wallet file.
   struct COMMAND_RPC_STORE
   {
     struct request
@@ -884,15 +915,16 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // 
   struct payment_details
   {
-    std::string payment_id;
-    std::string tx_hash;
-    uint64_t amount;
-    uint64_t block_height;
-    uint64_t unlock_time;
-    cryptonote::subaddress_index subaddr_index;
-    std::string address;
+    std::string payment_id;                     // Payment ID matching the input parameter.
+    std::string tx_hash;                        // Transaction hash used as the transaction ID.
+    uint64_t amount;                            // Amount for this payment.
+    uint64_t block_height;                      // Height of the block that first confirmed this payment.
+    uint64_t unlock_time;                       // Time (in block height) until this payment is safe to spend.
+    cryptonote::subaddress_index subaddr_index; // JSON object containing the major & minor subaddress index:
+    std::string address;                        // Address receiving the payment; Base58 representation of the public keys.
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(payment_id)
@@ -906,11 +938,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get a list of incoming payments using a given payment id.
   struct COMMAND_RPC_GET_PAYMENTS
   {
     struct request
     {
-      std::string payment_id;
+      std::string payment_id; // Payment ID used to find the payments (16 characters hex).
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(payment_id)
@@ -919,7 +952,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<payment_details> payments;
+      std::list<payment_details> payments; // List of payment details:
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(payments)
@@ -928,12 +961,18 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get a list of incoming payments using a given payment id, 
+  // or a list of payments ids, from a given height. 
+  //
+  // This method is the preferred method over get_paymentsbecause it 
+  // has the same functionality but is more extendable. 
+  // Either is fine for looking up transactions by a single payment ID.
   struct COMMAND_RPC_GET_BULK_PAYMENTS
   {
     struct request
     {
-      std::vector<std::string> payment_ids;
-      uint64_t min_block_height;
+      std::vector<std::string> payment_ids; // Payment IDs used to find the payments (16 characters hex).
+      uint64_t min_block_height;            // The block height at which to start looking for payments.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(payment_ids)
@@ -943,7 +982,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<payment_details> payments;
+      std::list<payment_details> payments; // List of payment details: 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(payments)
@@ -952,14 +991,15 @@ namespace wallet_rpc
   };
   
   LOKI_RPC_DOC_INTROSPECT
+  // 
   struct transfer_details
   {
-    uint64_t amount;
-    bool spent;
-    uint64_t global_index;
-    std::string tx_hash;
-    cryptonote::subaddress_index subaddr_index;
-    std::string key_image;
+    uint64_t amount;                            // Amount of this transfer.
+    bool spent;                                 // Indicates if this transfer has been spent.
+    uint64_t global_index;                      // Mostly internal use, can be ignored by most users.
+    std::string tx_hash;                        // Several incoming transfers may share the same hash if they were in the same transaction.
+    cryptonote::subaddress_index subaddr_index; // Subaddress index for incoming transfer.
+    std::string key_image;                      // Key image for the incoming transfer's unspent output (empty unless verbose is true).
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(amount)
@@ -972,13 +1012,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Return a list of incoming transfers to the wallet.
   struct COMMAND_RPC_INCOMING_TRANSFERS
   {
     struct request
     {
-      std::string transfer_type;
-      uint32_t account_index;
-      std::set<uint32_t> subaddr_indices;
+      std::string transfer_type;          // "all": all the transfers, "available": only transfers which are not yet spent, OR "unavailable": only transfers which are already spent.
+      uint32_t account_index;             // (Optional) Return transfers for this account. (defaults to 0)
+      std::set<uint32_t> subaddr_indices; // (Optional) Return transfers sent to these subaddresses.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(transfer_type)
@@ -989,7 +1030,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<transfer_details> transfers;
+      std::list<transfer_details> transfers; // List of information of the transfers details.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(transfers)
@@ -999,11 +1040,12 @@ namespace wallet_rpc
 
   //JSON RPC V2
   LOKI_RPC_DOC_INTROSPECT
+  // Return the spend or view private key.
   struct COMMAND_RPC_QUERY_KEY
   {
     struct request
     {
-      std::string key_type;
+      std::string key_type; // Which key to retrieve: "mnemonic" - the mnemonic seed (older wallets do not have one) OR "view_key" - the view key
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key_type)
@@ -1012,7 +1054,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string key;
+      std::string key; //  The view key will be hex encoded, while the mnemonic will be a string of words.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key)
@@ -1021,12 +1063,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Make an integrated address from the wallet address and a payment id.
   struct COMMAND_RPC_MAKE_INTEGRATED_ADDRESS
   {
     struct request
     {
-      std::string standard_address;
-      std::string payment_id;
+      std::string standard_address; // (Optional, defaults to primary address) Destination public address.
+      std::string payment_id;       // (Optional, defaults to a random ID) 16 characters hex encoded.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(standard_address)
@@ -1036,8 +1079,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string integrated_address;
-      std::string payment_id;
+      std::string integrated_address; // 
+      std::string payment_id;         // Hex encoded.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(integrated_address)
@@ -1047,11 +1090,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Retrieve the standard address and payment id corresponding to an integrated address.
   struct COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS
   {
     struct request
     {
-      std::string integrated_address;
+      std::string integrated_address; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(integrated_address)
@@ -1060,9 +1104,9 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string standard_address;
-      std::string payment_id;
-      bool is_subaddress;
+      std::string standard_address; // 
+      std::string payment_id;       // 
+      bool is_subaddress;           // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(standard_address)
@@ -1073,6 +1117,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Stops the wallet, storing the current state.
   struct COMMAND_RPC_STOP_WALLET
   {
     struct request
@@ -1089,11 +1134,15 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Rescan the blockchain from scratch, losing any information 
+  // which can not be recovered from the blockchain itself.
+  //
+  // This includes destination addresses, tx secret keys, tx notes, etc.
   struct COMMAND_RPC_RESCAN_BLOCKCHAIN
   {
     struct request
     {
-      bool hard;
+      bool hard; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_OPT(hard, false);
@@ -1108,12 +1157,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Set arbitrary string notes for transactions.
   struct COMMAND_RPC_SET_TX_NOTES
   {
     struct request
     {
-      std::list<std::string> txids;
-      std::list<std::string> notes;
+      std::list<std::string> txids; // Transaction ids.
+      std::list<std::string> notes; // Notes for the transactions.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txids)
@@ -1129,11 +1179,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get string notes for transactions.
   struct COMMAND_RPC_GET_TX_NOTES
   {
     struct request
     {
-      std::list<std::string> txids;
+      std::list<std::string> txids; // Transaction ids.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txids)
@@ -1142,7 +1193,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> notes;
+      std::list<std::string> notes; // Notes for the transactions.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(notes)
@@ -1151,12 +1202,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Set arbitrary attribute.
   struct COMMAND_RPC_SET_ATTRIBUTE
   {
     struct request
     {
-      std::string key;
-      std::string value;
+      std::string key;   // Attribute name.
+      std::string value; // Attribute value.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key)
@@ -1172,12 +1224,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get attribute value by name.
   struct COMMAND_RPC_GET_ATTRIBUTE
   {
     struct request
     {
 
-      std::string key;
+      std::string key; // Attribute name.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key)
@@ -1186,7 +1239,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string value;
+      std::string value; // Attribute value.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(value)
@@ -1195,11 +1248,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get transaction secret key from transaction id.
   struct COMMAND_RPC_GET_TX_KEY
   {
     struct request
     {
-      std::string txid;
+      std::string txid; // Transaction id.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1208,7 +1262,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_key;
+      std::string tx_key; // Transaction secret key.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_key)
@@ -1217,13 +1271,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Check a transaction in the blockchain with its secret key.
   struct COMMAND_RPC_CHECK_TX_KEY
   {
     struct request
     {
-      std::string txid;
-      std::string tx_key;
-      std::string address;
+      std::string txid;    // Transaction id.
+      std::string tx_key;  // Transaction secret key.
+      std::string address; // Destination public address of the transaction.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1234,9 +1289,9 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t received;
-      bool in_pool;
-      uint64_t confirmations;
+      uint64_t received;      // Amount of the transaction.
+      bool in_pool;           // States if the transaction is still in pool or has been added to a block.
+      uint64_t confirmations; // Number of block mined after the one with the transaction.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(received)
@@ -1247,13 +1302,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get transaction signature to prove it.
   struct COMMAND_RPC_GET_TX_PROOF
   {
     struct request
     {
-      std::string txid;
-      std::string address;
-      std::string message;
+      std::string txid;    // Transaction id.
+      std::string address; // Destination public address of the transaction.
+      std::string message; // (Optional) add a message to the signature to further authenticate the prooving process.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1264,7 +1320,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string signature;
+      std::string signature; // Transaction signature.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signature)
@@ -1273,14 +1329,15 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Prove a transaction by checking its signature.
   struct COMMAND_RPC_CHECK_TX_PROOF
   {
     struct request
     {
-      std::string txid;
-      std::string address;
-      std::string message;
-      std::string signature;
+      std::string txid;      // Transaction id.
+      std::string address;   // Destination public address of the transaction.
+      std::string message;   // (Optional) Should be the same message used in `get_tx_proof`.
+      std::string signature; // Transaction signature to confirm.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1292,10 +1349,10 @@ namespace wallet_rpc
 
     struct response
     {
-      bool good;
-      uint64_t received;
-      bool in_pool;
-      uint64_t confirmations;
+      bool good;              // States if the inputs proves the transaction.
+      uint64_t received;      // Amount of the transaction.
+      bool in_pool;           // States if the transaction is still in pool or has been added to a block.
+      uint64_t confirmations; // Number of block mined after the one with the transaction.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(good)
@@ -1307,23 +1364,24 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // 
   struct transfer_entry
   {
-    std::string txid;
-    std::string payment_id;
-    uint64_t height;
-    uint64_t timestamp;
-    uint64_t amount;
-    uint64_t fee;
-    std::string note;
-    std::list<transfer_destination> destinations;
-    std::string type;
-    uint64_t unlock_time;
-    cryptonote::subaddress_index subaddr_index;
-    std::string address;
-    bool double_spend_seen;
-    uint64_t confirmations;
-    uint64_t suggested_confirmations_threshold;
+    std::string txid;                             // Transaction ID for this transfer.
+    std::string payment_id;                       // Payment ID for this transfer.
+    uint64_t height;                              // Height of the first block that confirmed this transfer (0 if not mined yet).
+    uint64_t timestamp;                           // POSIX timestamp for when this transfer was first confirmed in a block (or timestamp submission if not mined yet).
+    uint64_t amount;                              // Amount transferred.
+    uint64_t fee;                                 // Transaction fee for this transfer.
+    std::string note;                             // Note about this transfer.
+    std::list<transfer_destination> destinations; // Array of JSON objects containing transfer destinations.
+    std::string type;                             // Type of transfer, one of the following: "in", "out", "pending", "failed", "pool".
+    uint64_t unlock_time;                         // Number of blocks until transfer is safely spendable.
+    cryptonote::subaddress_index subaddr_index;   // JSON object containing the major & minor subaddress index:
+    std::string address;                          // Address that transferred the funds. Base58 representation of the public keys.
+    bool double_spend_seen;                       // True if the key image(s) for the transfer have been seen before.
+    uint64_t confirmations;                       // Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).
+    uint64_t suggested_confirmations_threshold;   // Estimation of the confirmations needed for the transaction to be included in a block.
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(txid);
@@ -1345,12 +1403,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Generate a signature to prove a spend. Unlike proving a transaction, it does not requires the destination public address.
   struct COMMAND_RPC_GET_SPEND_PROOF
   {
     struct request
     {
-      std::string txid;
-      std::string message;
+      std::string txid;    // Transaction id.
+      std::string message; // (Optional) add a message to the signature to further authenticate the prooving process.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1360,7 +1419,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string signature;
+      std::string signature; // Spend signature.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signature)
@@ -1369,13 +1428,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Prove a spend using a signature. Unlike proving a transaction, it does not requires the destination public address.
   struct COMMAND_RPC_CHECK_SPEND_PROOF
   {
     struct request
     {
-      std::string txid;
-      std::string message;
-      std::string signature;
+      std::string txid;      // Transaction id.
+      std::string message;   // (Optional) Should be the same message used in `get_spend_proof`.
+      std::string signature; // Spend signature to confirm.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid)
@@ -1386,7 +1446,7 @@ namespace wallet_rpc
 
     struct response
     {
-      bool good;
+      bool good; // States if the inputs proves the spend.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(good)
@@ -1395,14 +1455,15 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Generate a signature to prove of an available amount in a wallet.
   struct COMMAND_RPC_GET_RESERVE_PROOF
   {
     struct request
     {
-      bool all;
-      uint32_t account_index;     // ignored when `all` is true
-      uint64_t amount;            // ignored when `all` is true
-      std::string message;
+      bool all;               // Proves all wallet balance to be disposable.
+      uint32_t account_index; // Specify the account from witch to prove reserve. (ignored if all is set to true)
+      uint64_t amount;        // Amount (in atomic units) to prove the account has for reserve. (ignored if all is set to true)
+      std::string message;    // (Optional) add a message to the signature to further authenticate the prooving process.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(all)
@@ -1414,7 +1475,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string signature;
+      std::string signature; // Reserve signature.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signature)
@@ -1423,13 +1484,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Proves a wallet has a disposable reserve using a signature.
   struct COMMAND_RPC_CHECK_RESERVE_PROOF
   {
     struct request
     {
-      std::string address;
-      std::string message;
-      std::string signature;
+      std::string address;   // Public address of the wallet.
+      std::string message;   // (Optional) Should be the same message used in get_reserve_proof.
+      std::string signature; // Reserve signature to confirm.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -1440,9 +1502,9 @@ namespace wallet_rpc
 
     struct response
     {
-      bool good;
-      uint64_t total;
-      uint64_t spent;
+      bool good;      // States if the inputs proves the reserve.
+      uint64_t total; //
+      uint64_t spent; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(good)
@@ -1453,21 +1515,21 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Returns a list of transfers.
   struct COMMAND_RPC_GET_TRANSFERS
   {
     struct request
     {
-      bool in;
-      bool out;
-      bool pending;
-      bool failed;
-      bool pool;
-
-      bool filter_by_height;
-      uint64_t min_height;
-      uint64_t max_height;
-      uint32_t account_index;
-      std::set<uint32_t> subaddr_indices;
+      bool in;                            // (Optional) Include incoming transfers.
+      bool out;                           // (Optional) Include outgoing transfers.
+      bool pending;                       // (Optional) Include pending transfers.
+      bool failed;                        // (Optional) Include failed transfers.
+      bool pool;                          // (Optional) Include transfers from the daemon's transaction pool.
+      bool filter_by_height;              // (Optional) Filter transfers by block height.
+      uint64_t min_height;                // (Optional) Minimum block height to scan for transfers, if filtering by height is enabled.
+      uint64_t max_height;                // (Optional) Maximum block height to scan for transfers, if filtering by height is enabled (defaults to max block height).
+      uint32_t account_index;             // (Optional) Index of the account to query for transfers. (defaults to 0)
+      std::set<uint32_t> subaddr_indices; // (Optional) List of subaddress indices to query for transfers. (defaults to 0)
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(in);
@@ -1485,11 +1547,11 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<transfer_entry> in;
-      std::list<transfer_entry> out;
-      std::list<transfer_entry> pending;
-      std::list<transfer_entry> failed;
-      std::list<transfer_entry> pool;
+      std::list<transfer_entry> in;      // 
+      std::list<transfer_entry> out;     //
+      std::list<transfer_entry> pending; //
+      std::list<transfer_entry> failed;  //
+      std::list<transfer_entry> pool;    // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(in);
@@ -1502,12 +1564,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Show information about a transfer to/from this address.
   struct COMMAND_RPC_GET_TRANSFER_BY_TXID
   {
     struct request
     {
-      std::string txid;
-      uint32_t account_index;
+      std::string txid;       // Transaction ID used to find the transfer.
+      uint32_t account_index; // (Optional) Index of the account to query for the transfer.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txid);
@@ -1517,8 +1580,8 @@ namespace wallet_rpc
 
     struct response
     {
-      transfer_entry transfer;
-      std::list<transfer_entry> transfers;
+      transfer_entry transfer;             // 
+      std::list<transfer_entry> transfers; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(transfer);
@@ -1528,11 +1591,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Sign a string.
   struct COMMAND_RPC_SIGN
   {
     struct request
     {
-      std::string data;
+      std::string data; // Anything you need to sign.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(data);
@@ -1541,7 +1605,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string signature;
+      std::string signature; // Signature generated against the "data" and the account public address.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(signature);
@@ -1550,13 +1614,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Verify a signature on a string.
   struct COMMAND_RPC_VERIFY
   {
     struct request
     {
-      std::string data;
-      std::string address;
-      std::string signature;
+      std::string data;      // What should have been signed.
+      std::string address;   // Public address of the wallet used to sign the data.
+      std::string signature; // Signature generated by `sign` method.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(data);
@@ -1567,7 +1632,7 @@ namespace wallet_rpc
 
     struct response
     {
-      bool good;
+      bool good; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(good);
@@ -1576,6 +1641,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Export all outputs in hex format.
   struct COMMAND_RPC_EXPORT_OUTPUTS
   {
     struct request
@@ -1586,7 +1652,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string outputs_data_hex;
+      std::string outputs_data_hex; // Wallet outputs in hex format.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(outputs_data_hex);
@@ -1595,11 +1661,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Import outputs in hex format.
   struct COMMAND_RPC_IMPORT_OUTPUTS
   {
     struct request
     {
-      std::string outputs_data_hex;
+      std::string outputs_data_hex; // Wallet outputs in hex format.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(outputs_data_hex);
@@ -1608,7 +1675,7 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t num_imported;
+      uint64_t num_imported; // Number of outputs imported.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(num_imported);
@@ -1617,11 +1684,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Export a signed set of key images.
   struct COMMAND_RPC_EXPORT_KEY_IMAGES
   {
     struct request
     {
-      bool requested_only;
+      bool requested_only; // Default `false`.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_OPT(requested_only, false);
@@ -1630,8 +1698,8 @@ namespace wallet_rpc
 
     struct signed_key_image
     {
-      std::string key_image;
-      std::string signature;
+      std::string key_image; // 
+      std::string signature; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key_image);
@@ -1641,8 +1709,8 @@ namespace wallet_rpc
 
     struct response
     {
-      uint32_t offset;
-      std::vector<signed_key_image> signed_key_images;
+      uint32_t offset;                                 //
+      std::vector<signed_key_image> signed_key_images; //
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(offset);
@@ -1652,12 +1720,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Import signed key images list and verify their spent status.
   struct COMMAND_RPC_IMPORT_KEY_IMAGES
   {
     struct signed_key_image
     {
-      std::string key_image;
-      std::string signature;
+      std::string key_image; // Key image of specific output
+      std::string signature; // Transaction signature.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key_image);
@@ -1678,9 +1747,9 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t height;
-      uint64_t spent;
-      uint64_t unspent;
+      uint64_t height;  
+      uint64_t spent;   // Amount (in atomic units) spent from those key images.
+      uint64_t unspent; // Amount (in atomic units) still available from those key images.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(height)
@@ -1693,11 +1762,11 @@ namespace wallet_rpc
   LOKI_RPC_DOC_INTROSPECT
   struct uri_spec
   {
-    std::string address;
-    std::string payment_id;
-    uint64_t amount;
-    std::string tx_description;
-    std::string recipient_name;
+    std::string address;        // Wallet address.
+    std::string payment_id;     // (Optional) 16 or 64 character hexadecimal payment id.
+    uint64_t amount;            // (Optional) the integer amount to receive, in atomic units.
+    std::string tx_description; // (Optional) Description of the reason for the tx.
+    std::string recipient_name; // (Optional) name of the payment recipient.
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(address);
@@ -1709,6 +1778,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Create a payment URI using the official URI spec.
   struct COMMAND_RPC_MAKE_URI
   {
     struct request: public uri_spec
@@ -1717,7 +1787,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string uri;
+      std::string uri; // This contains all the payment input information as a properly formatted payment URI.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(uri)
@@ -1726,11 +1796,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Parse a payment URI to get payment information.
   struct COMMAND_RPC_PARSE_URI
   {
     struct request
     {
-      std::string uri;
+      std::string uri; // This contains all the payment input information as a properly formatted payment URI.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(uri)
@@ -1739,8 +1810,8 @@ namespace wallet_rpc
 
     struct response
     {
-      uri_spec uri;
-      std::vector<std::string> unknown_parameters;
+      uri_spec uri;                                // JSON object containing payment information:
+      std::vector<std::string> unknown_parameters; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(uri);
@@ -1750,13 +1821,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Add an entry to the address book.
   struct COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY
   {
     struct request
     {
-      std::string address;
-      std::string payment_id;
-      std::string description;
+      std::string address;     // Public address of the entry.
+      std::string payment_id;  // (Optional), defaults to "0000000000000000000000000000000000000000000000000000000000000000".
+      std::string description; // (Optional), defaults to "".
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -1767,7 +1839,7 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t index;
+      uint64_t index; // The index of the address book entry.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index);
@@ -1776,11 +1848,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Retrieves entries from the address book.
   struct COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY
   {
     struct request
     {
-      std::list<uint64_t> entries;
+      std::list<uint64_t> entries; // Indices of the requested address book entries.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(entries)
@@ -1789,10 +1862,10 @@ namespace wallet_rpc
 
     struct entry
     {
-      uint64_t index;
-      std::string address;
-      std::string payment_id;
-      std::string description;
+      uint64_t index;          // Index of entry.
+      std::string address;     // Public address of the entry
+      std::string payment_id;  // (Optional) Random 32-byte/64-character hex string to identify a transaction.
+      std::string description; // Description of this address entry.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index)
@@ -1804,7 +1877,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::vector<entry> entries;
+      std::vector<entry> entries; // List of address book entries information.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(entries)
@@ -1813,11 +1886,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Delete an entry from the address book.
   struct COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY
   {
     struct request
     {
-      uint64_t index;
+      uint64_t index; // The index of the address book entry.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(index);
@@ -1832,6 +1906,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Rescan the blockchain for spent outputs.
   struct COMMAND_RPC_RESCAN_SPENT
   {
     struct request
@@ -1848,11 +1923,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Refresh a wallet after openning.
   struct COMMAND_RPC_REFRESH
   {
     struct request
     {
-      uint64_t start_height;
+      uint64_t start_height; // (Optional) The block height from which to start refreshing.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_OPT(start_height, (uint64_t) 0)
@@ -1861,8 +1937,8 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t blocks_fetched;
-      bool received_money;
+      uint64_t blocks_fetched; // Number of new blocks scanned.
+      bool received_money;     // States if transactions to the wallet have been found in the blocks.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(blocks_fetched);
@@ -1872,13 +1948,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Start mining in the loki daemon.
   struct COMMAND_RPC_START_MINING
   {
     struct request
     {
-      uint64_t    threads_count;
-      bool        do_background_mining;
-      bool        ignore_battery;
+      uint64_t    threads_count;        // Number of threads created for mining.
+      bool        do_background_mining; // Allow to start the miner in smart mining mode.
+      bool        ignore_battery;       // Ignore battery status (for smart mining only).
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(threads_count)
@@ -1895,6 +1972,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Stop mining in the loki daemon.
   struct COMMAND_RPC_STOP_MINING
   {
     struct request
@@ -1911,6 +1989,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get a list of available languages for your wallet's seed.
   struct COMMAND_RPC_GET_LANGUAGES
   {
     struct request
@@ -1920,7 +1999,7 @@ namespace wallet_rpc
     };
     struct response
     {
-      std::vector<std::string> languages;
+      std::vector<std::string> languages; // List of available languages.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(languages)
@@ -1929,13 +2008,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Create a new wallet. You need to have set the argument "–wallet-dir" when launching loki-wallet-rpc to make this work.
   struct COMMAND_RPC_CREATE_WALLET
   {
     struct request
     {
-      std::string filename;
-      std::string password;
-      std::string language;
+      std::string filename; // Set the wallet file name.
+      std::string password; // (Optional) Set the password to protect the wallet.
+      std::string language; // Language for your wallets' seed.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(filename)
@@ -1943,6 +2023,7 @@ namespace wallet_rpc
         KV_SERIALIZE(language)
       END_KV_SERIALIZE_MAP()
     };
+
     struct response
     {
       BEGIN_KV_SERIALIZE_MAP()
@@ -1951,18 +2032,20 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Open a wallet. You need to have set the argument "–wallet-dir" when launching loki-wallet-rpc to make this work.
   struct COMMAND_RPC_OPEN_WALLET
   {
     struct request
     {
-      std::string filename;
-      std::string password;
+      std::string filename; // Wallet name stored in –wallet-dir.
+      std::string password; // (Optional) only needed if the wallet has a password defined.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(filename)
         KV_SERIALIZE(password)
       END_KV_SERIALIZE_MAP()
     };
+
     struct response
     {
       BEGIN_KV_SERIALIZE_MAP()
@@ -1971,6 +2054,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Close the currently opened wallet, after trying to save it.
   struct COMMAND_RPC_CLOSE_WALLET
   {
     struct request
@@ -1987,18 +2071,20 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Change a wallet password.
   struct COMMAND_RPC_CHANGE_WALLET_PASSWORD
   {
     struct request
     {
-      std::string old_password;
-      std::string new_password;
+      std::string old_password; // (Optional) Current wallet password, if defined.
+      std::string new_password; // (Optional) New wallet password, if not blank.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(old_password)
         KV_SERIALIZE(new_password)
       END_KV_SERIALIZE_MAP()
     };
+
     struct response
     {
       BEGIN_KV_SERIALIZE_MAP()
@@ -2007,44 +2093,46 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // 
   struct COMMAND_RPC_RESTORE_DETERMINISTIC_WALLET
   {
     struct request
     {
-      uint64_t restore_height;
-      std::string filename;
-      std::string seed;
-      std::string seed_offset;
-      std::string password;
-      std::string language;
+      uint64_t restore_height; // Height in which to start scanning the Blockchain for transactions into and out of this Wallet.
+      std::string filename;    // Set the name of the Wallet.
+      std::string seed;        // Mnemonic seed of wallet (25 words).
+      std::string seed_offset; // 
+      std::string password;    // Set password for Wallet.
+      std::string language;    // Set language for the wallet.
 
       BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE_OPT(restore_height, (uint64_t)0)
-      KV_SERIALIZE(filename)
-      KV_SERIALIZE(seed)
-      KV_SERIALIZE(seed_offset)
-      KV_SERIALIZE(password)
-      KV_SERIALIZE(language)
+        KV_SERIALIZE_OPT(restore_height, (uint64_t)0)
+        KV_SERIALIZE(filename)
+        KV_SERIALIZE(seed)
+        KV_SERIALIZE(seed_offset)
+        KV_SERIALIZE(password)
+        KV_SERIALIZE(language)
       END_KV_SERIALIZE_MAP()
     };
 
     struct response
     {
-      std::string address;
-      std::string seed;
-      std::string info;
-      bool was_deprecated;
+      std::string address; // Public address of wallet.
+      std::string seed;    // Seed of wallet.
+      std::string info;    // Wallet information.
+      bool was_deprecated; // 
 
       BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(address)
-      KV_SERIALIZE(seed)
-      KV_SERIALIZE(info)
-      KV_SERIALIZE(was_deprecated)
+        KV_SERIALIZE(address)
+        KV_SERIALIZE(seed)
+        KV_SERIALIZE(info)
+        KV_SERIALIZE(was_deprecated)
       END_KV_SERIALIZE_MAP()
     };
   };
   
   LOKI_RPC_DOC_INTROSPECT
+  // Check if a wallet is a multisig one.
   struct COMMAND_RPC_IS_MULTISIG
   {
     struct request
@@ -2055,10 +2143,10 @@ namespace wallet_rpc
 
     struct response
     {
-      bool multisig;
-      bool ready;
-      uint32_t threshold;
-      uint32_t total;
+      bool multisig;      // States if the wallet is multisig.
+      bool ready;         // 
+      uint32_t threshold; // Amount of signature needed to sign a transfer.
+      uint32_t total;     // Total amount of signature in the multisig wallet.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(multisig)
@@ -2070,6 +2158,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Prepare a wallet for multisig by generating a multisig string to share with peers.
   struct COMMAND_RPC_PREPARE_MULTISIG
   {
     struct request
@@ -2080,7 +2169,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string multisig_info;
+      std::string multisig_info; // Multisig string to share with peers to create the multisig wallet.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(multisig_info)
@@ -2089,13 +2178,14 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Make a wallet multisig by importing peers multisig string.
   struct COMMAND_RPC_MAKE_MULTISIG
   {
     struct request
     {
-      std::vector<std::string> multisig_info;
-      uint32_t threshold;
-      std::string password;
+      std::vector<std::string> multisig_info; // List of multisig string from peers.
+      uint32_t threshold;                     // Amount of signatures needed to sign a transfer. Must be less or equal than the amount of signature in `multisig_info`.
+      std::string password;                   // Wallet password.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(multisig_info)
@@ -2106,8 +2196,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string address;
-      std::string multisig_info;
+      std::string address;       // Multisig wallet address.
+      std::string multisig_info; // Multisig string to share with peers to create the multisig wallet (extra step for N-1/N wallets).
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -2117,6 +2207,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Export multisig info for other participants.
   struct COMMAND_RPC_EXPORT_MULTISIG
   {
     struct request
@@ -2127,7 +2218,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string info;
+      std::string info; // Multisig info in hex format for other participants.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(info)
@@ -2136,11 +2227,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Import multisig info from other participants.
   struct COMMAND_RPC_IMPORT_MULTISIG
   {
     struct request
     {
-      std::vector<std::string> info;
+      std::vector<std::string> info; // List of multisig info in hex format from other participants.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(info)
@@ -2149,7 +2241,7 @@ namespace wallet_rpc
 
     struct response
     {
-      uint64_t n_outputs;
+      uint64_t n_outputs; // Number of outputs signed with those multisig info.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(n_outputs)
@@ -2158,12 +2250,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Turn this wallet into a multisig wallet, extra step for N-1/N wallets.
   struct COMMAND_RPC_FINALIZE_MULTISIG
   {
     struct request
     {
-      std::string password;
-      std::vector<std::string> multisig_info;
+      std::string password;                   // Wallet password.
+      std::vector<std::string> multisig_info; // List of multisig string from peers.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(password)
@@ -2173,7 +2266,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string address;
+      std::string address; // Multisig wallet address.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -2182,12 +2275,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // 
   struct COMMAND_RPC_EXCHANGE_MULTISIG_KEYS
   {
     struct request
     {
-      std::string password;
-      std::vector<std::string> multisig_info;
+      std::string password;                   // Wallet password.
+      std::vector<std::string> multisig_info; // List of multisig string from peers.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(password)
@@ -2197,8 +2291,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string address;
-      std::string multisig_info;
+      std::string address;       // Multisig wallet address.
+      std::string multisig_info; // Multisig string to share with peers to create the multisig wallet.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -2208,11 +2302,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Sign a transaction in multisig.
   struct COMMAND_RPC_SIGN_MULTISIG
   {
     struct request
     {
-      std::string tx_data_hex;
+      std::string tx_data_hex; // Multisig transaction in hex format, as returned by transfer under `multisig_txset`.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_data_hex)
@@ -2221,8 +2316,8 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_data_hex;
-      std::list<std::string> tx_hash_list;
+      std::string tx_data_hex;             // Multisig transaction in hex format.
+      std::list<std::string> tx_hash_list; // List of transaction Hash.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_data_hex)
@@ -2232,11 +2327,12 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Submit a signed multisig transaction.
   struct COMMAND_RPC_SUBMIT_MULTISIG
   {
     struct request
     {
-      std::string tx_data_hex;
+      std::string tx_data_hex; // Multisig transaction in hex format, as returned by sign_multisig under tx_data_hex.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_data_hex)
@@ -2245,7 +2341,7 @@ namespace wallet_rpc
 
     struct response
     {
-      std::list<std::string> tx_hash_list;
+      std::list<std::string> tx_hash_list; // List of transaction hash.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -2254,6 +2350,7 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Get RPC version Major & Minor integer-format, where Major is the first 16 bits and Minor the last 16 bits.
   struct COMMAND_RPC_GET_VERSION
   {
     struct request
@@ -2264,7 +2361,7 @@ namespace wallet_rpc
 
     struct response
     {
-      uint32_t version;
+      uint32_t version; // RPC version, formatted with Major * 2^16 + Minor(Major encoded over the first 16 bits, and Minor over the last 16 bits).
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(version)
@@ -2273,19 +2370,21 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Stake for Service Node.
   struct COMMAND_RPC_STAKE
   {
     struct request
     {
-      std::string        destination;
-      uint64_t           amount;
-      std::set<uint32_t> subaddr_indices;
-      std::string        service_node_key;
-      uint32_t           priority;
-      bool               get_tx_key;
-      bool               do_not_relay;
-      bool               get_tx_hex;
-      bool               get_tx_metadata;
+      std::string        destination;      // Primary Public address that the rewards will go to.
+      uint64_t           amount;           // Amount of Loki to stake in atomic units.
+      std::set<uint32_t> subaddr_indices;  // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
+      std::string        service_node_key; // Service Node Public Address.
+      uint32_t           priority;         // Set a priority for the transaction. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
+      bool               get_tx_key;       // (Optional) Return the transaction key after sending.
+      bool               do_not_relay;     // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
+      bool               get_tx_hex;       // Return the transaction as hex string after sending (Defaults to false)
+      bool               get_tx_metadata;  // Return the metadata needed to relay the transaction. (Defaults to false)
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_OPT(subaddr_indices, {});
         KV_SERIALIZE    (destination);
@@ -2301,14 +2400,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_hash;
-      std::string tx_key;
-      uint64_t amount;
-      uint64_t fee;
-      std::string tx_blob;
-      std::string tx_metadata;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::string tx_hash;        // Publically searchable transaction hash.
+      std::string tx_key;         // Transaction key if `get_tx_key` is `true`, otherwise, blank string.
+      uint64_t amount;            // Amount transferred for the transaction in atomic units.
+      uint64_t fee;               // Value in atomic units of the fee charged for the tx.
+      std::string tx_blob;        // Raw transaction represented as hex string, if get_tx_hex is true.
+      std::string tx_metadata;    // Set of transaction metadata needed to relay this transfer later, if `get_tx_metadata` is `true`.
+      std::string multisig_txset; // Set of multisig transactions in the process of being signed (empty for non-multisig).
+      std::string unsigned_txset; // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -2324,15 +2423,17 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Register Service Node.
   struct COMMAND_RPC_REGISTER_SERVICE_NODE
   {
     struct request
     {
-      std::string register_service_node_str;
-      bool        get_tx_key;
-      bool        do_not_relay;
-      bool        get_tx_hex;
-      bool        get_tx_metadata;
+      std::string register_service_node_str; // String supplied by the prepare_registration command.
+      bool        get_tx_key;                // (Optional) Return the transaction key after sending.
+      bool        do_not_relay;              // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
+      bool        get_tx_hex;                // Return the transaction as hex string after sending (Defaults to false)
+      bool        get_tx_metadata;           // Return the metadata needed to relay the transaction. (Defaults to false)
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(register_service_node_str);
         KV_SERIALIZE(get_tx_key)
@@ -2344,14 +2445,14 @@ namespace wallet_rpc
 
     struct response
     {
-      std::string tx_hash;
-      std::string tx_key;
-      uint64_t amount;
-      uint64_t fee;
-      std::string tx_blob;
-      std::string tx_metadata;
-      std::string multisig_txset;
-      std::string unsigned_txset;
+      std::string tx_hash;        // Publically searchable transaction hash.
+      std::string tx_key;         // Transaction key if get_tx_key is true, otherwise, blank string.
+      uint64_t amount;            // Amount transferred for the transaction in atomic units.
+      uint64_t fee;               // Value in atomic units of the fee charged for the tx.
+      std::string tx_blob;        // Raw transaction represented as hex string, if get_tx_hex is true.
+      std::string tx_metadata;    // Set of transaction metadata needed to relay this transfer later, if `get_tx_metadata` is `true`.
+      std::string multisig_txset; // Set of multisig transactions in the process of being signed (empty for non-multisig).
+      std::string unsigned_txset; // Set of unsigned tx for cold-signing purposes.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -2367,11 +2468,13 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  // Request to unlock stake by deregistering Service Node.
   struct COMMAND_RPC_REQUEST_STAKE_UNLOCK
   {
     struct request
     {
-      std::string service_node_key;
+      std::string service_node_key; // Service Node Public Key.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(service_node_key);
       END_KV_SERIALIZE_MAP()
@@ -2379,8 +2482,8 @@ namespace wallet_rpc
 
     struct response
     {
-      bool unlocked;
-      std::string msg;
+      bool unlocked;   // States if stake has been unlocked.
+      std::string msg; // Information on the unlocking process.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(unlocked)
@@ -2390,11 +2493,13 @@ namespace wallet_rpc
   };
   
   LOKI_RPC_DOC_INTROSPECT
+  // Check if Service Node can unlock it's stake.
   struct COMMAND_RPC_CAN_REQUEST_STAKE_UNLOCK
   {
     struct request
     {
-      std::string service_node_key;
+      std::string service_node_key; // Service node public address.
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(service_node_key);
       END_KV_SERIALIZE_MAP()
@@ -2402,8 +2507,8 @@ namespace wallet_rpc
 
     struct response
     {
-      bool can_unlock;
-      std::string msg;
+      bool can_unlock; // States if the stake can be locked.
+      std::string msg; // Information on the unlocking process.
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(can_unlock)
@@ -2413,13 +2518,14 @@ namespace wallet_rpc
   };
   
   LOKI_RPC_DOC_INTROSPECT
+  // Parse an address to validate if it's a valid Loki address.
   struct COMMAND_RPC_VALIDATE_ADDRESS
   {
     struct request
     {
-      std::string address;
-      bool any_net_type;
-      bool allow_openalias;
+      std::string address;  // Address to check.
+      bool any_net_type;    // 
+      bool allow_openalias; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -2432,10 +2538,10 @@ namespace wallet_rpc
 
     struct response
     {
-      bool valid;
-      bool integrated;
-      bool subaddress;
-      std::string nettype;
+      bool valid;                    // States if it is a valid Loki address.
+      bool integrated;               // States if it is an integrated address.
+      bool subaddress;               // States if it is a subaddress.
+      std::string nettype;           // States if the nettype is mainet, testnet, stagenet.
       std::string openalias_address;
 
       BEGIN_KV_SERIALIZE_MAP()


### PR DESCRIPTION
- Add comments to wallet_rpc_server_commands_defs.h for rpc-doc-generator to automate rpc documentation.