### PR TITLE
RPC endpoint for requesting random snodes

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -81,6 +81,15 @@ public: \
       epee::serialize_default(this_ref.variable, default_value); \
   } while (0);
 
+#define KV_SERIALIZE_OPT_N2(variable, val_name, default_value) \
+do { \
+  if (!epee::serialization::selector<is_store>::serialize(this_ref.variable, stg, hparent_section, val_name)) { \
+    epee::serialize_default(this_ref.variable, default_value); \
+  } else { \
+    this_ref.explicitly_set = true; \
+  } \
+} while (0);
+
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize_t_val_as_blob(this_ref.varialble, stg, hparent_section, val_name); 
 
@@ -107,6 +116,8 @@ public: \
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(varialble)     KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, #varialble) //skip is_pod compile time check
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
+/// same as KV_SERIALIZE_OPT, but will set `explicitly_set` to true if non-default value found
+#define KV_SERIALIZE_OPT2(variable,default_value)          KV_SERIALIZE_OPT_N2(variable, #variable, default_value)
 
 }
 

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -108,9 +108,6 @@ public: \
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
 
-#define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
-if (this_ref.parent_ref.fields.var) KV_SERIALIZE(var)
-
 }
 
 

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -108,6 +108,9 @@ public: \
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
 
+#define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
+if (this_ref.parent_ref.fields.var) KV_SERIALIZE(var)
+
 }
 
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2831,19 +2831,7 @@ namespace cryptonote
     res.height = m_core.get_current_blockchain_height();
     res.block_hash = string_tools::pod_to_hex(m_core.get_block_id_by_height(res.height - 1));
 
