### PR TITLE
Require storage server running for uptime proofs (v.2)

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -67,7 +67,7 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (60*60)
 #define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_FREQUENCY_IN_SECONDS * 2 + UPTIME_PROOF_BUFFER_IN_SECONDS)
 
-constexpr auto STORAGE_SERVER_PING_LIFETIME = std::chrono::seconds(UPTIME_PROOF_FREQUENCY_IN_SECONDS);
+#define STORAGE_SERVER_PING_LIFETIME                    UPTIME_PROOF_FREQUENCY_IN_SECONDS
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)(-1))

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <boost/uuid/uuid.hpp>
 #include <stdexcept>
+#include <chrono>
 
 #define CRYPTONOTE_DNS_TIMEOUT_MS                       20000
 
@@ -65,6 +66,8 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define UPTIME_PROOF_BUFFER_IN_SECONDS                  (5*60) // The acceptable window of time to accept a peer's uptime proof from its reported timestamp
 #define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (60*60)
 #define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_FREQUENCY_IN_SECONDS * 2 + UPTIME_PROOF_BUFFER_IN_SECONDS)
+
+constexpr auto STORAGE_SERVER_PING_LIFETIME = std::chrono::seconds(UPTIME_PROOF_FREQUENCY_IN_SECONDS);
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)(-1))

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1397,6 +1397,33 @@ namespace cryptonote
     return res;
   }
   //-----------------------------------------------------------------------------------------------
+
+  bool core::check_storage_server_ping() const
+  {
+    CRITICAL_REGION_LOCAL(m_ping_lock);
+
+    if (m_last_storage_server_ping.time_since_epoch().count() == 0) {
+      MWARNING("Never heard from the storage server!");
+      return false;
+    }
+
+    const auto elapsed = std::chrono::system_clock::now() - m_last_storage_server_ping;
+
+    if (elapsed > STORAGE_SERVER_PING_LIFETIME) {
+      MWARNING("Last heard from the storage server: "
+               << std::chrono::duration_cast<std::chrono::minutes>(elapsed).count() << " minutes ago!");
+      return false;
+    }
+
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
+  void core::update_storage_server_last_ping()
+  {
+    CRITICAL_REGION_LOCAL(m_ping_lock);
+    m_last_storage_server_ping = std::chrono::system_clock::now();
+  }
+  //-----------------------------------------------------------------------------------------------
   void core::on_transaction_relayed(const cryptonote::blobdata& tx_blob)
   {
     std::vector<std::pair<crypto::hash, cryptonote::blobdata>> txs;
@@ -1773,8 +1800,17 @@ namespace cryptonote
       // Code snippet from Github @Jagerman
       m_check_uptime_proof_interval.do_call([&states, this](){
         uint64_t last_uptime = m_quorum_cop.get_uptime_proof(states[0].pubkey).timestamp;
-        if (last_uptime <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS))
+        if (last_uptime <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS)) {
+
+          if (!this->check_storage_server_ping()) {
+            MERROR("Failed to submit uptime proof: have not heard from"
+                   << " the storage server recently. "
+                   << "Make sure that it is running!");
+            return true;
+          }
+
           this->submit_uptime_proof();
+        }
 
         return true;
       });

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -861,6 +861,18 @@ namespace cryptonote
       */
      service_nodes::proof_info get_uptime_proof(const crypto::public_key &key) const;
 
+     /**
+      * @brief Check if the ping last recieved from the storage server has expired
+      * 
+      * @return true if it has not expired
+      */
+     bool check_storage_server_ping() const;
+
+     /**
+      * @brief Update the storage server ping time
+      */
+     void update_storage_server_last_ping();
+
      /*
       * @brief get the blockchain pruning seed
       *
@@ -1139,6 +1151,10 @@ namespace cryptonote
      /// Service Node's public IP and storage server port
      uint32_t m_sn_public_ip;
      uint16_t m_storage_port;
+
+     /// Time point at which the storage server last pinged us
+     mutable epee::critical_section m_ping_lock;
+     std::chrono::system_clock::time_point m_last_storage_server_ping;
 
      size_t block_sync_size;
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1153,8 +1153,7 @@ namespace cryptonote
      uint16_t m_storage_port;
 
      /// Time point at which the storage server last pinged us
-     mutable epee::critical_section m_ping_lock;
-     std::chrono::system_clock::time_point m_last_storage_server_ping;
+     std::atomic<time_t> m_last_storage_server_ping;
 
      size_t block_sync_size;
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2884,6 +2884,15 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_storage_server_ping(const COMMAND_RPC_STORAGE_SERVER_PING::request&,
+                                               COMMAND_RPC_STORAGE_SERVER_PING::response&,
+                                               epee::json_rpc::error&,
+                                               const connection_context*)
+  {
+    m_core.update_storage_server_last_ping();
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
   {
     PERF_TIMER(on_get_staking_requirement);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -186,6 +186,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_all_service_nodes_keys",             on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
         MAP_JON_RPC_WE("get_staking_requirement",                on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
         MAP_JON_RPC_WE_IF("perform_blockchain_test",             on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
+        MAP_JON_RPC_WE_IF("storage_server_ping",                 on_storage_server_ping, COMMAND_RPC_STORAGE_SERVER_PING, !m_restricted)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -273,6 +274,7 @@ namespace cryptonote
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     /// Provide a proof that this node holds the blockchain
     bool on_perform_blockchain_test(const COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST::request& req, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_storage_server_ping(const COMMAND_RPC_STORAGE_SERVER_PING::request& req, COMMAND_RPC_STORAGE_SERVER_PING::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
     void on_get_checkpoints() { m_core.debug__print_checkpoints(); }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2826,6 +2826,21 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct COMMAND_RPC_STORAGE_SERVER_PING
+  {
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   LOKI_RPC_DOC_INTROSPECT
   // Get the required amount of Loki to become a Service Node at the queried height. 
   // For stagenet and testnet values, ensure the daemon is started with the 


### PR DESCRIPTION
This causes uptime proofs be submitted only if the daemon heard from the storage server recently.