### PR TITLE
Non-Enforced Transient Service Node Checkpointing

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -108,7 +108,7 @@ namespace cryptonote
                          "Vote is indexing out of bounds");
 
     const auto signature_it = std::find_if(checkpoint.signatures.begin(), checkpoint.signatures.end(), [&vote](service_nodes::voter_to_signature const &check) {
-      return vote.voters_quorum_index < check.quorum_index;
+      return vote.voters_quorum_index == check.quorum_index;
     });
 
     if (signature_it == checkpoint.signatures.end())

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -137,6 +137,7 @@ namespace cryptonote
       return true;
 #endif
 
+    CRITICAL_REGION_LOCAL(m_lock);
     std::vector<int> unique_vote_set(service_nodes::QUORUM_SIZE);
     auto pre_existing_checkpoint_it = m_points.find(vote.block_height);
     if (pre_existing_checkpoint_it != m_points.end())
@@ -161,7 +162,6 @@ namespace cryptonote
     }
 
     // TODO(doyle): Double work. Factor into a generic vote checker as we already have one in service node deregister
-    CRITICAL_REGION_LOCAL(m_lock);
     std::vector<checkpoint_t> &candidate_checkpoints    = m_staging_points[vote.block_height];
     std::vector<checkpoint_t>::iterator curr_checkpoint = candidate_checkpoints.end();
     for (auto it = candidate_checkpoints.begin(); it != candidate_checkpoints.end(); it++)

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -107,17 +107,16 @@ namespace cryptonote
                          false,
                          "Vote is indexing out of bounds");
 
-    const auto compare_vote_and_voter_to_signature = [](service_nodes::checkpoint_vote const &a, service_nodes::voter_to_signature const &b) {
-      return a.voters_quorum_index < b.quorum_index;
-    };
+    const auto signature_it = std::find_if(checkpoint.signatures.begin(), checkpoint.signatures.end(), [&vote](service_nodes::voter_to_signature const &check) {
+      return vote.voters_quorum_index < check.quorum_index;
+    });
 
-    auto signature_it = std::upper_bound(checkpoint.signatures.begin(), checkpoint.signatures.end(), vote, compare_vote_and_voter_to_signature);
-    if (signature_it == checkpoint.signatures.end() || signature_it->quorum_index != vote.voters_quorum_index)
+    if (signature_it == checkpoint.signatures.end())
     {
       service_nodes::voter_to_signature new_voter_to_signature = {};
       new_voter_to_signature.quorum_index                      = vote.voters_quorum_index;
       new_voter_to_signature.signature                         = vote.signature;
-      checkpoint.signatures.insert(signature_it, new_voter_to_signature);
+      checkpoint.signatures.push_back(new_voter_to_signature);
       return true;
     }
 
@@ -138,7 +137,7 @@ namespace cryptonote
 #endif
 
     CRITICAL_REGION_LOCAL(m_lock);
