### PR TITLE
Service Node Checkpointing Basic Syncing

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -194,8 +194,10 @@ int check_flush(cryptonote::core &core, std::vector<block_complete_entry> &block
   }
   core.prevalidate_block_hashes(core.get_blockchain_storage().get_db().height(), hashes);
 
+  // TODO(doyle): Checkpointing
+  std::vector<checkpoint_t> checkpoints;
   std::vector<block> pblocks;
-  if (!core.prepare_handle_incoming_blocks(blocks, pblocks))
+  if (!core.prepare_handle_incoming_blocks(blocks, pblocks, checkpoints))
   {
     MERROR("Failed to prepare to add blocks");
     return 1;

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -51,10 +51,25 @@ namespace cryptonote
 
   struct checkpoint_t
   {
+    uint8_t                                        version = 0;
     checkpoint_type                                type;
     uint64_t                                       height;
     crypto::hash                                   block_hash;
     std::vector<service_nodes::voter_to_signature> signatures; // Only service node checkpoints use signatures
+
+    BEGIN_SERIALIZE()
+      FIELD(version)
+      // TODO(doyle): Hmm too lazy to change enum decls around the codebase for now
+      {
+        uint8_t serialized_type = 0;
+        if (W) serialized_type = static_cast<uint8_t>(type);
+        FIELD_N("type", serialized_type);
+        if (!W) type = static_cast<checkpoint_type>(serialized_type);
+      }
+      FIELD(height)
+      FIELD(block_hash)
+      FIELD(signatures)
+    END_SERIALIZE()
   };
 
   struct height_to_hash

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1924,6 +1924,22 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
     rsp.blocks.push_back(block_complete_entry());
     block_complete_entry& e = rsp.blocks.back();
 
+    uint64_t const block_height = get_block_height(bl.second);
+    if ((block_height % service_nodes::CHECKPOINT_INTERVAL) == 0)
+    {
+      try
+      {
+        checkpoint_t checkpoint;
+        if (m_db->get_block_checkpoint(block_height, checkpoint))
+          e.checkpoint = t_serializable_object_to_blob(checkpoint);
+      }
+      catch (const std::exception &e)
+      {
+        MERROR("Get block checkpoint from DB failed non-trivially at height: " << block_height << ", what = " << e.what());
+        return false;
+      }
+    }
+
     // FIXME: s/rsp.missed_ids/missed_tx_id/ ?  Seems like rsp.missed_ids
     //        is for missed blocks, not missed transactions as well.
     get_transactions_blobs(bl.second.tx_hashes, e.txs, missed_tx_ids);
@@ -4426,7 +4442,7 @@ bool Blockchain::calc_batched_governance_reward(uint64_t height, uint64_t &rewar
 //    vs [k_image, output_keys] (m_scan_table). This is faster because it takes advantage of bulk queries
 //    and is threaded if possible. The table (m_scan_table) will be used later when querying output
 //    keys.
-bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks)
+bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints)
 {
   MTRACE("Blockchain::" << __func__);
   TIME_MEASURE_START(prepare);
@@ -4449,6 +4465,8 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   //  needs a batch, since a batch could otherwise be active while the
   //  txpool and blockchain locks were not held
 
+  // TODO(doyle): Checkpointing
+
   m_tx_pool.lock();
   CRITICAL_REGION_LOCAL1(m_blockchain_lock);
 
@@ -4458,6 +4476,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   for (const auto &entry : blocks_entry)
   {
     bytes += entry.block.size();
+    bytes += entry.checkpoint.size();
     for (const auto &tx_blob : entry.txs)
     {
       bytes += tx_blob.size();
@@ -4554,7 +4573,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
       waiter.wait(&tpool);
 
       if (m_cancel)
-        return false;
+         return false;
 
       for (const auto & map : maps)
       {
@@ -4565,6 +4584,10 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
 
   if (m_cancel)
     return false;
+
+  // Parse checkpoints
+  {
+  }
 
   if (blocks_exist)
   {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4585,8 +4585,34 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   if (m_cancel)
     return false;
 
-  // Parse checkpoints
+  // TODO(doyle): If PR to fix above gets the green-light no reason to not parse out checkpoints in the loop above that goes through all the block_entrys already
+  //
+  // NOTE: Parse checkpoints
+  //
+  for (size_t i = 0; i < blocks.size(); i++)
   {
+    blobdata const &checkpoint_blob = blocks_entry[i].checkpoint;
+    block const &block              = blocks[i];
+    uint64_t block_height           = get_block_height(block);
+    bool maybe_has_checkpoint       = (block_height % service_nodes::CHECKPOINT_INTERVAL == 0);
+
+    if (checkpoint_blob.size() && !maybe_has_checkpoint)
+    {
+      MDEBUG("Checkpoint blob given but not expecting a checkpoint at this height");
+      return false;
+    }
+
+    if (checkpoint_blob.size())
+    {
+      checkpoint_t checkpoint;
+      if (!t_serializable_object_from_blob(checkpoint, checkpoint_blob))
+      {
+        MDEBUG("Checkpoint blob available but failed to parse");
+        return false;
+      }
+
+      checkpoints.push_back(checkpoint);
+    }
   }
 
   if (blocks_exist)

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -248,10 +248,11 @@ namespace cryptonote
      *
      * @param blocks_entry a list of incoming blocks
      * @param blocks the parsed blocks
+     * @param checkpoints the parsed checkpoints
      *
      * @return false on erroneous blocks, else true
      */
-    bool prepare_handle_incoming_blocks(const std::vector<block_complete_entry>  &blocks_entry, std::vector<block> &blocks);
+    bool prepare_handle_incoming_blocks(const std::vector<block_complete_entry>  &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints);
 
     /**
      * @brief incoming blocks post-processing, cleanup, and disk sync

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1479,7 +1479,8 @@ namespace cryptonote
       return false;
     }
     std::vector<block> pblocks;
-    if (!prepare_handle_incoming_blocks(blocks, pblocks))
+    std::vector<checkpoint_t> checkpoints;
+    if (!prepare_handle_incoming_blocks(blocks, pblocks, checkpoints))
     {
       MERROR("Block found, but failed to prepare to add");
       m_miner.resume();
@@ -1532,10 +1533,10 @@ namespace cryptonote
   }
 
   //-----------------------------------------------------------------------------------------------
-  bool core::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks)
+  bool core::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints)
   {
     m_incoming_tx_lock.lock();
-    if (!m_blockchain_storage.prepare_handle_incoming_blocks(blocks_entry, blocks))
+    if (!m_blockchain_storage.prepare_handle_incoming_blocks(blocks_entry, blocks, checkpoints))
     {
       cleanup_handle_incoming_blocks(false);
       return false;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -174,7 +174,7 @@ namespace cryptonote
       *
       * @note see Blockchain::prepare_handle_incoming_blocks
       */
-     bool prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks);
+     bool prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints);
 
      /**
       * @copydoc Blockchain::cleanup_handle_incoming_blocks

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -53,6 +53,11 @@ namespace service_nodes
   {
     uint16_t          voter_index;
     crypto::signature signature;
+
+    BEGIN_SERIALIZE()
+      FIELD(voter_index)
+      FIELD(signature)
+    END_SERIALIZE()
   };
 
   struct checkpoint_vote { crypto::hash block_hash; };

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -126,9 +126,11 @@ namespace cryptonote
   {
     blobdata block;
     std::vector<blobdata> txs;
+    blobdata checkpoint;
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(block)
       KV_SERIALIZE(txs)
+      KV_SERIALIZE(checkpoint)
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1087,9 +1087,6 @@ namespace cryptonote
 
       context.m_requested_objects.erase(req_it);
       block_hashes.push_back(block_hash);
-
-      {
-      }
     }
 
     if(!context.m_requested_objects.empty())

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -990,9 +990,6 @@ namespace cryptonote
     context.m_last_request_time = boost::date_time::not_a_date_time;
 
     // calculate size of request
-    size_t size = 0;
-    for (const auto &element : arg.txs) size += element.size();
-
     size_t blocks_size = 0, checkpoints_size = 0;
     for (const auto &element : arg.blocks) {
       blocks_size += element.block.size();
@@ -1000,9 +997,8 @@ namespace cryptonote
         blocks_size += tx.size();
       checkpoints_size += element.checkpoint.size();
     }
-    size += blocks_size;
-    size += checkpoints_size;
 
+    size_t size = blocks_size + checkpoints_size;
     for (const auto &element : arg.missed_ids)
       size += sizeof(element.data);
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1364,6 +1364,13 @@ namespace cryptonote
 
           } // each download block
 
+          // TODO(doyle): Horribly incomplete
+          for (checkpoint_t const &checkpoint : checkpoints)
+          {
+            Blockchain &blockchain = m_core.get_blockchain_storage();
+            blockchain.update_checkpoint(checkpoint);
+          }
+
           MDEBUG(context << "Block process time (" << blocks.size() << " blocks, " << num_txs << " txs): " << block_process_time_full + transactions_process_time_full << " (" << transactions_process_time_full << "/" << block_process_time_full << ") ms");
 
           if (!m_core.cleanup_handle_incoming_blocks())

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -88,7 +88,7 @@ namespace tests
     cryptonote::Blockchain &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class proxy_core."); }
     bool get_test_drop_download() {return true;}
     bool get_test_drop_download_height() {return true;}
-    bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks) { return true; }
+    bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks, std::vector<cryptonote::checkpoint_t> &checkpoints) { return true; }
     bool cleanup_handle_incoming_blocks(bool force_sync = false) { return true; }
     uint64_t get_target_blockchain_height() const { return 1; }
     size_t get_block_sync_size(uint64_t height) const { return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT; }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -881,7 +881,8 @@ public:
     cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
     cryptonote::blobdata bd = t_serializable_object_to_blob(b);
     std::vector<cryptonote::block> pblocks;
-    if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {bd, {}}), pblocks))
+    std::vector<cryptonote::checkpoint_t> checkpoints;
+    if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {bd, {}, {}}), pblocks, checkpoints))
     {
       m_c.handle_incoming_block(bd, &b, bvc);
       m_c.cleanup_handle_incoming_blocks();
@@ -911,7 +912,8 @@ public:
 
     cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
     std::vector<cryptonote::block> pblocks;
-    if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {sr_block.data, {}}), pblocks))
+    std::vector<cryptonote::checkpoint_t> checkpoints;
+    if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {sr_block.data, {}, {}}), pblocks, checkpoints))
     {
       m_c.handle_incoming_block(sr_block.data, NULL, bvc);
       m_c.cleanup_handle_incoming_blocks();

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -63,7 +63,7 @@ public:
   cryptonote::Blockchain &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class test_core."); }
   bool get_test_drop_download() const {return true;}
   bool get_test_drop_download_height() const {return true;}
-  bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks) { return true; }
+  bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks, std::vector<cryptonote::checkpoint_t> &checkpoints) { return true; }
   bool cleanup_handle_incoming_blocks(bool force_sync = false) { return true; }
   uint64_t get_target_blockchain_height() const { return 1; }
   size_t get_block_sync_size(uint64_t height) const { return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT; }


### PR DESCRIPTION
Allows basic syncing of checkpoints between peers by adding it to the sync payloads when requesting for "objects" in the sync progress.

No enforcing is done to ensure ordering of the checkpoints yet, pruning not implemented yet either.