### PR TITLE
Service Node Checkpointing: More reliable transportation of votes, culling of old checkpoints

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -811,6 +811,7 @@ public:
                             );
 
   virtual void update_block_checkpoint(checkpoint_t const &checkpoint) = 0;
+  virtual void remove_block_checkpoint(uint64_t height) = 0;
   virtual bool get_block_checkpoint   (uint64_t height, checkpoint_t &checkpoint) const = 0;
   virtual bool get_top_checkpoint     (checkpoint_t &checkpoint) const = 0;
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3790,6 +3790,30 @@ void BlockchainLMDB::update_block_checkpoint(checkpoint_t const &checkpoint)
     throw0(DB_ERROR(lmdb_error("Failed to update block checkpoint in db transaction: ", ret).c_str()));
 }
 
+void BlockchainLMDB::remove_block_checkpoint(uint64_t height)
+{
+  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
+
+  check_open();
+  mdb_txn_cursors *m_cursors = &m_wcursors;
+  CURSOR(block_checkpoints);
+
+  MDB_val_set(key, height);
+  MDB_val value = {};
+  int ret = mdb_cursor_get(m_cur_block_checkpoints, &key, &value, MDB_SET_KEY);
+  if (ret == MDB_SUCCESS)
+  {
+    ret = mdb_cursor_del(m_cur_block_checkpoints, 0);
+    if (ret)
+      throw0(DB_ERROR(lmdb_error("Failed to delete block checkpoint: ", ret).c_str()));
+  }
+  else
+  {
+    if (ret != MDB_NOTFOUND)
+      throw1(DB_ERROR(lmdb_error("Failed to locate block checkpoint for removal: ", ret).c_str()));
+  }
+}
+
 bool BlockchainLMDB::get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const
 {
   TXN_PREFIX_RDONLY();

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3810,7 +3810,7 @@ void BlockchainLMDB::remove_block_checkpoint(uint64_t height)
   else
   {
     if (ret != MDB_NOTFOUND)
-      throw1(DB_ERROR(lmdb_error("Failed to locate block checkpoint for removal: ", ret).c_str()));
+      throw1(DB_ERROR(lmdb_error("Failed non-trivially to get cursor for checkpoint to delete: ", ret).c_str()));
   }
 }
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -313,6 +313,7 @@ public:
                             , const std::vector<std::pair<transaction, blobdata>>& txs
                             ) override;
   void update_block_checkpoint(checkpoint_t const &checkpoint) override;
+  void remove_block_checkpoint(uint64_t height) override;
   bool get_block_checkpoint   (uint64_t height, checkpoint_t &checkpoint) const override;
   bool get_top_checkpoint     (checkpoint_t &checkpoint) const override;
   std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = 0) const override;

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -156,18 +156,22 @@ namespace cryptonote
       CHECK_AND_ASSERT_MES(checkpoint.signatures.size() == 0, false, "Non service-node checkpoints should have no signatures");
     }
 
+    bool result        = true;
+    bool batch_started = false;
     try
     {
-      auto guard = db_wtxn_guard(m_db);
+      batch_started = m_db->batch_start();
       m_db->update_block_checkpoint(checkpoint);
     }
     catch (const std::exception& e)
     {
       MERROR("Failed to add checkpoint with hash: " << checkpoint.block_hash << " at height: " << checkpoint.height << ", what = " << e.what());
-      return false;
+      result = false;
     }
 
-    return true;
+    if (batch_started)
+      m_db->batch_stop();
+    return result;
   }
   //---------------------------------------------------------------------------
   void checkpoints::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -197,6 +197,7 @@ namespace cryptonote
     bool init(network_type nettype, struct BlockchainDB *db);
 
   private:
+    uint64_t m_last_cull_height = 0;
     BlockchainDB *m_db;
   };
 

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -36,6 +36,7 @@
 #include "crypto/hash.h"
 #include "cryptonote_config.h"
 #include "cryptonote_core/service_node_voting.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
 
 #define ADD_CHECKPOINT(h, hash)  CHECK_AND_ASSERT(add_checkpoint(h,  hash), false);
 #define JSON_HASH_FILE_NAME "checkpoints.json"
