### PR TITLE
Service node checkpointing: deprecate tx extra deregister, add infrastructure for deregistration

### DIFF
--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -160,6 +160,7 @@ public:
   virtual void update_block_checkpoint(struct checkpoint_t const &checkpoint) override {}
   virtual bool get_block_checkpoint   (uint64_t height, struct checkpoint_t &checkpoint) const override { return false; }
   virtual bool get_top_checkpoint     (struct checkpoint_t &checkpoint) const override { return false; }
+  virtual void remove_block_checkpoint(uint64_t height) override {}
   virtual std::vector<cryptonote::checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints) const override { return {}; }
 
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }

--- a/src/common/loki_integration_test_hooks.h
+++ b/src/common/loki_integration_test_hooks.h
@@ -39,7 +39,13 @@ std::vector<std::string> separate_stdin_to_space_delim_args   (fixed_buffer cons
 extern const command_line::arg_descriptor<std::string, false> arg_integration_test_hardforks_override;
 extern const command_line::arg_descriptor<std::string, false> arg_integration_test_shared_mem_name;
 extern boost::mutex integration_test_mutex;
-extern bool core_is_idle;
+
+extern struct integration_test_t
+{
+  bool core_is_idle;
+  bool disable_checkpoint_quorum;
+  bool disable_uptime_quorum;
+} integration_test;
 
 }; // namespace loki
 
@@ -72,7 +78,9 @@ static sem_t              *global_stdin_ready_semaphore;
 
 namespace loki
 {
-bool core_is_idle;
+
+integration_test_t integration_test;
+
 const command_line::arg_descriptor<std::string, false> arg_integration_test_hardforks_override = {
   "integration-test-hardforks-override"
 , "Specify custom hardfork heights and launch in fakenet mode"

--- a/src/common/loki_integration_test_hooks.h
+++ b/src/common/loki_integration_test_hooks.h
@@ -23,7 +23,7 @@ namespace loki
 {
 struct fixed_buffer
 {
-  static const int SIZE = 32768;
+  static const int SIZE = 65536;
   char data[SIZE];
   int  len;
 };

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -168,8 +168,8 @@ namespace cryptonote
       version_3_per_output_unlock_times,
       version_4_tx_types,
     };
-    static version get_min_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
-    static version get_max_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
+    static version get_min_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype = MAINNET);
+    static version get_max_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype = MAINNET);
 
     // tx information
     size_t   version;
@@ -546,7 +546,7 @@ namespace cryptonote
     return result;
   }
 
-  inline enum transaction_prefix::version transaction_prefix::get_max_version_for_hf(int hf_version, cryptonote::network_type nettype)
+  inline enum transaction_prefix::version transaction_prefix::get_max_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype)
   {
     nettype = validate_nettype(nettype);
     if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_8)
@@ -558,7 +558,7 @@ namespace cryptonote
     return transaction::version_4_tx_types;
   }
 
-  inline enum transaction_prefix::version transaction_prefix::get_min_version_for_hf(int hf_version, cryptonote::network_type nettype)
+  inline enum transaction_prefix::version transaction_prefix::get_min_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype)
   {
     nettype = validate_nettype(nettype);
     if (nettype == MAINNET) // NOTE(loki): Add an exception for mainnet as there are v2's on mainnet.

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1579,7 +1579,7 @@ namespace cryptonote
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height)
   {
     const blobdata bd                 = get_block_hashing_blob(b);
-    const uint8_t hf_version              = b.major_version;
+    const uint8_t hf_version          = b.major_version;
     crypto::cn_slow_hash_type cn_type = cn_slow_hash_type::heavy_v1;
 
     if (hf_version >= network_version_11_infinite_staking)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -701,12 +701,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool add_service_node_deregister_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister_& deregistration)
   {
-    tx_extra_field field = tx_extra_service_node_deregister_{deregistration.version,
-                                                             deregistration.quorum,
-                                                             deregistration.block_height,
-                                                             deregistration.service_node_index,
-                                                             deregistration.votes};
-
+    tx_extra_field field = deregistration;
     std::ostringstream oss;
     binary_archive<true> ar(oss);
     bool r = ::do_serialize(ar, field);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -717,9 +717,9 @@ namespace cryptonote
   tx_extra_service_node_deregister_ convert_legacy_tx_extra_deregister(tx_extra_service_node_deregister_legacy const &legacy)
   {
     tx_extra_service_node_deregister_ result = {};
-    result.version                           = tx_extra_service_node_deregister_::version_0_checkpointing;
+    result.vote_version                      = service_nodes::quorum_vote_t::version_0_infinite_staking;
+    result.vote_type                         = static_cast<uint8_t>(service_nodes::quorum_vote_type::uptime_deregister);
     result.block_height                      = legacy.block_height;
-    result.quorum                            = tx_extra_service_node_deregister_::quorum_uptime;
     result.service_node_index                = legacy.service_node_index;
     result.votes.reserve(legacy.votes.size());
 
@@ -736,7 +736,7 @@ namespace cryptonote
 
   bool convert_tx_extra_service_node_deregister_to_legacy(tx_extra_service_node_deregister_ const &deregister, tx_extra_service_node_deregister_legacy &legacy)
   {
-    if (deregister.quorum != tx_extra_service_node_deregister_::quorum_uptime)
+    if (static_cast<service_nodes::quorum_vote_type>(deregister.vote_type) != service_nodes::quorum_vote_type::uptime_deregister)
       return false;
 
     legacy.block_height       = deregister.block_height;

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -753,7 +753,7 @@ namespace cryptonote
     return true;
   }
 
-  bool get_service_node_deregister_from_tx_extra(int hf_version, std::vector<uint8_t> const &tx_extra, tx_extra_service_node_deregister_ &deregister)
+  bool get_service_node_deregister_from_tx_extra(uint8_t hf_version, std::vector<uint8_t> const &tx_extra, tx_extra_service_node_deregister_ &deregister)
   {
     if (hf_version >= cryptonote::network_version_12_checkpointing)
     {
@@ -1579,7 +1579,7 @@ namespace cryptonote
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height)
   {
     const blobdata bd                 = get_block_hashing_blob(b);
-    const int hf_version              = b.major_version;
+    const uint8_t hf_version              = b.major_version;
     crypto::cn_slow_hash_type cn_type = cn_slow_hash_type::heavy_v1;
 
     if (hf_version >= network_version_11_infinite_staking)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -996,7 +996,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   uint64_t get_block_height(const block& b)
   {
-    CHECK_AND_ASSERT_MES(b.miner_tx.vin.size() == 1, 0, "wrong miner tx in block: " << get_block_hash(b) << ", b.miner_tx.vin.size() != 1");
+    CHECK_AND_ASSERT_MES(b.miner_tx.vin.size() == 1, 0, "wrong miner tx in block: " << get_block_hash(b) << ", b.miner_tx.vin.size() != 1 (size is: " << b.miner_tx.vin.size() << ")");
     CHECKED_GET_SPECIFIC_VARIANT(b.miner_tx.vin[0], const txin_gen, coinbase_in, 0);
     return coinbase_in.height;
   }

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -107,7 +107,7 @@ namespace cryptonote
 
   tx_extra_service_node_deregister_ convert_legacy_tx_extra_deregister                (tx_extra_service_node_deregister_legacy const &legacy);
   bool                              convert_tx_extra_service_node_deregister_to_legacy(tx_extra_service_node_deregister_ const &deregister, tx_extra_service_node_deregister_legacy &legacy);
-  bool                              get_service_node_deregister_from_tx_extra         (int hf_version, std::vector<uint8_t> const &tx_extra, tx_extra_service_node_deregister_ &deregister);
+  bool                              get_service_node_deregister_from_tx_extra         (uint8_t hf_version, std::vector<uint8_t> const &tx_extra, tx_extra_service_node_deregister_ &deregister);
 
   bool get_service_node_register_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_register& registration);
   bool get_service_node_pubkey_from_tx_extra(const std::vector<uint8_t>& tx_extra, crypto::public_key& pubkey);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -61,6 +61,8 @@ namespace cryptonote
   bool is_v1_tx(const blobdata_ref& tx_blob);
   bool is_v1_tx(const blobdata& tx_blob);
 
+  bool parse_tx_extra(const std::vector<uint8_t>& tx_extra, std::vector<tx_extra_field>& tx_extra_fields);
+
   // skip_fields: How many fields of type <T> to skip
   template<typename T>
   bool find_tx_extra_field_by_type(const std::vector<tx_extra_field>& tx_extra_fields, T& field, size_t skip_fields = 0)
@@ -83,7 +85,15 @@ namespace cryptonote
     return false;
   }
 
-  bool parse_tx_extra(const std::vector<uint8_t>& tx_extra, std::vector<tx_extra_field>& tx_extra_fields);
+  template<typename T>
+  bool find_tx_extra_field_in_blob(const std::vector<uint8_t>& tx_extra, T& field, size_t skip_fields = 0)
+  {
+    std::vector<tx_extra_field> tx_extra_fields;
+    parse_tx_extra(tx_extra, tx_extra_fields);
+    bool result = find_tx_extra_field_by_type(tx_extra_fields, field, skip_fields);
+    return result;
+  }
+
   bool sort_tx_extra(const std::vector<uint8_t>& tx_extra, std::vector<uint8_t> &sorted_tx_extra, bool allow_partial = false);
   crypto::public_key get_tx_pub_key_from_extra(const std::vector<uint8_t>& tx_extra, size_t pk_index = 0);
   crypto::public_key get_tx_pub_key_from_extra(const transaction_prefix& tx, size_t pk_index = 0);
@@ -92,9 +102,14 @@ namespace cryptonote
   void add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key);
   void add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key);
 
-  bool add_service_node_deregister_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister& deregistration);
+  bool add_service_node_deregister_legacy_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister_legacy& deregistration);
+  bool add_service_node_deregister_to_tx_extra       (std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister_& deregistration);
+
+  tx_extra_service_node_deregister_ convert_legacy_tx_extra_deregister                (tx_extra_service_node_deregister_legacy const &legacy);
+  bool                              convert_tx_extra_service_node_deregister_to_legacy(tx_extra_service_node_deregister_ const &deregister, tx_extra_service_node_deregister_legacy &legacy);
+  bool                              get_service_node_deregister_from_tx_extra         (int hf_version, std::vector<uint8_t> const &tx_extra, tx_extra_service_node_deregister_ &deregister);
+
   bool get_service_node_register_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_register& registration);
-  bool get_service_node_deregister_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_deregister& deregistration);
   bool get_service_node_pubkey_from_tx_extra(const std::vector<uint8_t>& tx_extra, crypto::public_key& pubkey);
   bool get_service_node_contributor_from_tx_extra(const std::vector<uint8_t>& tx_extra, cryptonote::account_public_address& address);
   bool add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const std::vector<cryptonote::account_public_address>& addresses, uint64_t portions_for_operator, const std::vector<uint64_t>& portions, uint64_t expiration_timestamp, const crypto::signature& signature);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -283,8 +283,8 @@ namespace cryptonote
       END_SERIALIZE()
     };
 
