### PR TITLE
Extend Service Node List to store multiple types of quorums

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2940,14 +2940,14 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return false;
       }
 
-      const std::shared_ptr<const service_nodes::quorum_state> quorum_state = m_service_node_list.get_quorum_state(deregister.block_height);
-      if (!quorum_state)
+      const std::shared_ptr<const service_nodes::quorum_uptime_proof> uptime_quorum = m_service_node_list.get_uptime_quorum(deregister.block_height);
+      if (!uptime_quorum)
       {
         MERROR_VER("Deregister TX could not get quorum for height: " << deregister.block_height);
         return false;
       }
 
-      if (!service_nodes::deregister_vote::verify_deregister(nettype(), deregister, tvc.m_vote_ctx, *quorum_state))
+      if (!service_nodes::deregister_vote::verify_deregister(nettype(), deregister, tvc.m_vote_ctx, *uptime_quorum))
       {
         tvc.m_verifivation_failed = true;
         MERROR_VER("tx " << get_transaction_hash(tx) << ": deregister tx could not be completely verified reason: " << print_vote_verification_context(tvc.m_vote_ctx));
@@ -3010,15 +3010,15 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
           continue;
         }
 
-        const std::shared_ptr<const service_nodes::quorum_state> existing_deregister_quorum_state = m_service_node_list.get_quorum_state(existing_deregister.block_height);
-        if (!existing_deregister_quorum_state)
+        const std::shared_ptr<const service_nodes::quorum_uptime_proof> existing_uptime_quorum = m_service_node_list.get_uptime_quorum(existing_deregister.block_height);
+        if (!existing_uptime_quorum)
         {
-          MERROR_VER("could not get quorum state for recent deregister tx");
+          MERROR_VER("could not get uptime quorum for recent deregister tx");
           continue;
         }
 
-        if (existing_deregister_quorum_state->nodes_to_test[existing_deregister.service_node_index] ==
-            quorum_state->nodes_to_test[deregister.service_node_index])
+        if (existing_uptime_quorum->nodes_to_test[existing_deregister.service_node_index] ==
+            uptime_quorum->nodes_to_test[deregister.service_node_index])
         {
           MERROR_VER("Already seen this deregister tx (aka double spend)");
           tvc.m_double_spend = true;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2039,9 +2039,9 @@ namespace cryptonote
     return si.available;
   }
   //-----------------------------------------------------------------------------------------------
-  const std::shared_ptr<const service_nodes::quorum_state> core::get_quorum_state(uint64_t height) const
+  const std::shared_ptr<const service_nodes::quorum_uptime_proof> core::get_uptime_quorum(uint64_t height) const
   {
-    return m_service_node_list.get_quorum_state(height);
+    return m_service_node_list.get_uptime_quorum(height);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::is_service_node(const crypto::public_key& pubkey) const
@@ -2089,8 +2089,8 @@ namespace cryptonote
       return false;
     }
 
