### PR TITLE
Add helper functions to facilitate more reliable integration tests

### DIFF
--- a/src/common/loki_integration_test_hooks.h
+++ b/src/common/loki_integration_test_hooks.h
@@ -165,6 +165,7 @@ uint32_t const MSG_MAGIC_BYTES = 0x7428da3f;
 void write_to_stdout_shared_mem(char const *buf, int buf_len)
 {
   assert(global_stdout_shared_mem);
+  assert(buf_len < loki::fixed_buffer::SIZE);
 
   int sem_value = 0;
   sem_getvalue(global_stdout_ready_semaphore, &sem_value);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -352,9 +352,9 @@ namespace cryptonote
       const bool testnet = command_line::get_arg(vm, arg_testnet_on);
       const bool stagenet = command_line::get_arg(vm, arg_stagenet_on);
       m_nettype = testnet ? TESTNET : stagenet ? STAGENET : MAINNET;
-      m_deregister_vote_pool.m_nettype = m_nettype;
     }
 
+    m_deregister_vote_pool.m_nettype = m_nettype;
     m_config_folder = command_line::get_arg(vm, arg_data_dir);
 
     auto data_dir = boost::filesystem::path(m_config_folder);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -49,7 +49,6 @@
 #include "cryptonote_basic/cryptonote_stat_info.h"
 #include "warnings.h"
 #include "crypto/hash.h"
-
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
@@ -910,6 +909,13 @@ namespace cryptonote
       */
      bool check_blockchain_pruning();
 
+     /**
+      * @brief attempt to relay the pooled deregister votes
+      *
+      * @return true, necessary for binding this function to a periodic invoker
+      */
+     bool relay_deregister_votes();
+
    private:
 
      /**
@@ -1065,13 +1071,6 @@ namespace cryptonote
       * @return true
       */
      bool relay_txpool_transactions();
-
-     /**
-      * @brief attempt to relay the pooled deregister votes
-      *
-      * @return true, necessary for binding this function to a periodic invoker
-      */
-     bool relay_deregister_votes();
 
      /**
       * @brief checks DNS versions

--- a/src/cryptonote_core/service_node_deregister.cpp
+++ b/src/cryptonote_core/service_node_deregister.cpp
@@ -192,7 +192,11 @@ namespace service_nodes
 
     // TODO(doyle): Rate-limiting: A better threshold value that follows suite with transaction relay time back-off
     const time_t now       = time(NULL);
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     const time_t THRESHOLD = 60 * 2;
+#else
+    const time_t THRESHOLD = 0;
+#endif
 
     std::vector<deregister_vote> result;
     for (const auto &deregister_entry : m_deregisters)

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -343,6 +343,16 @@ t_command_server::t_command_server(
     , std::bind(&t_command_parser_executor::check_blockchain_pruning, &m_parser, p::_1)
     , "Check the blockchain pruning."
     );
+
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    m_command_lookup.set_handler(
+      "relay_votes_and_uptime", std::bind([rpc_server](std::vector<std::string> const &args) {
+        rpc_server->on_relay_uptime_and_votes();
+        return true;
+      }, p::_1)
+    , ""
+    );
+#endif
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)
@@ -373,7 +383,7 @@ bool t_command_server::start_handling(std::function<void(void)> exit_handler)
   {
     // TODO(doyle): Hack, don't hook into input until the daemon has completely initialised, i.e. you can print the status
     while(!loki::core_is_idle) {}
-    mlog_set_categories("");
+    mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
 
     for (;;)
     {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1838,12 +1838,14 @@ namespace nodetool
       return 1;
     }
 
+#if !defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     if(has_too_many_connections(context.m_remote_address))
     {
       LOG_PRINT_CCONTEXT_L1("CONNECTION FROM " << context.m_remote_address.host_str() << " REFUSED, too many connections from the same address");
       drop_connection(context);
       return 1;
     }
+#endif
 
     //associate peer_id with this connection
     context.peer_id = arg.node_data.peer_id;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -256,6 +256,16 @@ namespace cryptonote
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    void on_relay_uptime_and_votes()
+    {
+      m_core.submit_uptime_proof();
+      m_core.relay_deregister_votes();
+      std::cout << "Votes and uptime relayed";
+      loki::write_redirected_stdout_to_shared_mem();
+    }
+#endif
+
 private:
     bool check_core_busy();
     bool check_core_ready();


### PR DESCRIPTION
Provides a way to programatically force votes and uptime proofs to be sent in integration tests. Also disables the IP rate limiting in integration mode so we can have as many interconnected nodes in a private network for the tests.

Fix deregister pool not being assigned a nettype if in fakechain mode.