-    uint8_t           version;
-    uint8_t           quorum;
+    uint8_t           version = version_0_checkpointing;
+    uint8_t           quorum  = quorum_invalid;
     uint64_t          block_height;
     uint16_t          service_node_index;
     std::vector<vote> votes;

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -272,7 +272,7 @@ namespace cryptonote
     {
       vote() = default;
       vote(crypto::signature const &signature, uint16_t validator_index): signature(signature), validator_index(validator_index) { }
-      uint8_t           version;
+      uint8_t           version = version_0_checkpointing;
       uint16_t          validator_index;
       crypto::signature signature;
 

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -259,20 +259,11 @@ namespace cryptonote
 
   struct tx_extra_service_node_deregister_
   {
-    enum version { version_0_checkpointing };
-    enum quorum
-    {
-      quorum_uptime,
-      quorum_checkpoint,
-      quorum_count,
-      quorum_invalid = quorum_count,
-    };
-
     struct vote
     {
       vote() = default;
       vote(crypto::signature const &signature, uint16_t validator_index): signature(signature), validator_index(validator_index) { }
-      uint8_t           version = version_0_checkpointing;
+      uint8_t           version = 0;
       uint16_t          validator_index;
       crypto::signature signature;
 
@@ -283,15 +274,25 @@ namespace cryptonote
       END_SERIALIZE()
     };
 
-    uint8_t           version = version_0_checkpointing;
-    uint8_t           quorum  = quorum_invalid;
+    uint8_t           version = 0;
+    // TODO(loki): vote_version/vote_type maps to quorum_vote_t version and
+    // type, but getting that declaration into tx_extra is not nice without
+    // having to bend backwards since tx_extra is included in everything, so
+    // trying to get it to include another file is a herculean task
+
+    // We need the data so that we can rederive the signature for clients to
+    // check the validity
+    uint8_t           vote_version;
+    uint8_t           vote_type;
+
     uint64_t          block_height;
     uint16_t          service_node_index;
     std::vector<vote> votes;
 
     BEGIN_SERIALIZE()
       VARINT_FIELD(version)
-      VARINT_FIELD(quorum)
+      VARINT_FIELD(vote_version)
+      VARINT_FIELD(vote_type)
       VARINT_FIELD(block_height)
       VARINT_FIELD(service_node_index)
       FIELD(votes)
@@ -358,7 +359,6 @@ namespace cryptonote
 }
 
 BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister_legacy::vote);
-BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister_::vote);
 BLOB_SERIALIZER(cryptonote::tx_extra_tx_key_image_proofs::proof);
 
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding,                        TX_EXTRA_TAG_PADDING);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -272,8 +272,15 @@ namespace cryptonote
     {
       vote() = default;
       vote(crypto::signature const &signature, uint16_t validator_index): signature(signature), validator_index(validator_index) { }
-      crypto::signature signature;
+      uint8_t           version;
       uint16_t          validator_index;
+      crypto::signature signature;
+
+      BEGIN_SERIALIZE()
+        VARINT_FIELD(version)
+        VARINT_FIELD(validator_index)
+        FIELD       (signature)
+      END_SERIALIZE()
     };
 
     uint8_t           version;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -111,6 +111,7 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
+  { network_version_12_checkpointing,    6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3124,7 +3124,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return false;
       }
 
-      const std::shared_ptr<const service_nodes::testing_quorum> quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::deregister, deregister.block_height);
+      const std::shared_ptr<const service_nodes::testing_quorum> quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::uptime, deregister.block_height);
       if (!quorum)
       {
         MERROR_VER("Deregister TX could not get quorum for height: " << deregister.block_height);
@@ -3194,7 +3194,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
           continue;
         }
 
-        const std::shared_ptr<const service_nodes::testing_quorum> existing_quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::deregister, existing_deregister.block_height);
+        const std::shared_ptr<const service_nodes::testing_quorum> existing_quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::uptime, existing_deregister.block_height);
         if (!existing_quorum)
         {
           MERROR_VER("could not get uptime quorum for recent deregister tx");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -111,7 +111,6 @@ static const hard_fork_record testnet_hard_forks[] =
   { network_version_9_service_nodes,     3, 0, 1533631123 },
   { network_version_10_bulletproofs,     4, 0, 1542681077 },
   { network_version_11_infinite_staking, 5, 0, 1551223964 },
-  { network_version_12_checkpointing,    6, 0, 1551223965 },
 };
 
 static const hard_fork_record stagenet_hard_forks[] =

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3129,7 +3129,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
 
       std::shared_ptr<const service_nodes::testing_quorum> quorum =
           m_service_node_list.get_testing_quorum(desired_quorum_type, deregister.block_height);