-    const auto quorum_state = m_service_node_list.get_quorum_state(vote.block_height);
-    if (!quorum_state)
+    const auto uptime_quorum = m_service_node_list.get_uptime_quorum(vote.block_height);
+    if (!uptime_quorum)
     {
       vvc.m_verification_failed  = true;
       vvc.m_invalid_block_height = true;
@@ -2100,7 +2100,7 @@ namespace cryptonote
 
     cryptonote::transaction deregister_tx;
     int hf_version = m_blockchain_storage.get_current_hard_fork_version();
-    bool result    = m_deregister_vote_pool.add_vote(hf_version, vote, vvc, *quorum_state, deregister_tx);
+    bool result    = m_deregister_vote_pool.add_vote(hf_version, vote, vvc, *uptime_quorum, deregister_tx);
     if (result && vvc.m_full_tx_deregister_made)
     {
       tx_verification_context tvc = AUTO_VAL_INIT(tvc);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -811,7 +811,7 @@ namespace cryptonote
 
       * @return Null shared ptr if quorum has not been determined yet for height
       */
-     const std::shared_ptr<const service_nodes::quorum_state> get_quorum_state(uint64_t height) const;
+     const std::shared_ptr<const service_nodes::quorum_uptime_proof> get_uptime_quorum(uint64_t height) const;
 
      /**
       * @brief Get a non owning reference to the list of blacklisted key images

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -46,7 +46,7 @@ namespace cryptonote
 
 namespace service_nodes
 {
-  struct quorum_state;
+  struct quorum_uptime_proof;
 
   struct deregister_vote
   {
@@ -64,10 +64,10 @@ namespace service_nodes
 
     static bool verify_deregister(cryptonote::network_type nettype, const cryptonote::tx_extra_service_node_deregister& deregister,
                                   cryptonote::vote_verification_context& vvc,
-                                  const service_nodes::quorum_state &quorum);
+                                  const service_nodes::quorum_uptime_proof &quorum);
 
     static bool verify_vote(cryptonote::network_type nettype, const deregister_vote& v, cryptonote::vote_verification_context &vvc,
-                            const service_nodes::quorum_state &quorum);
+                            const service_nodes::quorum_uptime_proof &quorum);
   };
 
   class deregister_vote_pool
@@ -79,7 +79,7 @@ namespace service_nodes
       bool add_vote(const int hf_version,
                     const deregister_vote& new_vote,
                     cryptonote::vote_verification_context& vvc,
-                    const service_nodes::quorum_state &quorum_state,
+                    const service_nodes::quorum_uptime_proof &uptime_quorum,
                     cryptonote::transaction &tx);
 
       // TODO(loki): Review relay behaviour and all the cases when it should be triggered

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -104,7 +104,7 @@ namespace service_nodes
       if (m_core.get_hard_fork_version(m_last_height) < 9)
         continue;
 
-      const std::shared_ptr<const quorum_state> state = m_core.get_quorum_state(m_last_height);
+      const std::shared_ptr<const quorum_uptime_proof> state = m_core.get_uptime_quorum(m_last_height);
       if (!state)
       {
         // TODO(loki): Fatal error

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "blockchain.h"
+#include "serialization/serialization.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler_common.h"
 
 namespace cryptonote
@@ -42,6 +43,38 @@ namespace service_nodes
   {
       uint64_t timestamp;
       uint16_t version_major, version_minor, version_patch;
+  };
+
+  struct quorum_checkpointing
+  {
+    std::vector<crypto::public_key> quorum_nodes;
+    BEGIN_SERIALIZE()
+      FIELD(quorum_nodes)
+    END_SERIALIZE()
+  };
+
+  struct quorum_uptime_proof
+  {
+    std::vector<crypto::public_key> quorum_nodes;
+    std::vector<crypto::public_key> nodes_to_test;
+
+    BEGIN_SERIALIZE()
+      FIELD(quorum_nodes)
+      FIELD(nodes_to_test)
+    END_SERIALIZE()
+  };
+
+  struct quorum_manager
+  {
+    std::shared_ptr<const quorum_uptime_proof>  uptime_proof;
+    std::shared_ptr<const quorum_checkpointing> checkpointing;
+  };
+
+  enum struct quorum_type
+  {
+    uptime_proof = 0,
+    checkpointing,
+    count,
   };
 
   class quorum_cop

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2352,18 +2352,18 @@ namespace cryptonote
     PERF_TIMER(on_get_quorum_state);
     bool r;
 
-    const auto quorum_state = m_core.get_quorum_state(req.height);
-    r = (quorum_state != nullptr);
+    const auto uptime_quorum = m_core.get_uptime_quorum(req.height);
+    r = (uptime_quorum != nullptr);
     if (r)
     {
       res.status = CORE_RPC_STATUS_OK;
-      res.quorum_nodes.reserve (quorum_state->quorum_nodes.size());
-      res.nodes_to_test.reserve(quorum_state->nodes_to_test.size());
+      res.quorum_nodes.reserve (uptime_quorum->quorum_nodes.size());
+      res.nodes_to_test.reserve(uptime_quorum->nodes_to_test.size());
 
-      for (const auto &key : quorum_state->quorum_nodes)
+      for (const auto &key : uptime_quorum->quorum_nodes)
         res.quorum_nodes.push_back(epee::string_tools::pod_to_hex(key));
 
-      for (const auto &key : quorum_state->nodes_to_test)
+      for (const auto &key : uptime_quorum->nodes_to_test)
         res.nodes_to_test.push_back(epee::string_tools::pod_to_hex(key));
     }
     else
@@ -2398,9 +2398,9 @@ namespace cryptonote
     res.quorum_entries.reserve(height_end - height_begin + 1);
     for (auto h = height_begin; h <= height_end; ++h)
     {
-      const auto quorum_state = m_core.get_quorum_state(h);
+      const auto uptime_quorum = m_core.get_uptime_quorum(h);
 
-      if (!quorum_state) {
+      if (!uptime_quorum) {
         failed_height = h;
         break;
       }
@@ -2410,13 +2410,13 @@ namespace cryptonote
       auto &entry = res.quorum_entries.back();
 
       entry.height = h;
-      entry.quorum_nodes.reserve(quorum_state->quorum_nodes.size());
-      entry.nodes_to_test.reserve(quorum_state->nodes_to_test.size());
+      entry.quorum_nodes.reserve(uptime_quorum->quorum_nodes.size());
+      entry.nodes_to_test.reserve(uptime_quorum->nodes_to_test.size());
 
-      for (const auto &key : quorum_state->quorum_nodes)
+      for (const auto &key : uptime_quorum->quorum_nodes)
         entry.quorum_nodes.push_back(epee::string_tools::pod_to_hex(key));
 
-      for (const auto &key : quorum_state->nodes_to_test)
+      for (const auto &key : uptime_quorum->nodes_to_test)
         entry.nodes_to_test.push_back(epee::string_tools::pod_to_hex(key));
 
     }

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -692,9 +692,9 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     tx_extra_service_node_deregister deregistration;
     get_service_node_deregister_from_tx_extra(dereg_tx.extra, deregistration);
 
-    const auto quorum_state = c.get_quorum_state(deregistration.block_height);
-    CHECK_TEST_CONDITION(quorum_state);
-    const auto pk_a = quorum_state->nodes_to_test.at(deregistration.service_node_index);
+    const auto uptime_quorum = c.get_uptime_quorum(deregistration.block_height);
+    CHECK_TEST_CONDITION(uptime_quorum);
+    const auto pk_a = uptime_quorum->nodes_to_test.at(deregistration.service_node_index);
 
     /// Check present
     const bool found_a = contains(sn_list, pk_a);

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -123,7 +123,7 @@ TEST(service_nodes, vote_validation)
   cryptonote::keypair service_node_voter = cryptonote::keypair::generate(hw::get_device("default"));
   int voter_index = 0;
 
-  service_nodes::quorum_state state = {};
+  service_nodes::quorum_uptime_proof state = {};
   {
     state.quorum_nodes.resize(10);
     state.nodes_to_test.resize(state.quorum_nodes.size());
@@ -191,7 +191,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
   const size_t num_voters = 10;
   cryptonote::keypair voters[num_voters] = {};
 
-  service_nodes::quorum_state state = {};
+  service_nodes::quorum_uptime_proof state = {};
   {
     state.quorum_nodes.resize(num_voters);
     state.nodes_to_test.resize(num_voters);


### PR DESCRIPTION
We can store quorums for uptime proof checking and checkpointing nodes now.

Haven't updated the RPC commands or command server to return checkpointing nodes yet. That can go in another PR. 