### PR TITLE
Fix reported wrong amount in stake error message

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5819,7 +5819,7 @@ bool simple_wallet::stake(const std::vector<std::string> &args_)
     {
       if (!cryptonote::parse_amount(amount, local_args[1]) || amount == 0)
       {
-        fail_msg_writer() << tr("amount is wrong: ") << local_args[2] <<
+        fail_msg_writer() << tr("amount is wrong: ") << local_args[1] <<
           ", " << tr("expected number from ") << print_money(1) << " to " << print_money(std::numeric_limits<uint64_t>::max());
         return true;
       }


### PR DESCRIPTION
43436b081 got rid of the address from the stake command for 3.0,
shifting the arguments, but the index on the error message didn't get
shifted so the error message printed the wrong value.