### PR TITLE
Add blockchain testing routine

### DIFF
--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -155,6 +155,7 @@ bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions) {
 
 uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n)
 {
+  assert(n > 0);
   uint64_t secureMax = mersenne_twister.max() - mersenne_twister.max() % n;
   uint64_t x;
   do x = mersenne_twister(); while (x >= secureMax);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -185,6 +185,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_all_service_nodes",                  on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes_keys",             on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
         MAP_JON_RPC_WE("get_staking_requirement",                on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
+        MAP_JON_RPC_WE("perform_blockchain_test",                on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -270,6 +271,8 @@ namespace cryptonote
     bool on_get_all_service_nodes_keys(const COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::request& req, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx);
     bool on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    /// Provide a proof that this node holds the blockchain
+    bool on_perform_blockchain_test(const COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST::request& req, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
     void on_get_checkpoints() { m_core.debug__print_checkpoints(); }

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -185,7 +185,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_all_service_nodes",                  on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes_keys",             on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
         MAP_JON_RPC_WE("get_staking_requirement",                on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
-        MAP_JON_RPC_WE("perform_blockchain_test",                on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST)
+        MAP_JON_RPC_WE_IF("perform_blockchain_test",             on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2698,6 +2698,43 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST
+  {
+    struct request
+    {
+      /// json encoded req_params; parsing delayed so
+      /// that we can verify the signature first
+      std::string signed_params;
+      std::string signature;
+
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(signed_params)
+      KV_SERIALIZE(signature)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct req_params {
+      uint64_t max_height;
+      uint64_t seed;
+
+        BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(max_height)
+        KV_SERIALIZE(seed)
+        END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      uint64_t res_height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(status)
+      KV_SERIALIZE(res_height)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   LOKI_RPC_DOC_INTROSPECT
   // Get information on Service Nodes.
   struct COMMAND_RPC_GET_SERVICE_NODES

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2702,25 +2702,13 @@ namespace cryptonote
   {
     struct request
     {
-      /// json encoded req_params; parsing delayed so
-      /// that we can verify the signature first
-      std::string signed_params;
-      std::string signature;
-
-      BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(signed_params)
-      KV_SERIALIZE(signature)
-      END_KV_SERIALIZE_MAP()
-    };
-
-    struct req_params {
       uint64_t max_height;
       uint64_t seed;
 
-        BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(max_height)
-        KV_SERIALIZE(seed)
-        END_KV_SERIALIZE_MAP()
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(max_height)
+      KV_SERIALIZE(seed)
+      END_KV_SERIALIZE_MAP()
     };
 
     struct response

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -284,7 +284,6 @@ double WalletManagerImpl::miningHashRate()
     cryptonote::COMMAND_RPC_MINING_STATUS::request mreq;
     cryptonote::COMMAND_RPC_MINING_STATUS::response mres;
 
-    epee::net_utils::http::http_simple_client http_client;
     if (!epee::net_utils::invoke_http_json("/mining_status", mreq, mres, m_http_client))
       return 0.0;
     if (!mres.active)


### PR DESCRIPTION
- adds a blockchain testing routine that can only be called by the owner of the service node (requires signature)
- the main idea is to perform a large number of blockchain queries sequentially and thus discourage querying a remote node (these tests will have a timeout).
- incorporates block and transaction blobs.