-    std::vector<int> unique_vote_set(service_nodes::QUORUM_SIZE);
+    std::array<int, service_nodes::QUORUM_SIZE> unique_vote_set = {};
     auto pre_existing_checkpoint_it = m_points.find(vote.block_height);
     if (pre_existing_checkpoint_it != m_points.end())
     {

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -144,7 +144,7 @@ namespace cryptonote
      *
      * @return a const reference to the checkpoints container
      */
-    const std::map<uint64_t, checkpoint_t>& get_points() const { return m_points; };
+    const std::map<uint64_t, std::list<checkpoint_t>>& get_points() const { return m_points; };
 
     /**
      * @brief checks if our checkpoints container conflicts with another

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -82,7 +82,7 @@ namespace cryptonote
      */
     bool add_checkpoint(uint64_t height, const std::string& hash_str);
 
-    bool add_or_update_checkpoint(uint64_t height, checkpoint_t const &checkpoint);
+    bool add_or_update_service_node_checkpoint(crypto::hash const &block_hash, service_nodes::checkpoint_vote const &vote);
 
     /**
      * @brief checks if there is a checkpoint in the future

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -139,7 +139,7 @@ namespace cryptonote
      *
      * @return a const reference to the checkpoints container
      */
-    const std::map<uint64_t, checkpoint_t>& get_points() const { return m_points; };
+    std::map<uint64_t, checkpoint_t> get_points() const { return m_points; };
 
     /**
      * @brief checks if our checkpoints container conflicts with another

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -30,7 +30,7 @@
 
 #pragma once
 #include <map>
-#include <list>
+#include <vector>
 #include "misc_log_ex.h"
 #include "crypto/hash.h"
 #include "cryptonote_config.h"
@@ -138,9 +138,7 @@ namespace cryptonote
      *
      * @return a const reference to the checkpoints container
      */
-    const std::map<uint64_t, std::list<checkpoint_t>>& get_points() const { return m_points; };
-
-    void handle_block_added(uint64_t height);
+    const std::map<uint64_t, checkpoint_t>& get_points() const { return m_points; };
 
     /**
      * @brief checks if our checkpoints container conflicts with another
@@ -197,8 +195,9 @@ namespace cryptonote
     bool load_checkpoints_from_dns(network_type nettype = MAINNET);
 
   private:
-    uint64_t                                    m_oldest_possible_reorg_limit = 0;
-    std::map<uint64_t, std::list<checkpoint_t>> m_points; //!< the checkpoints container
+    std::vector<checkpoint_t>        m_staging_points;
+    uint64_t                         m_oldest_possible_reorg_limit = 0;
+    std::map<uint64_t, checkpoint_t> m_points; //!< the checkpoints container
   };
 
 }

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -31,6 +31,8 @@
 #pragma once
 #include <map>
 #include <vector>
+#include <list>
+
 #include "misc_log_ex.h"
 #include "crypto/hash.h"
 #include "cryptonote_config.h"
@@ -77,7 +79,7 @@ namespace cryptonote
      */
     bool add_checkpoint(uint64_t height, const std::string& hash_str);
 
-    bool add_or_update_service_node_checkpoint(crypto::hash const &block_hash, service_nodes::checkpoint_vote const &vote);
+    bool add_checkpoint_vote(service_nodes::checkpoint_vote const &vote);
 
     /**
      * @brief checks if there is a checkpoint in the future
@@ -160,8 +162,6 @@ namespace cryptonote
      */
     bool init_default_checkpoints(network_type nettype);
 
-    // TODO(doyle): CHECKPOINTING(doyle): bool init_service_node_checkpoints(Blockchain const &blockchain);
-
     /**
      * @brief load new checkpoints
      *
@@ -195,10 +195,10 @@ namespace cryptonote
     bool load_checkpoints_from_dns(network_type nettype = MAINNET);
 
   private:
-    std::vector<checkpoint_t>        m_staging_points;
-    uint64_t                         m_oldest_possible_reorg_limit = 0;
-    std::map<uint64_t, checkpoint_t> m_points; //!< the checkpoints container
-    mutable epee::critical_section m_lock;
+    std::unordered_map<uint64_t, std::vector<checkpoint_t>> m_staging_points; // Incomplete service node checkpoints being voted on
+    uint64_t                                                m_oldest_possible_reorg_limit = 0;
+    std::map<uint64_t, checkpoint_t>                        m_points; //!< the checkpoints container
+    mutable epee::critical_section                          m_lock;
   };
 
 }

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -65,12 +65,6 @@ namespace cryptonote
   class checkpoints
   {
   public:
-
-    /**
-     * @brief default constructor
-     */
-    checkpoints();
-
     /**
      * @brief adds a checkpoint to the container
      *
@@ -146,6 +140,8 @@ namespace cryptonote
      */
     const std::map<uint64_t, std::list<checkpoint_t>>& get_points() const { return m_points; };
 
+    void handle_block_added(uint64_t height);
+
     /**
      * @brief checks if our checkpoints container conflicts with another
      *
@@ -201,6 +197,7 @@ namespace cryptonote
     bool load_checkpoints_from_dns(network_type nettype = MAINNET);
 
   private:
+    uint64_t                                    m_oldest_possible_reorg_limit = 0;
     std::map<uint64_t, std::list<checkpoint_t>> m_points; //!< the checkpoints container
   };
 

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -31,7 +31,6 @@
 #pragma once
 #include <map>
 #include <vector>
-#include <list>
 
 #include "misc_log_ex.h"
 #include "crypto/hash.h"

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -40,6 +40,7 @@
 
 namespace cryptonote
 {
+  struct Blockchain;
   enum struct checkpoint_type
   {
     predefined_or_dns,
@@ -105,18 +106,14 @@ namespace cryptonote
      *
      * @param height the height to be checked
      * @param h the hash to be checked
-     * @param is_a_checkpoint return-by-reference if there is a checkpoint at the given height
+     * @param blockchain the blockchain to query ancestor blocks from the current height
+     * @param is_a_checkpoint optional return-by-pointer if there is a checkpoint at the given height
      *
      * @return true if there is no checkpoint at the given height,
      *         true if the passed parameters match the stored checkpoint,
      *         false otherwise
      */
-    bool check_block(uint64_t height, const crypto::hash& h, bool& is_a_checkpoint) const;
-
-    /**
-     * @overload
-     */
-    bool check_block(uint64_t height, const crypto::hash& h) const;
+    bool check_block(uint64_t height, const crypto::hash& h, cryptonote::Blockchain const &blockchain, bool *is_a_checkpoint = nullptr) const;
 
     /**
      * @brief checks if alternate chain blocks should be kept for a given height

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -30,6 +30,7 @@
 
 #pragma once
 #include <map>
+#include <list>
 #include "misc_log_ex.h"
 #include "crypto/hash.h"
 #include "cryptonote_config.h"
@@ -113,7 +114,7 @@ namespace cryptonote
      *         true if the passed parameters match the stored checkpoint,
      *         false otherwise
      */
-    bool check_block(uint64_t height, const crypto::hash& h, cryptonote::Blockchain const &blockchain, bool *is_a_checkpoint = nullptr) const;
+    bool check_block(uint64_t height, const crypto::hash& h, bool *is_a_checkpoint = nullptr) const;
 
     /**
      * @brief checks if alternate chain blocks should be kept for a given height
@@ -200,7 +201,7 @@ namespace cryptonote
     bool load_checkpoints_from_dns(network_type nettype = MAINNET);
 
   private:
-    std::map<uint64_t, checkpoint_t> m_points; //!< the checkpoints container
+    std::map<uint64_t, std::list<checkpoint_t>> m_points; //!< the checkpoints container
   };
 
 }

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -198,6 +198,7 @@ namespace cryptonote
     std::vector<checkpoint_t>        m_staging_points;
     uint64_t                         m_oldest_possible_reorg_limit = 0;
     std::map<uint64_t, checkpoint_t> m_points; //!< the checkpoints container
+    mutable epee::critical_section m_lock;
   };
 
 }

--- a/src/common/loki.cpp
+++ b/src/common/loki.cpp
@@ -584,10 +584,3 @@ std::string loki::hex64_to_base32z(const std::string &src)
 
   return result;
 }
-
-bool loki::u64_subtract_no_underflow(uint64_t a, uint64_t b, uint64_t *output)
-{
-  bool result = (a >= b);
-  if (output) *output = a - b;
-  return result;
-}

--- a/src/common/loki.cpp
+++ b/src/common/loki.cpp
@@ -584,3 +584,10 @@ std::string loki::hex64_to_base32z(const std::string &src)
 
   return result;
 }
+
+bool loki::u64_subtract_no_underflow(uint64_t a, uint64_t b, uint64_t *output)
+{
+  bool result = (a >= b);
+  if (output) *output = a - b;
+  return result;
+}

--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -36,9 +36,10 @@
 
 namespace loki
 {
-double      round           (double);
-double      exp2            (double);
-std::string hex64_to_base32z(std::string const& src);
+double      round                    (double);
+double      exp2                     (double);
+std::string hex64_to_base32z         (std::string const& src);
+bool        u64_subtract_no_underflow(uint64_t a, uint64_t b, uint64_t *output);
 }; // namespace Loki
 
 #endif // LOKI_H

--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -36,9 +36,9 @@
 
 namespace loki
 {
-double      round                    (double);
-double      exp2                     (double);
-std::string hex64_to_base32z         (std::string const& src);
+double      round           (double);
+double      exp2            (double);
+std::string hex64_to_base32z(std::string const& src);
 }; // namespace Loki
 
 #endif // LOKI_H

--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -39,7 +39,6 @@ namespace loki
 double      round                    (double);
 double      exp2                     (double);
 std::string hex64_to_base32z         (std::string const& src);
-bool        u64_subtract_no_underflow(uint64_t a, uint64_t b, uint64_t *output);
 }; // namespace Loki
 
 #endif // LOKI_H

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -263,6 +263,7 @@ namespace cryptonote
     network_version_9_service_nodes, // Proof Of Stake w/ Service Nodes
     network_version_10_bulletproofs, // Bulletproofs, Service Node Grace Registration Period, Batched Governance
     network_version_11_infinite_staking,
+    network_version_12_checkpointing,
 
     network_version_count,
   };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -112,6 +112,7 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
+  { network_version_12_checkpointing,    6, 0, 1551223964 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =
@@ -3532,7 +3533,6 @@ leave:
     }
 
   }
-  m_checkpoints.handle_block_added(get_current_blockchain_height());
 
   TIME_MEASURE_FINISH(longhash_calculating_time);
   if (precomputed)
@@ -3950,7 +3950,7 @@ void Blockchain::check_against_checkpoints(const checkpoints& points, bool enfor
     if (block_height >= m_db->height()) // if the checkpoint is for a block we don't have yet, move on
       break;
 
-    if (!points.check_block(block_height, m_db->get_block_hash_from_height(block_height), *this))
+    if (!points.check_block(block_height, m_db->get_block_hash_from_height(block_height), nullptr))
     {
       // if asked to enforce checkpoints, roll back to a couple of blocks before the checkpoint
       if (enforce)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4007,11 +4007,18 @@ bool Blockchain::update_checkpoints(const std::string& file_path, bool check_dns
   return true;
 }
 //------------------------------------------------------------------
-bool Blockchain::create_or_update_service_node_checkpoint(service_nodes::checkpoint_vote const &vote)
+bool Blockchain::add_checkpoint_vote(service_nodes::checkpoint_vote const &vote)
 {
-  // TODO(doyle): Need to validate hash?
-  crypto::hash const block_hash = get_block_id_by_height(vote.block_height);
-  m_checkpoints.add_or_update_service_node_checkpoint(block_hash, vote);
+  crypto::hash const canonical_block_hash = get_block_id_by_height(vote.block_height);
+  if (vote.block_hash != canonical_block_hash)
+  {
+    // NOTE: Vote is not for a block on the canonical chain, check if it's part
+    // of an alternative chain
+    if (m_alternative_chains.find(vote.block_hash) == m_alternative_chains.end())
+      return false;
+  }
+
+  m_checkpoints.add_checkpoint_vote(vote);
   return true;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -112,7 +112,6 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
-  { network_version_12_checkpointing,    6, 0, 1551223964 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4909,6 +4909,15 @@ void Blockchain::cache_block_template(const block &b, const cryptonote::account_
   m_btc_valid = true;
 }
 
+void Blockchain::update_service_node_checkpoint(service_nodes::checkpoint const &new_checkpoint)
+{
+  crypto::hash const block_hash             = get_block_id_by_height(new_checkpoint.block_height);
+  service_nodes::checkpoint &old_checkpoint = m_service_node_checkpoints[block_hash];
+
+  if (new_checkpoint.signatures.size() > old_checkpoint.signatures.size())
+    old_checkpoint.signatures = std::move(new_checkpoint.signatures);
+}
+
 namespace cryptonote {
 template bool Blockchain::get_transactions(const std::vector<crypto::hash>&, std::vector<transaction>&, std::vector<crypto::hash>&) const;
 template bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>&, std::vector<cryptonote::blobdata>&, std::vector<crypto::hash>&, bool) const;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3530,7 +3530,9 @@ leave:
       bvc.m_verifivation_failed = true;
       goto leave;
     }
+
   }
+  m_checkpoints.handle_block_added(get_current_blockchain_height());
 
   TIME_MEASURE_FINISH(longhash_calculating_time);
   if (precomputed)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3937,11 +3937,6 @@ bool Blockchain::add_new_block(const block& bl_, block_verification_context& bvc
 //      caller decide course of action.
 void Blockchain::check_against_checkpoints(const checkpoints& points, bool enforce)
 {
-  // 1. The proposed chain must be built from one of the last two checkpoints C1 or C2;
-  // 2. Nodes shall not accept more than (N*3) - 1 blocks since the last checkpoint (Where N is the reorg limit);
-  // 3. If two chains of proof of work are produced with the same cumulative difficulty, Service Nodes should choose the chain based on the lowest hamming distance of the chain tip’s blockhash to 0, and;
-  // 4. The latest checkpoint C3 can invalidate two checkpoints back to C1.
-
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   bool stop_batch = m_db->batch_start();
 
@@ -4010,12 +4005,12 @@ bool Blockchain::update_checkpoints(const std::string& file_path, bool check_dns
   return true;
 }
 //------------------------------------------------------------------
-bool Blockchain::add_or_update_service_node_checkpoint(uint64_t height, checkpoint_t const &new_checkpoint)
+bool Blockchain::create_or_update_service_node_checkpoint(service_nodes::checkpoint_vote const &vote)
 {
-  bool result = false;
-  if (new_checkpoint.type == checkpoint_type::service_node)
-    result = m_checkpoints.add_or_update_checkpoint(height, new_checkpoint);
-  return result;
+  // TODO(doyle): Need to validate hash?
+  crypto::hash const block_hash = get_block_id_by_height(vote.block_height);
+  m_checkpoints.add_or_update_service_node_checkpoint(block_hash, vote);
+  return true;
 }
 //------------------------------------------------------------------
 void Blockchain::set_enforce_dns_checkpoints(bool enforce_checkpoints)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1619,7 +1619,7 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
     bei.height = alt_chain.size() ? it_prev->second.height + 1 : m_db->get_block_height(b.prev_id) + 1;
 
     bool is_a_checkpoint = false;
-    if(!m_checkpoints.check_block(bei.height, id, *this, &is_a_checkpoint))
+    if(!m_checkpoints.check_block(bei.height, id, &is_a_checkpoint))
     {
       LOG_ERROR("CHECKPOINT VALIDATION FAILED");
       bvc.m_verifivation_failed = true;
@@ -3524,7 +3524,7 @@ leave:
   // is correct.
   if(m_checkpoints.is_in_checkpoint_zone(get_current_blockchain_height()))
   {
-    if(!m_checkpoints.check_block(get_current_blockchain_height(), id, *this))
+    if(!m_checkpoints.check_block(get_current_blockchain_height(), id))
     {
       LOG_ERROR("CHECKPOINT VALIDATION FAILED");
       bvc.m_verifivation_failed = true;
@@ -4026,7 +4026,7 @@ void Blockchain::block_longhash_worker(uint64_t height, const epee::span<const b
   for (const auto & block : blocks)
   {
     if (m_cancel)
-       break;
+      break;
     crypto::hash id = get_block_hash(block);
     crypto::hash pow = get_block_longhash(block, height++);
     map.emplace(id, pow);
@@ -4401,7 +4401,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
       waiter.wait(&tpool);
 
       if (m_cancel)
-         return false;
+        return false;
 
       for (const auto & map : maps)
       {
@@ -4442,11 +4442,11 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   std::vector<std::pair<cryptonote::transaction, crypto::hash>> txes(total_txs);
 
 #define SCAN_TABLE_QUIT(m) \
-        do { \
-            MERROR_VER(m) ;\
-            m_scan_table.clear(); \
-            return false; \
-        } while(0); \
+  do { \
+    MERROR_VER(m) ;\
+    m_scan_table.clear(); \
+    return false; \
+  } while(0); \
 
   // generate sorted tables for all amounts and absolute offsets
   size_t tx_index = 0, block_index = 0;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -777,7 +777,7 @@ namespace cryptonote
     };
 
     // TODO(doyle): CHECKPOINTING(doyle):
-    bool create_or_update_service_node_checkpoint(service_nodes::checkpoint_vote const &vote);
+    bool add_checkpoint_vote(service_nodes::checkpoint_vote const &vote);
 
     // user options, must be called before calling init()
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -95,12 +95,17 @@ namespace cryptonote
     void debug__print_checkpoints()
     {
       const std::map<uint64_t, checkpoint_t> &checkpoint_map = m_checkpoints.get_points();
-      for (auto &it : checkpoint_map)
+      if (checkpoint_map.empty())
       {
-        checkpoint_t const &checkpoint = it.second;
-        printf("Checkpoint [%zu] ", it.first);
-        printf("(%s)", (checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined");
-        printf("\n");
+          std::cout << "Checkpoint: None available";
+      }
+      else
+      {
+        for (auto &it : checkpoint_map)
+        {
+          checkpoint_t const &checkpoint = it.second;
+          std::cout << "Checkpoint [" << it.first << "]" << ((checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined") << "\n";
+        }
       }
     }
 
@@ -765,8 +770,14 @@ namespace cryptonote
      */
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
+    struct service_node_checkpoint_pool_entry
+    {
+      uint64_t                                    height;
+      std::vector<service_nodes::checkpoint_vote> votes;
+    };
+
     // TODO(doyle): CHECKPOINTING(doyle):
-    bool add_or_update_service_node_checkpoint(uint64_t height, checkpoint_t const &new_checkpoint);
+    bool create_or_update_service_node_checkpoint(service_nodes::checkpoint_vote const &vote);
 
     // user options, must be called before calling init()
 
@@ -1063,12 +1074,6 @@ namespace cryptonote
      * @param nblocks number of blocks to be removed
      */
     void pop_blocks(uint64_t nblocks);
-
-    struct service_node_checkpoint_pool_entry
-    {
-      uint64_t     height;
-      checkpoint_t checkpoint;
-    };
 
     std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1074,8 +1074,9 @@ namespace cryptonote
 
     tx_memory_pool& m_tx_pool;
 
-    service_nodes::service_node_list&    m_service_node_list;
-    service_nodes::deregister_vote_pool& m_deregister_vote_pool;
+    service_nodes::service_node_list&                           m_service_node_list;
+    std::unordered_map<crypto::hash, service_nodes::checkpoint> m_service_node_checkpoints;
+    service_nodes::deregister_vote_pool&                        m_deregister_vote_pool;
 
     mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
 
@@ -1506,5 +1507,12 @@ namespace cryptonote
      * At some point, may be used to push an update to miners
      */
     void cache_block_template(const block &b, const cryptonote::account_public_address &address, const blobdata &nonce, const difficulty_type &diff, uint64_t expected_reward, uint64_t pool_cookie);
+
+     /*
+      * @brief CHECKPOINTING(doyle):
+      *
+      * @return CHECKPOINTING(doyle):
+      */
+     void update_service_node_checkpoint(service_nodes::checkpoint const &new_checkpoint);
   };
 }  // namespace cryptonote

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1050,6 +1050,14 @@ namespace cryptonote
      */
     void pop_blocks(uint64_t nblocks);
 
