### PR TITLE
Revert behaviour for is_alternative_block_allowed

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -246,7 +246,11 @@ namespace cryptonote
       // so we can't reorg past that height. If it's predefined, that's ok as
       // well, we can't reorg past that height so irrespective, always accept
       // the height of this next checkpoint.
-      if (it != m_points.begin())
+      if (it == m_points.begin())
+      {
+        return true; // NOTE: Only one service node checkpoint recorded, we can override this checkpoint.
+      }
+      else
       {
         --it;
         sentinel_reorg_height = it->first;

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -238,22 +238,19 @@ namespace cryptonote
     uint64_t sentinel_reorg_height = it->first;
     if (it->second.type == checkpoint_type::service_node)
     {
-      // NOTE: Find the first non service node checkpoint OR the 2nd oldest
-      // service node checkpoint. Whichever came first, that is the oldest block
-      // at which we can accept an alternative block at
+      // NOTE: The current checkpoint is a service node checkpoint. Go back
+      // 1 checkpoint, which will either be another service node checkpoint or
+      // a predefined one.
 
-      size_t num_snode_checkpoints = 0;
-      for (; it != m_points.begin(); --it)
+      // If it's a service node checkpoint, this is the 2nd newest checkpoint,
+      // so we can't reorg past that height. If it's predefined, that's ok as
+      // well, we can't reorg past that height so irrespective, always accept
+      // the height of this next checkpoint.
+      if (it != m_points.begin())
       {
-        checkpoint_t const &check_checkpoint = it->second;
-        if (check_checkpoint.type == checkpoint_type::predefined_or_dns ||
-            ++num_snode_checkpoints == 2)
-        {
-          break;
-        }
+        --it;
+        sentinel_reorg_height = it->first;
       }
-
-      sentinel_reorg_height = it->first;
     }
 
     bool result = sentinel_reorg_height < block_height;

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -195,7 +195,6 @@ namespace cryptonote
 
   private:
     std::unordered_map<uint64_t, std::vector<checkpoint_t>> m_staging_points; // Incomplete service node checkpoints being voted on
-    uint64_t                                                m_oldest_possible_reorg_limit = 0;
     std::map<uint64_t, checkpoint_t>                        m_points; //!< the checkpoints container
     mutable epee::critical_section                          m_lock;
   };


### PR DESCRIPTION
Broke the unit_test, then on fixing realised that we have to allow the behaviour of accepting alt-blocks inbetween checkpoints. Git commit message below V

We must allow alternative blocks between checkpoints otherwise if
multiple chains fork and are halted inbetween checkpoints- if you sync
to the alt chain, you must be able to accept the alternative blocks from
the other chains of which one of them will have the correct series of
blocks for the canonical chain.