### PR TITLE
Incorporate service node ip address into uptime proofs

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -185,7 +185,7 @@ namespace cryptonote
   , "Globally reachable IP address for incoming storage server requests (required for Service Nodes)"
   };
   static const command_line::arg_descriptor<uint16_t> arg_sn_bind_port = {
-    "sn-bind-port"
+    "storage-server-bind-port"
   , "Port a storage server instance is listening on. Note that it is a Service Node's responsibility to make sure it is properly configured (Loki Launcher does that automatically)."
   , 0};
   static const command_line::arg_descriptor<std::string> arg_block_notify = {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -815,6 +815,11 @@ namespace cryptonote
        */
      bool is_service_node(const crypto::public_key& pubkey) const;
 
+
+     epee::net_utils::ipv4_network_address get_service_node_endpoint() const {
+       return m_service_node_endpoint;
+     }
+
      /**
       * @brief Add a service node vote
       *
@@ -1133,6 +1138,9 @@ namespace cryptonote
      bool m_service_node;
      crypto::secret_key m_service_node_key;
      crypto::public_key m_service_node_pubkey;
+
+     /// Node's public IP and storage server port
+     epee::net_utils::ipv4_network_address m_service_node_endpoint;
 
      size_t block_sync_size;
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -816,8 +816,12 @@ namespace cryptonote
      bool is_service_node(const crypto::public_key& pubkey) const;
 
 
-     epee::net_utils::ipv4_network_address get_service_node_endpoint() const {
-       return m_service_node_endpoint;
+     uint32_t get_service_node_public_ip() const {
+       return m_sn_public_ip;
+     }
+
+     uint16_t get_storage_port() const {
+       return m_storage_port;
      }
 
      /**
@@ -1139,8 +1143,9 @@ namespace cryptonote
      crypto::secret_key m_service_node_key;
      crypto::public_key m_service_node_pubkey;
 
-     /// Node's public IP and storage server port
-     epee::net_utils::ipv4_network_address m_service_node_endpoint;
+     /// Service Node's public IP and storage server port
+     uint32_t m_sn_public_ip;
+     uint16_t m_storage_port;
 
      size_t block_sync_size;
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1480,6 +1480,20 @@ namespace service_nodes
   }
 
 
+  void service_node_list::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) {
+
+    const uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
+
+    if (hf_version < cryptonote::network_version_12_checkpointing) return;
+
+    CRITICAL_REGION_LOCAL(m_sn_mutex);
+    auto &sn_info = m_transient_state.service_nodes_infos.at(proof.pubkey);
+
+    sn_info.public_ip = proof.storage_endpoint.ip();
+    sn_info.storage_port = proof.storage_endpoint.port();
+  }
+
+
   bool service_node_list::load()
   {
     LOG_PRINT_L1("service_node_list::load()");

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1489,8 +1489,8 @@ namespace service_nodes
     CRITICAL_REGION_LOCAL(m_sn_mutex);
     auto &sn_info = m_transient_state.service_nodes_infos.at(proof.pubkey);
 
-    sn_info.public_ip = proof.storage_endpoint.ip();
-    sn_info.storage_port = proof.storage_endpoint.port();
+    sn_info.public_ip = proof.public_ip;
+    sn_info.storage_port = proof.storage_port;
   }
 
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -203,7 +203,7 @@ namespace service_nodes
 
     void get_all_service_nodes_public_keys(std::vector<crypto::public_key>& keys, bool fully_funded_nodes_only) const;
 
-    /// Search for public ip and storage port and add them to the service node list
+    /// Record public ip and storage port and add them to the service node list
     void handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
 
     struct rollback_event

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -103,6 +103,8 @@ namespace service_nodes
     uint64_t                           portions_for_operator;
     swarm_id_t                         swarm_id;
     cryptonote::account_public_address operator_address;
+    uint32_t                           public_ip;
+    uint16_t                           storage_port;
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -126,7 +128,9 @@ namespace service_nodes
       {
         VARINT_FIELD(swarm_id)
       }
-      VARINT_FIELD(dummy)
+      VARINT_FIELD(public_ip)
+      VARINT_FIELD(storage_port)
+
     END_SERIALIZE()
   };
 
@@ -198,6 +202,9 @@ namespace service_nodes
     bool store();
 
     void get_all_service_nodes_public_keys(std::vector<crypto::public_key>& keys, bool fully_funded_nodes_only) const;
+
+    /// Search for public ip and storage port and add them to the service node list
+    void handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
 
     struct rollback_event
     {

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -33,6 +33,7 @@
 #include "cryptonote_core.h"
 #include "version.h"
 #include "common/loki.h"
+#include <boost/endian/conversion.hpp>
 
 #include "common/loki_integration_test_hooks.h"
 
@@ -382,12 +383,36 @@ namespace service_nodes
     return result;
   }
 
+  /// NOTE(maxim): we can remove this after hardfork
   static crypto::hash make_hash(crypto::public_key const &pubkey, uint64_t timestamp)
   {
     char buf[44] = "SUP"; // Meaningless magic bytes
     crypto::hash result;
     memcpy(buf + 4, reinterpret_cast<const void *>(&pubkey), sizeof(pubkey));
     memcpy(buf + 4 + sizeof(pubkey), reinterpret_cast<const void *>(&timestamp), sizeof(timestamp));
+    crypto::cn_fast_hash(buf, sizeof(buf), result);
+
+    return result;
+  }
+
+  static crypto::hash make_hash_v2(crypto::public_key const &pubkey, uint64_t timestamp, epee::net_utils::ipv4_network_address na)
+  {
+    constexpr size_t BUFFER_SIZE = sizeof(pubkey) + sizeof(timestamp) + sizeof(na.ip()) + sizeof(na.port());
+
+    const auto pub_ip = na.ip();
+    const auto storage_port = na.port();
+
+    boost::endian::native_to_little_inplace(timestamp);
+    boost::endian::native_to_little_inplace(pub_ip);
+    boost::endian::native_to_little_inplace(storage_port);
+
+    char buf[BUFFER_SIZE];
+    crypto::hash result;
+    memcpy(buf, reinterpret_cast<const void *>(&pubkey), sizeof(pubkey));
+    memcpy(buf + sizeof(pubkey), reinterpret_cast<const void *>(&timestamp), sizeof(timestamp));
+    memcpy(buf + sizeof(pubkey) + sizeof(timestamp), reinterpret_cast<const void *>(&pub_ip), sizeof(pub_ip));
+    memcpy(buf + sizeof(pubkey) + sizeof(timestamp) + sizeof(pub_ip), reinterpret_cast<const void *>(&storage_port), sizeof(storage_port));
+
     crypto::cn_fast_hash(buf, sizeof(buf), result);
 
     return result;
@@ -420,9 +445,34 @@ namespace service_nodes
     if (m_uptime_proof_seen[pubkey].timestamp >= now - (UPTIME_PROOF_FREQUENCY_IN_SECONDS / 2))
       return false; // already received one uptime proof for this node recently.
 
-    crypto::hash hash = make_hash(pubkey, timestamp);
-    if (!crypto::check_signature(hash, pubkey, sig))
+    crypto::hash hash;
+
+    const uint64_t hf12_height = m_core.get_earliest_ideal_height_for_version(cryptonote::network_version_12_checkpointing);
+
+    const bool enforce_v2 = (hf12_height != std::numeric_limits<uint64_t>::max() && height >= hf12_height + 2);
+
+    /// Accept both old and new uptime proofs in a small window of 2 blocks
+    /// after switching to hf 12; (for simplicity accept new signatures before hf 12 too)
+    bool signature_ok = false;
+    if (!enforce_v2) {
+
+      hash = make_hash(pubkey, timestamp);
+
+      signature_ok = crypto::check_signature(hash, pubkey, sig);
+
+      if (!signature_ok) {
+        hash = make_hash_v2(pubkey, timestamp, proof.storage_endpoint);
+        signature_ok = crypto::check_signature(hash, pubkey, sig);
+      }
+
+    } else {
+      hash = make_hash_v2(pubkey, timestamp, proof.storage_endpoint);
+      signature_ok = crypto::check_signature(hash, pubkey, sig);
+    }
+
+    if (!signature_ok) {
       return false;
+    }
 
     m_uptime_proof_seen[pubkey] = {now, proof.snode_version_major, proof.snode_version_minor, proof.snode_version_patch};
     return true;
@@ -438,10 +488,22 @@ namespace service_nodes
     crypto::secret_key seckey;
     m_core.get_service_node_keys(pubkey, seckey);
 
+    epee::net_utils::ipv4_network_address sn_address = m_core.get_service_node_endpoint();
+
     req.timestamp           = time(nullptr);
     req.pubkey              = pubkey;
+    req.storage_endpoint    = sn_address;
 
-    crypto::hash hash = make_hash(req.pubkey, req.timestamp);
+    crypto::hash hash;
+
+    const uint8_t version = m_core.get_blockchain_storage().get_current_hard_fork_version();
+
+    if (version < cryptonote::network_version_12_checkpointing) {
+      hash = make_hash(req.pubkey, req.timestamp);
+    } else {
+      hash = make_hash_v2(req.pubkey, req.timestamp, req.storage_endpoint);
+    }
+
     crypto::generate_signature(hash, pubkey, seckey, req.sig);
   }
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -399,8 +399,8 @@ namespace service_nodes
   {
     constexpr size_t BUFFER_SIZE = sizeof(pubkey) + sizeof(timestamp) + sizeof(na.ip()) + sizeof(na.port());
 
-    const auto pub_ip = na.ip();
-    const auto storage_port = na.port();
+    auto pub_ip = na.ip();
+    auto storage_port = na.port();
 
     boost::endian::native_to_little_inplace(timestamp);
     boost::endian::native_to_little_inplace(pub_ip);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -468,6 +468,9 @@ namespace service_nodes
     } else {
       hash = make_hash_v2(pubkey, timestamp, proof.storage_endpoint);
       signature_ok = crypto::check_signature(hash, pubkey, sig);
+
+      /// Sanity check; we do the same on lokid startup
+      if (proof.storage_endpoint.is_local() || proof.storage_endpoint.is_loopback()) return false;
     }
 
     if (!signature_ok) {

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -33,6 +33,7 @@
 #include <list>
 #include "serialization/keyvalue_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
+#include "net/net_utils_base.h"
 #include "cryptonote_basic/blobdatatype.h"
 
 #include "common/loki.h"
@@ -344,12 +345,14 @@ namespace cryptonote
       uint64_t timestamp;
       crypto::public_key pubkey;
       crypto::signature sig;
+      epee::net_utils::ipv4_network_address storage_endpoint;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(snode_version_major)
         KV_SERIALIZE(snode_version_minor)
         KV_SERIALIZE(snode_version_patch)
         KV_SERIALIZE(timestamp)
+        KV_SERIALIZE(storage_endpoint)
         KV_SERIALIZE_VAL_POD_AS_BLOB(pubkey)
         KV_SERIALIZE_VAL_POD_AS_BLOB(sig)
       END_KV_SERIALIZE_MAP()

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -345,14 +345,16 @@ namespace cryptonote
       uint64_t timestamp;
       crypto::public_key pubkey;
       crypto::signature sig;
-      epee::net_utils::ipv4_network_address storage_endpoint;
+      uint32_t public_ip;
+      uint16_t storage_port;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(snode_version_major)
         KV_SERIALIZE(snode_version_minor)
         KV_SERIALIZE(snode_version_patch)
         KV_SERIALIZE(timestamp)
-        KV_SERIALIZE(storage_endpoint)
+        KV_SERIALIZE(public_ip)
+        KV_SERIALIZE(storage_port)
         KV_SERIALIZE_VAL_POD_AS_BLOB(pubkey)
         KV_SERIALIZE_VAL_POD_AS_BLOB(sig)
       END_KV_SERIALIZE_MAP()

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2738,6 +2738,8 @@ namespace cryptonote
       entry.last_reward_transaction_index = pubkey_info.info.last_reward_transaction_index;
       entry.last_uptime_proof             = proof.timestamp;
       entry.service_node_version          = {proof.version_major, proof.version_minor, proof.version_patch};
+      entry.public_ip                     = string_tools::get_ip_string_from_int32(pubkey_info.info.public_ip);
+      entry.storage_port                  = pubkey_info.info.storage_port;
 
       entry.contributors.reserve(pubkey_info.info.contributors.size());
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2785,6 +2785,8 @@ namespace cryptonote
         uint64_t                  portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
         uint64_t                  swarm_id;                      // The identifier of the Service Node's current swarm.
         std::string               operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
+        std::string               public_ip;                     // The public ip address of the service node
+        uint16_t                  storage_port;                  // The port number associated with the storage server
 
         BEGIN_KV_SERIALIZE_MAP()
             KV_SERIALIZE(service_node_pubkey)
@@ -2801,6 +2803,8 @@ namespace cryptonote
             KV_SERIALIZE(portions_for_operator)
             KV_SERIALIZE(swarm_id)
             KV_SERIALIZE(operator_address)
+            KV_SERIALIZE(public_ip)
+            KV_SERIALIZE(storage_port)
         END_KV_SERIALIZE_MAP()
       };
 


### PR DESCRIPTION
- add options to specify public ip and storage server port;
- advertise them via uptime proofs;
- add ip address and storage port to get_service_nodes rpc response.