### PR TITLE
Remove unneeded SFINAE on check_tx/block_verification

### DIFF
--- a/tests/core_tests/bulletproofs.h
+++ b/tests/core_tests/bulletproofs.h
@@ -50,7 +50,7 @@ struct gen_bp_tx_validation_base : public test_chain_unit_base
       return !tvc.m_verifivation_failed && tx_added;
   }
 
-  bool check_tx_verification_context(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t tx_added, size_t event_idx, const std::vector<cryptonote::transaction>& /*txs*/)
+  bool check_tx_verification_context_array(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t tx_added, size_t event_idx, const std::vector<cryptonote::transaction>& /*txs*/)
   {
     size_t failed = 0;
     for (const cryptonote::tx_verification_context &tvc: tvcs)

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -1256,3 +1256,21 @@ bool test_chain_unit_base::verify(const std::string& cb_name, cryptonote::core& 
   }
   return cb_it->second(c, ev_index, events);
 }
+
+bool test_chain_unit_base::check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_idx, const cryptonote::block& /*blk*/)
+{
+  return !bvc.m_verifivation_failed;
+}
+
+bool test_chain_unit_base::check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool /*tx_added*/, size_t /*event_index*/, const cryptonote::transaction& /*tx*/)
+{
+  return !tvc.m_verifivation_failed;
+}
+
+bool test_chain_unit_base::check_tx_verification_context_array(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t /*tx_added*/, size_t /*event_index*/, const std::vector<cryptonote::transaction>& /*txs*/)
+{
+  for (const cryptonote::tx_verification_context &tvc: tvcs)
+    if (tvc.m_verifivation_failed)
+      return false;
+  return true;
+}

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -156,6 +156,10 @@ public:
 
   void register_callback(const std::string& cb_name, verify_callback cb);
   bool verify(const std::string& cb_name, cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry> &events);
+  bool check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_idx, const cryptonote::block& /*blk*/);
+  bool check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool /*tx_added*/, size_t /*event_index*/, const cryptonote::transaction& /*tx*/);
+  bool check_tx_verification_context_array(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t /*tx_added*/, size_t /*event_index*/, const std::vector<cryptonote::transaction>& /*txs*/);
+
 private:
   callbacks_map m_callbacks;
 };
