### PR TITLE
Integration Test: Granular block mining

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -81,7 +81,6 @@ using namespace epee;
 
 #include "miner.h"
 
-
 namespace cryptonote
 {
 
@@ -585,6 +584,14 @@ namespace cryptonote
           if (!m_config_folder_path.empty())
             epee::serialization::store_t_to_json_file(m_config, m_config_folder_path + "/" + MINER_CONFIG_FILE_NAME);
         }
+
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+        if (m_debug_mine_singular_block)
+        {
+          m_debug_mine_singular_block = false;
+          stop();
+        }
+#endif
       }
       nonce+=m_threads_total;
       ++m_hashes;

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -589,7 +589,7 @@ namespace cryptonote
         if (m_debug_mine_singular_block)
         {
           m_debug_mine_singular_block = false;
-          stop();
+          break;
         }
 #endif
       }
@@ -599,6 +599,9 @@ namespace cryptonote
     }
     MGINFO("Miner thread stopped ["<< th_local_index << "]");
     --m_threads_active;
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    stop();
+#endif
     return true;
   }
   //-----------------------------------------------------------------------------------------------------

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -88,6 +88,21 @@ namespace cryptonote
     bool set_mining_target(uint8_t mining_target);
     uint64_t get_block_reward() const { return m_block_reward; }
 
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    std::atomic<bool> m_debug_mine_singular_block;
+    bool debug_mine_singular_block(const account_public_address& adr)
+    {
+      boost::thread::attributes attrs;
+      attrs.set_stack_size(THREAD_STACK_SIZE);
+
+      m_debug_mine_singular_block = true;
+      bool result = start(adr, 1 /*thread_counts*/, attrs, false /*do_background*/, false /*ignore_battery*/);
+      while(is_mining()) { }
+      return result;
+    }
+#endif
+
+
     static constexpr uint8_t  BACKGROUND_MINING_DEFAULT_IDLE_THRESHOLD_PERCENTAGE       = 90;
     static constexpr uint8_t  BACKGROUND_MINING_MIN_IDLE_THRESHOLD_PERCENTAGE           = 50;
     static constexpr uint8_t  BACKGROUND_MINING_MAX_IDLE_THRESHOLD_PERCENTAGE           = 99;

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -367,6 +367,19 @@ t_command_server::t_command_server(
       }, p::_1)
     , ""
     );
+
+    m_command_lookup.set_handler(
+      "debug_mine_singular_block", std::bind([rpc_server](std::vector<std::string> const &args) {
+        if (args.size())
+          rpc_server->on_debug_mine_singular_block(args[0]);
+        else
+          std::cout << "Invalid args sent to debug_mine_singular_block";
+
+        loki::write_redirected_stdout_to_shared_mem();
+        return true;
+      }, p::_1)
+    , ""
+    );
 #endif
 }
 

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -369,11 +369,12 @@ t_command_server::t_command_server(
     );
 
     m_command_lookup.set_handler(
-      "debug_mine_singular_block", std::bind([rpc_server](std::vector<std::string> const &args) {
-        if (args.size())
-          rpc_server->on_debug_mine_singular_block(args[0]);
+      "debug_mine_n_blocks", std::bind([rpc_server](std::vector<std::string> const &args) {
+        uint64_t num_blocks = 0;
+        if (args.size() == 2 && epee::string_tools::get_xtype_from_string(num_blocks, args[1]))
+          rpc_server->on_debug_mine_n_blocks(args[0], num_blocks);
         else
-          std::cout << "Invalid args sent to debug_mine_singular_block";
+          std::cout << "Invalid args, expected debug_mine_n_blocks <address> <num_blocks>";
 
         loki::write_redirected_stdout_to_shared_mem();
         return true;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -286,7 +286,7 @@ namespace cryptonote
       loki::write_redirected_stdout_to_shared_mem();
     }
 
-    void on_debug_mine_singular_block(std::string const &address)
+    void on_debug_mine_n_blocks(std::string const &address, uint64_t num_blocks)
     {
       cryptonote::miner &miner = m_core.get_miner();
       if (miner.is_mining())
@@ -302,10 +302,13 @@ namespace cryptonote
         return;
       }
 
-      if(!miner.debug_mine_singular_block(info.address))
+      for (uint64_t i = 0; i < num_blocks; i++)
       {
-        std::cout << "Failed, mining not started";
-        return;
+        if(!miner.debug_mine_singular_block(info.address))
+        {
+          std::cout << "Failed, mining not started";
+          return;
+        }
       }
 
       std::cout << "Mining stopped in daemon";

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -285,6 +285,31 @@ namespace cryptonote
       std::cout << "Votes and uptime relayed";
       loki::write_redirected_stdout_to_shared_mem();
     }
+
+    void on_debug_mine_singular_block(std::string const &address)
+    {
+      cryptonote::miner &miner = m_core.get_miner();
+      if (miner.is_mining())
+      {
+        std::cout << "Already mining";
+        return;
+      }
+
+      cryptonote::address_parse_info info;
+      if(!get_account_address_from_str(info, m_core.get_nettype(), address))
+      {
+        std::cout << "Failed, wrong address";
+        return;
+      }
+
+      if(!miner.debug_mine_singular_block(info.address))
+      {
+        std::cout << "Failed, mining not started";
+        return;
+      }
+
+      std::cout << "Mining stopped in daemon";
+    }
 #endif
 
 private:


### PR DESCRIPTION
Add debug_mine_singular_block command enabled in integration tests to allow mining of exactly one block at a time.

This is needed for sensitive block timing to test lifetime of votes and checkpoints more accurately and behaviour of pruning at boundaries of their lifetime.