### PR TITLE
Various integration test fixes for checkpointing

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -117,18 +117,22 @@ namespace cryptonote
 
   static bool update_checkpoint_in_db_safe(BlockchainDB *db, checkpoint_t const &checkpoint)
   {
+    bool result        = true;
+    bool batch_started = false;
     try
     {
-      auto guard = db_wtxn_guard(db);
+      batch_started = db->batch_start();
       db->update_block_checkpoint(checkpoint);
     }
     catch (const std::exception& e)
     {
       MERROR("Failed to add checkpoint with hash: " << checkpoint.block_hash << " at height: " << checkpoint.height << ", what = " << e.what());
-      return false;
+      result = false;
     }
 
-    return true;
+    if (batch_started)
+      db->batch_stop();
+    return result;
   }
   //---------------------------------------------------------------------------
   bool checkpoints::add_checkpoint(uint64_t height, const std::string& hash_str)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4187,6 +4187,7 @@ bool Blockchain::update_checkpoints(const std::string& file_path)
 //------------------------------------------------------------------
 bool Blockchain::update_checkpoint(cryptonote::checkpoint_t const &checkpoint)
 {
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
   bool result = m_checkpoints.update_checkpoint(checkpoint);
   return result;
 }

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -111,6 +111,9 @@ namespace service_nodes
     if (!m_core.get_service_node_keys(my_pubkey, my_seckey))
       return;
 
+    if (!m_core.is_service_node(my_pubkey))
+      return;
+
     uint64_t const height = cryptonote::get_block_height(block);
     for (int i = 0; i < (int)quorum_type::count; i++)
     {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -561,7 +561,6 @@ bool t_rpc_command_executor::show_status() {
   }
 
   tools::success_msg_writer() << str.str();
-
   return true;
 }
 
@@ -1801,6 +1800,13 @@ bool t_rpc_command_executor::ban(const std::string &ip, time_t seconds)
         }
     }
 
+    // TODO(doyle): Work around because integration tests break when using
+    // mlog_set_categories(""), so emit the block message using msg writer
+    // instead of the logging system.
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    tools::success_msg_writer() << "Host " << ip << " blocked.";
+#endif
+
     return true;
 }
 
@@ -1837,6 +1843,9 @@ bool t_rpc_command_executor::unban(const std::string &ip)
         }
     }
 
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+    tools::success_msg_writer() << "Host " << ip << " unblocked.";
+#endif
     return true;
 }
 


### PR DESCRIPTION
Some checkpointing bugs found when implementing some integration tests.

- Don't try participate in quorums at startup if you are not a service node
- Add lock for when potentially writing to the DB
- Pre-existing batch can be open whilst updating checkpoint so can't use
  DB guards
- Temporarily emit the ban message using msgwriter instead of logs to allow nodes to disconnect from the chain and private mine in tests