@@ -533,77 +537,6 @@ uint64_t get_amount(const cryptonote::account_base& account, const cryptonote::t
 uint64_t get_balance(const cryptonote::account_base& addr, const std::vector<cryptonote::block>& blockchain, const map_hash2tx_t& mtx);
 uint64_t get_unlocked_balance(const cryptonote::account_base& addr, const std::vector<cryptonote::block>& blockchain, const map_hash2tx_t& mtx);
 
-//--------------------------------------------------------------------------
-template<class t_test_class>
-auto do_check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool tx_added, size_t event_index, const cryptonote::transaction& tx, t_test_class& validator, int)
-  -> decltype(validator.check_tx_verification_context(tvc, tx_added, event_index, tx))
-{
-  return validator.check_tx_verification_context(tvc, tx_added, event_index, tx);
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool do_check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool tx_added, size_t /*event_index*/, const cryptonote::transaction& /*tx*/, t_test_class&, long)
-{
-  // Default block verification context check
-  if (tvc.m_verifivation_failed)
-    throw std::runtime_error("Transaction verification failed");
-  return true;
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool tx_added, size_t event_index, const cryptonote::transaction& tx, t_test_class& validator)
-{
-  // SFINAE in action
-  return do_check_tx_verification_context(tvc, tx_added, event_index, tx, validator, 0);
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-auto do_check_tx_verification_context(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t tx_added, size_t event_index, const std::vector<cryptonote::transaction>& txs, t_test_class& validator, int)
-  -> decltype(validator.check_tx_verification_context(tvcs, tx_added, event_index, txs))
-{
-  return validator.check_tx_verification_context(tvcs, tx_added, event_index, txs);
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool do_check_tx_verification_context(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t tx_added, size_t /*event_index*/, const std::vector<cryptonote::transaction>& /*txs*/, t_test_class&, long)
-{
-  // Default block verification context check
-  for (const cryptonote::tx_verification_context &tvc: tvcs)
-    if (tvc.m_verifivation_failed)
-      throw std::runtime_error("Transaction verification failed");
-  return true;
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool check_tx_verification_context(const std::vector<cryptonote::tx_verification_context>& tvcs, size_t tx_added, size_t event_index, const std::vector<cryptonote::transaction>& txs, t_test_class& validator)
-{
-  // SFINAE in action
-  return do_check_tx_verification_context(tvcs, tx_added, event_index, txs, validator, 0);
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-auto do_check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_index, const cryptonote::block& blk, t_test_class& validator, int)
-  -> decltype(validator.check_block_verification_context(bvc, event_index, blk))
-{
-  return validator.check_block_verification_context(bvc, event_index, blk);
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool do_check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t /*event_index*/, const cryptonote::block& /*blk*/, t_test_class&, long)
-{
-  // Default block verification context check
-  if (bvc.m_verifivation_failed)
-    throw std::runtime_error("Block verification failed");
-  return true;
-}
-//--------------------------------------------------------------------------
-template<class t_test_class>
-bool check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_index, const cryptonote::block& blk, t_test_class& validator)
-{
-  // SFINAE in action
-  return do_check_block_verification_context(bvc, event_index, blk, validator, 0);
-}
-
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
@@ -653,7 +586,7 @@ public:
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_txs_keeped_by_block, false, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
-    bool r = check_tx_verification_context(tvc, tx_added, m_ev_index, tx, m_validator);
+    bool r = m_validator.check_tx_verification_context(tvc, tx_added, m_ev_index, tx);
     CHECK_AND_NO_ASSERT_MES(r, false, "tx verification context check failed");
     return true;
   }
@@ -673,7 +606,7 @@ public:
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_txs(tx_blobs, tvcs, m_txs_keeped_by_block, false, false);
     size_t tx_added = m_c.get_pool_transactions_count() - pool_size;
-    bool r = check_tx_verification_context(tvcs, tx_added, m_ev_index, txs, m_validator);
+    bool r = m_validator.check_tx_verification_context_array(tvcs, tx_added, m_ev_index, txs);
     CHECK_AND_NO_ASSERT_MES(r, false, "tx verification context check failed");
     return true;
   }
@@ -684,7 +617,7 @@ public:
 
     cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
     m_c.handle_incoming_block(t_serializable_object_to_blob(b), bvc);
-    bool r = check_block_verification_context(bvc, m_ev_index, b, m_validator);
+    bool r = m_validator.check_block_verification_context(bvc, m_ev_index, b);
     CHECK_AND_NO_ASSERT_MES(r, false, "block verification context check failed");
     return r;
   }
@@ -717,7 +650,7 @@ public:
     {
       blk = cryptonote::block();
     }
-    bool r = check_block_verification_context(bvc, m_ev_index, blk, m_validator);
+    bool r = m_validator.check_block_verification_context(bvc, m_ev_index, blk);
     CHECK_AND_NO_ASSERT_MES(r, false, "block verification context check failed");
     return true;
   }
@@ -741,7 +674,7 @@ public:
       tx = cryptonote::transaction();
     }
 
-    bool r = check_tx_verification_context(tvc, tx_added, m_ev_index, tx, m_validator);
+    bool r = m_validator.check_tx_verification_context(tvc, tx_added, m_ev_index, tx);
     CHECK_AND_NO_ASSERT_MES(r, false, "transaction verification context check failed");
     return true;
   }


### PR DESCRIPTION
Only needed because they want to overload check tx verification to handle vectors of tx verifications, so just give that function an explicit name instead to allow C++ to compile it.