### PR TITLE
Partially revert rescan force

### DIFF
--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -119,6 +119,7 @@ namespace service_nodes
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
     size_t total_num_locked_contributions() const;
 
+    int                                dummy; // FIXME(doyle)
     BEGIN_SERIALIZE_OBJECT()
       VARINT_FIELD(version)
       VARINT_FIELD(registration_height)
@@ -136,6 +137,7 @@ namespace service_nodes
       {
         VARINT_FIELD(swarm_id)
       }
+      VARINT_FIELD(dummy)
     END_SERIALIZE()
   };
 


### PR DESCRIPTION
Forcing a rescan at startup results in problematic daemons to do *two*
rescans: one initially at startup, then another when the reorg (which
goes past the 30-block limit) happens.  That's undesirable--it could
keep problem nodes down for a long time before sending an uptime proof.