### PR TITLE
Add missing depends to version.cpp generator

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -43,7 +43,8 @@ elseif (GIT_FOUND OR Git_FOUND)
                       "-D" "GIT=${GIT_EXECUTABLE}"
                       "-D" "TO=${CMAKE_BINARY_DIR}/version.cpp"
                       "-P" "cmake/GenVersion.cmake"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DEPENDS           "${CMAKE_SOURCE_DIR}/src/version.cpp.in")
 else()
   message(STATUS "WARNING: Git was not found!")
   write_static_version_header("unknown")


### PR DESCRIPTION
When git is installed and you aren't building a release tag, the command
that generates build/version.cpp never gets reinvoked if the generated
version.cpp already exists, so if you build, pull a new update, then
rebuild you get the wrong version everywhere.

(This still isn't perfect--if you change commits within the same version
you end up with the wrong commit tag in the version--but at least the
version itself will be right.)