+    struct service_node_checkpoint_pool_entry
+    {
+      uint64_t     height;
+      checkpoint_t checkpoint;
+    };
+
+    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
+
 #ifndef IN_UNIT_TESTS
   private:
 #endif
@@ -1075,7 +1083,6 @@ namespace cryptonote
     tx_memory_pool& m_tx_pool;
 
     service_nodes::service_node_list&                           m_service_node_list;
-    std::unordered_map<crypto::hash, service_nodes::checkpoint> m_service_node_checkpoints;
     service_nodes::deregister_vote_pool&                        m_deregister_vote_pool;
 
     mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
@@ -1507,12 +1514,5 @@ namespace cryptonote
      * At some point, may be used to push an update to miners
      */
     void cache_block_template(const block &b, const cryptonote::account_public_address &address, const blobdata &nonce, const difficulty_type &diff, uint64_t expected_reward, uint64_t pool_cookie);
-
-     /*
-      * @brief CHECKPOINTING(doyle):
-      *
-      * @return CHECKPOINTING(doyle):
-      */
-     void update_service_node_checkpoint(service_nodes::checkpoint const &new_checkpoint);
   };
 }  // namespace cryptonote

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -97,14 +97,14 @@ namespace cryptonote
       const std::map<uint64_t, checkpoint_t> &checkpoint_map = m_checkpoints.get_points();
       if (checkpoint_map.empty())
       {
-          std::cout << "Checkpoint: None available";
+          std::cout << "Checkpoint: None available" << std::endl;
       }
       else
       {
         for (auto &it : checkpoint_map)
         {
           checkpoint_t const &checkpoint = it.second;
-          std::cout << "Checkpoint [" << it.first << "]" << ((checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined") << "\n";
+          std::cout << "Checkpoint [" << it.first << "]" << ((checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined") << std::endl;
         }
       }
     }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -94,7 +94,7 @@ namespace cryptonote
   public:
     void debug__print_checkpoints()
     {
-      const std::map<uint64_t, std::list<checkpoint_t>> &checkpoint_map = m_checkpoints.get_points();
+      const std::map<uint64_t, checkpoint_t> &checkpoint_map = m_checkpoints.get_points();
       if (checkpoint_map.empty())
       {
           std::cout << "Checkpoint: None available" << std::endl;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -770,13 +770,14 @@ namespace cryptonote
      */
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
+    // TODO(doyle): CHECKPOINTING(doyle):
     struct service_node_checkpoint_pool_entry
     {
       uint64_t                                    height;
       std::vector<service_nodes::checkpoint_vote> votes;
     };
 
-    // TODO(doyle): CHECKPOINTING(doyle):
+    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
     bool add_checkpoint_vote(service_nodes::checkpoint_vote const &vote);
 
     // user options, must be called before calling init()
@@ -1075,8 +1076,6 @@ namespace cryptonote
      */
     void pop_blocks(uint64_t nblocks);
 
-    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
-
 #ifndef IN_UNIT_TESTS
   private:
 #endif
@@ -1101,8 +1100,8 @@ namespace cryptonote
 
     tx_memory_pool& m_tx_pool;
 
-    service_nodes::service_node_list&                           m_service_node_list;
-    service_nodes::deregister_vote_pool&                        m_deregister_vote_pool;
+    service_nodes::service_node_list&    m_service_node_list;
+    service_nodes::deregister_vote_pool& m_deregister_vote_pool;
 
     mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -92,6 +92,18 @@ namespace cryptonote
   class Blockchain
   {
   public:
+    void debug__print_checkpoints()
+    {
+      const std::map<uint64_t, checkpoint_t> &checkpoint_map = m_checkpoints.get_points();
+      for (auto &it : checkpoint_map)
+      {
+        checkpoint_t const &checkpoint = it.second;
+        printf("Checkpoint [%zu] ", it.first);
+        printf("(%s)", (checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined");
+        printf("\n");
+      }
+    }
+
     /**
      * @brief Now-defunct (TODO: remove) struct from in-memory blockchain
      */
@@ -753,6 +765,8 @@ namespace cryptonote
      */
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
+    // TODO(doyle): CHECKPOINTING(doyle):
+    bool add_or_update_service_node_checkpoint(uint64_t height, checkpoint_t const &new_checkpoint);
 
     // user options, must be called before calling init()
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -101,7 +101,7 @@ namespace cryptonote
       }
       else
       {
-        for (auto &it : checkpoint_map)
+        for (auto const &it : checkpoint_map)
         {
           checkpoint_t const &checkpoint = it.second;
           std::cout << "Checkpoint [" << it.first << "]" << ((checkpoint.type == checkpoint_type::service_node) ? "Service Node" : "Predefined") << std::endl;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -94,7 +94,7 @@ namespace cryptonote
   public:
     void debug__print_checkpoints()
     {
-      const std::map<uint64_t, checkpoint_t> &checkpoint_map = m_checkpoints.get_points();
+      const std::map<uint64_t, std::list<checkpoint_t>> &checkpoint_map = m_checkpoints.get_points();
       if (checkpoint_map.empty())
       {
           std::cout << "Checkpoint: None available" << std::endl;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -770,6 +770,14 @@ namespace cryptonote
      */
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
+    // TODO(doyle): CHECKPOINTING(doyle):
+    struct service_node_checkpoint_pool_entry
+    {
+      uint64_t                                    height;
+      std::vector<service_nodes::checkpoint_vote> votes;
+    };
+
+    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
     bool add_checkpoint_vote(service_nodes::checkpoint_vote const &vote);
 
     // user options, must be called before calling init()
@@ -1094,15 +1102,6 @@ namespace cryptonote
 
     service_nodes::service_node_list&    m_service_node_list;
     service_nodes::deregister_vote_pool& m_deregister_vote_pool;
-
-    // TODO(doyle): CHECKPOINTING(doyle):
-    struct service_node_checkpoint_pool_entry
-    {
-      uint64_t                                    height;
-      std::vector<service_nodes::checkpoint_vote> votes;
-    };
-
-    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
 
     mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -770,14 +770,6 @@ namespace cryptonote
      */
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
-    // TODO(doyle): CHECKPOINTING(doyle):
-    struct service_node_checkpoint_pool_entry
-    {
-      uint64_t                                    height;
-      std::vector<service_nodes::checkpoint_vote> votes;
-    };
-
-    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
     bool add_checkpoint_vote(service_nodes::checkpoint_vote const &vote);
 
     // user options, must be called before calling init()
@@ -1102,6 +1094,15 @@ namespace cryptonote
 
     service_nodes::service_node_list&    m_service_node_list;
     service_nodes::deregister_vote_pool& m_deregister_vote_pool;
+
+    // TODO(doyle): CHECKPOINTING(doyle):
+    struct service_node_checkpoint_pool_entry
+    {
+      uint64_t                                    height;
+      std::vector<service_nodes::checkpoint_vote> votes;
+    };
+
+    std::vector<service_node_checkpoint_pool_entry> m_checkpoint_pool;
 
     mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1401,9 +1401,9 @@ namespace cryptonote
     {
       for (service_nodes::checkpoint_vote &vote : pool_entry.votes)
       {
-        const time_t last_sent       = now - vote.time_last_sent_p2p;
+        const time_t elapsed         = now - vote.time_last_sent_p2p;
         const time_t RELAY_THRESHOLD = 60 * 2;
-        if (last_sent > RELAY_THRESHOLD)
+        if (elapsed > RELAY_THRESHOLD)
         {
           relayed_votes.push_back(&vote);
           req.votes.push_back(vote);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2156,8 +2156,8 @@ namespace cryptonote
       if (vote.block_height >= latest_height)
         return false;
 
-      uint64_t delta_height = latest_height - vote.block_height;
-      if (delta_height > 10000)
+      uint64_t vote_age = latest_height - vote.block_height;
+      if (vote_age > ((service_nodes::CHECKPOINT_INTERVAL * 3) - 1))
         return false;
     }
 
@@ -2180,7 +2180,7 @@ namespace cryptonote
       // NOTE(loki): We don't validate that the hash belongs to a valid block
       // just yet, just that the signature is valid.
       crypto::public_key const &voters_pub_key = state->quorum_nodes[vote.voters_quorum_index];
-      if (!crypto::check_signature(vote.hash, voters_pub_key, vote.signature))
+      if (!crypto::check_signature(vote.block_hash, voters_pub_key, vote.signature))
       {
         LOG_PRINT_L1("TODO(doyle): CHECKPOINTING(doyle): Writeme");
         return false;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1601,6 +1601,7 @@ namespace cryptonote
       bvc.m_verifivation_failed = true;
       return false;
     }
+
     add_new_block(b, bvc);
     if(update_miner_blocktemplate && bvc.m_added_to_main_chain)
        update_miner_block_template();
@@ -2219,10 +2220,10 @@ namespace cryptonote
         if (pool_entry.checkpoint.signatures.size() >= service_nodes::MIN_VOTES_TO_CHECKPOINT)
         {
           // TODO(doyle): CHECKPOINTING(doyle): Implement me
-          // if (!m_checkpoints.add_or_update_checkpoint(pool_entry.height, pool_entry.checkpoint))
-          // {
-          //   // TODO(doyle): Panic
-          // }
+          if (!m_blockchain_storage.add_or_update_service_node_checkpoint(pool_entry.height, pool_entry.checkpoint))
+          {
+            // TODO(doyle): Panic, mismatching hash with pre-existing checkpoint
+          }
         }
       }
     }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2066,6 +2066,11 @@ namespace cryptonote
     return m_service_node_list.get_uptime_quorum(height);
   }
   //-----------------------------------------------------------------------------------------------
+  const std::shared_ptr<const service_nodes::quorum_checkpointing> core::get_checkpointing_quorum(uint64_t height) const
+  {
+    return m_service_node_list.get_checkpointing_quorum(height);
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::is_service_node(const crypto::public_key& pubkey) const
   {
     return m_service_node_list.is_service_node(pubkey);
@@ -2163,7 +2168,7 @@ namespace cryptonote
 
     // Validate Vote
     {
-      const std::shared_ptr<const service_nodes::quorum_state> state = get_quorum_state(vote.block_height);
+      const std::shared_ptr<const service_nodes::quorum_uptime_proof> state = get_uptime_quorum(vote.block_height);
       if (!state)
       {
         // TODO(loki): Fatal error

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2188,54 +2188,7 @@ namespace cryptonote
     }
 
     // TODO(doyle): CHECKPOINTING(doyle): We need to check the hash they're voting on matches across votes
-    // Get Matching Checkpoint
-    std::vector<Blockchain::service_node_checkpoint_pool_entry> &checkpoint_pool = m_blockchain_storage.m_checkpoint_pool;
-    auto it = std::find_if(checkpoint_pool.begin(), checkpoint_pool.end(), [&vote](Blockchain::service_node_checkpoint_pool_entry const &checkpoint) {
-        return (checkpoint.height == vote.block_height);
-    });
-
-    if (it == checkpoint_pool.end())
-    {
-      Blockchain::service_node_checkpoint_pool_entry pool_entry = {};
-      pool_entry.height                                         = vote.block_height;
-      checkpoint_pool.push_back(pool_entry);
-      it = (checkpoint_pool.end() - 1);
-    }
-
-    // 1. The proposed chain must be built from one of the last two checkpoints C1 or C2;
-    // 2. Nodes shall not accept more than (N*3) - 1 blocks since the last checkpoint (Where N is the reorg limit);
-    // 3. If two chains of proof of work are produced with the same cumulative difficulty, Service Nodes should choose the chain based on the lowest hamming distance of the chain tip’s blockhash to 0, and;
-    // 4. The latest checkpoint C3 can invalidate two checkpoints back to C1.
-
-    // Add Vote if Unique to Checkpoint
-    {
-      Blockchain::service_node_checkpoint_pool_entry &pool_entry = (*it);
-      auto vote_it = std::find_if(pool_entry.votes.begin(), pool_entry.votes.end(), [&vote](service_nodes::checkpoint_vote const &preexisting_vote) {
-          return (preexisting_vote.voters_quorum_index == vote.voters_quorum_index);
-      });
-
-      if (vote_it == pool_entry.votes.end())
-      {
-        pool_entry.votes.push_back(vote);
-        if (pool_entry.votes.size() >= service_nodes::MIN_VOTES_TO_CHECKPOINT)
-        {
-          if (pool_entry.votes.size() == service_nodes::MIN_VOTES_TO_CHECKPOINT)
-          {
-            // NOTE: We just hit the threshold for collecting votes, we can form a checkpoint with the votes we have
-            for (service_nodes::checkpoint_vote const &stored_vote : pool_entry.votes)
-            {
-              m_blockchain_storage.create_or_update_service_node_checkpoint(stored_vote);
-            }
-          }
-          else
-          {
-            // Enough votes to form a checkpoint, we're receiving extra votes within an acceptable time frame, just append it to the checkpoint
-            m_blockchain_storage.create_or_update_service_node_checkpoint(vote);
-          }
-        }
-      }
-    }
-
+    m_blockchain_storage.add_checkpoint_vote(vote);
     return true;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2177,9 +2177,10 @@ namespace cryptonote
         return false;
       }
 
+      // NOTE(loki): We don't validate that the hash belongs to a valid block
+      // just yet, just that the signature is valid.
       crypto::public_key const &voters_pub_key = state->quorum_nodes[vote.voters_quorum_index];
-      crypto::hash const check_hash            = get_block_id_by_height(vote.block_height);
-      if (!crypto::check_signature(check_hash, voters_pub_key, vote.signature))
+      if (!crypto::check_signature(vote.hash, voters_pub_key, vote.signature))
       {
         LOG_PRINT_L1("TODO(doyle): CHECKPOINTING(doyle): Writeme");
         return false;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1111,9 +1111,9 @@ namespace cryptonote
      tx_memory_pool m_mempool; //!< transaction pool instance
      Blockchain m_blockchain_storage; //!< Blockchain instance
 
-     service_nodes::deregister_vote_pool    m_deregister_vote_pool;
-     service_nodes::service_node_list       m_service_node_list;
-     service_nodes::quorum_cop              m_quorum_cop;
+     service_nodes::deregister_vote_pool m_deregister_vote_pool;
+     service_nodes::service_node_list    m_service_node_list;
+     service_nodes::quorum_cop           m_quorum_cop;
 
      i_cryptonote_protocol* m_pprotocol; //!< cryptonote protocol instance
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1145,7 +1145,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*60*5, true> m_blockchain_pruning_interval; //!< interval for incremental blockchain pruning
 
      epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer;
-     epee::math_helper::once_a_time_seconds<60*2, false> m_checkpoint_auto_relayer;
+     epee::math_helper::once_a_time_seconds<10, false> m_checkpoint_auto_relayer;
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1138,7 +1138,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*60*5, true> m_blockchain_pruning_interval; //!< interval for incremental blockchain pruning
 
      epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer;
-     epee::math_helper::once_a_time_seconds<10, false> m_checkpoint_auto_relayer;
+     epee::math_helper::once_a_time_seconds<60*2, false> m_checkpoint_auto_relayer;
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -852,7 +852,7 @@ namespace cryptonote
 
       * @return
       */
-     bool update_service_node_checkpoint(const service_nodes::checkpoint_vote& vote);
+     bool add_checkpoint_vote(const service_nodes::checkpoint_vote& vote, vote_verification_context &vvc);
 
 
      /**
@@ -1084,6 +1084,20 @@ namespace cryptonote
      bool relay_txpool_transactions();
 
      /**
+      * @brief attempt to relay the pooled deregister votes
+      *
+      * @return true, necessary for binding this function to a periodic invoker
+      */
+     bool relay_deregister_votes();
+
+     /**
+      * @brief attempt to relay the pooled checkpoint votes
+      *
+      * @return true, necessary for binding this function to a periodic invoker
+      */
+     bool relay_checkpoint_votes();
+
+     /**
       * @brief checks DNS versions
       *
       * @return true on success, false otherwise
@@ -1143,13 +1157,15 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*60*12, false> m_store_blockchain_interval; //!< interval for manual storing of Blockchain, if enabled
      epee::math_helper::once_a_time_seconds<60*60*2, true> m_fork_moaner; //!< interval for checking HardFork status
      epee::math_helper::once_a_time_seconds<60*2, false> m_txpool_auto_relayer; //!< interval for checking re-relaying txpool transactions
-     epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer; //!< interval for checking re-relaying deregister votes
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
      epee::math_helper::once_a_time_seconds<UPTIME_PROOF_BUFFER_IN_SECONDS, true> m_check_uptime_proof_interval; //!< interval for checking our own uptime proof
      epee::math_helper::once_a_time_seconds<30, true> m_uptime_proof_pruner;
      epee::math_helper::once_a_time_seconds<90, false> m_block_rate_interval; //!< interval for checking block rate
      epee::math_helper::once_a_time_seconds<60*60*5, true> m_blockchain_pruning_interval; //!< interval for incremental blockchain pruning
+
+     epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer;
+     epee::math_helper::once_a_time_seconds<60*2, false> m_checkpoint_auto_relayer;
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -795,6 +795,15 @@ namespace cryptonote
      const std::shared_ptr<const service_nodes::quorum_uptime_proof> get_uptime_quorum(uint64_t height) const;
 
      /**
+      * @brief Get the deterministic list of service node's public keys for nodes responsible for checkpointing
+      *
+      * @param height Block height to deterministically recreate the quorum list from
+
+      * @return Null shared ptr if quorum has not been determined yet for height
+      */
+     const std::shared_ptr<const service_nodes::quorum_checkpointing> get_checkpointing_quorum(uint64_t height) const;
+
+     /**
       * @brief Get a non owning reference to the list of blacklisted key images
       */
      const std::vector<service_nodes::key_image_blacklist_entry> &get_service_node_blacklisted_key_images() const;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -827,14 +827,15 @@ namespace cryptonote
       */
      std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
 
-    /**
-      * @brief get whether `pubkey` is known as a service node
-      *
-      * @param pubkey the public key to test
-      *
-      * @return whether `pubkey` is known as a service node
-      */
-    bool is_service_node(const crypto::public_key& pubkey) const;
+     /**
+       * @brief get whether `pubkey` is known as a service node
+       *
+       * @param pubkey the public key to test
+       *
+       * @return whether `pubkey` is known as a service node
+       */
+     bool is_service_node(const crypto::public_key& pubkey) const;
+
      /**
       * @brief Add a vote to deregister a service node from network
       *
@@ -843,6 +844,16 @@ namespace cryptonote
       * @return Whether the vote was added to the partial deregister pool
       */
      bool add_deregister_vote(const service_nodes::deregister_vote& vote, vote_verification_context &vvc);
+
+     /**
+      * @brief TODO(doyle): CHECKPOINTING(doyle):
+      *
+      * @param TODO(doyle): CHECKPOINTING(doyle):
+
+      * @return
+      */
+     bool update_service_node_checkpoint(const service_nodes::checkpoint_vote& vote);
+
 
      /**
       * @brief Get the keypair for this service node.
@@ -1112,9 +1123,10 @@ namespace cryptonote
      tx_memory_pool m_mempool; //!< transaction pool instance
      Blockchain m_blockchain_storage; //!< Blockchain instance
 
-     service_nodes::deregister_vote_pool m_deregister_vote_pool;
-     service_nodes::service_node_list    m_service_node_list;
-     service_nodes::quorum_cop           m_quorum_cop;
+     service_nodes::deregister_vote_pool    m_deregister_vote_pool;
+     service_nodes::service_node_list       m_service_node_list;
+     service_nodes::quorum_cop              m_quorum_cop;
+     std::vector<service_nodes::checkpoint> m_checkpoint_pool;
 
      i_cryptonote_protocol* m_pprotocol; //!< cryptonote protocol instance
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -409,27 +409,6 @@ namespace cryptonote
      void set_cryptonote_protocol(i_cryptonote_protocol* pprotocol);
 
      /**
-      * @copydoc Blockchain::set_checkpoints
-      *
-      * @note see Blockchain::set_checkpoints()
-      */
-     void set_checkpoints(checkpoints&& chk_pts);
-
-     /**
-      * @brief set the file path to read from when loading checkpoints
-      *
-      * @param path the path to set ours as
-      */
-     void set_checkpoints_file_path(const std::string& path);
-
-     /**
-      * @brief set whether or not we enforce DNS checkpoints
-      *
-      * @param enforce_dns enforce DNS checkpoints or not
-      */
-     void set_enforce_dns_checkpoints(bool enforce_dns);
-
-     /**
       * @brief set whether or not to enable or disable DNS checkpoints
       *
       * @param disble whether to disable DNS checkpoints
@@ -1140,7 +1119,6 @@ namespace cryptonote
      service_nodes::deregister_vote_pool    m_deregister_vote_pool;
      service_nodes::service_node_list       m_service_node_list;
      service_nodes::quorum_cop              m_quorum_cop;
-     std::vector<service_nodes::checkpoint> m_checkpoint_pool;
 
      i_cryptonote_protocol* m_pprotocol; //!< cryptonote protocol instance
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -901,13 +901,6 @@ namespace cryptonote
       */
      bool check_blockchain_pruning();
 
-     /**
-      * @brief attempt to relay the pooled deregister votes
-      *
-      * @return true, necessary for binding this function to a periodic invoker
-      */
-     bool relay_deregister_votes();
-
    private:
 
      /**

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -901,6 +901,13 @@ namespace cryptonote
       */
      bool check_blockchain_pruning();
 
+     /**
+      * @brief attempt to relay the pooled deregister votes
+      *
+      * @return true, necessary for binding this function to a periodic invoker
+      */
+     bool relay_deregister_votes();
+
    private:
 
      /**
@@ -1056,13 +1063,6 @@ namespace cryptonote
       * @return true
       */
      bool relay_txpool_transactions();
-
-     /**
-      * @brief attempt to relay the pooled deregister votes
-      *
-      * @return true, necessary for binding this function to a periodic invoker
-      */
-     bool relay_deregister_votes();
 
      /**
       * @brief attempt to relay the pooled checkpoint votes

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -82,6 +82,8 @@ namespace cryptonote
    {
    public:
 
+     void debug__print_checkpoints() { m_blockchain_storage.debug__print_checkpoints(); }
+
       /**
        * @brief constructor
        *

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -51,7 +51,7 @@ namespace service_nodes
   struct checkpoint_vote
   {
     uint64_t          block_height;
-    crypto::hash      hash;
+    crypto::hash      block_hash;
     uint32_t          voters_quorum_index;
     crypto::signature signature;
     uint64_t          time_last_sent_p2p;

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -55,6 +55,20 @@ namespace service_nodes
     crypto::signature signature;
   };
 
+  struct voter_to_signature
+  {
+    uint16_t          quorum_index;
+    crypto::signature signature;
+    uint64_t          time_last_sent_p2p;
+  };
+
+  struct checkpoint
+  {
+    uint64_t                        block_height;
+    crypto::hash                    prev_block_with_checkpoint;
+    std::vector<voter_to_signature> signatures;
+  };
+
   struct deregister_vote
   {
     static const uint64_t VOTE_LIFETIME_BY_HEIGHT       = BLOCKS_EXPECTED_IN_HOURS(2);
@@ -75,19 +89,6 @@ namespace service_nodes
 
     static bool verify_vote(cryptonote::network_type nettype, const deregister_vote& v, cryptonote::vote_verification_context &vvc,
                             const service_nodes::quorum_uptime_proof &quorum);
-  };
-
-  struct voter_to_signature
-  {
-    uint16_t          quorum_index;
-    crypto::signature signature;
-  };
-
-  struct checkpoint
-  {
-    uint64_t                        block_height;
-    crypto::hash                    block_hash;
-    std::vector<voter_to_signature> signatures;
   };
 
   class deregister_vote_pool

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -48,6 +48,13 @@ namespace service_nodes
 {
   struct quorum_uptime_proof;
 
+  struct checkpoint_vote
+  {
+    uint64_t          block_height;
+    uint32_t          voters_quorum_index;
+    crypto::signature signature;
+  };
+
   struct deregister_vote
   {
     static const uint64_t VOTE_LIFETIME_BY_HEIGHT       = BLOCKS_EXPECTED_IN_HOURS(2);
@@ -68,6 +75,19 @@ namespace service_nodes
 
     static bool verify_vote(cryptonote::network_type nettype, const deregister_vote& v, cryptonote::vote_verification_context &vvc,
                             const service_nodes::quorum_uptime_proof &quorum);
+  };
+
+  struct voter_to_signature
+  {
+    uint16_t          quorum_index;
+    crypto::signature signature;
+  };
+
+  struct checkpoint
+  {
+    uint64_t                        block_height;
+    crypto::hash                    block_hash;
+    std::vector<voter_to_signature> signatures;
   };
 
   class deregister_vote_pool

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -60,7 +60,6 @@ namespace service_nodes
   {
     uint16_t          quorum_index;
     crypto::signature signature;
-    uint64_t          time_last_sent_p2p;
   };
 
   struct deregister_vote

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -51,6 +51,7 @@ namespace service_nodes
   struct checkpoint_vote
   {
     uint64_t          block_height;
+    crypto::hash      hash;
     uint32_t          voters_quorum_index;
     crypto::signature signature;
     uint64_t          time_last_sent_p2p;

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -53,6 +53,7 @@ namespace service_nodes
     uint64_t          block_height;
     uint32_t          voters_quorum_index;
     crypto::signature signature;
+    uint64_t          time_last_sent_p2p;
   };
 
   struct voter_to_signature
@@ -60,13 +61,6 @@ namespace service_nodes
     uint16_t          quorum_index;
     crypto::signature signature;
     uint64_t          time_last_sent_p2p;
-  };
-
-  struct checkpoint
-  {
-    uint64_t                        block_height;
-    crypto::hash                    prev_block_with_checkpoint;
-    std::vector<voter_to_signature> signatures;
   };
 
   struct deregister_vote

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -160,7 +160,6 @@ namespace service_nodes
           {
             service_nodes::checkpoint_vote vote = {};
             vote.block_height                   = m_last_height;
-            // vote.block_hash                     = m_core.get_block_id_by_height(block_height_to_checkpoint);
             vote.voters_quorum_index            = my_index_in_quorum;
 
             cryptonote::vote_verification_context vvc = {};

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -160,14 +160,15 @@ namespace service_nodes
         {
           service_nodes::checkpoint_vote vote = {};
           vote.block_height                   = block_height_to_checkpoint;
+          vote.block_hash                     = m_core.get_block_id_by_height(block_height_to_checkpoint);
           vote.voters_quorum_index            = my_index_in_quorum;
-          crypto::hash block_hash             = m_core.get_block_id_by_height(block_height_to_checkpoint);
-          crypto::generate_signature(block_hash, my_pubkey, my_seckey, vote.signature);
+          crypto::generate_signature(vote.block_hash, my_pubkey, my_seckey, vote.signature);
 
           cryptonote::vote_verification_context vvc = {};
           if (!m_core.add_checkpoint_vote(vote, vvc))
           {
             // TODO(doyle): CHECKPOINTING(doyle):
+            LOG_ERROR("Failed to add checkpoint vote reason: " << print_vote_verification_context(vvc, &vote));
           }
         }
       }

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -108,7 +108,7 @@ namespace service_nodes
       if (m_core.get_hard_fork_version(m_uptime_proof_height) < 9)
         continue;
 
-      const std::shared_ptr<const quorum_uptime_proof> state = m_core.get_uptime_quorum(m_last_height);
+      const std::shared_ptr<const quorum_uptime_proof> state = m_core.get_uptime_quorum(m_uptime_proof_height);
       if (!state)
       {
         // TODO(loki): Fatal error
@@ -163,7 +163,7 @@ namespace service_nodes
     if (height % CHECKPOINT_INTERVAL != 0)
       return;
 
-    const std::shared_ptr<const quorum_state> state = m_core.get_quorum_state(height);
+    const std::shared_ptr<const quorum_checkpointing> state = m_core.get_checkpointing_quorum(height);
     if (!state)
     {
       // TODO(loki): Fatal error

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -84,7 +84,7 @@ namespace service_nodes
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     time_t const min_lifetime = 0;
 #else
-    time_t const min_lifetime = 0; // 60 * 60 * 2;
+    time_t const min_lifetime = 60 * 60 * 2;
 #endif
     bool alive_for_min_time   = (now - m_core.get_start_time()) >= min_lifetime;
     if (!alive_for_min_time)
@@ -152,7 +152,7 @@ namespace service_nodes
   void quorum_cop::process_checkpoint_quorum(cryptonote::block const &block)
   {
     uint64_t const height = cryptonote::get_block_height(block);
-    if (m_core.get_hard_fork_version(height) < cryptonote::network_version_11_infinite_staking)
+    if (m_core.get_hard_fork_version(height) < cryptonote::network_version_12_checkpointing)
       return;
 
     crypto::public_key my_pubkey;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -42,31 +42,36 @@
 namespace service_nodes
 {
   quorum_cop::quorum_cop(cryptonote::core& core)
-    : m_core(core), m_last_height(0)
+    : m_core(core), m_uptime_proof_height(0)
   {
     init();
   }
 
   void quorum_cop::init()
   {
-    m_last_height = 0;
+    m_uptime_proof_height = 0;
     m_uptime_proof_seen.clear();
   }
 
   void quorum_cop::blockchain_detached(uint64_t height)
   {
-    if (m_last_height >= height)
+    if (m_uptime_proof_height >= height)
     {
-      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes up to " << m_last_height);
+      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes up to " << m_uptime_proof_height);
       LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_IN_BLOCKS << ". This should never happen! Please report this to the devs.");
-      m_last_height = height;
+      m_uptime_proof_height = height;
     }
   }
 
   void quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
-    uint64_t const height        = cryptonote::get_block_height(block);
+    process_uptime_quorum(block);
+    process_checkpoint_quorum(block);
+  }
 
+  void quorum_cop::process_uptime_quorum(cryptonote::block const &block)
+  {
+    uint64_t const height = cryptonote::get_block_height(block);
     if (m_core.get_hard_fork_version(height) < 9)
       return;
 
@@ -88,7 +93,6 @@ namespace service_nodes
     }
 
     uint64_t const latest_height = std::max(m_core.get_current_blockchain_height(), m_core.get_target_blockchain_height());
-
     if (latest_height < service_nodes::deregister_vote::VOTE_LIFETIME_BY_HEIGHT)
       return;
 
@@ -96,20 +100,19 @@ namespace service_nodes
     if (height < execute_justice_from_height)
       return;
 
-    if (m_last_height < execute_justice_from_height)
-      m_last_height = execute_justice_from_height;
+    if (m_uptime_proof_height < execute_justice_from_height)
+      m_uptime_proof_height = execute_justice_from_height;
 
-
-    for (;m_last_height < (height - REORG_SAFETY_BUFFER_IN_BLOCKS); m_last_height++)
+    for (;m_uptime_proof_height < (height - REORG_SAFETY_BUFFER_IN_BLOCKS); m_uptime_proof_height++)
     {
-      if (m_core.get_hard_fork_version(m_last_height) < 9)
+      if (m_core.get_hard_fork_version(m_uptime_proof_height) < 9)
         continue;
 
       const std::shared_ptr<const quorum_uptime_proof> state = m_core.get_uptime_quorum(m_last_height);
       if (!state)
       {
         // TODO(loki): Fatal error
-        LOG_ERROR("Quorum state for height: " << m_last_height << " was not cached in daemon!");
+        LOG_ERROR("Quorum state for height: " << m_uptime_proof_height << " was not cached in daemon!");
         continue;
       }
 
@@ -118,7 +121,7 @@ namespace service_nodes
         continue;
 
       //
-      // I am in the quorum
+      // NOTE: I am in the quorum
       //
       size_t my_index_in_quorum = it - state->quorum_nodes.begin();
       for (size_t node_index = 0; node_index < state->nodes_to_test.size(); ++node_index)
@@ -126,7 +129,7 @@ namespace service_nodes
         const crypto::public_key &node_key = state->nodes_to_test[node_index];
 
         //
-        // Handle deregister votes
+        // NOTE: Handle deregister votes
         //
         {
           CRITICAL_REGION_LOCAL(m_lock);
@@ -136,7 +139,7 @@ namespace service_nodes
           if (vote_off_node)
           {
             service_nodes::deregister_vote vote = {};
-            vote.block_height        = m_last_height;
+            vote.block_height        = m_uptime_proof_height;
             vote.service_node_index  = node_index;
             vote.voters_quorum_index = my_index_in_quorum;
             vote.signature           = service_nodes::deregister_vote::sign_vote(vote.block_height, vote.service_node_index, my_pubkey, my_seckey);
@@ -149,31 +152,59 @@ namespace service_nodes
           }
         }
       }
-
-      //
-      // Handle Checkpointing
-      //
-      if (m_last_height % CHECKPOINT_INTERVAL == 0)
-      {
-        uint64_t block_height_to_checkpoint = 0;
-        if (loki::u64_subtract_no_underflow(m_last_height, CHECKPOINT_INTERVAL, &block_height_to_checkpoint))
-        {
-          service_nodes::checkpoint_vote vote = {};
-          vote.block_height                   = block_height_to_checkpoint;
-          vote.block_hash                     = m_core.get_block_id_by_height(block_height_to_checkpoint);
-          vote.voters_quorum_index            = my_index_in_quorum;
-          crypto::generate_signature(vote.block_hash, my_pubkey, my_seckey, vote.signature);
-
-          cryptonote::vote_verification_context vvc = {};
-          if (!m_core.add_checkpoint_vote(vote, vvc))
-          {
-            // TODO(doyle): CHECKPOINTING(doyle):
-            LOG_ERROR("Failed to add checkpoint vote reason: " << print_vote_verification_context(vvc, &vote));
-          }
-        }
-      }
     }
   }
+
+  void quorum_cop::process_checkpoint_quorum(cryptonote::block const &block)
+  {
+    uint64_t const height = cryptonote::get_block_height(block);
+    if (m_core.get_hard_fork_version(height) < cryptonote::network_version_11_infinite_staking)
+      return;
+
+    crypto::public_key my_pubkey;
+    crypto::secret_key my_seckey;
+    if (!m_core.get_service_node_keys(my_pubkey, my_seckey))
+      return;
+
+    if (height % CHECKPOINT_INTERVAL != 0)
+      return;
+
+    const std::shared_ptr<const quorum_state> state = m_core.get_quorum_state(height);
+    if (!state)
+    {
+      // TODO(loki): Fatal error
+      LOG_ERROR("Quorum state for height: " << height << " was not cached in daemon!");
+      return;
+    }
+
+    auto it = std::find(state->quorum_nodes.begin(), state->quorum_nodes.end(), my_pubkey);
+    if (it == state->quorum_nodes.end())
+      return;
+
+    //
+    // NOTE: I am in the quorum, handle checkpointing
+    //
+    size_t my_index_in_quorum           = it - state->quorum_nodes.begin();
+    service_nodes::checkpoint_vote vote = {};
+    if (!cryptonote::get_block_hash(block, vote.block_hash))
+    {
+      // TODO(loki): Fatal error
+      LOG_ERROR("Could not get block hash for block on height: " << height);
+      return;
+    }
+
+    vote.block_height        = height;
+    vote.voters_quorum_index = my_index_in_quorum;
+    crypto::generate_signature(vote.block_hash, my_pubkey, my_seckey, vote.signature);
+
+    cryptonote::vote_verification_context vvc = {};
+    if (!m_core.add_checkpoint_vote(vote, vvc))
+    {
+      // TODO(doyle): CHECKPOINTING(doyle):
+      LOG_ERROR("Failed to add checkpoint vote reason: " << print_vote_verification_context(vvc, nullptr));
+    }
+  }
+
 
   static crypto::hash make_hash(crypto::public_key const &pubkey, uint64_t timestamp)
   {

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -152,7 +152,6 @@ namespace service_nodes
         //
         // Handle Checkpointing
         //
-        const uint64_t CHECKPOINT_INTERVAL = 4;
         if (m_last_height % CHECKPOINT_INTERVAL == 0)
         {
           uint64_t block_height_to_checkpoint = 0;

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -89,6 +89,9 @@ namespace service_nodes
     void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs) override;
     void blockchain_detached(uint64_t height) override;
 
+    void process_uptime_quorum    (cryptonote::block const &block);
+    void process_checkpoint_quorum(cryptonote::block const &block);
+
     bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
 
     static const uint64_t REORG_SAFETY_BUFFER_IN_BLOCKS = 20;
@@ -103,7 +106,7 @@ namespace service_nodes
   private:
 
     cryptonote::core& m_core;
-    uint64_t m_last_height;
+    uint64_t m_uptime_proof_height;
 
     std::unordered_map<crypto::public_key, proof_info> m_uptime_proof_seen;
     mutable epee::critical_section m_lock;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -10,6 +10,7 @@ namespace service_nodes {
   constexpr size_t   QUORUM_SIZE                      = 10;
   constexpr size_t   QUORUM_LIFETIME                  = (6 * deregister_vote::DEREGISTER_LIFETIME_BY_HEIGHT);
   constexpr size_t   MIN_VOTES_TO_KICK_SERVICE_NODE   = 7;
+  constexpr size_t   MIN_VOTES_TO_CHECKPOINT          = MIN_VOTES_TO_KICK_SERVICE_NODE;
   constexpr size_t   NTH_OF_THE_NETWORK_TO_TEST       = 100;
   constexpr size_t   MIN_NODES_TO_TEST                = 50;
   constexpr size_t   MAX_SWARM_SIZE                   = 10;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -9,7 +9,7 @@
 namespace service_nodes {
   constexpr size_t   QUORUM_SIZE                      = 10;
   constexpr size_t   QUORUM_LIFETIME                  = (6 * deregister_vote::DEREGISTER_LIFETIME_BY_HEIGHT);
-  constexpr size_t   MIN_VOTES_TO_KICK_SERVICE_NODE   = 7;
+  constexpr size_t   MIN_VOTES_TO_KICK_SERVICE_NODE   = 2;
   constexpr size_t   MIN_VOTES_TO_CHECKPOINT          = MIN_VOTES_TO_KICK_SERVICE_NODE;
   constexpr size_t   NTH_OF_THE_NETWORK_TO_TEST       = 100;
   constexpr size_t   MIN_NODES_TO_TEST                = 50;
@@ -37,6 +37,8 @@ namespace service_nodes {
 
   using swarm_id_t = uint64_t;
   constexpr swarm_id_t   UNASSIGNED_SWARM_ID          = UINT64_MAX;
+  static_assert(MIN_VOTES_TO_KICK_SERVICE_NODE <= QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
+  static_assert(MIN_VOTES_TO_CHECKPOINT        <= QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
 inline uint64_t staking_num_lock_blocks(cryptonote::network_type nettype)
 {

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -33,6 +33,7 @@ namespace service_nodes {
   constexpr int      MAX_KEY_IMAGES_PER_CONTRIBUTOR   = 1;
   constexpr uint64_t QUEUE_SWARM_ID                   = 0;
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
+  constexpr uint64_t CHECKPOINT_INTERVAL              = 4;
 
   using swarm_id_t = uint64_t;
   constexpr swarm_id_t   UNASSIGNED_SWARM_ID          = UINT64_MAX;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -9,7 +9,7 @@
 namespace service_nodes {
   constexpr size_t   QUORUM_SIZE                      = 10;
   constexpr size_t   QUORUM_LIFETIME                  = (6 * deregister_vote::DEREGISTER_LIFETIME_BY_HEIGHT);
-  constexpr size_t   MIN_VOTES_TO_KICK_SERVICE_NODE   = 2;
+  constexpr size_t   MIN_VOTES_TO_KICK_SERVICE_NODE   = 7;
   constexpr size_t   MIN_VOTES_TO_CHECKPOINT          = MIN_VOTES_TO_KICK_SERVICE_NODE;
   constexpr size_t   NTH_OF_THE_NETWORK_TO_TEST       = 100;
   constexpr size_t   MIN_NODES_TO_TEST                = 50;

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -336,4 +336,20 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_NEW_CHECKPOINT_VOTE
+  {
+    const static int ID = BC_COMMANDS_POOL_BASE + 12;
+
+    struct request
+    {
+      std::vector<service_nodes::checkpoint_vote> votes;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(votes)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -129,13 +129,14 @@ namespace cryptonote
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_deregister_vote(int command, NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& context);
     int handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context);
+    int handle_notify_new_checkpoint_vote(int command, NOTIFY_NEW_CHECKPOINT_VOTE::request& arg, cryptonote_connection_context& context);
 
     //----------------- i_bc_protocol_layout ---------------------------------------
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context);
-    //----------------- uptime proof ---------------------------------------
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context);
+    virtual bool relay_checkpoint_votes(NOTIFY_NEW_CHECKPOINT_VOTE::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool should_drop_connection(cryptonote_connection_context& context, uint32_t next_stripe);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -94,6 +94,7 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)
       HANDLE_NOTIFY_T2(NOTIFY_NEW_DEREGISTER_VOTE, &cryptonote_protocol_handler::handle_notify_new_deregister_vote)
       HANDLE_NOTIFY_T2(NOTIFY_UPTIME_PROOF, &cryptonote_protocol_handler::handle_uptime_proof)
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_CHECKPOINT_VOTE, &cryptonote_protocol_handler::handle_notify_new_checkpoint_vote)
     END_INVOKE_MAP2()
 
     bool on_idle();

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -45,6 +45,7 @@ namespace cryptonote
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
+    virtual bool relay_checkpoint_votes(NOTIFY_NEW_CHECKPOINT_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
 
   /************************************************************************/
@@ -61,6 +62,10 @@ namespace cryptonote
       return false;
     }
     virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)
+    {
+      return false;
+    }
+    virtual bool relay_checkpoint_votes(NOTIFY_NEW_CHECKPOINT_VOTE::request& arg, cryptonote_connection_context& exclude_context)
     {
       return false;
     }

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -57,6 +57,8 @@ public:
     , cryptonote::core_rpc_server* rpc_server = NULL
     );
 
+  bool print_checkpoints(const std::vector<std::string>& args) { m_executor.print_checkpoints(); return true; }
+
   bool print_peer_list(const std::vector<std::string>& args);
 
   bool print_peer_list_stats(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -343,6 +343,11 @@ t_command_server::t_command_server(
     , std::bind(&t_command_parser_executor::check_blockchain_pruning, &m_parser, p::_1)
     , "Check the blockchain pruning."
     );
+    m_command_lookup.set_handler(
+      "print_checkpoints"
+    , std::bind(&t_command_parser_executor::print_checkpoints, &m_parser, p::_1)
+    , ""
+    );
 
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     m_command_lookup.set_handler(

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -68,6 +68,8 @@ public:
 
   ~t_rpc_command_executor();
 
+  bool print_checkpoints() { m_rpc_server->on_get_checkpoints(); return true; }
+
   bool print_peer_list(bool white = true, bool gray = true, size_t limit = 0);
 
   bool print_peer_list_stats();

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -40,6 +40,11 @@
 #include "p2p/net_node.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+#include "common/loki_integration_test_hooks.h"
+#endif
+
+
 // yes, epee doesn't properly use its full namespace when calling its
 // functions from macros.  *sigh*
 using namespace epee;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -256,6 +256,8 @@ namespace cryptonote
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
+    void on_get_checkpoints() { m_core.debug__print_checkpoints(); }
+
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     void on_relay_uptime_and_votes()
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2783,7 +2783,7 @@ void wallet2::fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, 
     uint64_t missing_blocks = m_checkpoints.get_max_height() - m_blockchain.size();
     while (missing_blocks-- > 0)
       m_blockchain.push_back(crypto::null_hash); // maybe a bit suboptimal, but deque won't do huge reallocs like vector
-    m_blockchain.push_back(m_checkpoints.get_points().at(checkpoint_height));
+    m_blockchain.push_back(m_checkpoints.get_points().at(checkpoint_height).block_hash);
     m_blockchain.trim(checkpoint_height);
     short_chain_history.clear();
     get_short_chain_history(short_chain_history);

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -109,6 +109,7 @@ namespace tests
     uint64_t prevalidate_block_hashes(uint64_t height, const std::vector<crypto::hash> &hashes) { return 0; }
     // TODO(loki): Write tests
     bool add_deregister_vote(const service_nodes::deregister_vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
+    bool add_checkpoint_vote(const service_nodes::checkpoint_vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
     bool pad_transactions() const { return false; }
     uint32_t get_blockchain_pruning_seed() const { return 0; }
     bool prune_blockchain(uint32_t pruning_seed) const { return true; }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -91,6 +91,7 @@ public:
 
   // TODO(loki): Write tests
   bool add_deregister_vote(const service_nodes::deregister_vote& vote, cryptonote::vote_verification_context &vvc) { return true; }
+  bool add_checkpoint_vote(const service_nodes::checkpoint_vote& vote, cryptonote::vote_verification_context &vvc) { return true; }
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;


### PR DESCRIPTION
First part of checkpointing, votes are submitted when receiving new blocks, once enough votes are collected- then a service node checkpoint is added to the checkpoints collection.

Once the checkpoint is committed, you will not accept any alternative blocks older than 2 checkpoints pre-ceeding the newly committed checkpoint which essentially means you can not reorganise to before that checkpointed height.

This is transient, in that this information is only stored in memory not on disk, non-enforced in that there's no punishment for not making checkpoints nor is it checked that we're generating checkpoints.

A lot of copy-pasta from deregister code as they have very similar code paths. Refactoring later, just breaking down the implementation into parts to make it easier to review.