### PR TITLE
[DO NOT MERGE] set service nodes to bind RPC externally

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2076,6 +2076,11 @@ namespace cryptonote
     return m_service_node_list.is_service_node(pubkey);
   }
   //-----------------------------------------------------------------------------------------------
+  bool core::is_service_node() const
+  {
+    return m_service_node;
+  }
+  //-----------------------------------------------------------------------------------------------
   const std::vector<service_nodes::key_image_blacklist_entry> &core::get_service_node_blacklisted_key_images() const
   {
     const auto &result = m_service_node_list.get_blacklisted_key_images();

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -827,6 +827,13 @@ namespace cryptonote
      bool is_service_node(const crypto::public_key& pubkey) const;
 
      /**
+       * @brief get whether this node is a service node
+       *
+       * @return whether this node is a service node
+       */
+     bool is_service_node() const;
+
+     /**
       * @brief Add a vote to deregister a service node from network
       *
       * @param vote The vote for deregistering a service node.

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -93,6 +93,20 @@ namespace cryptonote
     if (!rpc_config)
       return false;
 
+    if (m_core.is_service_node())
+    {
+      if (tools::is_local_address(rpc_config->bind_ip))
+      {
+        MWARNING("Running a service node sets RPC to bind externally.  RPC binding to 0.0.0.0 (IPv4)");
+        rpc_config->bind_ip = "0.0.0.0";
+      }
+      if (rpc_config->use_ipv6 && tools::is_local_address(rpc_config->bind_ipv6_address))
+      {
+        MWARNING("Running a service node sets RPC to bind externally.  RPC binding to [::] (IPv6)");
+        rpc_config->bind_ipv6_address = "::";
+      }
+    }
+
     m_bootstrap_daemon_address = command_line::get_arg(vm, arg_bootstrap_daemon_address);
     if (!m_bootstrap_daemon_address.empty())
     {


### PR DESCRIPTION
This PR changes such that if the daemon is set to run as a service node
and the address(es) to bind RPC to are local, they are set to the
appropriate 'any' address, and a warning is printed/logged.

PR flagged "[DO NOT MERGE]" upon request.