@@ -56,6 +57,7 @@ namespace cryptonote
     uint64_t                                       height;
     crypto::hash                                   block_hash;
     std::vector<service_nodes::voter_to_signature> signatures; // Only service node checkpoints use signatures
+    uint64_t                                       prev_height;
 
     BEGIN_SERIALIZE()
       FIELD(version)
@@ -69,6 +71,7 @@ namespace cryptonote
       FIELD(height)
       FIELD(block_hash)
       FIELD(signatures)
+      FIELD(prev_height)
     END_SERIALIZE()
   };
 
@@ -103,8 +106,13 @@ namespace cryptonote
    * either from a json file or via DNS from a checkpoint-hosting server.
    */
   class checkpoints
+    : public cryptonote::BlockAddedHook,
+      public cryptonote::BlockchainDetachedHook
   {
   public:
+    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs) override;
+    void blockchain_detached(uint64_t height) override;
+
     /**
      * @brief adds a checkpoint to the container
      *
@@ -118,6 +126,13 @@ namespace cryptonote
     bool add_checkpoint(uint64_t height, const std::string& hash_str);
 
     bool update_checkpoint(checkpoint_t const &checkpoin);
+
+    /*
+       @brief Remove checkpoints that should not be stored persistently, i.e.
+       any checkpoint whose height is not divisible by
+       service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL
+     */
+    void prune_checkpoints(uint64_t height) const;
 
     /**
      * @brief checks if there is a checkpoint in the future

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4586,36 +4586,6 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   if (m_cancel)
     return false;
 
-  // TODO(doyle): If PR to fix above gets the green-light no reason to not parse out checkpoints in the loop above that goes through all the block_entrys already
-  //
-  // NOTE: Parse checkpoints
-  //
-  for (size_t i = 0; i < blocks.size(); i++)
-  {
-    blobdata const &checkpoint_blob = blocks_entry[i].checkpoint;
-    block const &block              = blocks[i];
-    uint64_t block_height           = get_block_height(block);
-    bool maybe_has_checkpoint       = (block_height % service_nodes::CHECKPOINT_INTERVAL == 0);
-
-    if (checkpoint_blob.size() && !maybe_has_checkpoint)
-    {
-      MDEBUG("Checkpoint blob given but not expecting a checkpoint at this height");
-      return false;
-    }
-
-    if (checkpoint_blob.size())
-    {
-      checkpoint_t checkpoint;
-      if (!t_serializable_object_from_blob(checkpoint, checkpoint_blob))
-      {
-        MDEBUG("Checkpoint blob available but failed to parse");
-        return false;
-      }
-
-      checkpoints.push_back(checkpoint);
-    }
-  }
-
   if (blocks_exist)
   {
     MDEBUG("Skipping remainder of prepare blocks. Blocks exist.");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -111,7 +111,6 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
-  { network_version_12_checkpointing,    6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -111,6 +111,7 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
+  { network_version_12_checkpointing,    6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =
@@ -1923,6 +1924,9 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
 
     rsp.blocks.push_back(block_complete_entry());
     block_complete_entry& e = rsp.blocks.back();
+
+    static_assert((service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL % service_nodes::CHECKPOINT_INTERVAL == 0),
+                  "Use CHECKPOINT_INTERVAL as blanket catch-all to detect if the height can potentially have a checkpoint");
 
     uint64_t const block_height = get_block_height(bl.second);
     if ((block_height % service_nodes::CHECKPOINT_INTERVAL) == 0)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -346,7 +346,7 @@ namespace cryptonote
 
     m_service_node = command_line::get_arg(vm, arg_service_node);
 
-    if (m_service_node && 0) {
+    if (m_service_node) {
       /// TODO: parse these options early, before we start p2p server etc?
       m_storage_port = command_line::get_arg(vm, arg_sn_bind_port);
 
@@ -1801,7 +1801,7 @@ namespace cryptonote
     std::vector<service_nodes::service_node_pubkey_info> const states = get_service_node_list_state({ m_service_node_pubkey });
     if (!states.empty() && states[0].info.registration_height + 1 < get_current_blockchain_height())
     {
-      //Code snippet from Github @Jagerman
+      // Code snippet from Github @Jagerman
       m_check_uptime_proof_interval.do_call([&states, this](){
         uint64_t last_uptime = m_quorum_cop.get_uptime_proof(states[0].pubkey).timestamp;
         if (last_uptime <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS)) {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -346,7 +346,7 @@ namespace cryptonote
 
     m_service_node = command_line::get_arg(vm, arg_service_node);
 
-    if (m_service_node) {
+    if (m_service_node && 0) {
       /// TODO: parse these options early, before we start p2p server etc?
       m_storage_port = command_line::get_arg(vm, arg_sn_bind_port);
 
@@ -1573,7 +1573,7 @@ namespace cryptonote
       m_miner.resume();
       return false;
     }
-    m_blockchain_storage.add_new_block(b, bvc);
+    add_new_block(b, bvc);
     cleanup_handle_incoming_blocks(true);
     //anyway - update miner template
     update_miner_block_template();
@@ -1616,9 +1616,9 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::add_new_block(const block& b, block_verification_context& bvc)
   {
+    relay_service_node_votes(); // NOTE: nop if synchronising due to not accepting votes whilst syncing
     return m_blockchain_storage.add_new_block(b, bvc);
   }
-
   //-----------------------------------------------------------------------------------------------
   bool core::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints)
   {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1801,7 +1801,7 @@ namespace cryptonote
     std::vector<service_nodes::service_node_pubkey_info> const states = get_service_node_list_state({ m_service_node_pubkey });
     if (!states.empty() && states[0].info.registration_height + 1 < get_current_blockchain_height())
     {
-      // Code snippet from Github @Jagerman
+      //Code snippet from Github @Jagerman
       m_check_uptime_proof_interval.do_call([&states, this](){
         uint64_t last_uptime = m_quorum_cop.get_uptime_proof(states[0].pubkey).timestamp;
         if (last_uptime <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS)) {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1320,15 +1320,9 @@ namespace service_nodes
       {
         if (hf_version >= cryptonote::network_version_12_checkpointing)
         {
-#if 1
-          num_workers                = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
-          size_t num_remaining_nodes = pub_keys_indexes.size() - num_workers;
-          num_validators             = std::min(num_remaining_nodes, CHECKPOINT_QUORUM_SIZE);
-#else
           num_validators             = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
           size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
           num_workers                = std::min(num_remaining_nodes, CHECKPOINT_QUORUM_SIZE);
-#endif
         }
       }
       else

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1319,9 +1319,15 @@ namespace service_nodes
       {
         if (hf_version >= cryptonote::network_version_12_checkpointing)
         {
+#if 1
+          num_workers                = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+          size_t num_remaining_nodes = pub_keys_indexes.size() - num_workers;
+          num_validators             = std::min(num_remaining_nodes, CHECKPOINT_QUORUM_SIZE);
+#else
           num_validators             = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
           size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
           num_workers                = std::min(num_remaining_nodes, CHECKPOINT_QUORUM_SIZE);
+#endif
         }
       }
       else

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -346,6 +346,7 @@ namespace service_nodes
         for (const auto &contribution : contributor.locked_contributions)
         {
           key_image_blacklist_entry entry = {};
+          entry.version                   = get_min_service_node_info_version_for_hf(hard_fork_version);
           entry.key_image                 = contribution.key_image;
           entry.unlock_height             = block_height + staking_num_lock_blocks(m_blockchain.nettype());
           m_transient_state.key_image_blacklist.push_back(entry);
@@ -1531,15 +1532,13 @@ namespace service_nodes
     {
       {
         testing_quorum const &deregister = states.quorums[(int)quorum_type::deregister];
-        if (deregister.validators.size() > 0 || deregister.workers.size() > 0)
-          m_transient_state.quorum_states[states.height].deregister = std::make_shared<testing_quorum>(deregister);
+        m_transient_state.quorum_states[states.height].deregister = std::make_shared<testing_quorum>(deregister);
       }
 
       if (states.version >= service_node_info::version_3_checkpointing)
       {
         testing_quorum const &checkpointing = states.quorums[(int)quorum_type::checkpointing];
-        if (checkpointing.validators.size() > 0 || checkpointing.workers.size() > 0)
-          m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
+        m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
       }
     }
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -41,9 +41,17 @@ namespace service_nodes
 {
   struct service_node_info // registration information
   {
+    enum version
+    {
+      version_0,
+      version_1_swarms,
+      version_2_infinite_staking,
+      version_3_checkpointing,
+    };
+
     struct contribution_t
     {
-      uint8_t            version = version_2_infinite_staking;
+      uint8_t            version;
       crypto::public_key key_image_pub_key;
       crypto::key_image  key_image;
       uint64_t           amount;
@@ -54,14 +62,6 @@ namespace service_nodes
         FIELD(key_image)
         VARINT_FIELD(amount)
       END_SERIALIZE()
-    };
-
-    enum version
-    {
-      version_0,
-      version_1_swarms,
-      version_2_infinite_staking,
-      version_3_checkpointing,
     };
 
     struct contributor_t
@@ -125,12 +125,12 @@ namespace service_nodes
       FIELD(operator_address)
 
       if (version >= service_node_info::version_1_swarms)
-      {
         VARINT_FIELD(swarm_id)
+      if (version >= service_node_info::version_3_checkpointing)
+      {
+        VARINT_FIELD(public_ip)
+        VARINT_FIELD(storage_port)
       }
-      VARINT_FIELD(public_ip)
-      VARINT_FIELD(storage_port)
-
     END_SERIALIZE()
   };
 
@@ -147,7 +147,7 @@ namespace service_nodes
 
   struct key_image_blacklist_entry
   {
-    uint8_t           version = service_node_info::version_2_infinite_staking;
+    uint8_t           version;
     crypto::key_image key_image;
     uint64_t          unlock_height;
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -16,7 +16,6 @@ namespace service_nodes {
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_BREADCRUMB_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
   constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
-  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME_                 = ((CHECKPOINT_INTERVAL * 3) - 1);
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
   constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -15,7 +15,8 @@ namespace service_nodes {
 
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_BREADCRUMB_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
-  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = ((CHECKPOINT_INTERVAL * 3) - 1);
+  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
+  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME_                 = ((CHECKPOINT_INTERVAL * 3) - 1);
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
   constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -13,7 +13,7 @@ namespace service_nodes {
   constexpr size_t   DEREGISTER_MIN_NODES_TO_TEST              = 50;
   constexpr uint64_t DEREGISTER_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
 
-  constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_BREADCRUMB_INTERVAL == 0)
+  constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
   constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -13,14 +13,15 @@ namespace service_nodes {
   constexpr size_t   DEREGISTER_MIN_NODES_TO_TEST              = 50;
   constexpr uint64_t DEREGISTER_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
 
-  constexpr uint64_t CHECKPOINT_INTERVAL                   = 4;
-  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME              = ((CHECKPOINT_INTERVAL * 3) - 1);
+  constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_BREADCRUMB_INTERVAL == 0)
+  constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
+  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = ((CHECKPOINT_INTERVAL * 3) - 1);
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
-  constexpr size_t   CHECKPOINT_QUORUM_SIZE                = 2;
-  constexpr size_t   CHECKPOINT_MIN_VOTES                  = 2;
+  constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
+  constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;
 #else
-  constexpr size_t   CHECKPOINT_QUORUM_SIZE                = 20;
-  constexpr size_t   CHECKPOINT_MIN_VOTES                  = 18;
+  constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 20;
+  constexpr size_t   CHECKPOINT_MIN_VOTES                      = 18;
 #endif
 
   static_assert(DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE <= DEREGISTER_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1083,6 +1083,9 @@ namespace cryptonote
 
       context.m_requested_objects.erase(req_it);
       block_hashes.push_back(block_hash);
+
+      {
+      }
     }
 
     if(!context.m_requested_objects.empty())

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1083,9 +1083,6 @@ namespace cryptonote
 
       context.m_requested_objects.erase(req_it);
       block_hashes.push_back(block_hash);
-
-      {
-      }
     }
 
     if(!context.m_requested_objects.empty())


### PR DESCRIPTION
Allows culling of old checkpoints such that, all checkpoints are synced but we cull checkpoints < 60 blocks old, and keep checkpoints generated where (height % 60 == 0).

Also make a slight modification and transmit the votes we have everytime we find/receive a block. This makes votes less likely to be missed- we still transmit inbetween blocks at the same interval incase blocks go longer than 2 minutes, which is semi-common.

We can still miss checkpoints- if blocks are found too quick- this will probably be fixed when I incorporate the previous_height field of checkpoints in.