### PR TITLE
Restore old style hashing for non-standard TX's so hashes match

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1348,7 +1348,12 @@ namespace cryptonote
     }
     else
     {
-      hashes[1] = crypto::null_hash;
+      transaction &tt = const_cast<transaction&>(t);
+      std::stringstream ss;
+      binary_archive<true> ba(ss);
+      bool r = tt.rct_signatures.serialize_rctsig_base(ba, t.vin.size(), t.vout.size());
+      CHECK_AND_ASSERT_MES(r, false, "Failed to serialize rct signatures base");
+      cryptonote::get_blob_hash(ss.str(), hashes[1]);
     }
 
     // prunable rct


### PR DESCRIPTION
Incorrect assumption that if a tx does not have prunable contents (i.e. deregister/key image unlocks) then we represent the 2nd of the 3 hashes as the null_hash when forming a TX hash.

In actuality the old hash calculation always tags the RCT type and its value and hashes atleast those 2 values in the event that the transaction has no inputs or outputs.

This fixes failing to sync past any deregistration/key image unlocks on the dev branch.