-    // check if any field is set
-    char unset_bytes[sizeof(req.fields)];
-    memset(unset_bytes, 0, sizeof(req.fields));
-
-    bool some_set = memcmp(unset_bytes, reinterpret_cast<const void*>(&req.fields), sizeof(req.fields));
-
-    if (!some_set) {
-      // set all to true
-      memset(reinterpret_cast<void*>(&res.fields), 0xFF, sizeof(res.fields));
-    } else {
-      res.fields = req.fields;
-    }
-
+    res.fields = req.fields;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2820,7 +2820,7 @@ namespace cryptonote
     res.service_node_states.reserve(sn_infos.size());
 
     for (auto &pubkey_info : sn_infos) {
-      COMMAND_RPC_GET_N_SERVICE_NODES::response::entry entry = {res};
+      COMMAND_RPC_GET_N_SERVICE_NODES::response::entry entry = {res.fields};
 
       fill_sn_response_entry(entry, pubkey_info);
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2700,8 +2700,8 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  template<typename Response>
-  void core_rpc_server::fill_sn_response_entry(Response &entry, const service_nodes::service_node_pubkey_info &sn_info) {
+  template<typename response>
+  void core_rpc_server::fill_sn_response_entry(response &entry, const service_nodes::service_node_pubkey_info &sn_info) {
 
     const auto proof = m_core.get_uptime_proof(sn_info.pubkey);
 
@@ -2796,6 +2796,15 @@ namespace cryptonote
                                                const connection_context*)
   {
     std::vector<service_nodes::service_node_pubkey_info> sn_infos = m_core.get_service_node_list_state({});
+
+    if (req.fully_funded_only) {
+      const auto end =
+        std::remove_if(sn_infos.begin(), sn_infos.end(), [](const service_nodes::service_node_pubkey_info& snpk_info) {
+          return !snpk_info.info.is_fully_funded();
+        });
+      
+      sn_infos.erase(end, sn_infos.end());
+    }
 
     if (req.limit != 0) {
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -31,6 +31,8 @@
 
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/endian/conversion.hpp>
+#include <algorithm>
+#include <cstring>
 #include "include_base_utils.h"
 #include "string_tools.h"
 using namespace epee;
@@ -2698,6 +2700,51 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  template<typename Response>
+  void core_rpc_server::fill_sn_response_entry(Response &entry, const service_nodes::service_node_pubkey_info &sn_info) {
+
+    const auto proof = m_core.get_uptime_proof(sn_info.pubkey);
+
+    entry.service_node_pubkey           = string_tools::pod_to_hex(sn_info.pubkey);
+    entry.registration_height           = sn_info.info.registration_height;
+    entry.requested_unlock_height       = sn_info.info.requested_unlock_height;
+    entry.last_reward_block_height      = sn_info.info.last_reward_block_height;
+    entry.last_reward_transaction_index = sn_info.info.last_reward_transaction_index;
+    entry.last_uptime_proof             = proof.timestamp;
+    entry.service_node_version          = {proof.version_major, proof.version_minor, proof.version_patch};
+    entry.public_ip                     = string_tools::get_ip_string_from_int32(sn_info.info.public_ip);
+    entry.storage_port                  = sn_info.info.storage_port;
+
+    entry.contributors.reserve(sn_info.info.contributors.size());
+
+    using namespace service_nodes;
+    for (service_node_info::contributor_t const &contributor : sn_info.info.contributors)
+    {
+      entry.contributors.push_back({});
+      auto &new_contributor = entry.contributors.back();
+      new_contributor.amount   = contributor.amount;
+      new_contributor.reserved = contributor.reserved;
+      new_contributor.address  = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, contributor.address);
+
+      new_contributor.locked_contributions.reserve(contributor.locked_contributions.size());
+      for (service_node_info::contribution_t const &src : contributor.locked_contributions)
+      {
+        new_contributor.locked_contributions.push_back({});
+        auto &dest = new_contributor.locked_contributions.back();
+        dest.amount                                                = src.amount;
+        dest.key_image                                             = string_tools::pod_to_hex(src.key_image);
+        dest.key_image_pub_key                                     = string_tools::pod_to_hex(src.key_image_pub_key);
+      }
+    }
+
+    entry.total_contributed             = sn_info.info.total_contributed;
+    entry.total_reserved                = sn_info.info.total_reserved;
+    entry.staking_requirement           = sn_info.info.staking_requirement;
+    entry.portions_for_operator         = sn_info.info.portions_for_operator;
+    entry.operator_address              = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, sn_info.info.operator_address);
+    entry.swarm_id                      = sn_info.info.swarm_id;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
   {
     PERF_TIMER(on_get_service_nodes);
@@ -2735,50 +2782,58 @@ namespace cryptonote
     for (auto &pubkey_info : pubkey_info_list)
     {
       COMMAND_RPC_GET_SERVICE_NODES::response::entry entry = {};
-
-      const auto proof = m_core.get_uptime_proof(pubkey_info.pubkey);
-
-      entry.service_node_pubkey           = string_tools::pod_to_hex(pubkey_info.pubkey);
-      entry.registration_height           = pubkey_info.info.registration_height;
-      entry.requested_unlock_height       = pubkey_info.info.requested_unlock_height;
-      entry.last_reward_block_height      = pubkey_info.info.last_reward_block_height;
-      entry.last_reward_transaction_index = pubkey_info.info.last_reward_transaction_index;
-      entry.last_uptime_proof             = proof.timestamp;
-      entry.service_node_version          = {proof.version_major, proof.version_minor, proof.version_patch};
-      entry.public_ip                     = string_tools::get_ip_string_from_int32(pubkey_info.info.public_ip);
-      entry.storage_port                  = pubkey_info.info.storage_port;
-
-      entry.contributors.reserve(pubkey_info.info.contributors.size());
-
-      using namespace service_nodes;
-      for (service_node_info::contributor_t const &contributor : pubkey_info.info.contributors)
-      {
-        COMMAND_RPC_GET_SERVICE_NODES::response::contributor new_contributor = {};
-        new_contributor.amount   = contributor.amount;
-        new_contributor.reserved = contributor.reserved;
-        new_contributor.address  = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, contributor.address);
-
-        new_contributor.locked_contributions.reserve(contributor.locked_contributions.size());
-        for (service_node_info::contribution_t const &src : contributor.locked_contributions)
-        {
-          COMMAND_RPC_GET_SERVICE_NODES::response::contribution dest = {};
-          dest.amount                                                = src.amount;
-          dest.key_image                                             = string_tools::pod_to_hex(src.key_image);
-          dest.key_image_pub_key                                     = string_tools::pod_to_hex(src.key_image_pub_key);
-          new_contributor.locked_contributions.push_back(dest);
-        }
-
-        entry.contributors.push_back(new_contributor);
-      }
-
-      entry.total_contributed             = pubkey_info.info.total_contributed;
-      entry.total_reserved                = pubkey_info.info.total_reserved;
-      entry.staking_requirement           = pubkey_info.info.staking_requirement;
-      entry.portions_for_operator         = pubkey_info.info.portions_for_operator;
-      entry.operator_address              = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, pubkey_info.info.operator_address);
-      entry.swarm_id                      = pubkey_info.info.swarm_id;
+      fill_sn_response_entry(entry, pubkey_info);
 
       res.service_node_states.push_back(entry);
+    }
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_n_service_nodes(const COMMAND_RPC_GET_N_SERVICE_NODES::request& req,
+                                               COMMAND_RPC_GET_N_SERVICE_NODES::response& res,
+                                               epee::json_rpc::error&,
+                                               const connection_context*)
+  {
+    std::vector<service_nodes::service_node_pubkey_info> sn_infos = m_core.get_service_node_list_state({});
+
+    if (req.limit != 0) {
+
+      const auto limit = std::min(sn_infos.size(), static_cast<size_t>(req.limit));
+
+      std::random_device rd;
+      std::mt19937 mt(rd());
+
+      std::shuffle(sn_infos.begin(), sn_infos.end(), mt);
+
+      sn_infos.resize(limit);
+    }
+
+    res.service_node_states.reserve(sn_infos.size());
+
+    for (auto &pubkey_info : sn_infos) {
+      COMMAND_RPC_GET_N_SERVICE_NODES::response::entry entry = {res};
+
+      fill_sn_response_entry(entry, pubkey_info);
+
+      res.service_node_states.push_back(entry);
+    }
+
+    res.status = CORE_RPC_STATUS_OK;
+    res.height = m_core.get_current_blockchain_height();
+    res.block_hash = string_tools::pod_to_hex(m_core.get_block_id_by_height(res.height - 1));
+
+    // check if any field is set
+    char unset_bytes[sizeof(req.fields)];
+    memset(unset_bytes, 0, sizeof(req.fields));
+
+    bool some_set = memcmp(unset_bytes, reinterpret_cast<const void*>(&req.fields), sizeof(req.fields));
+
+    if (!some_set) {
+      // set all to true
+      memset(reinterpret_cast<void*>(&res.fields), 0xFF, sizeof(res.fields));
+    } else {
+      res.fields = req.fields;
     }
 
     return true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2810,8 +2810,7 @@ namespace cryptonote
 
       const auto limit = std::min(sn_infos.size(), static_cast<size_t>(req.limit));
 
-      std::random_device rd;
-      std::mt19937 mt(rd());
+      static thread_local std::mt19937 mt{std::random_device{}()};
 
       std::shuffle(sn_infos.begin(), sn_infos.end(), mt);
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -323,8 +323,8 @@ private:
     bool check_core_busy();
     bool check_core_ready();
 
-    template<typename Response>
-    void fill_sn_response_entry(Response &entry, const service_nodes::service_node_pubkey_info &sn_info);
+    template<typename response>
+    void fill_sn_response_entry(response &entry, const service_nodes::service_node_pubkey_info &sn_info);
     
     //utils
     uint64_t get_block_reward(const block& blk);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -184,6 +184,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_service_nodes",                      on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes",                  on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes_keys",             on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
+        MAP_JON_RPC_WE("get_n_service_nodes",                    on_get_n_service_nodes, COMMAND_RPC_GET_N_SERVICE_NODES)
         MAP_JON_RPC_WE("get_staking_requirement",                on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
         MAP_JON_RPC_WE_IF("perform_blockchain_test",             on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
         MAP_JON_RPC_WE_IF("storage_server_ping",                 on_storage_server_ping, COMMAND_RPC_STORAGE_SERVER_PING, !m_restricted)
@@ -269,6 +270,7 @@ namespace cryptonote
     bool on_get_service_node_blacklisted_key_images(const COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::request& req, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_get_n_service_nodes(const COMMAND_RPC_GET_N_SERVICE_NODES::request& req, COMMAND_RPC_GET_N_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_all_service_nodes_keys(const COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::request& req, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx);
     bool on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
@@ -320,6 +322,9 @@ namespace cryptonote
 private:
     bool check_core_busy();
     bool check_core_ready();
+
+    template<typename Response>
+    void fill_sn_response_entry(Response &entry, const service_nodes::service_node_pubkey_info &sn_info);
     
     //utils
     uint64_t get_block_reward(const block& blk);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2827,7 +2827,7 @@ namespace cryptonote
   };
 
   #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
-  if (this_ref.requested_fields.var) KV_SERIALIZE(var)
+  if (this_ref.requested_fields.var || !this_ref.requested_fields.explicitly_set) KV_SERIALIZE(var)
 
   struct COMMAND_RPC_GET_N_SERVICE_NODES
   {
@@ -2835,6 +2835,9 @@ namespace cryptonote
     // Boolean values indicate whether corresponding
     // fields should be included in the response
     struct requested_fields_t {
+
+      bool explicitly_set = false;
+
       bool service_node_pubkey;
       bool registration_height;
       bool requested_unlock_height;
@@ -2857,24 +2860,24 @@ namespace cryptonote
       bool height;
 
       BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(service_node_pubkey)
-      KV_SERIALIZE(registration_height)
-      KV_SERIALIZE(requested_unlock_height)
-      KV_SERIALIZE(last_reward_block_height)
-      KV_SERIALIZE(last_reward_transaction_index)
-      KV_SERIALIZE(last_uptime_proof)
-      KV_SERIALIZE(service_node_version)
-      KV_SERIALIZE(contributors)
-      KV_SERIALIZE(total_contributed)
-      KV_SERIALIZE(total_reserved)
-      KV_SERIALIZE(staking_requirement)
-      KV_SERIALIZE(portions_for_operator)
-      KV_SERIALIZE(swarm_id)
-      KV_SERIALIZE(operator_address)
-      KV_SERIALIZE(public_ip)
-      KV_SERIALIZE(storage_port)
-      KV_SERIALIZE(block_hash)
-      KV_SERIALIZE(height)
+      KV_SERIALIZE_OPT2(service_node_pubkey, false)
+      KV_SERIALIZE_OPT2(registration_height, false)
+      KV_SERIALIZE_OPT2(requested_unlock_height, false)
+      KV_SERIALIZE_OPT2(last_reward_block_height, false)
+      KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
+      KV_SERIALIZE_OPT2(last_uptime_proof, false)
+      KV_SERIALIZE_OPT2(service_node_version, false)
+      KV_SERIALIZE_OPT2(contributors, false)
+      KV_SERIALIZE_OPT2(total_contributed, false)
+      KV_SERIALIZE_OPT2(total_reserved, false)
+      KV_SERIALIZE_OPT2(staking_requirement, false)
+      KV_SERIALIZE_OPT2(portions_for_operator, false)
+      KV_SERIALIZE_OPT2(swarm_id, false)
+      KV_SERIALIZE_OPT2(operator_address, false)
+      KV_SERIALIZE_OPT2(public_ip, false)
+      KV_SERIALIZE_OPT2(storage_port, false)
+      KV_SERIALIZE_OPT2(block_hash, false)
+      KV_SERIALIZE_OPT2(height, false)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2826,6 +2826,136 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct COMMAND_RPC_GET_N_SERVICE_NODES
+  {
+
+    // Boolean values indicate whether corresponding
+    // fields should be included in the response
+    struct included_fields {
+      bool service_node_pubkey;
+      bool registration_height;
+      bool requested_unlock_height;
+      bool last_reward_block_height;
+      bool last_reward_transaction_index;
+      bool last_uptime_proof;
+
+      bool service_node_version;
+      bool contributors;
+      bool total_contributed;
+      bool total_reserved;
+      bool staking_requirement;
+      bool portions_for_operator;
+      bool swarm_id;
+      bool operator_address;
+      bool public_ip;
+      bool storage_port;
+
+      bool block_hash;
+      bool height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(service_node_pubkey)
+      KV_SERIALIZE(registration_height)
+      KV_SERIALIZE(requested_unlock_height)
+      KV_SERIALIZE(last_reward_block_height)
+      KV_SERIALIZE(last_reward_transaction_index)
+      KV_SERIALIZE(last_uptime_proof)
+      KV_SERIALIZE(service_node_version)
+      KV_SERIALIZE(contributors)
+      KV_SERIALIZE(total_contributed)
+      KV_SERIALIZE(total_reserved)
+      KV_SERIALIZE(staking_requirement)
+      KV_SERIALIZE(portions_for_operator)
+      KV_SERIALIZE(swarm_id)
+      KV_SERIALIZE(operator_address)
+      KV_SERIALIZE(public_ip)
+      KV_SERIALIZE(storage_port)
+      KV_SERIALIZE(block_hash)
+      KV_SERIALIZE(height)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    using contribution = COMMAND_RPC_GET_SERVICE_NODES::response_t::contribution;
+    using contributor = COMMAND_RPC_GET_SERVICE_NODES::response_t::contributor;
+
+    struct request
+    {
+      uint32_t limit;
+      included_fields fields;
+
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(limit)
+      KV_SERIALIZE(fields)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+
+      struct entry {
+        const response &parent_ref;
+
+        entry(const response& res)
+          : parent_ref(res)
+        {}
+
+        std::string               service_node_pubkey;           // The public key of the Service Node.
+        uint64_t                  registration_height;           // The height at which the registration for the Service Node arrived on the blockchain.
+        uint64_t                  requested_unlock_height;       // The height at which contributions will be released and the Service Node expires. 0 if not requested yet.
+        uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
+        uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
+        uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
+        std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
+        std::vector<contributor>  contributors;                  // Array of contributors, contributing to this Service Node.
+        uint64_t                  total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
+        uint64_t                  total_reserved;                // The total amount of Loki in atomic units reserved in this Service Node.
+        uint64_t                  staking_requirement;           // The staking requirement in atomic units that is required to be contributed to become a Service Node.
+        uint64_t                  portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
+        uint64_t                  swarm_id;                      // The identifier of the Service Node's current swarm.
+        std::string               operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
+        std::string               public_ip;                     // The public ip address of the service node
+        uint16_t                  storage_port;                  // The port number associated with the storage server
+
+        BEGIN_KV_SERIALIZE_MAP()
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(service_node_pubkey);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(registration_height);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(requested_unlock_height);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_block_height);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_transaction_index);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_uptime_proof);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(service_node_version);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(contributors);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(total_contributed);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(total_reserved);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(staking_requirement);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(portions_for_operator);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(swarm_id);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(operator_address);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(public_ip);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(storage_port);
+        END_KV_SERIALIZE_MAP()
+      };
+
+      included_fields fields;
+
+      std::vector<entry> service_node_states; // Array of service node registration information
+      uint64_t    height;                     // Current block's height.
+      std::string block_hash;                 // Current block's hash.
+      std::string status;                     // Generic RPC error code. "OK" is the success value.
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(service_node_states)
+        KV_SERIALIZE(status)
+        if (this_ref.fields.height) {
+          KV_SERIALIZE(height)
+        }
+        if (this_ref.fields.block_hash) {
+          KV_SERIALIZE(block_hash)
+        }
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_STORAGE_SERVER_PING
   {
     struct request

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2829,6 +2829,8 @@ namespace cryptonote
   #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
   if (this_ref.requested_fields.var || !this_ref.requested_fields.explicitly_set) KV_SERIALIZE(var)
 
+  LOKI_RPC_DOC_INTROSPECT
+  // Get information on a random subset of Service Nodes.
   struct COMMAND_RPC_GET_N_SERVICE_NODES
   {
 
@@ -2836,7 +2838,7 @@ namespace cryptonote
     // fields should be included in the response
     struct requested_fields_t {
 
-      bool explicitly_set = false;
+      bool explicitly_set = false;          // internal use only: incicates whether one of the other parameters has been explicitly set
 
       bool service_node_pubkey;
       bool registration_height;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2827,14 +2827,14 @@ namespace cryptonote
   };
 
   #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
-  if (this_ref.parent_ref.fields.var) KV_SERIALIZE(var)
+  if (this_ref.requested_fields.var) KV_SERIALIZE(var)
 
   struct COMMAND_RPC_GET_N_SERVICE_NODES
   {
 
     // Boolean values indicate whether corresponding
     // fields should be included in the response
-    struct included_fields {
+    struct requested_fields_t {
       bool service_node_pubkey;
       bool registration_height;
       bool requested_unlock_height;
@@ -2881,11 +2881,11 @@ namespace cryptonote
     using contribution = COMMAND_RPC_GET_SERVICE_NODES::response_t::contribution;
     using contributor = COMMAND_RPC_GET_SERVICE_NODES::response_t::contributor;
 
-    struct request
+    struct request_t
     {
       uint32_t limit;
       bool fully_funded_only;
-      included_fields fields;
+      requested_fields_t fields;
 
       BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(limit)
@@ -2893,15 +2893,16 @@ namespace cryptonote
       KV_SERIALIZE(fields)
       END_KV_SERIALIZE_MAP()
     };
+    typedef epee::misc_utils::struct_init<request_t> request;
 
-    struct response
+    struct response_t
     {
 
       struct entry {
-        const response &parent_ref;
+        const requested_fields_t& requested_fields;
 
-        entry(const response& res)
-          : parent_ref(res)
+        entry(const requested_fields_t& res)
+          : requested_fields(res)
         {}
 
         std::string               service_node_pubkey;           // The public key of the Service Node.
@@ -2941,7 +2942,7 @@ namespace cryptonote
         END_KV_SERIALIZE_MAP()
       };
 
-      included_fields fields;
+      requested_fields_t fields;
 
       std::vector<entry> service_node_states; // Array of service node registration information
       uint64_t    height;                     // Current block's height.
@@ -2959,6 +2960,7 @@ namespace cryptonote
         }
       END_KV_SERIALIZE_MAP()
     };
+    typedef epee::misc_utils::struct_init<response_t> response;
   };
 
   struct COMMAND_RPC_STORAGE_SERVER_PING

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2826,6 +2826,9 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
+  if (this_ref.parent_ref.fields.var) KV_SERIALIZE(var)
+
   struct COMMAND_RPC_GET_N_SERVICE_NODES
   {
 
@@ -2881,10 +2884,12 @@ namespace cryptonote
     struct request
     {
       uint32_t limit;
+      bool fully_funded_only;
       included_fields fields;
 
       BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(limit)
+      KV_SERIALIZE(fully_funded_only)
       KV_SERIALIZE(fields)
       END_KV_SERIALIZE_MAP()
     };


### PR DESCRIPTION
- if `limit` is set, return up to `limit` number of random service nodes
- if `fields` is set, only include the fields listed there
- if `fully_funded_only` is set, only return fully funded service nodes

Example usage:
```
{
    "jsonrpc":"2.0",
    "id":"0",
    "method":"get_n_service_nodes",
    "params": {
    	"limit": 20,
    	"fields" : {
    		"service_node_pubkey": true,
    		"public_ip": true,
    		"storage_port": true,
    		"height": true,
    		"block_hash": true
    	}
    }
}
```

Response:

```

{
    "id": "0",
    "jsonrpc": "2.0",
    "result": {
        "block_hash": "9d83ba6aaf51a2454918482e4a4f2862e69e41089d482e23e4288d03810f5122",
        "height": 132,
        "service_node_states": [
            {
                "public_ip": "1.4.6.7",
                "service_node_pubkey": "19c984a182e58cadbb71449079be322423ba285ac0967486a064d48a17306dda",
                "storage_port": 5902
            },
            {
                "public_ip": "0.0.0.0",
                "service_node_pubkey": "11cdade59ed60fdf57e8d3b16c962cbf2ea479876a9feb74728f872d09d9b00a",
                "storage_port": 0
            },
            {
                "public_ip": "0.0.0.0",
                "service_node_pubkey": "83e834b8f9d0d1b7aa0e2aedd0b47498d6d7b9ffa37dc6e935eb409cfa8bcd17",
                "storage_port": 0
            }
        ],
        "status": "OK"
    }
}
```

Example 2 (returns all entries for all nodes)

```
{
    "jsonrpc":"2.0",
    "id":"0",
    "method":"get_n_service_nodes"
}
```