-      if (service_nodes::verify_tx_deregister(deregister, get_current_blockchain_height(), tvc.m_vote_ctx, *quorum))
+      if (!service_nodes::verify_tx_deregister(deregister, get_current_blockchain_height(), tvc.m_vote_ctx, *quorum))
       {
         tvc.m_verifivation_failed = true;
         MERROR_VER("tx " << get_transaction_hash(tx) << ": deregister tx could not be completely verified reason: "

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2831,7 +2831,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   if(pmax_used_block_height)
     *pmax_used_block_height = 0;
 
-  const int hf_version = m_hardfork->get_current_version();
+  const uint8_t hf_version = m_hardfork->get_current_version();
 
   // Min/Max Type/Version Check
   {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1617,8 +1617,15 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::add_new_block(const block& b, block_verification_context& bvc)
   {
-    relay_service_node_votes(); // NOTE: nop if synchronising due to not accepting votes whilst syncing
-    return m_blockchain_storage.add_new_block(b, bvc);
+    bool result = m_blockchain_storage.add_new_block(b, bvc);
+    if (result)
+    {
+      // TODO(loki): PERF(loki): This causes perf problems in integration mode, so in real-time operation it may not be
+      // noticeable but could bubble up and cause slowness if the runtime variables align up undesiredly.
+
+      relay_service_node_votes(); // NOTE: nop if synchronising due to not accepting votes whilst syncing
+    }
+    return result;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::prepare_handle_incoming_blocks(const std::vector<block_complete_entry> &blocks_entry, std::vector<block> &blocks, std::vector<checkpoint_t> &checkpoints)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2199,7 +2199,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::add_service_node_vote(const service_nodes::quorum_vote_t& vote, vote_verification_context &vvc)
   {
-    bool result = m_quorum_cop.handle_vote(vote, vvc, m_service_node ? &m_service_node_pubkey : nullptr);
+    bool result = m_quorum_cop.handle_vote(vote, vvc);
     return result;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1448,6 +1448,7 @@ namespace cryptonote
     int hf_version = get_blockchain_storage().get_current_hard_fork_version();
     if (hf_version < cryptonote::network_version_11_infinite_staking)
     {
+      // TODO(doyle): Remove post HF12
       NOTIFY_NEW_DEREGISTER_VOTE::request req = {};
       for (service_nodes::quorum_vote_t const &vote : relayable_votes)
       {
@@ -2191,7 +2192,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::add_service_node_vote(const service_nodes::quorum_vote_t& vote, vote_verification_context &vvc)
   {
-    bool result = m_quorum_cop.handle_vote(vote, vvc);
+    bool result = m_quorum_cop.handle_vote(vote, vvc, m_service_node ? &m_service_node_pubkey : nullptr);
     return result;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1445,7 +1445,7 @@ namespace cryptonote
   bool core::relay_service_node_votes()
   {
     std::vector<service_nodes::quorum_vote_t> relayable_votes = m_quorum_cop.get_relayable_votes();
-    int hf_version = get_blockchain_storage().get_current_hard_fork_version();
+    uint8_t hf_version = get_blockchain_storage().get_current_hard_fork_version();
     if (hf_version < cryptonote::network_version_11_infinite_staking)
     {
       // TODO(doyle): Remove post HF12

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1875,7 +1875,7 @@ namespace cryptonote
     m_mempool.on_idle();
 
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
-    loki::core_is_idle = true;
+    loki::integration_test.core_is_idle = true;
 #endif
 
     return true;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -185,7 +185,7 @@ namespace cryptonote
     bool                v2_rct;
 
     loki_construct_tx_params() = default;
-    loki_construct_tx_params(int hf_version)
+    loki_construct_tx_params(uint8_t hf_version)
     {
       *this = {};
       v4_allow_tx_types    = (hf_version >= cryptonote::network_version_11_infinite_staking);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -49,7 +49,7 @@
 
 namespace service_nodes
 {
-  static int get_min_service_node_info_version_for_hf(int hf_version)
+  static int get_min_service_node_info_version_for_hf(uint8_t hf_version)
   {
     if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_9_service_nodes)
       return service_node_info::version_0;
@@ -514,7 +514,7 @@ namespace service_nodes
       return false;
     }
 
-    int hf_version = m_blockchain.get_hard_fork_version(block_height);
+    uint8_t hf_version = m_blockchain.get_hard_fork_version(block_height);
 
     if (!check_service_node_portions(hf_version, service_node_portions)) return false;
 
@@ -701,7 +701,7 @@ namespace service_nodes
       return; // Is not a contribution TX don't need to check it.
 
     parsed_tx_contribution parsed_contribution = {};
-    const int hf_version = m_blockchain.get_hard_fork_version(block_height);
+    const uint8_t hf_version = m_blockchain.get_hard_fork_version(block_height);
     if (!get_contribution(m_blockchain.nettype(), hf_version, tx, block_height, parsed_contribution))
     {
       LOG_PRINT_L1("Contribution TX: Could not decode contribution for service node: " << pubkey << " on height: " << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
@@ -1386,7 +1386,7 @@ namespace service_nodes
 
   bool service_node_list::store()
   {
-    int hf_version = m_blockchain.get_current_hard_fork_version();
+    uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
     if (hf_version < cryptonote::network_version_9_service_nodes)
       return true;
 
@@ -1619,7 +1619,7 @@ namespace service_nodes
   converted_registration_args convert_registration_args(cryptonote::network_type nettype,
                                                         const std::vector<std::string>& args,
                                                         uint64_t staking_requirement,
-                                                        int hf_version)
+                                                        uint8_t hf_version)
   {
     converted_registration_args result = {};
     if (args.size() % 2 == 0 || args.size() < 3)
@@ -1785,7 +1785,7 @@ namespace service_nodes
   }
 
   bool make_registration_cmd(cryptonote::network_type nettype,
-      int hf_version,
+      uint8_t hf_version,
       uint64_t staking_requirement,
       const std::vector<std::string>& args,
       const crypto::public_key& service_node_pubkey,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -140,8 +140,8 @@ namespace service_nodes
     const auto &it = m_transient_state.quorum_states.find(height);
     if (it != m_transient_state.quorum_states.end())
     {
-      if (type == quorum_type::deregister)
-        return it->second.deregister;
+      if (type == quorum_type::uptime)
+        return it->second.uptime;
       else if (type == quorum_type::checkpointing)
         return it->second.checkpointing;
       else
@@ -307,7 +307,7 @@ namespace service_nodes
       return false;
     }
 
-    const auto state = get_testing_quorum(quorum_type::deregister, deregister.block_height);
+    const auto state = get_testing_quorum(quorum_type::uptime, deregister.block_height);
     if (!state)
     {
       // TODO(loki): Not being able to find a quorum is fatal! We want better caching abilities.
@@ -1307,13 +1307,13 @@ namespace service_nodes
       auto quorum                                = std::make_shared<testing_quorum>();
       std::vector<size_t> const pub_keys_indexes = generate_shuffled_service_node_index_list(snode_list, block_hash, type);
 
-      if (type == quorum_type::deregister)
+      if (type == quorum_type::uptime)
       {
         if (hf_version >= cryptonote::network_version_9_service_nodes)
         {
-          num_validators             = std::min(pub_keys_indexes.size(), DEREGISTER_QUORUM_SIZE);
+          num_validators             = std::min(pub_keys_indexes.size(), UPTIME_QUORUM_SIZE);
           size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
-          num_workers                = std::max(num_remaining_nodes/DEREGISTER_NTH_OF_THE_NETWORK_TO_TEST, std::min(DEREGISTER_MIN_NODES_TO_TEST, num_remaining_nodes));
+          num_workers                = std::max(num_remaining_nodes/UPTIME_NTH_OF_THE_NETWORK_TO_TEST, std::min(UPTIME_MIN_NODES_TO_TEST, num_remaining_nodes));
         }
       }
       else if (type == quorum_type::checkpointing)
@@ -1351,8 +1351,8 @@ namespace service_nodes
         }
       }
 
-      if (type == quorum_type::deregister)
-        manager.deregister = quorum;
+      if (type == quorum_type::uptime)
+        manager.uptime = quorum;
       else
         manager.checkpointing = quorum;
     }
@@ -1404,8 +1404,8 @@ namespace service_nodes
         quorum.height                   = kv_pair.first;
         quorum_manager const &manager   = kv_pair.second;
 
-        if (manager.deregister)
-          quorum.quorums[(int)quorum_type::deregister] = *manager.deregister;
+        if (manager.uptime)
+          quorum.quorums[(int)quorum_type::uptime] = *manager.uptime;
 
         if (quorum.version >= service_node_info::version_3_checkpointing)
         {
@@ -1525,8 +1525,8 @@ namespace service_nodes
     for (const auto& states : data_in.quorum_states)
     {
       {
-        testing_quorum const &deregister = states.quorums[(int)quorum_type::deregister];
-        m_transient_state.quorum_states[states.height].deregister = std::make_shared<testing_quorum>(deregister);
+        testing_quorum const &uptime = states.quorums[(int)quorum_type::uptime];
+        m_transient_state.quorum_states[states.height].uptime = std::make_shared<testing_quorum>(uptime);
       }
 
       if (states.version >= service_node_info::version_3_checkpointing)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -308,10 +308,9 @@ namespace service_nodes
       return false;
     }
 
-    quorum_type type = (deregister.quorum == cryptonote::tx_extra_service_node_deregister_::quorum_uptime)
+    quorum_type type = (static_cast<quorum_vote_type>(deregister.vote_type) == quorum_vote_type::uptime_deregister)
                            ? quorum_type::uptime
                            : quorum_type::checkpointing;
-
     const auto state = get_testing_quorum(type, deregister.block_height);
     if (!state)
     {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1315,7 +1315,7 @@ namespace service_nodes
       {
         num_validators             = std::min(pub_keys_indexes.size(), UPTIME_QUORUM_SIZE);
         size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
-        num_workers                = std::max(num_remaining_nodes/UPTIME_NTH_OF_THE_NETWORK_TO_TEST, std::min(UPTIME_MIN_NODES_TO_TEST, num_remaining_nodes));
+        num_workers                = std::max(num_remaining_nodes/UPTIME_FRACTION_OF_THE_NETWORK_TO_TEST, std::min(UPTIME_MIN_NODES_TO_TEST, num_remaining_nodes));
       }
       else if (type == quorum_type::checkpointing)
       {

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -377,10 +377,10 @@ namespace service_nodes
   converted_registration_args convert_registration_args(cryptonote::network_type nettype,
                                                         const std::vector<std::string>& args,
                                                         uint64_t staking_requirement,
-                                                        int hf_version);
+                                                        uint8_t hf_version);
 
   bool make_registration_cmd(cryptonote::network_type nettype,
-      int hf_version,
+      uint8_t hf_version,
       uint64_t staking_requirement,
       const std::vector<std::string>& args,
       const crypto::public_key& service_node_pubkey,

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -303,7 +303,7 @@ namespace service_nodes
       BEGIN_SERIALIZE()
         FIELD(version)
         FIELD(height)
-        FIELD_N("deregister_quorum", quorums[(size_t)quorum_type::deregister])
+        FIELD_N("uptime_quorum", quorums[(size_t)quorum_type::uptime])
         if (version >= service_node_info::version_3_checkpointing)
           FIELD_N("checkpointing_quorum", quorums[(size_t)quorum_type::checkpointing])
       END_SERIALIZE()

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -195,7 +195,7 @@ namespace service_nodes
                                                                        my_pubkey,
                                                                        my_seckey);
               cryptonote::vote_verification_context vvc = {};
-              if (!handle_vote(vote, vvc, &my_pubkey))
+              if (!handle_vote(vote, vvc))
                 LOG_ERROR("Failed to add uptime deregister vote reason: " << print_vote_verification_context(vvc, &vote));
             }
           }
@@ -250,7 +250,7 @@ namespace service_nodes
                                                           my_seckey);
 
                 cryptonote::vote_verification_context vvc = {};
-                if (!handle_vote(vote, vvc, &my_pubkey))
+                if (!handle_vote(vote, vvc))
                   LOG_ERROR("Failed to add checkpoint deregister vote reason: " << print_vote_verification_context(vvc, &vote));
               }
             }
@@ -303,7 +303,7 @@ namespace service_nodes
                   vote.signature      = make_signature_from_vote(vote, my_pubkey, my_seckey);
 
                   cryptonote::vote_verification_context vvc = {};
-                  if (!handle_vote(vote, vvc, &my_pubkey))
+                  if (!handle_vote(vote, vvc))
                     LOG_ERROR("Failed to add checkpoint vote reason: " << print_vote_verification_context(vvc, nullptr));
                 }
               }
@@ -333,7 +333,7 @@ namespace service_nodes
     m_vote_pool.remove_used_votes(hf_version, txs);
   }
 
-  bool quorum_cop::handle_vote(quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc, crypto::public_key const *my_pubkey)
+  bool quorum_cop::handle_vote(quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc)
   {
     vvc = {};
     quorum_type desired_quorum_type = quorum_type::invalid;
@@ -376,7 +376,7 @@ namespace service_nodes
     }
 
     uint64_t latest_height             = std::max(m_core.get_current_blockchain_height(), m_core.get_target_blockchain_height());
-    std::vector<pool_vote_entry> votes = m_vote_pool.add_pool_vote_if_unique(latest_height, vote, vvc, *quorum, my_pubkey);
+    std::vector<pool_vote_entry> votes = m_vote_pool.add_pool_vote_if_unique(latest_height, vote, vvc, *quorum);
     bool result                        = !vvc.m_verification_failed;
 
     if (!vvc.m_added_to_pool) // NOTE: Not unique vote

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -328,7 +328,7 @@ namespace service_nodes
     // Otherwise peers will silently drop connection from each other when they
     // go around P2Ping votes due to passing around old votes
     uint64_t const height = cryptonote::get_block_height(block) + 1;
-    int hf_version        = block.major_version;
+    uint8_t hf_version    = block.major_version;
     m_vote_pool.remove_expired_votes(height);
     m_vote_pool.remove_used_votes(hf_version, txs);
   }
@@ -413,7 +413,7 @@ namespace service_nodes
                 return result;
               });
 
-          int hf_version            = m_core.get_blockchain_storage().get_current_hard_fork_version();
+          uint8_t hf_version        = m_core.get_blockchain_storage().get_current_hard_fork_version();
           transaction deregister_tx = {};
           deregister_tx.version     = transaction::get_max_version_for_hf(hf_version, m_core.get_nettype());
           deregister_tx.type        = transaction::type_deregister;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -82,6 +82,13 @@ namespace service_nodes
       LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_IN_BLOCKS << ". This should never happen! Please report this to the devs.");
       m_last_height_checkpointed = height;
     }
+
+    if (m_last_height_checkpointers_validated >= height)
+    {
+      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes up to " << m_last_height_checkpointers_validated);
+      LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_IN_BLOCKS << ". This should never happen! Please report this to the devs.");
+      m_last_height_checkpointers_validated = height;
+    }
     m_vote_pool.remove_expired_votes(height);
   }
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -140,6 +140,12 @@ namespace service_nodes
     for (int i = 0; i <= (int)max_quorum_type; i++)
     {
       quorum_type const type = static_cast<quorum_type>(i);
+
+#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+      if (loki::integration_test.disable_checkpoint_quorum && type == quorum_type::checkpointing) continue;
+      if (loki::integration_test.disable_uptime_quorum     && type == quorum_type::uptime) continue;
+#endif
+
       switch(type)
       {
         default:
@@ -152,12 +158,7 @@ namespace service_nodes
         {
           // NOTE: Wait atleast 2 hours before we're allowed to vote so that we collect uptimes from everyone on the network
           time_t const now = time(nullptr);
-#if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
-          time_t const min_lifetime = 0;
-#else
-          time_t const min_lifetime = 60 * 60 * 2;
-#endif
-          bool alive_for_min_time = (now - m_core.get_start_time()) >= min_lifetime;
+          bool alive_for_min_time = (now - m_core.get_start_time()) >= UPTIME_MIN_TIME_IN_S_BEFORE_VOTING;
           if (!alive_for_min_time)
             break;
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -395,6 +395,16 @@ namespace service_nodes
           deregister.service_node_index                = vote.deregister.worker_index;
           deregister.votes.reserve(votes.size());
 
+          if (vote.type == quorum_vote_type::uptime_deregister)
+            deregister.quorum = tx_extra_service_node_deregister_::quorum_uptime;
+          else if (vote.type == quorum_vote_type::checkpoint_deregister)
+            deregister.quorum = tx_extra_service_node_deregister_::quorum_checkpoint;
+          else
+          {
+            LOG_PRINT_L0("Unhandled vote type in conversion to tx extra service node quorum type with value: " << (int)vote.type);
+            return false;
+          }
+
           std::transform(
               votes.begin(), votes.end(), std::back_inserter(deregister.votes), [](pool_vote_entry const &pool_vote) {
                 auto result =

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -118,7 +118,7 @@ namespace service_nodes
     time_t const now = time(nullptr);
     bool alive_for_min_time = (now - m_core.get_start_time()) >= MIN_TIME_IN_S_BEFORE_VOTING;
     if (!alive_for_min_time)
-      break;
+      return;
 
     int const hf_version = block.major_version;
     if (hf_version < cryptonote::network_version_9_service_nodes)
@@ -208,7 +208,7 @@ namespace service_nodes
             break;
 
           if (height < (start_voting_from_height + VOTE_LIFETIME))
-            continue;
+            break;
 
           // NOTE: Cast deregister votes if service nodes have not participated
           uint64_t constexpr half_vote_lifetime             = VOTE_LIFETIME / 2;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -127,8 +127,7 @@ namespace service_nodes
       return;
 
     uint64_t const height                            = cryptonote::get_block_height(block);
-    // service_nodes::quorum_type const max_quorum_type = service_nodes::max_quorum_type_for_hf(hf_version);
-    service_nodes::quorum_type const max_quorum_type = quorum_type::uptime;
+    service_nodes::quorum_type const max_quorum_type = service_nodes::max_quorum_type_for_hf(hf_version);
 
     uint64_t const latest_height = std::max(m_core.get_current_blockchain_height(), m_core.get_target_blockchain_height());
     if (latest_height < VOTE_LIFETIME)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -116,7 +116,7 @@ namespace service_nodes
   {
     // NOTE: Wait atleast 2 hours before we're allowed to vote so that we collect necessary voting information from people on the network
     time_t const now = time(nullptr);
-    bool alive_for_min_time = (now - m_core.get_start_time()) >= UPTIME_MIN_TIME_IN_S_BEFORE_VOTING;
+    bool alive_for_min_time = (now - m_core.get_start_time()) >= MIN_TIME_IN_S_BEFORE_VOTING;
     if (!alive_for_min_time)
       break;
 

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -60,7 +60,7 @@ namespace service_nodes
 
   struct quorum_manager
   {
-    std::shared_ptr<const testing_quorum> deregister;
+    std::shared_ptr<const testing_quorum> uptime;
     std::shared_ptr<const testing_quorum> checkpointing;
   };
 
@@ -93,7 +93,8 @@ namespace service_nodes
     cryptonote::core& m_core;
     voting_pool       m_vote_pool;
     uint64_t          m_uptime_proof_height;
-    uint64_t          m_last_checkpointed_height;
+    uint64_t          m_last_height_checkpointed;
+    uint64_t          m_last_height_checkpointers_validated;
 
     std::unordered_map<crypto::public_key, proof_info> m_uptime_proof_seen;
     mutable epee::critical_section m_lock;

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -78,7 +78,7 @@ namespace service_nodes
 
     void                       set_votes_relayed  (std::vector<quorum_vote_t> const &relayed_votes);
     std::vector<quorum_vote_t> get_relayable_votes();
-    bool                       handle_vote        (quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc);
+    bool                       handle_vote        (quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc, crypto::public_key const *my_pubkey);
     bool                       handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
 
     static const uint64_t REORG_SAFETY_BUFFER_IN_BLOCKS = 20;

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -78,7 +78,7 @@ namespace service_nodes
 
     void                       set_votes_relayed  (std::vector<quorum_vote_t> const &relayed_votes);
     std::vector<quorum_vote_t> get_relayable_votes();
-    bool                       handle_vote        (quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc, crypto::public_key const *my_pubkey);
+    bool                       handle_vote        (quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc);
     bool                       handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
 
     static const uint64_t REORG_SAFETY_BUFFER_IN_BLOCKS = 20;

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -8,7 +8,6 @@
 
 namespace service_nodes {
 
-
 uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t height, int hf_version)
 {
   if (m_nettype == cryptonote::TESTNET || m_nettype == cryptonote::FAKECHAIN)

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -8,7 +8,7 @@
 
 namespace service_nodes {
 
-uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t height, int hf_version)
+uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t height, uint8_t hf_version)
 {
   if (m_nettype == cryptonote::TESTNET || m_nettype == cryptonote::FAKECHAIN)
       return COIN * 100;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -84,7 +84,7 @@ namespace service_nodes {
   {
     quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::uptime
                                                                                          : quorum_type::checkpointing;
-    assert((size_t)result < (size_t)quorum_type::count - 1);
+    assert((size_t)result < (size_t)quorum_type::count);
     return result;
   }
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -8,10 +8,11 @@
 
 namespace service_nodes {
   constexpr size_t   UPTIME_QUORUM_SIZE                    = 10;
-  constexpr size_t   UPTIME_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
   constexpr size_t   UPTIME_NTH_OF_THE_NETWORK_TO_TEST     = 100;
   constexpr size_t   UPTIME_MIN_NODES_TO_TEST              = 50;
-  constexpr uint64_t UPTIME_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
+
+  constexpr size_t   DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
+  constexpr uint64_t DEREGISTER_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
 
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
@@ -24,7 +25,7 @@ namespace service_nodes {
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 18;
 #endif
 
-  static_assert(UPTIME_MIN_VOTES_TO_KICK_SERVICE_NODE <= UPTIME_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
+  static_assert(DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE <= UPTIME_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
   static_assert(CHECKPOINT_MIN_VOTES <= CHECKPOINT_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
   constexpr size_t   MAX_SWARM_SIZE                   = 10;
@@ -47,7 +48,7 @@ namespace service_nodes {
   constexpr int      MAX_KEY_IMAGES_PER_CONTRIBUTOR   = 1;
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
-  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = UPTIME_VOTE_LIFETIME;
+  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = DEREGISTER_VOTE_LIFETIME;
   constexpr size_t   QUORUM_LIFETIME                   = (6 * DEREGISTER_TX_LIFETIME_IN_BLOCKS);
 
 
@@ -68,7 +69,7 @@ namespace service_nodes {
   {
     switch (type)
     {
-      case quorum_type::uptime:        return UPTIME_VOTE_LIFETIME;
+      case quorum_type::uptime:        return DEREGISTER_VOTE_LIFETIME;
       case quorum_type::checkpointing: return CHECKPOINT_VOTE_LIFETIME;
       default:
       {

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -14,10 +14,13 @@ namespace service_nodes {
 
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = VOTE_LIFETIME; // Persistently store the checkpoints at these intervals
+
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
+  constexpr size_t   UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 1;
   constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;
 #else
+  constexpr size_t   UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 60 * 60 * 2;
   constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 20;
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 18;
 #endif

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -16,13 +16,13 @@ namespace service_nodes {
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = VOTE_LIFETIME; // Persistently store the checkpoints at these intervals
 
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
-  constexpr ptrdiff_t UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 1;
-  constexpr size_t    CHECKPOINT_QUORUM_SIZE                    = 1;
-  constexpr size_t    CHECKPOINT_MIN_VOTES                      = 1;
+  constexpr ptrdiff_t MIN_TIME_IN_S_BEFORE_VOTING = 1;
+  constexpr size_t    CHECKPOINT_QUORUM_SIZE      = 1;
+  constexpr size_t    CHECKPOINT_MIN_VOTES        = 1;
 #else
-  constexpr ptrdiff_t UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 60 * 60 * 2;
-  constexpr size_t    CHECKPOINT_QUORUM_SIZE                    = 20;
-  constexpr size_t    CHECKPOINT_MIN_VOTES                      = 18;
+  constexpr ptrdiff_t MIN_TIME_IN_S_BEFORE_VOTING = 60 * 60 * 2;
+  constexpr size_t    CHECKPOINT_QUORUM_SIZE      = 20;
+  constexpr size_t    CHECKPOINT_MIN_VOTES        = 18;
 #endif
 
   static_assert(DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE <= UPTIME_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -80,25 +80,33 @@ namespace service_nodes {
     }
   }
 
-static_assert(STAKING_PORTIONS != UINT64_MAX, "UINT64_MAX is used as the invalid value for failing to calculate the min_node_contribution");
-// return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount in loki atomic units
-uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
-uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
+  inline quorum_type max_quorum_type_for_hf(int hf_version)
+  {
+    quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::uptime
+                                                                                         : quorum_type::checkpointing;
+    assert((size_t)result < (size_t)quorum_type::count - 1);
+    return result;
+  }
 
-uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, int hf_version);
+  static_assert(STAKING_PORTIONS != UINT64_MAX, "UINT64_MAX is used as the invalid value for failing to calculate the min_node_contribution");
+  // return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount in loki atomic units
+  uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
+  uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
 
-uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
+  uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, int hf_version);
 
-/// Check if portions are sufficiently large (provided the contributions
-/// are made in the specified order) and don't exceed the required amount
-bool check_service_node_portions(uint8_t version, const std::vector<uint64_t>& portions);
+  uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
 
-crypto::hash generate_request_stake_unlock_hash(uint32_t nonce);
-uint64_t     get_locked_key_image_unlock_height(cryptonote::network_type nettype, uint64_t node_register_height, uint64_t curr_height);
+  /// Check if portions are sufficiently large (provided the contributions
+  /// are made in the specified order) and don't exceed the required amount
+  bool check_service_node_portions(uint8_t version, const std::vector<uint64_t>& portions);
 
-// Returns lowest x such that (staking_requirement * x/STAKING_PORTIONS) >= amount
-uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount);
+  crypto::hash generate_request_stake_unlock_hash(uint32_t nonce);
+  uint64_t     get_locked_key_image_unlock_height(cryptonote::network_type nettype, uint64_t node_register_height, uint64_t curr_height);
 
-bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions);
-uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n);
+  // Returns lowest x such that (staking_requirement * x/STAKING_PORTIONS) >= amount
+  uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount);
+
+  bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions);
+  uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n);
 }

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -65,7 +65,7 @@ namespace service_nodes {
     }
   }
 
-  inline quorum_type max_quorum_type_for_hf(int hf_version)
+  inline quorum_type max_quorum_type_for_hf(uint8_t hf_version)
   {
     quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::uptime
                                                                                          : quorum_type::checkpointing;
@@ -78,7 +78,7 @@ namespace service_nodes {
   uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
   uint64_t get_min_node_contribution_in_portions(uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);
 
-  uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, int hf_version);
+  uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height, uint8_t hf_version);
 
   uint64_t portions_to_amount(uint64_t portions, uint64_t staking_requirement);
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -5,9 +5,9 @@
 #include "cryptonote_core/service_node_voting.h"
 
 namespace service_nodes {
-  constexpr size_t   UPTIME_QUORUM_SIZE                    = 10;
-  constexpr size_t   UPTIME_NTH_OF_THE_NETWORK_TO_TEST     = 100;
-  constexpr size_t   UPTIME_MIN_NODES_TO_TEST              = 50;
+  constexpr size_t   UPTIME_QUORUM_SIZE                     = 10;
+  constexpr size_t   UPTIME_FRACTION_OF_THE_NETWORK_TO_TEST = 100;
+  constexpr size_t   UPTIME_MIN_NODES_TO_TEST               = 50;
 
   constexpr size_t   DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
   constexpr uint64_t VOTE_LIFETIME                             = 60;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -2,9 +2,7 @@
 
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
-#include "service_node_voting.h"
-
-#include <random>
+#include "cryptonote_core/service_node_voting.h"
 
 namespace service_nodes {
   constexpr size_t   UPTIME_QUORUM_SIZE                    = 10;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -10,11 +10,10 @@ namespace service_nodes {
   constexpr size_t   UPTIME_MIN_NODES_TO_TEST              = 50;
 
   constexpr size_t   DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
-  constexpr uint64_t DEREGISTER_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
+  constexpr uint64_t VOTE_LIFETIME                             = 60;
 
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
-  constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
-  constexpr uint64_t CHECKPOINT_VOTE_LIFETIME                  = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
+  constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = VOTE_LIFETIME; // Persistently store the checkpoints at these intervals
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
   constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;
@@ -46,7 +45,7 @@ namespace service_nodes {
   constexpr int      MAX_KEY_IMAGES_PER_CONTRIBUTOR   = 1;
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
-  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = DEREGISTER_VOTE_LIFETIME;
+  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = VOTE_LIFETIME;
   constexpr size_t   QUORUM_LIFETIME                   = (6 * DEREGISTER_TX_LIFETIME_IN_BLOCKS);
 
 
@@ -60,21 +59,6 @@ namespace service_nodes {
       case cryptonote::FAKECHAIN: return 30;
       case cryptonote::TESTNET:   return BLOCKS_EXPECTED_IN_DAYS(2);
       default:                    return BLOCKS_EXPECTED_IN_DAYS(30);
-    }
-  }
-
-  inline uint64_t quorum_vote_lifetime(quorum_type type)
-  {
-    switch (type)
-    {
-      case quorum_type::uptime:        return DEREGISTER_VOTE_LIFETIME;
-      case quorum_type::checkpointing: return CHECKPOINT_VOTE_LIFETIME;
-      default:
-      {
-        assert("Unhandled enum type" == 0);
-        return 0;
-      }
-      break;
     }
   }
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -16,13 +16,13 @@ namespace service_nodes {
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = VOTE_LIFETIME; // Persistently store the checkpoints at these intervals
 
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
-  constexpr size_t   UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 1;
-  constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 1;
-  constexpr size_t   CHECKPOINT_MIN_VOTES                      = 1;
+  constexpr ptrdiff_t UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 1;
+  constexpr size_t    CHECKPOINT_QUORUM_SIZE                    = 1;
+  constexpr size_t    CHECKPOINT_MIN_VOTES                      = 1;
 #else
-  constexpr size_t   UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 60 * 60 * 2;
-  constexpr size_t   CHECKPOINT_QUORUM_SIZE                    = 20;
-  constexpr size_t   CHECKPOINT_MIN_VOTES                      = 18;
+  constexpr ptrdiff_t UPTIME_MIN_TIME_IN_S_BEFORE_VOTING        = 60 * 60 * 2;
+  constexpr size_t    CHECKPOINT_QUORUM_SIZE                    = 20;
+  constexpr size_t    CHECKPOINT_MIN_VOTES                      = 18;
 #endif
 
   static_assert(DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE <= UPTIME_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -7,11 +7,11 @@
 #include <random>
 
 namespace service_nodes {
-  constexpr size_t   DEREGISTER_QUORUM_SIZE                    = 10;
-  constexpr size_t   DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
-  constexpr size_t   DEREGISTER_NTH_OF_THE_NETWORK_TO_TEST     = 100;
-  constexpr size_t   DEREGISTER_MIN_NODES_TO_TEST              = 50;
-  constexpr uint64_t DEREGISTER_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
+  constexpr size_t   UPTIME_QUORUM_SIZE                    = 10;
+  constexpr size_t   UPTIME_MIN_VOTES_TO_KICK_SERVICE_NODE = 7;
+  constexpr size_t   UPTIME_NTH_OF_THE_NETWORK_TO_TEST     = 100;
+  constexpr size_t   UPTIME_MIN_NODES_TO_TEST              = 50;
+  constexpr uint64_t UPTIME_VOTE_LIFETIME                  = BLOCKS_EXPECTED_IN_HOURS(2);
 
   constexpr uint64_t CHECKPOINT_INTERVAL                       = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
   constexpr uint64_t CHECKPOINT_STORE_PERSISTENTLY_INTERVAL    = 60; // Persistently store the checkpoints at these intervals
@@ -24,7 +24,7 @@ namespace service_nodes {
   constexpr size_t   CHECKPOINT_MIN_VOTES                      = 18;
 #endif
 
-  static_assert(DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE <= DEREGISTER_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
+  static_assert(UPTIME_MIN_VOTES_TO_KICK_SERVICE_NODE <= UPTIME_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
   static_assert(CHECKPOINT_MIN_VOTES <= CHECKPOINT_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
   constexpr size_t   MAX_SWARM_SIZE                   = 10;
@@ -47,7 +47,7 @@ namespace service_nodes {
   constexpr int      MAX_KEY_IMAGES_PER_CONTRIBUTOR   = 1;
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
-  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = DEREGISTER_VOTE_LIFETIME;
+  constexpr uint64_t DEREGISTER_TX_LIFETIME_IN_BLOCKS  = UPTIME_VOTE_LIFETIME;
   constexpr size_t   QUORUM_LIFETIME                   = (6 * DEREGISTER_TX_LIFETIME_IN_BLOCKS);
 
 
@@ -68,7 +68,7 @@ namespace service_nodes {
   {
     switch (type)
     {
-      case quorum_type::deregister:    return DEREGISTER_VOTE_LIFETIME;
+      case quorum_type::uptime:        return UPTIME_VOTE_LIFETIME;
       case quorum_type::checkpointing: return CHECKPOINT_VOTE_LIFETIME;
       default:
       {

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -20,7 +20,7 @@ namespace service_nodes {
   constexpr size_t    CHECKPOINT_QUORUM_SIZE      = 1;
   constexpr size_t    CHECKPOINT_MIN_VOTES        = 1;
 #else
-  constexpr ptrdiff_t MIN_TIME_IN_S_BEFORE_VOTING = 60 * 60 * 2;
+  constexpr ptrdiff_t MIN_TIME_IN_S_BEFORE_VOTING = UPTIME_PROOF_MAX_TIME_IN_SECONDS;
   constexpr size_t    CHECKPOINT_QUORUM_SIZE      = 20;
   constexpr size_t    CHECKPOINT_MIN_VOTES        = 18;
 #endif

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -239,7 +239,7 @@ namespace service_nodes
     return true;
   }
 
-  quorum_vote_t make_deregister_vote(int hf_version, make_deregister_type type, uint64_t block_height, uint16_t validator_index, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &sec_key)
+  quorum_vote_t make_deregister_vote(uint8_t hf_version, make_deregister_type type, uint64_t block_height, uint16_t validator_index, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &sec_key)
   {
     quorum_vote_t result = {};
 
@@ -549,7 +549,7 @@ namespace service_nodes
     return result;
   }
 
-  void voting_pool::remove_used_votes(int hf_version, std::vector<cryptonote::transaction> const &txs)
+  void voting_pool::remove_used_votes(uint8_t hf_version, std::vector<cryptonote::transaction> const &txs)
   {
     // TODO(doyle): Cull checkpoint votes
     CRITICAL_REGION_LOCAL(m_lock);

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -432,7 +432,7 @@ namespace service_nodes
     time_t const now = time(nullptr);
     std::vector<quorum_vote_t> result;
 
-    for (std::vector<deregister_pool_entry> const *pool : get_deregister_pools_const())
+    for (std::vector<deregister_pool_entry> const *pool : get_deregister_pools())
     {
       for (deregister_pool_entry const &pool_entry : (*pool))
       {

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -162,7 +162,7 @@ namespace service_nodes
       }
 
       uint64_t delta_height = latest_height - deregister.block_height;
-      if (delta_height >= service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS)
+      if (latest_height >= deregister.block_height && delta_height >= service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS)
       {
         LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
                      << " and service node: "     << deregister.service_node_index
@@ -353,8 +353,8 @@ namespace service_nodes
         case quorum_vote_type::uptime_deregister:
         {
           std::vector<deregister_pool_entry> *pool_to_check = nullptr;
-          if (find_vote.type == quorum_vote_type::checkpoint_deregister) pool_to_check = &m_uptime_deregister_pool;
-          else                                                           pool_to_check = &m_checkpoint_deregister_pool;
+          if (find_vote.type == quorum_vote_type::checkpoint_deregister) pool_to_check = &m_checkpoint_deregister_pool;
+          else                                                           pool_to_check = &m_uptime_deregister_pool;
 
           auto it = std::find_if(pool_to_check->begin(), pool_to_check->end(), [find_vote](deregister_pool_entry const &entry) {
               return (entry.height == find_vote.block_height &&
@@ -481,8 +481,8 @@ namespace service_nodes
       case quorum_vote_type::uptime_deregister:
       {
         std::vector<deregister_pool_entry> *pool_to_check = nullptr;
-        if (vote.type == quorum_vote_type::checkpoint_deregister) pool_to_check = &m_uptime_deregister_pool;
-        else                                                      pool_to_check = &m_checkpoint_deregister_pool;
+        if (vote.type == quorum_vote_type::checkpoint_deregister) pool_to_check = &m_checkpoint_deregister_pool;
+        else                                                      pool_to_check = &m_uptime_deregister_pool;
 
         time_t const now = time(NULL);
         auto it = std::find_if(pool_to_check->begin(), pool_to_check->end(), [&vote](deregister_pool_entry const &entry) {

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -166,6 +166,12 @@ namespace service_nodes
                             cryptonote::vote_verification_context &vvc,
                             const service_nodes::testing_quorum &quorum)
   {
+    if (deregister.vote_version >= quorum_vote_t::version_count)
+    {
+      LOG_PRINT_L1("Deregister TX specified invalid vote_version: " << deregister.vote_version);
+      return false;
+    }
+
     // Check if deregister is too old or too new to hold onto
     {
       if (deregister.block_height >= latest_height)

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -77,7 +77,7 @@ namespace service_nodes
     crypto::hash result;
     if (version <= quorum_vote_t::version_0_infinite_staking)
     {
-      const int buf_size = sizeof(block_height) + sizeof(service_node_index);
+      constexpr int buf_size = sizeof(block_height) + sizeof(service_node_index);
       char buf[buf_size];
 
       memcpy(buf, reinterpret_cast<void *>(&block_height), sizeof(block_height));
@@ -86,7 +86,7 @@ namespace service_nodes
     }
     else
     {
-      const int buf_size = sizeof(block_height) + sizeof(service_node_index) + sizeof(vote_type) + sizeof(version);
+      constexpr int buf_size = sizeof(block_height) + sizeof(service_node_index) + sizeof(vote_type) + sizeof(version);
       char buf[buf_size];
       char *buf_ptr = buf;
 
@@ -660,6 +660,7 @@ namespace service_nodes
 #define ASSIGN_DEREGISTER_ENTRIES(array)                                                                               \
   array[0] = &m_uptime_deregister_pool;                                                                                \
   array[1] = &m_checkpoint_deregister_pool
+
   voting_pool::deregister_pool_array voting_pool::get_deregister_pools()
   {
     deregister_pool_array result = {};

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -668,7 +668,7 @@ namespace service_nodes
     return result;
   }
 
-  voting_pool::deregister_pool_array_const voting_pool::get_deregister_pools_const() const
+  voting_pool::deregister_pool_array_const voting_pool::get_deregister_pools() const
   {
     deregister_pool_array_const result = {};
     ASSIGN_DEREGISTER_ENTRIES(result);

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -313,7 +313,7 @@ namespace service_nodes
                                                   << " blocks and has been rejected.");
         vvc.m_invalid_block_height = true;
       }
-      else if (vote.block_height > latest_height)
+      else if (vote.block_height >= latest_height)
       {
         LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is newer than: " << latest_height
                                                   << " (latest block height) and has been rejected.");

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -482,8 +482,7 @@ namespace service_nodes
   std::vector<pool_vote_entry> voting_pool::add_pool_vote_if_unique(uint64_t latest_height,
                                                                     const quorum_vote_t &vote,
                                                                     cryptonote::vote_verification_context &vvc,
-                                                                    const service_nodes::testing_quorum &quorum,
-                                                                    const crypto::public_key *my_pubkey)
+                                                                    const service_nodes::testing_quorum &quorum)
   {
     std::vector<pool_vote_entry> result = {};
 

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -109,7 +109,7 @@ namespace service_nodes
   };
 
   enum struct make_deregister_type { uptime, checkpoint };
-  quorum_vote_t     make_deregister_vote             (int hf_version,
+  quorum_vote_t     make_deregister_vote             (uint8_t hf_version,
                                                       make_deregister_type type,
                                                       uint64_t block_height,
                                                       uint16_t index_in_group,
@@ -160,7 +160,7 @@ namespace service_nodes
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                       set_relayed           (const std::vector<quorum_vote_t>& votes);
     void                       remove_expired_votes  (uint64_t height);
-    void                       remove_used_votes     (int hf_version, std::vector<cryptonote::transaction> const &txs);
+    void                       remove_used_votes     (uint8_t hf_version, std::vector<cryptonote::transaction> const &txs);
     std::vector<quorum_vote_t> get_relayable_votes   () const;
 
     bool                       has_received_vote_from(quorum_vote_type type, std::vector<crypto::public_key> const &quorum, crypto::public_key const &key, uint64_t height) const;

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -64,7 +64,7 @@ namespace service_nodes
   struct checkpoint_vote { crypto::hash block_hash; };
   struct deregister_vote { uint16_t worker_index; };
 
-  enum struct quorum_type
+  enum struct quorum_type : uint8_t
   {
     uptime = 0,
     checkpointing,
@@ -72,9 +72,9 @@ namespace service_nodes
     invalid = count,
   };
 
-  enum struct quorum_vote_type
+  enum struct quorum_vote_type : uint8_t
   {
-    uptime_deregister,
+    uptime_deregister = 0,
     checkpoint,
     checkpoint_deregister,
   };
@@ -82,7 +82,8 @@ namespace service_nodes
   enum struct quorum_group { invalid, validator, worker };
   struct quorum_vote_t
   {
-    uint8_t           version = 0;
+    enum version { version_0_infinite_staking, version_1_checkpointing, version_count };
+    uint8_t           version = (version_count - 1);
     quorum_vote_type  type;
     uint64_t          block_height;
     quorum_group      group;
@@ -140,9 +141,10 @@ namespace service_nodes
   {
     // return: The vector of votes if the vote is valid (and even if it is not unique) otherwise nullptr
     std::vector<pool_vote_entry> add_pool_vote_if_unique(uint64_t latest_height,
-                                                         const quorum_vote_t& vote,
-                                                         cryptonote::vote_verification_context& vvc,
-                                                         const service_nodes::testing_quorum &quorum);
+                                                         const quorum_vote_t &vote,
+                                                         cryptonote::vote_verification_context &vvc,
+                                                         const service_nodes::testing_quorum &quorum,
+                                                         const crypto::public_key *my_pubkey);
 
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                       set_relayed           (const std::vector<quorum_vote_t>& votes);

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -51,11 +51,12 @@ namespace service_nodes
 
   struct voter_to_signature
   {
+    uint8_t           version = 0;
     uint16_t          voter_index;
     crypto::signature signature;
 
     BEGIN_SERIALIZE()
-      FIELD(voter_index)
+      VARINT_FIELD(voter_index)
       FIELD(signature)
     END_SERIALIZE()
   };
@@ -70,14 +71,6 @@ namespace service_nodes
     count,
     invalid = count,
   };
-
-  inline quorum_type max_quorum_type_for_hf(int hf_version)
-  {
-    quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::uptime
-                                                                                         : quorum_type::checkpointing;
-    assert((size_t)result < (size_t)quorum_type::count - 1);
-    return result;
-  }
 
   enum struct quorum_vote_type
   {
@@ -122,6 +115,7 @@ namespace service_nodes
   crypto::signature make_signature_from_vote         (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
   crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister_ const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);
 
+  // TODO(doyle): Remove post HF12
   // NOTE: This preserves the deregister vote format pre-checkpointing so that
   // up to the hardfork, we can still deserialize and serialize until we switch
   // over to the new format

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -178,8 +178,8 @@ namespace service_nodes
 
     using deregister_pool_array       = std::array<std::vector<deregister_pool_entry>       *, 2>;
     using deregister_pool_array_const = std::array<std::vector<deregister_pool_entry> const *, 2>;
-    deregister_pool_array       get_deregister_pools      ();
-    deregister_pool_array_const get_deregister_pools_const() const;
+    deregister_pool_array       get_deregister_pools();
+    deregister_pool_array_const get_deregister_pools() const;
   };
 }; // namespace service_nodes
 

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -96,10 +96,21 @@ namespace service_nodes
   };
 
   enum struct make_deregister_type { uptime, checkpoint };
-  quorum_vote_t     make_deregister_vote             (make_deregister_type type, uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
+  quorum_vote_t     make_deregister_vote             (make_deregister_type type,
+                                                      uint64_t block_height,
+                                                      uint16_t index_in_group,
+                                                      uint16_t worker_index,
+                                                      crypto::public_key const &pub_key,
+                                                      crypto::secret_key const &secret_key);
+  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister& deregister,
+                                                      uint64_t latest_height,
+                                                      cryptonote::vote_verification_context& vvc,
+                                                      const service_nodes::testing_quorum &quorum);
+  bool              verify_vote                      (const quorum_vote_t& vote,
+                                                      uint64_t latest_height,
+                                                      cryptonote::vote_verification_context &vvc,
+                                                      const service_nodes::testing_quorum &quorum);
 
-  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister& deregister, cryptonote::vote_verification_context& vvc, const service_nodes::testing_quorum &quorum);
-  bool              verify_vote                      (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
   crypto::signature make_signature_from_vote         (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
   crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);
 
@@ -140,8 +151,7 @@ namespace service_nodes
     bool                       has_received_vote_from(quorum_vote_type type, std::vector<crypto::public_key> const &quorum, crypto::public_key const &key, uint64_t height) const;
 
   private:
-
-    typedef struct deregister_pool_entry
+    struct deregister_pool_entry
     {
       deregister_pool_entry(uint64_t height, uint32_t worker_index): height(height), worker_index(worker_index) {}
       uint64_t                     height;
@@ -162,6 +172,11 @@ namespace service_nodes
     std::vector<checkpoint_pool_entry> m_checkpoint_pool;
 
     mutable epee::critical_section m_lock;
+
+    using deregister_pool_array       = std::array<std::vector<deregister_pool_entry>       *, 2>;
+    using deregister_pool_array_const = std::array<std::vector<deregister_pool_entry> const *, 2>;
+    deregister_pool_array       get_deregister_pools      ();
+    deregister_pool_array_const get_deregister_pools_const() const;
   };
 }; // namespace service_nodes
 

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -95,7 +95,8 @@ namespace service_nodes
     };
   };
 
-  quorum_vote_t     make_deregister_vote(uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
+  enum struct make_deregister_type { uptime, checkpoint };
+  quorum_vote_t     make_deregister_vote             (make_deregister_type type, uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
 
   bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister& deregister, cryptonote::vote_verification_context& vvc, const service_nodes::testing_quorum &quorum);
   bool              verify_vote                      (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
@@ -131,20 +132,25 @@ namespace service_nodes
                                                          const service_nodes::testing_quorum &quorum);
 
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
-    void                         set_relayed         (const std::vector<quorum_vote_t>& votes);
-    void                         remove_expired_votes(uint64_t height);
-    void                         remove_used_votes   (std::vector<cryptonote::transaction> const &txs);
-    std::vector<quorum_vote_t>   get_relayable_votes () const;
+    void                       set_relayed           (const std::vector<quorum_vote_t>& votes);
+    void                       remove_expired_votes  (uint64_t height);
+    void                       remove_used_votes     (std::vector<cryptonote::transaction> const &txs);
+    std::vector<quorum_vote_t> get_relayable_votes   () const;
+
+    bool                       has_received_vote_from(quorum_vote_type type, std::vector<crypto::public_key> const &quorum, crypto::public_key const &key, uint64_t height) const;
 
   private:
-    struct deregister_pool_entry
+
+    typedef struct deregister_pool_entry
     {
       deregister_pool_entry(uint64_t height, uint32_t worker_index): height(height), worker_index(worker_index) {}
       uint64_t                     height;
       uint32_t                     worker_index;
       std::vector<pool_vote_entry> votes;
     };
-    std::vector<deregister_pool_entry> m_deregister_pool;
+
+    std::vector<deregister_pool_entry> m_uptime_deregister_pool;
+    std::vector<deregister_pool_entry> m_checkpoint_deregister_pool;
 
     struct checkpoint_pool_entry
     {

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -42,7 +42,7 @@
 namespace cryptonote
 {
   struct vote_verification_context;
-  struct tx_extra_service_node_deregister;
+  struct tx_extra_service_node_deregister_;
 };
 
 namespace service_nodes
@@ -70,6 +70,14 @@ namespace service_nodes
     count,
     invalid = count,
   };
+
+  inline quorum_type max_quorum_type_for_hf(int hf_version)
+  {
+    quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::uptime
+                                                                                         : quorum_type::checkpointing;
+    assert((size_t)result < (size_t)quorum_type::count - 1);
+    return result;
+  }
 
   enum struct quorum_vote_type
   {
@@ -102,7 +110,7 @@ namespace service_nodes
                                                       uint16_t worker_index,
                                                       crypto::public_key const &pub_key,
                                                       crypto::secret_key const &secret_key);
-  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister& deregister,
+  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister_& deregister,
                                                       uint64_t latest_height,
                                                       cryptonote::vote_verification_context& vvc,
                                                       const service_nodes::testing_quorum &quorum);
@@ -112,7 +120,7 @@ namespace service_nodes
                                                       const service_nodes::testing_quorum &quorum);
 
   crypto::signature make_signature_from_vote         (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
-  crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);
+  crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister_ const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);
 
   // NOTE: This preserves the deregister vote format pre-checkpointing so that
   // up to the hardfork, we can still deserialize and serialize until we switch
@@ -145,7 +153,7 @@ namespace service_nodes
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                       set_relayed           (const std::vector<quorum_vote_t>& votes);
     void                       remove_expired_votes  (uint64_t height);
-    void                       remove_used_votes     (std::vector<cryptonote::transaction> const &txs);
+    void                       remove_used_votes     (int hf_version, std::vector<cryptonote::transaction> const &txs);
     std::vector<quorum_vote_t> get_relayable_votes   () const;
 
     bool                       has_received_vote_from(quorum_vote_type type, std::vector<crypto::public_key> const &quorum, crypto::public_key const &key, uint64_t height) const;

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -155,8 +155,7 @@ namespace service_nodes
     std::vector<pool_vote_entry> add_pool_vote_if_unique(uint64_t latest_height,
                                                          const quorum_vote_t &vote,
                                                          cryptonote::vote_verification_context &vvc,
-                                                         const service_nodes::testing_quorum &quorum,
-                                                         const crypto::public_key *my_pubkey);
+                                                         const service_nodes::testing_quorum &quorum);
 
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                       set_relayed           (const std::vector<quorum_vote_t>& votes);

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -65,16 +65,24 @@ namespace service_nodes
 
   enum struct quorum_type
   {
-    deregister = 0,
+    uptime = 0,
     checkpointing,
     count,
+    invalid = count,
+  };
+
+  enum struct quorum_vote_type
+  {
+    uptime_deregister,
+    checkpoint,
+    checkpoint_deregister,
   };
 
   enum struct quorum_group { invalid, validator, worker };
   struct quorum_vote_t
   {
     uint8_t           version = 0;
-    quorum_type       type;
+    quorum_vote_type  type;
     uint64_t          block_height;
     quorum_group      group;
     uint16_t          index_in_group;

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -109,21 +109,9 @@ namespace service_nodes
   };
 
   enum struct make_deregister_type { uptime, checkpoint };
-  quorum_vote_t     make_deregister_vote             (uint8_t hf_version,
-                                                      make_deregister_type type,
-                                                      uint64_t block_height,
-                                                      uint16_t index_in_group,
-                                                      uint16_t worker_index,
-                                                      crypto::public_key const &pub_key,
-                                                      crypto::secret_key const &secret_key);
-  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister_& deregister,
-                                                      uint64_t latest_height,
-                                                      cryptonote::vote_verification_context& vvc,
-                                                      const service_nodes::testing_quorum &quorum);
-  bool              verify_vote                      (const quorum_vote_t& vote,
-                                                      uint64_t latest_height,
-                                                      cryptonote::vote_verification_context &vvc,
-                                                      const service_nodes::testing_quorum &quorum);
+  quorum_vote_t make_deregister_vote(uint8_t hf_version, make_deregister_type type, uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
+  bool          verify_tx_deregister(const cryptonote::tx_extra_service_node_deregister_& deregister, uint64_t latest_height, cryptonote::vote_verification_context& vvc, const service_nodes::testing_quorum &quorum);
+  bool          verify_vote         (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
 
   crypto::signature make_signature_from_vote         (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
   crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister_ const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -79,6 +79,17 @@ namespace service_nodes
     checkpoint_deregister,
   };
 
+  inline char const *quorum_vote_type_label(quorum_vote_type type)
+  {
+    switch(type)
+    {
+      default: return "Unknown";
+      case quorum_vote_type::uptime_deregister:     return "Uptime Deregister";
+      case quorum_vote_type::checkpoint:            return "Checkpoint";
+      case quorum_vote_type::checkpoint_deregister: return "Checkpoint Deregister";
+    }
+  }
+
   enum struct quorum_group { invalid, validator, worker };
   struct quorum_vote_t
   {
@@ -98,7 +109,8 @@ namespace service_nodes
   };
 
   enum struct make_deregister_type { uptime, checkpoint };
-  quorum_vote_t     make_deregister_vote             (make_deregister_type type,
+  quorum_vote_t     make_deregister_vote             (int hf_version,
+                                                      make_deregister_type type,
                                                       uint64_t block_height,
                                                       uint16_t index_in_group,
                                                       uint16_t worker_index,

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -124,8 +124,9 @@ namespace cryptonote
 
     if (tx_type == transaction::type_deregister)
     {
-      tx_extra_service_node_deregister deregister;
-      if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+      int hf_version = m_blockchain.get_current_hard_fork_version();
+      tx_extra_service_node_deregister_ deregister;
+      if (!get_service_node_deregister_from_tx_extra(hf_version, tx.extra, deregister))
       {
         MERROR("Could not get service node deregister from tx, possibly corrupt tx in your blockchain, rejecting malformed deregister");
         return true;
@@ -138,8 +139,8 @@ namespace cryptonote
         if (pool_tx.get_type() != transaction::type_deregister)
           continue;
 
-        tx_extra_service_node_deregister pool_tx_deregister;
-        if (!get_service_node_deregister_from_tx_extra(pool_tx.extra, pool_tx_deregister))
+        tx_extra_service_node_deregister_ pool_tx_deregister;
+        if (!get_service_node_deregister_from_tx_extra(hf_version, pool_tx.extra, pool_tx_deregister))
         {
           MERROR("Could not get service node deregister from tx, possibly corrupt tx in your blockchain");
           continue;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -124,7 +124,7 @@ namespace cryptonote
 
     if (tx_type == transaction::type_deregister)
     {
-      int hf_version = m_blockchain.get_current_hard_fork_version();
+      uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
       tx_extra_service_node_deregister_ deregister;
       if (!get_service_node_deregister_from_tx_extra(hf_version, tx.extra, deregister))
       {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -745,14 +745,14 @@ namespace cryptonote
       return 1;
     }
 
-    for(auto it = arg.votes.begin(); it != arg.votes.end();)
+    for(std::vector<service_nodes::quorum_vote_t>::iterator it = arg.votes.begin(); it != arg.votes.end();)
     {
       cryptonote::vote_verification_context vvc = {};
       m_core.add_service_node_vote(*it, vvc);
 
       if (vvc.m_verification_failed)
       {
-        LOG_PRINT_CCONTEXT_L1("Checkpoint vote verification failed, dropping connection");
+        LOG_PRINT_CCONTEXT_L1("Vote type: " << service_nodes::quorum_vote_type_label(it->type) << ", verification failed, dropping connection");
         drop_connection(context, false /*add_fail*/, false /*flush_all_spans i.e. delete cached block data from this peer*/);
         return 1;
       }

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -412,7 +412,7 @@ bool t_command_server::start_handling(std::function<void(void)> exit_handler)
   {
     // TODO(doyle): Hack, don't hook into input until the daemon has completely initialised, i.e. you can print the status
     while(!loki::core_is_idle) {}
-    mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
+    // mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
 
     for (;;)
     {

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -369,12 +369,41 @@ t_command_server::t_command_server(
     );
 
     m_command_lookup.set_handler(
-      "debug_mine_n_blocks", std::bind([rpc_server](std::vector<std::string> const &args) {
-        uint64_t num_blocks = 0;
-        if (args.size() == 2 && epee::string_tools::get_xtype_from_string(num_blocks, args[1]))
-          rpc_server->on_debug_mine_n_blocks(args[0], num_blocks);
-        else
-          std::cout << "Invalid args, expected debug_mine_n_blocks <address> <num_blocks>";
+      "integration_test", std::bind([rpc_server](std::vector<std::string> const &args) {
+        bool valid_cmd      = false;
+        if (args.size() == 1)
+        {
+          valid_cmd                                  = true;
+          char const TOGGLE_CHECKPOINT_QUORUM_ARG[] = "toggle_checkpoint_quorum";
+          char const TOGGLE_UPTIME_QUORUM_ARG[]     = "toggle_uptime_quorum";
+          if (args[0] == TOGGLE_CHECKPOINT_QUORUM_ARG)
+          {
+            loki::integration_test.disable_checkpoint_quorum = !loki::integration_test.disable_checkpoint_quorum;
+          }
+          else if (args[0] == TOGGLE_UPTIME_QUORUM_ARG)
+          {
+            loki::integration_test.disable_uptime_quorum = !loki::integration_test.disable_uptime_quorum;
+          }
+          else
+          {
+            valid_cmd = false;
+          }
+
+          if (valid_cmd)
+            std::cout << args[0] << " toggled";
+        }
+        else if (args.size() == 3)
+        {
+          uint64_t num_blocks = 0;
+          if (args[0] == "debug_mine_n_blocks" && epee::string_tools::get_xtype_from_string(num_blocks, args[2]))
+          {
+            rpc_server->on_debug_mine_n_blocks(args[1], num_blocks);
+            valid_cmd = true;
+          }
+        }
+
+        if (!valid_cmd)
+          std::cout << " integration_test invalid command";
 
         loki::write_redirected_stdout_to_shared_mem();
         return true;
@@ -411,7 +440,7 @@ bool t_command_server::start_handling(std::function<void(void)> exit_handler)
   auto handle_shared_mem_ins_and_outs = [&]()
   {
     // TODO(doyle): Hack, don't hook into input until the daemon has completely initialised, i.e. you can print the status
-    while(!loki::core_is_idle) {}
+    while(!loki::integration_test.core_is_idle) {}
     mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
 
     for (;;)

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -412,7 +412,7 @@ bool t_command_server::start_handling(std::function<void(void)> exit_handler)
   {
     // TODO(doyle): Hack, don't hook into input until the daemon has completely initialised, i.e. you can print the status
     while(!loki::core_is_idle) {}
-    // mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
+    mlog_set_categories(""); // TODO(doyle): We shouldn't have to do this.
 
     for (;;)
     {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2806,7 +2806,7 @@ bool t_rpc_command_executor::prepare_registration()
 
   // Query the latest known block height and nettype
   uint64_t block_height            = 0;
-  int hf_version                   = cryptonote::network_version_9_service_nodes;
+  uint8_t hf_version               = cryptonote::network_version_9_service_nodes;
   cryptonote::network_type nettype = cryptonote::UNDEFINED;
   {
     cryptonote::COMMAND_RPC_GET_INFO::request req;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2586,7 +2586,7 @@ namespace cryptonote
     }
 
     std::string err_msg;
-    int hf_version = m_core.get_hard_fork_version(m_core.get_current_blockchain_height());
+    uint8_t hf_version = m_core.get_hard_fork_version(m_core.get_current_blockchain_height());
     if (!service_nodes::make_registration_cmd(m_core.get_nettype(), hf_version, req.staking_requirement, req.args, service_node_pubkey, service_node_key, res.registration_cmd, req.make_friendly, err_msg))
     {
       error_resp.code    = CORE_RPC_ERROR_CODE_WRONG_PARAM;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2488,7 +2488,7 @@ namespace cryptonote
     PERF_TIMER(on_get_quorum_state);
     bool r;
 
-    const auto uptime_quorum = m_core.get_testing_quorum(service_nodes::quorum_type::deregister, req.height);
+    const auto uptime_quorum = m_core.get_testing_quorum(service_nodes::quorum_type::uptime, req.height);
     r = (uptime_quorum != nullptr);
     if (r)
     {
@@ -2534,7 +2534,7 @@ namespace cryptonote
     res.quorum_entries.reserve(height_end - height_begin + 1);
     for (auto h = height_begin; h <= height_end; ++h)
     {
-      const auto uptime_quorum = m_core.get_testing_quorum(service_nodes::quorum_type::deregister, h);
+      const auto uptime_quorum = m_core.get_testing_quorum(service_nodes::quorum_type::uptime, h);
 
       if (!uptime_quorum) {
         failed_height = h;

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -299,7 +299,7 @@ cryptonote::transaction linear_chain_generator::create_deregister_tx(const crypt
     const auto pk = reg->keys.pub;
     const auto sk = reg->keys.sec;
 
-    service_nodes::quorum_vote_t deregister_vote = service_nodes::make_deregister_vote(service_nodes::make_deregister_type::uptime, deregister.block_height, voter.idx_in_quorum, deregister.service_node_index, pk, sk);
+    service_nodes::quorum_vote_t deregister_vote = service_nodes::make_deregister_vote(get_hf_version(), service_nodes::make_deregister_type::uptime, deregister.block_height, voter.idx_in_quorum, deregister.service_node_index, pk, sk);
     deregister.votes.push_back({ deregister_vote.signature, (uint32_t)voter.idx_in_quorum });
   }
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -197,7 +197,7 @@ cryptonote::block linear_chain_generator::create_block_on_fork(const cryptonote:
 
 QuorumState linear_chain_generator::get_quorum_idxs(const cryptonote::block& block) const
 {
-  if (sn_list_.size() <= service_nodes::DEREGISTER_QUORUM_SIZE) {
+  if (sn_list_.size() <= service_nodes::UPTIME_QUORUM_SIZE) {
     std::cerr << "Not enough service nodes\n";
     return {};
   }
@@ -218,11 +218,11 @@ QuorumState linear_chain_generator::get_quorum_idxs(const cryptonote::block& blo
 
   QuorumState quorum;
 
-  for (auto i = 0u; i < service_nodes::DEREGISTER_QUORUM_SIZE; ++i) {
+  for (auto i = 0u; i < service_nodes::UPTIME_QUORUM_SIZE; ++i) {
     quorum.voters.push_back({ sn_list_.at(pub_keys_indexes[i]).keys.pub, i });
   }
 
-  for (auto i = service_nodes::DEREGISTER_QUORUM_SIZE; i < pub_keys_indexes.size(); ++i) {
+  for (auto i = service_nodes::UPTIME_QUORUM_SIZE; i < pub_keys_indexes.size(); ++i) {
     quorum.to_test.push_back({ sn_list_.at(pub_keys_indexes[i]).keys.pub, i });
   }
 
@@ -280,7 +280,7 @@ cryptonote::transaction linear_chain_generator::create_deregister_tx(const crypt
                                                                      bool commit)
 {
 
-  cryptonote::tx_extra_service_node_deregister deregister;
+  cryptonote::tx_extra_service_node_deregister_legacy deregister;
   deregister.block_height = height;
 
   const auto idx = get_idx_in_tested(pk, height);
@@ -324,7 +324,7 @@ boost::optional<uint32_t> linear_chain_generator::get_idx_in_tested(const crypto
   const auto& to_test = get_quorum_idxs(height).to_test;
 
   for (const auto& sn : to_test) {
-    if (sn.sn_pk == pk) return sn.idx_in_quorum - service_nodes::DEREGISTER_QUORUM_SIZE;
+    if (sn.sn_pk == pk) return sn.idx_in_quorum - service_nodes::UPTIME_QUORUM_SIZE;
   }
 
   return boost::none;
@@ -716,14 +716,14 @@ cryptonote::transaction make_registration_tx(std::vector<test_event_entry>& even
 cryptonote::transaction make_deregistration_tx(const std::vector<test_event_entry>& events,
                                                const cryptonote::account_base& account,
                                                const cryptonote::block& head,
-                                               const cryptonote::tx_extra_service_node_deregister& deregister,
+                                               const cryptonote::tx_extra_service_node_deregister_legacy& deregister,
                                                uint8_t hf_version,
                                                uint64_t fee)
 {
   cryptonote::transaction tx;
 
   std::vector<uint8_t> extra;
-  const bool full_tx_deregister_made = cryptonote::add_service_node_deregister_to_tx_extra(tx.extra, deregister);
+  const bool full_tx_deregister_made = cryptonote::add_service_node_deregister_legacy_to_tx_extra(tx.extra, deregister);
 
   if (!full_tx_deregister_made) {
     MERROR("Could not add deregister to extra");

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -299,7 +299,7 @@ cryptonote::transaction linear_chain_generator::create_deregister_tx(const crypt
     const auto pk = reg->keys.pub;
     const auto sk = reg->keys.sec;
 
-    service_nodes::quorum_vote_t deregister_vote = service_nodes::make_deregister_vote(deregister.block_height, voter.idx_in_quorum, deregister.service_node_index, pk, sk);
+    service_nodes::quorum_vote_t deregister_vote = service_nodes::make_deregister_vote(service_nodes::make_deregister_type::uptime, deregister.block_height, voter.idx_in_quorum, deregister.service_node_index, pk, sk);
     deregister.votes.push_back({ deregister_vote.signature, (uint32_t)voter.idx_in_quorum });
   }
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1215,7 +1215,7 @@ cryptonote::transaction make_default_registration_tx(std::vector<test_event_entr
 cryptonote::transaction make_deregistration_tx(const std::vector<test_event_entry>& events,
                                                const cryptonote::account_base& account,
                                                const cryptonote::block& head,
-                                               const cryptonote::tx_extra_service_node_deregister& deregister, uint8_t hf_version, uint64_t fee);
+                                               const cryptonote::tx_extra_service_node_deregister_legacy& deregister, uint8_t hf_version, uint64_t fee);
 
 // NOTE(loki): These macros assume hardfork version 7 and are from the old Monero testing code
 #define MAKE_TX_MIX(VEC_EVENTS, TX_NAME, FROM, TO, AMOUNT, NMIX, HEAD)                       \

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -240,7 +240,7 @@ public:
     bf_hf_version= 1 << 8
   };
 
-  explicit test_generator(int hf_version = 7) : m_hf_version(hf_version) {}
+  explicit test_generator(uint8_t hf_version = 7) : m_hf_version(hf_version) {}
   void get_block_chain(std::vector<block_info>& blockchain,        const crypto::hash& head, size_t n) const;
   void get_block_chain(std::vector<cryptonote::block>& blockchain, const crypto::hash& head, size_t n) const;
   void get_last_n_block_weights(std::vector<uint64_t>& block_weights, const crypto::hash& head, size_t n) const;
@@ -266,7 +266,7 @@ public:
     const cryptonote::account_base& miner_acc, const std::vector<crypto::hash>& tx_hashes, size_t txs_size);
 
 
-  int m_hf_version;
+  uint8_t m_hf_version;
 
 private:
   std::unordered_map<crypto::hash, block_info> m_blocks_info;

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -689,7 +689,7 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     CHECK_TEST_CONDITION(dereg_tx.get_type() == transaction::type_deregister);
 
     tx_extra_service_node_deregister deregistration;
-    get_service_node_deregister_from_tx_extra(dereg_tx.extra, deregistration);
+    find_tx_extra_field_by_type(dereg_tx.extra, deregistration);
 
     const auto uptime_quorum = c.get_testing_quorum(service_nodes::quorum_type::uptime, deregistration.block_height);
     CHECK_TEST_CONDITION(uptime_quorum);

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -369,7 +369,7 @@ bool test_deregister_safety_buffer::generate(std::vector<test_event_entry> &even
   /// register 21 random service nodes
   std::vector<cryptonote::transaction> reg_txs;
 
-  constexpr auto SERVICE_NODES_NEEDED = service_nodes::DEREGISTER_QUORUM_SIZE * 2 + 1;
+  constexpr auto SERVICE_NODES_NEEDED = service_nodes::UPTIME_QUORUM_SIZE * 2 + 1;
   static_assert(SN_KEYS_COUNT >= SERVICE_NODES_NEEDED, "not enough pre-computed service node keys");
 
   for (auto i = 0u; i < SERVICE_NODES_NEEDED; ++i)
@@ -688,8 +688,9 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     const auto dereg_tx = boost::get<cryptonote::transaction>(event_a);
     CHECK_TEST_CONDITION(dereg_tx.get_type() == transaction::type_deregister);
 
-    tx_extra_service_node_deregister deregistration;
-    find_tx_extra_field_by_type(dereg_tx.extra, deregistration);
+    int hf_version = c.get_blockchain_storage().get_current_hard_fork_version();
+    tx_extra_service_node_deregister_ deregistration;
+    get_service_node_deregister_from_tx_extra(hf_version, dereg_tx.extra, deregistration);
 
     const auto uptime_quorum = c.get_testing_quorum(service_nodes::quorum_type::uptime, deregistration.block_height);
     CHECK_TEST_CONDITION(uptime_quorum);

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -691,7 +691,7 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     tx_extra_service_node_deregister deregistration;
     get_service_node_deregister_from_tx_extra(dereg_tx.extra, deregistration);
 
-    const auto uptime_quorum = c.get_testing_quorum(service_nodes::quorum_type::deregister, deregistration.block_height);
+    const auto uptime_quorum = c.get_testing_quorum(service_nodes::quorum_type::uptime, deregistration.block_height);
     CHECK_TEST_CONDITION(uptime_quorum);
     const auto pk_a = uptime_quorum->workers.at(deregistration.service_node_index);
 

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -688,7 +688,7 @@ bool sn_test_rollback::test_registrations(cryptonote::core& c, size_t ev_index, 
     const auto dereg_tx = boost::get<cryptonote::transaction>(event_a);
     CHECK_TEST_CONDITION(dereg_tx.get_type() == transaction::type_deregister);
 
-    int hf_version = c.get_blockchain_storage().get_current_hard_fork_version();
+    uint8_t hf_version = c.get_blockchain_storage().get_current_hard_fork_version();
     tx_extra_service_node_deregister_ deregistration;
     get_service_node_deregister_from_tx_extra(hf_version, dereg_tx.extra, deregistration);
 

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -203,7 +203,7 @@ TEST(service_nodes, vote_validation)
   }
 }
 
-TEST(service_nodes, tx_extra_deregister_validation)
+TEST(service_nodes, tx_extra_deregister_legacy_validation)
 {
   // Generate a quorum and the voter
   const size_t num_voters = 10;

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -140,7 +140,8 @@ TEST(service_nodes, vote_validation)
   // Valid vote
   uint64_t block_height = 70;
   service_nodes::quorum_vote_t valid_vote =
-      service_nodes::make_deregister_vote(service_nodes::make_deregister_type::uptime,
+      service_nodes::make_deregister_vote(cryptonote::network_version_12_checkpointing,
+                                          service_nodes::make_deregister_type::uptime,
                                           block_height,
                                           voter_index,
                                           1 /*worker_index*/,

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -223,17 +223,20 @@ TEST(service_nodes, tx_extra_deregister_legacy_validation)
   }
 
   // Valid deregister
-  cryptonote::tx_extra_service_node_deregister valid_deregister = {};
-  uint64_t const BLOCK_HEIGHT                                   = 100;
+  cryptonote::tx_extra_service_node_deregister_ valid_deregister = {};
+  uint64_t const BLOCK_HEIGHT                                    = 100;
+  static_assert(BLOCK_HEIGHT > service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS,
+                "Require block height to be greater than the lifetime, otherwise we can't test that a too old "
+                "deregister is rejected");
   {
-    valid_deregister.block_height       = BLOCK_HEIGHT;
+    valid_deregister.block_height       = BLOCK_HEIGHT - 1;
     valid_deregister.service_node_index = 1;
     valid_deregister.votes.reserve(num_voters);
     for (size_t i = 0; i < num_voters; ++i)
     {
-      cryptonote::keypair const *voter                        = voters + i;
-      cryptonote::tx_extra_service_node_deregister::vote vote = {};
-      vote.validator_index                                    = i;
+      cryptonote::keypair const *voter                         = voters + i;
+      cryptonote::tx_extra_service_node_deregister_::vote vote = {};
+      vote.validator_index                                     = i;
       vote.signature = service_nodes::make_signature_from_tx_deregister(valid_deregister, voter->pub, voter->sec);
       valid_deregister.votes.push_back(vote);
     }

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -139,7 +139,13 @@ TEST(service_nodes, vote_validation)
 
   // Valid vote
   uint64_t block_height = 70;
-  service_nodes::quorum_vote_t valid_vote = service_nodes::make_deregister_vote(block_height, voter_index, 1 /*worker_index*/, service_node_voter.pub, service_node_voter.sec);
+  service_nodes::quorum_vote_t valid_vote =
+      service_nodes::make_deregister_vote(service_nodes::make_deregister_type::uptime,
+                                          block_height,
+                                          voter_index,
+                                          1 /*worker_index*/,
+                                          service_node_voter.pub,
+                                          service_node_voter.sec);
   {
     cryptonote::vote_verification_context vvc = {};
     bool result = service_nodes::verify_vote(valid_vote, block_height, vvc, state);

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -142,7 +142,7 @@ TEST(service_nodes, vote_validation)
   service_nodes::quorum_vote_t valid_vote =
       service_nodes::make_deregister_vote(cryptonote::network_version_12_checkpointing,
                                           service_nodes::make_deregister_type::uptime,
-                                          block_height,
+                                          block_height - 1, // NOTE: Can't vote for the current height we're mining for
                                           voter_index,
                                           1 /*worker_index*/,
                                           service_node_voter.pub,

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -224,8 +224,9 @@ TEST(service_nodes, tx_extra_deregister_validation)
 
   // Valid deregister
   cryptonote::tx_extra_service_node_deregister valid_deregister = {};
+  uint64_t const BLOCK_HEIGHT                                   = 100;
   {
-    valid_deregister.block_height       = 10;
+    valid_deregister.block_height       = BLOCK_HEIGHT;
     valid_deregister.service_node_index = 1;
     valid_deregister.votes.reserve(num_voters);
     for (size_t i = 0; i < num_voters; ++i)
@@ -238,7 +239,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
     }
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(valid_deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(valid_deregister, BLOCK_HEIGHT, vvc, state);
     if (!result)
       printf("%s\n", cryptonote::print_vote_verification_context(vvc));
     ASSERT_TRUE(result);
@@ -251,7 +252,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
       deregister.votes.pop_back();
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT, vvc, state);
     ASSERT_FALSE(result);
   }
 
@@ -261,7 +262,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
     deregister.votes[0] = deregister.votes[1];
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT, vvc, state);
     ASSERT_FALSE(result);
   }
 
@@ -271,7 +272,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
     deregister.votes[0].signature = deregister.votes[1].signature;
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT, vvc, state);
     ASSERT_FALSE(result);
   }
 
@@ -281,7 +282,7 @@ TEST(service_nodes, tx_extra_deregister_validation)
     deregister.votes[0].validator_index = state.validators.size() + 10;
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT, vvc, state);
     ASSERT_FALSE(result);
   }
 
@@ -291,7 +292,23 @@ TEST(service_nodes, tx_extra_deregister_validation)
     deregister.service_node_index = state.workers.size() + 10;
 
     cryptonote::vote_verification_context vvc = {};
-    bool result = service_nodes::verify_tx_deregister(deregister, vvc, state);
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT, vvc, state);
+    ASSERT_FALSE(result);
+  }
+
+  // Deregister too old
+  {
+    auto deregister                           = valid_deregister;
+    cryptonote::vote_verification_context vvc = {};
+    bool result = service_nodes::verify_tx_deregister(deregister, 0, vvc, state);
+    ASSERT_FALSE(result);
+  }
+
+  // Deregister too new
+  {
+    auto deregister                           = valid_deregister;
+    cryptonote::vote_verification_context vvc = {};
+    bool result = service_nodes::verify_tx_deregister(deregister, BLOCK_HEIGHT + 1000, vvc, state);
     ASSERT_FALSE(result);
   }
 }

--- a/tests/unit_tests/testdb.h
+++ b/tests/unit_tests/testdb.h
@@ -76,6 +76,7 @@ public:
   virtual void update_block_checkpoint(cryptonote::checkpoint_t const &checkpoint) override {}
   virtual bool get_block_checkpoint   (uint64_t height, cryptonote::checkpoint_t &checkpoint) const override { return false; }
   virtual bool get_top_checkpoint     (cryptonote::checkpoint_t &checkpoint) const override { return false; }
+  virtual void remove_block_checkpoint(uint64_t height) override {}
   virtual std::vector<cryptonote::checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints) const override { return {};}
   virtual cryptonote::blobdata get_block_blob(const crypto::hash& h) const override { return cryptonote::blobdata(); }
   virtual uint64_t get_block_height(const crypto::hash& h) const override { return 0; }


### PR DESCRIPTION
Mostly renaming and shuffling code around to support more flexible deregistrations. Previously the tx_extra_service_node_deregister now named tx_extra_service_node_deregister_legacy has no way of encoding new information into it, i.e. indicating which quorum (checkpoint or uptime) to validate signatures against.

In the future we can expect multiple quorums, so we want a way to allow specifying deregistering because of a different quorum into the tx extra and so I've introduced a new one to replace it that has versioning information so we can add and remove fields.

Old deregisters in the tx extra are parsed into the legacy struct then converted into the new style struct and so we maintain one code-path for handling the validity of deregisters.

Deregistration not complete, but committing now because this is getting big.