### PR TITLE
Relaxed relax dereg (stripped)

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -1396,7 +1396,7 @@ int main(int argc, char* argv[])
         for (const auto &out: tx.vout)
         {
           uint64_t amount = out.amount;
-          if (miner_tx && tx.version >= 2)
+          if (miner_tx && tx.version >= cryptonote::txversion::v2_ringct)
             amount = 0;
 
           if (opt_rct_only && amount != 0)

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
       for (const auto &out: tx.vout)
       {
         uint64_t amount = out.amount;
-        if (miner_tx && tx.version >= 2)
+        if (miner_tx && tx.version >= txversion::v2_ringct)
           amount = 0;
         if (amount == 0)
           continue;

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -166,7 +166,7 @@ namespace cryptonote
   };
   enum class txtype : uint16_t {
     standard,
-    deregister,
+    state_change,
     key_image_unlock,
     _count
   };
@@ -202,9 +202,9 @@ namespace cryptonote
       {
         FIELD(output_unlock_times)
         if (version == txversion::v3_per_output_unlock_times) {
-          bool is_deregister = type == txtype::deregister;
-          FIELD(is_deregister)
-          type = is_deregister ? txtype::deregister : txtype::standard;
+          bool is_state_change = type == txtype::state_change;
+          FIELD(is_state_change)
+          type = is_state_change ? txtype::state_change : txtype::standard;
         }
       }
       VARINT_FIELD(unlock_time)
@@ -585,7 +585,7 @@ namespace cryptonote
     switch(type)
     {
       case txtype::standard:         return "standard";
-      case txtype::deregister:       return "deregister";
+      case txtype::state_change:     return "state_change";
       case txtype::key_image_unlock: return "key_image_unlock";
       default: assert(false);        return "xx_unhandled_type";
     }

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -156,23 +156,35 @@ namespace cryptonote
   template<> inline unsigned int getpos(binary_archive<true> &ar) { return ar.stream().tellp(); }
   template<> inline unsigned int getpos(binary_archive<false> &ar) { return ar.stream().tellg(); }
 
+  enum class txversion : uint16_t {
+    v0 = 0,
+    v1,
+    v2_ringct,
+    v3_per_output_unlock_times,
+    v4_tx_types,
+    _count,
+  };
+  enum class txtype : uint16_t {
+    standard,
+    deregister,
+    key_image_unlock,
+    _count
+  };
+
+
   class transaction_prefix
   {
 
   public:
-    enum version
-    {
-      version_0 = 0,
-      version_1,
-      version_2,
-      version_3_per_output_unlock_times,
-      version_4_tx_types,
-    };
-    static version get_min_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
-    static version get_max_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
+    static char const *version_to_string(txversion v);
+    static char const *type_to_string(txtype type);
+
+    static txversion get_min_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
+    static txversion get_max_version_for_hf(int hf_version, cryptonote::network_type nettype = MAINNET);
 
     // tx information
-    size_t   version;
+    txversion version;
+    txtype type;
 
     // not used after version 2, but remains for compatibility
     uint64_t unlock_time;  //number of block (or time), used as a limitation like: spend this tx not early then block/time
@@ -184,62 +196,42 @@ namespace cryptonote
 
     std::vector<uint64_t> output_unlock_times;
 
-    enum type_t
-    {
-      type_standard,
-      type_deregister,
-      type_key_image_unlock,
-      type_count,
-    };
-
-    static char const *type_to_string(type_t type);
-    static char const *type_to_string(uint16_t type_as_uint);
-
-    union
-    {
-      bool is_deregister; // not used after version >= version_4_tx_types
-      uint16_t type;
-    };
-
     BEGIN_SERIALIZE()
-      VARINT_FIELD(version)
-      if (version > 2)
+      ENUM_FIELD(version, version >= txversion::v1 && version < txversion::_count);
+      if (version >= txversion::v3_per_output_unlock_times)
       {
         FIELD(output_unlock_times)
-        if (version == version_3_per_output_unlock_times)
+        if (version == txversion::v3_per_output_unlock_times) {
+          bool is_deregister = type == txtype::deregister;
           FIELD(is_deregister)
+          type = is_deregister ? txtype::deregister : txtype::standard;
+        }
       }
-      if(version == 0 || version > version_4_tx_types) return false;
       VARINT_FIELD(unlock_time)
       FIELD(vin)
       FIELD(vout)
-      if (version >= 3 && vout.size() != output_unlock_times.size()) return false;
+      if (version >= txversion::v3_per_output_unlock_times && vout.size() != output_unlock_times.size())
+        return false;
       FIELD(extra)
-      if (version >= version_4_tx_types)
-      {
-        VARINT_FIELD(type) // NOTE(loki): Overwrites is_deregister
-        if (static_cast<uint16_t>(type) >= type_count) return false;
-      }
+      if (version >= txversion::v4_tx_types)
+        ENUM_FIELD_N("type", type, type < txtype::_count);
     END_SERIALIZE()
 
-  public:
     transaction_prefix(){ set_null(); }
     void set_null()
     {
-      version = 1;
+      version = txversion::v1;
       unlock_time = 0;
       vin.clear();
       vout.clear();
       extra.clear();
       output_unlock_times.clear();
-      type = type_standard;
+      type = txtype::standard;
     }
-    type_t get_type   ()                  const;
-    bool   set_type   (type_t new_type);
 
     uint64_t get_unlock_time(size_t out_index) const
     {
-      if (version >= version_3_per_output_unlock_times)
+      if (version >= txversion::v3_per_output_unlock_times)
       {
         if (out_index >= output_unlock_times.size())
         {
@@ -299,7 +291,7 @@ namespace cryptonote
       if (std::is_same<Archive<W>, binary_archive<W>>())
         prefix_size = getpos(ar) - start_pos;
 
-      if (version == 1)
+      if (version == txversion::v1)
       {
         if (std::is_same<Archive<W>, binary_archive<W>>())
           unprunable_size = getpos(ar) - start_pos;
@@ -366,7 +358,7 @@ namespace cryptonote
     {
       FIELDS(*static_cast<transaction_prefix *>(this))
 
-      if (version == 1)
+      if (version == txversion::v1)
       {
       }
       else
@@ -546,92 +538,64 @@ namespace cryptonote
     return result;
   }
 
-  inline enum transaction_prefix::version transaction_prefix::get_max_version_for_hf(int hf_version, cryptonote::network_type nettype)
+  inline enum txversion transaction_prefix::get_max_version_for_hf(int hf_version, cryptonote::network_type nettype)
   {
     nettype = validate_nettype(nettype);
     if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_8)
-      return transaction::version_2;
+      return txversion::v2_ringct;
 
     if (hf_version >= cryptonote::network_version_9_service_nodes && hf_version <= cryptonote::network_version_10_bulletproofs)
-      return transaction::version_3_per_output_unlock_times;
+      return txversion::v3_per_output_unlock_times;
 
-    return transaction::version_4_tx_types;
+    return txversion::v4_tx_types;
   }
 
-  inline enum transaction_prefix::version transaction_prefix::get_min_version_for_hf(int hf_version, cryptonote::network_type nettype)
+  inline enum txversion transaction_prefix::get_min_version_for_hf(int hf_version, cryptonote::network_type nettype)
   {
     nettype = validate_nettype(nettype);
     if (nettype == MAINNET) // NOTE(loki): Add an exception for mainnet as there are v2's on mainnet.
     {
       if (hf_version == cryptonote::network_version_10_bulletproofs)
-        return transaction::version_2;
+        return txversion::v2_ringct;
     }
 
     if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_9_service_nodes)
-      return transaction::version_2;
+      return txversion::v2_ringct;
 
     if (hf_version == cryptonote::network_version_10_bulletproofs)
-      return transaction::version_3_per_output_unlock_times;
+      return txversion::v3_per_output_unlock_times;
 
-    return transaction::version_4_tx_types;
+    return txversion::v4_tx_types;
   }
 
-  inline transaction_prefix::type_t transaction_prefix::get_type() const
+  inline char const *transaction_prefix::version_to_string(txversion v)
   {
-    if (version <= version_2)
-      return type_standard;
-
-    if (version == version_3_per_output_unlock_times)
+    switch(v)
     {
-      if (is_deregister) return type_deregister;
-      return type_standard;
+      case txversion::v1:                         return "1";
+      case txversion::v2_ringct:                  return "2_ringct";
+      case txversion::v3_per_output_unlock_times: return "3_per_output_unlock_times";
+      case txversion::v4_tx_types:                return "4_tx_types";
+      default: assert(false);                     return "xx_unhandled_version";
     }
-
-    // NOTE(loki): Type is range checked on deserialisation, so hitting this is a developer error
-    assert(static_cast<uint16_t>(type) < static_cast<uint16_t>(type_count));
-    return static_cast<transaction::type_t>(type);
   }
 
-  inline bool transaction_prefix::set_type(transaction_prefix::type_t new_type)
-  {
-    bool result = false;
-    if (version <= version_2)
-      result = (new_type == type_standard);
-
-    if (version == version_3_per_output_unlock_times)
-    {
-      if (new_type == type_standard || new_type == type_deregister)
-        result = true;
-    }
-    else
-    {
-      result = true;
-    }
-
-    if (result)
-    {
-      assert(static_cast<uint16_t>(new_type) <= static_cast<uint16_t>(type_count)); // NOTE(loki): Developer error
-      type = static_cast<uint16_t>(new_type);
-    }
-
-    return result;
-  }
-
-  inline char const *transaction_prefix::type_to_string(uint16_t type_as_uint)
-  {
-    return type_to_string(static_cast<type_t>(type_as_uint));
-  }
-
-  inline char const *transaction_prefix::type_to_string(type_t type)
+  inline char const *transaction_prefix::type_to_string(txtype type)
   {
     switch(type)
     {
-      case type_standard:         return "standard";
-      case type_deregister:       return "deregister";
-      case type_key_image_unlock: return "key_image_unlock";
-      case type_count:            return "xx_count";
-      default: assert(false);     return "xx_unhandled_type";
+      case txtype::standard:         return "standard";
+      case txtype::deregister:       return "deregister";
+      case txtype::key_image_unlock: return "key_image_unlock";
+      default: assert(false);        return "xx_unhandled_type";
     }
+  }
+
+  inline std::ostream &operator<<(std::ostream &os, txtype t) {
+    return os << transaction::type_to_string(t);
+  }
+  inline std::ostream &operator<<(std::ostream &os, txversion v) {
+    return os << transaction::version_to_string(v);
   }
 }
 

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -175,9 +175,9 @@ namespace boost
     {
       a & x.output_unlock_times;
       if (x.version == cryptonote::txversion::v3_per_output_unlock_times) {
-        bool is_deregister = x.type == cryptonote::txtype::deregister;
+        bool is_deregister = x.type == cryptonote::txtype::state_change;
         a & is_deregister;
-        x.type = is_deregister ? cryptonote::txtype::deregister : cryptonote::txtype::standard;
+        x.type = is_deregister ? cryptonote::txtype::state_change : cryptonote::txtype::standard;
       }
     }
     a & x.unlock_time;

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -147,42 +147,52 @@ namespace boost
     a & x.target;
   }
 
+  template <class Archive>
+  inline void serialize(Archive &a, cryptonote::txversion &x, const boost::serialization::version_type ver)
+  {
+    uint16_t v = static_cast<uint16_t>(x);
+    a & v;
+    if (v >= static_cast<uint16_t>(cryptonote::txversion::_count))
+      throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported tx version");
+    x = static_cast<cryptonote::txversion>(v);
+  }
+
+  template <class Archive>
+  inline void serialize(Archive &a, cryptonote::txtype &x, const boost::serialization::version_type ver)
+  {
+    uint16_t txtype = static_cast<uint16_t>(x);
+    a & txtype;
+    if (txtype >= static_cast<uint16_t>(cryptonote::txtype::_count))
+      throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported tx type");
+    x = static_cast<cryptonote::txtype>(txtype);
+  }
 
   template <class Archive>
   inline void serialize(Archive &a, cryptonote::transaction_prefix &x, const boost::serialization::version_type ver)
   {
     a & x.version;
-    if (x.version > 2)
+    if (x.version >= cryptonote::txversion::v3_per_output_unlock_times)
     {
       a & x.output_unlock_times;
-      if (x.version == cryptonote::transaction::version_3_per_output_unlock_times)
-        a & x.is_deregister;
+      if (x.version == cryptonote::txversion::v3_per_output_unlock_times) {
+        bool is_deregister = x.type == cryptonote::txtype::deregister;
+        a & is_deregister;
+        x.type = is_deregister ? cryptonote::txtype::deregister : cryptonote::txtype::standard;
+      }
     }
     a & x.unlock_time;
     a & x.vin;
     a & x.vout;
     a & x.extra;
-    if (x.version >= cryptonote::transaction::version_4_tx_types)
+    if (x.version >= cryptonote::txversion::v4_tx_types)
       a & x.type;
   }
 
   template <class Archive>
   inline void serialize(Archive &a, cryptonote::transaction &x, const boost::serialization::version_type ver)
   {
-    a & x.version;
-    if (x.version > 2)
-    {
-      a & x.output_unlock_times;
-      if (x.version == cryptonote::transaction::version_3_per_output_unlock_times)
-        a & x.is_deregister;
-    }
-    a & x.unlock_time;
-    a & x.vin;
-    a & x.vout;
-    a & x.extra;
-    if (x.version >= cryptonote::transaction::version_4_tx_types)
-      a & x.type;
-    if (x.version == 1)
+    serialize(a, static_cast<cryptonote::transaction_prefix &>(x), ver);
+    if (x.version == cryptonote::txversion::v1)
     {
       a & x.signatures;
     }

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -92,9 +92,10 @@ namespace cryptonote
   void add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key);
   void add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key);
 
-  bool add_service_node_deregister_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister& deregistration);
+  bool add_service_node_state_change_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_state_change& state_change, uint8_t hf_version);
+  bool get_service_node_state_change_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_state_change& state_change, uint8_t hf_version);
   bool get_service_node_register_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_register& registration);
-  bool get_service_node_deregister_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_deregister& deregistration);
+
   bool get_service_node_pubkey_from_tx_extra(const std::vector<uint8_t>& tx_extra, crypto::public_key& pubkey);
   bool get_service_node_contributor_from_tx_extra(const std::vector<uint8_t>& tx_extra, cryptonote::account_public_address& address);
   bool add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const std::vector<cryptonote::account_public_address>& addresses, uint64_t portions_for_operator, const std::vector<uint64_t>& portions, uint64_t expiration_timestamp, const crypto::signature& signature);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -30,26 +30,45 @@
 
 #pragma once
 
-#define TX_EXTRA_PADDING_MAX_COUNT            255
-#define TX_EXTRA_NONCE_MAX_COUNT              255
+#include "serialization/serialization.h"
+#include "serialization/binary_archive.h"
+#include "serialization/variant.h"
+#include "crypto/crypto.h"
+#include <boost/variant.hpp>
 
-#define TX_EXTRA_TAG_PADDING                  0x00
-#define TX_EXTRA_TAG_PUBKEY                   0x01
-#define TX_EXTRA_NONCE                        0x02
-#define TX_EXTRA_MERGE_MINING_TAG             0x03
-#define TX_EXTRA_TAG_ADDITIONAL_PUBKEYS       0x04
-#define TX_EXTRA_TAG_SERVICE_NODE_REGISTER    0x70
-#define TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER  0x71
-#define TX_EXTRA_TAG_SERVICE_NODE_WINNER      0x72
-#define TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR 0x73
-#define TX_EXTRA_TAG_SERVICE_NODE_PUBKEY      0x74
-#define TX_EXTRA_TAG_TX_SECRET_KEY            0x75
-#define TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS      0x76
-#define TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK      0x77
-#define TX_EXTRA_MYSTERIOUS_MINERGATE_TAG     0xDE
 
-#define TX_EXTRA_NONCE_PAYMENT_ID             0x00
-#define TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID   0x01
+#define TX_EXTRA_PADDING_MAX_COUNT              255
+#define TX_EXTRA_NONCE_MAX_COUNT                255
+
+#define TX_EXTRA_TAG_PADDING                    0x00
+#define TX_EXTRA_TAG_PUBKEY                     0x01
+#define TX_EXTRA_NONCE                          0x02
+#define TX_EXTRA_MERGE_MINING_TAG               0x03
+#define TX_EXTRA_TAG_ADDITIONAL_PUBKEYS         0x04
+#define TX_EXTRA_TAG_SERVICE_NODE_REGISTER      0x70
+#define TX_EXTRA_TAG_SERVICE_NODE_DEREG_OLD     0x71
+#define TX_EXTRA_TAG_SERVICE_NODE_WINNER        0x72
+#define TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR   0x73
+#define TX_EXTRA_TAG_SERVICE_NODE_PUBKEY        0x74
+#define TX_EXTRA_TAG_TX_SECRET_KEY              0x75
+#define TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS        0x76
+#define TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK        0x77
+#define TX_EXTRA_TAG_SERVICE_NODE_STATE_CHANGE  0x78
+
+#define TX_EXTRA_MYSTERIOUS_MINERGATE_TAG       0xDE
+
+#define TX_EXTRA_NONCE_PAYMENT_ID               0x00
+#define TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID     0x01
+
+namespace service_nodes {
+  enum class new_state : uint16_t
+  {
+    deregister,
+    decommission,
+    recommission,
+    _count
+  };
+};
 
 namespace cryptonote
 {
@@ -235,7 +254,7 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
-  struct tx_extra_service_node_deregister
+  struct tx_extra_service_node_state_change
   {
     struct vote
     {
@@ -243,11 +262,65 @@ namespace cryptonote
       vote(crypto::signature const &signature, uint32_t validator_index): signature(signature), validator_index(validator_index) { }
       crypto::signature signature;
       uint32_t          validator_index;
+
+      BEGIN_SERIALIZE()
+        VARINT_FIELD(validator_index);
+        FIELD(signature);
+      END_SERIALIZE()
     };
+
+    service_nodes::new_state state;
+    uint64_t                 block_height;
+    uint32_t                 service_node_index;
+    std::vector<vote>        votes;
+
+    tx_extra_service_node_state_change() = default;
+
+    template <typename... VotesArgs>
+    tx_extra_service_node_state_change(service_nodes::new_state state, uint64_t block_height, uint32_t service_node_index, VotesArgs &&...votes)
+        : state{state}, block_height{block_height}, service_node_index{service_node_index}, votes{std::forward<VotesArgs>(votes)...} {}
+
+    // Compares equal if this represents a state change of the same SN (does *not* require equality of stored votes)
+    bool operator==(const tx_extra_service_node_state_change &sc) const {
+      return state == sc.state && block_height == sc.block_height && service_node_index == sc.service_node_index;
+    }
+
+    BEGIN_SERIALIZE()
+      ENUM_FIELD(state, state < service_nodes::new_state::_count);
+      VARINT_FIELD(block_height);
+      VARINT_FIELD(service_node_index);
+      FIELD(votes);
+    END_SERIALIZE()
+  };
+
+  // Pre-Heimdall service node deregistration data; it doesn't carry the state change (it is only
+  // used for deregistrations), and is stored slightly less efficiently in the tx extra data.
+  struct tx_extra_service_node_deregister_old
+  {
+#pragma pack(push, 4)
+    struct vote { // Not simply using state_change::vote because this gets blob serialized for v11 backwards compat
+      vote() = default;
+      vote(const tx_extra_service_node_state_change::vote &v) : signature{v.signature}, validator_index{v.validator_index} {}
+      crypto::signature signature;
+      uint32_t          validator_index;
+
+      operator tx_extra_service_node_state_change::vote() const { return {signature, validator_index}; }
+    };
+#pragma pack(pop)
+    static_assert(sizeof(vote) == sizeof(crypto::signature) + sizeof(uint32_t), "deregister_old tx extra vote size is not packed");
 
     uint64_t          block_height;
     uint32_t          service_node_index;
     std::vector<vote> votes;
+
+    tx_extra_service_node_deregister_old() = default;
+    tx_extra_service_node_deregister_old(const tx_extra_service_node_state_change &state_change)
+      : block_height{state_change.block_height},
+        service_node_index{state_change.service_node_index},
+        votes{state_change.votes.begin(), state_change.votes.end()}
+    {
+      assert(state_change.state == service_nodes::new_state::deregister);
+    }
 
     BEGIN_SERIALIZE()
       FIELD(block_height)
@@ -272,6 +345,7 @@ namespace cryptonote
       crypto::key_image key_image;
       crypto::signature signature;
     };
+    static_assert(sizeof(proof) == sizeof(crypto::key_image) + sizeof(crypto::signature), "tx_extra key image proof data structure is not packed");
 
     std::vector<proof> proofs;
 
@@ -285,6 +359,9 @@ namespace cryptonote
     crypto::key_image key_image;
     crypto::signature signature;
     uint32_t          nonce;
+
+    // Compares equal if this represents the same key image unlock (but does *not* require equality of signature/nonce)
+    bool operator==(const tx_extra_tx_key_image_unlock &other) const { return key_image == other.key_image; }
 
     BEGIN_SERIALIZE()
       FIELD(key_image)
@@ -307,27 +384,29 @@ namespace cryptonote
                          tx_extra_service_node_register,
                          tx_extra_service_node_contributor,
                          tx_extra_service_node_winner,
-                         tx_extra_service_node_deregister,
+                         tx_extra_service_node_state_change,
+                         tx_extra_service_node_deregister_old,
                          tx_extra_tx_secret_key,
                          tx_extra_tx_key_image_proofs,
                          tx_extra_tx_key_image_unlock
                         > tx_extra_field;
 }
 
-BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister::vote);
+BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister_old::vote);
 BLOB_SERIALIZER(cryptonote::tx_extra_tx_key_image_proofs::proof);
 
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding,                  TX_EXTRA_TAG_PADDING);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_pub_key,                  TX_EXTRA_TAG_PUBKEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_nonce,                    TX_EXTRA_NONCE);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_merge_mining_tag,         TX_EXTRA_MERGE_MINING_TAG);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_additional_pub_keys,      TX_EXTRA_TAG_ADDITIONAL_PUBKEYS);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_mysterious_minergate,     TX_EXTRA_MYSTERIOUS_MINERGATE_TAG);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_register,    TX_EXTRA_TAG_SERVICE_NODE_REGISTER);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_deregister,  TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_contributor, TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_winner,      TX_EXTRA_TAG_SERVICE_NODE_WINNER);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_pubkey,      TX_EXTRA_TAG_SERVICE_NODE_PUBKEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_secret_key,            TX_EXTRA_TAG_TX_SECRET_KEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_proofs,      TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_unlock,      TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding,                     TX_EXTRA_TAG_PADDING);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_pub_key,                     TX_EXTRA_TAG_PUBKEY);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_nonce,                       TX_EXTRA_NONCE);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_merge_mining_tag,            TX_EXTRA_MERGE_MINING_TAG);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_additional_pub_keys,         TX_EXTRA_TAG_ADDITIONAL_PUBKEYS);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_mysterious_minergate,        TX_EXTRA_MYSTERIOUS_MINERGATE_TAG);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_register,       TX_EXTRA_TAG_SERVICE_NODE_REGISTER);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_state_change,   TX_EXTRA_TAG_SERVICE_NODE_STATE_CHANGE);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_deregister_old, TX_EXTRA_TAG_SERVICE_NODE_DEREG_OLD);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_contributor,    TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_winner,         TX_EXTRA_TAG_SERVICE_NODE_WINNER);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_pubkey,         TX_EXTRA_TAG_SERVICE_NODE_PUBKEY);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_secret_key,               TX_EXTRA_TAG_TX_SECRET_KEY);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_proofs,         TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_unlock,         TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1275,8 +1275,8 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
       return false;
     }
 
-    auto min_version = transaction::get_min_version_for_hf(version, nettype());
-    auto max_version = transaction::get_max_version_for_hf(version, nettype());
+    const auto min_version = transaction::get_min_version_for_hf(version, nettype());
+    const auto max_version = transaction::get_max_version_for_hf(version, nettype());
     if (b.miner_tx.version < min_version || b.miner_tx.version > max_version)
     {
       MERROR_VER("Coinbase invalid version: " << b.miner_tx.version << " for hardfork: " << version << " min/max version:  " << min_version << "/" << max_version);
@@ -2831,12 +2831,12 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   if(pmax_used_block_height)
     *pmax_used_block_height = 0;
 
-  const int hf_version = m_hardfork->get_current_version();
+  const auto hf_version = m_hardfork->get_current_version();
 
   // Min/Max Type/Version Check
   {
-    auto min_version = transaction::get_min_version_for_hf(hf_version, nettype());
-    auto max_version = transaction::get_max_version_for_hf(hf_version, nettype());
+    const auto min_version = transaction::get_min_version_for_hf(hf_version, nettype());
+    const auto max_version = transaction::get_max_version_for_hf(hf_version, nettype());
 
     if (hf_version >= network_version_11_infinite_staking)
       tvc.m_invalid_type |= (tx.type > txtype::key_image_unlock);
@@ -3111,61 +3111,61 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       return false;
     }
 
-    if (tx.type == txtype::deregister)
+    if (tx.type == txtype::state_change)
     {
       // Check the inputs (votes) of the transaction have not already been
       // submitted to the blockchain under another transaction using a different
       // combination of votes.
-      tx_extra_service_node_deregister deregister;
-      if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+      tx_extra_service_node_state_change state_change;
+      if (!get_service_node_state_change_from_tx_extra(tx.extra, state_change, hf_version))
       {
-        MERROR_VER("Deregister TX did not have the deregister metadata in the tx_extra");
+        MERROR_VER("TX did not have the state change metadata in the tx_extra");
         return false;
       }
 
-      const std::shared_ptr<const service_nodes::testing_quorum> quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::deregister, deregister.block_height);
+      auto quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::obligations, state_change.block_height);
       if (!quorum)
       {
-        MERROR_VER("Deregister TX could not get quorum for height: " << deregister.block_height);
+        MERROR_VER("State change TX could not get quorum for height: " << state_change.block_height);
         return false;
       }
 
-      if (!service_nodes::verify_tx_deregister(deregister, tvc.m_vote_ctx, *quorum))
+      if (!service_nodes::verify_tx_state_change(state_change, tvc.m_vote_ctx, *quorum, hf_version))
       {
         tvc.m_verifivation_failed = true;
-        MERROR_VER("tx " << get_transaction_hash(tx) << ": deregister tx could not be completely verified reason: " << print_vote_verification_context(tvc.m_vote_ctx));
+        MERROR_VER("tx " << get_transaction_hash(tx) << ": state change tx could not be completely verified reason: " << print_vote_verification_context(tvc.m_vote_ctx));
         return false;
       }
 
-      // Check if deregister is too old or too new to hold onto
+      // Check if state change is too old or too new to hold onto
       {
         const uint64_t curr_height = get_current_blockchain_height();
-        if (deregister.block_height >= curr_height)
+        if (state_change.block_height >= curr_height)
         {
-          LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
-                       << " and service node: "              << deregister.service_node_index
-                       << ", is newer than current height: " << curr_height
-                       << " blocks and has been rejected.");
+          LOG_PRINT_L1("Received state change tx for height: " << state_change.block_height
+              << " and service node: "                << state_change.service_node_index
+              << ", is newer than current height: "   << curr_height
+              << " blocks and has been rejected.");
           tvc.m_vote_ctx.m_invalid_block_height = true;
           tvc.m_verifivation_failed             = true;
           return false;
         }
 
-        uint64_t delta_height = curr_height - deregister.block_height;
-        if (delta_height >= service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS)
+        uint64_t delta_height = curr_height - state_change.block_height;
+        if (delta_height >= service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS)
         {
-          LOG_PRINT_L1("Received deregister tx for height: " << deregister.block_height
-                       << " and service node: "     << deregister.service_node_index
-                       << ", is older than: "       << service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS
-                       << " blocks and has been rejected. The current height is: " << curr_height);
+          LOG_PRINT_L1("Received state change tx for height: " << state_change.block_height
+              << " and service node: "                << state_change.service_node_index
+              << ", is older than: "                  << service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS
+              << " blocks and has been rejected. The current height is: " << curr_height);
           tvc.m_vote_ctx.m_invalid_block_height = true;
           tvc.m_verifivation_failed             = true;
           return false;
         }
       }
 
-      const uint64_t height            = deregister.block_height;
-      const size_t num_blocks_to_check = service_nodes::DEREGISTER_TX_LIFETIME_IN_BLOCKS;
+      const uint64_t height                = state_change.block_height;
+      constexpr size_t num_blocks_to_check = service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS;
 
       std::vector<std::pair<cryptonote::blobdata,block>> blocks;
       std::vector<cryptonote::blobdata> txs;
@@ -3183,27 +3183,27 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
           continue;
         }
 
-        if (existing_tx.type != txtype::deregister)
+        if (existing_tx.type != txtype::state_change)
           continue;
 
-        tx_extra_service_node_deregister existing_deregister;
-        if (!get_service_node_deregister_from_tx_extra(existing_tx.extra, existing_deregister))
+        tx_extra_service_node_state_change existing_state_change;
+        if (!get_service_node_state_change_from_tx_extra(existing_tx.extra, existing_state_change, hf_version))
         {
-          MERROR_VER("could not get service node deregister from tx extra, possibly corrupt tx");
+          MERROR_VER("could not get service node state change from tx extra, possibly corrupt tx");
           continue;
         }
 
-        const std::shared_ptr<const service_nodes::testing_quorum> existing_quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::deregister, existing_deregister.block_height);
+        const auto existing_quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::obligations, existing_state_change.block_height);
         if (!existing_quorum)
         {
-          MERROR_VER("could not get uptime quorum for recent deregister tx");
+          MERROR_VER("could not get obligations quorum for recent state change tx");
           continue;
         }
 
-        if (existing_quorum->workers[existing_deregister.service_node_index] ==
-            quorum->workers[deregister.service_node_index])
+        if (existing_quorum->workers[existing_state_change.service_node_index] ==
+            quorum->workers[state_change.service_node_index])
         {
-          MERROR_VER("Already seen this deregister tx (aka double spend)");
+          MERROR_VER("Already seen this state change tx (aka double spend)");
           tvc.m_double_spend = true;
           return false;
         }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -641,10 +641,6 @@ namespace cryptonote
     /**
      * @brief check that a transaction's outputs conform to current standards
      *
-     * This function checks, for example at the time of this writing, that
-     * each output is of the form a * 10^b (phrased differently, that if
-     * written out would have only one non-zero digit in base 10).
-     *
      * @param tx the transaction to check the outputs of
      * @param tvc returned info about tx verification
      *
@@ -1186,6 +1182,9 @@ namespace cryptonote
      * Currently this function calls ring signature validation for each
      * transaction.
      *
+     * This fails if called on a non-standard metadata transaction such as a deregister; you
+     * generally want to call check_tx() instead, which calls this if appropriate.
+     *
      * @param tx the transaction to validate
      * @param tvc returned information about tx verification
      * @param pmax_related_block_height return-by-pointer the height of the most recent block in the input set
@@ -1193,6 +1192,22 @@ namespace cryptonote
      * @return false if any validation step fails, otherwise true
      */
     bool check_tx_inputs(transaction& tx, tx_verification_context &tvc, uint64_t* pmax_used_block_height = NULL);
+
+    /**
+     * @brief validates SN metadata transaction properties
+     *
+     * Checks the given service node metatransaction (i.e. deregister, unlock request, etc.) for
+     * validity.  Fails if called with a non-metatransaction, or if there is something wrong with
+     * the metatransaction.
+     *
+     * This fails if called on a standard (non-meta) transaction such as a regular transaction or a
+     * SN registration; you generally want to call check_tx() instead, which calls this if
+     * appropriate.
+     *
+     * @param tx the transaction to validate
+     * @param tvc returned information about tx verification
+     */
+    bool check_service_node_tx(transaction &tx, tx_verification_context &tvc);
 
     /**
      * @brief performs a blockchain reorganization according to the longest chain rule

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1148,7 +1148,7 @@ namespace cryptonote
      * @return false if any keys are not found or any inputs are not unlocked, otherwise true
      */
     template<class visitor_t>
-    inline bool scan_outputkeys_for_indexes(size_t tx_version, const txin_to_key& tx_in_to_key, visitor_t &vis, const crypto::hash &tx_prefix_hash, uint64_t* pmax_related_block_height = NULL) const;
+    bool scan_outputkeys_for_indexes(const txin_to_key& tx_in_to_key, visitor_t &vis, const crypto::hash &tx_prefix_hash, uint64_t* pmax_related_block_height = NULL) const;
 
     /**
      * @brief collect output public keys of a transaction input set
@@ -1170,7 +1170,7 @@ namespace cryptonote
      *
      * @return false if any output is not yet unlocked, or is missing, otherwise true
      */
-    bool check_tx_input(size_t tx_version,const txin_to_key& txin, const crypto::hash& tx_prefix_hash, const std::vector<crypto::signature>& sig, const rct::rctSig &rct_signatures, std::vector<rct::ctkey> &output_keys, uint64_t* pmax_related_block_height);
+    bool check_tx_input(txversion tx_version, const txin_to_key& txin, const crypto::hash& tx_prefix_hash, const std::vector<crypto::signature>& sig, const rct::rctSig &rct_signatures, std::vector<rct::ctkey> &output_keys, uint64_t* pmax_related_block_height);
 
     /**
      * @brief validate a transaction's inputs and their keys

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2172,9 +2172,9 @@ namespace cryptonote
     return m_service_node_list.get_testing_quorum(type, height);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::is_service_node(const crypto::public_key& pubkey) const
+  bool core::is_service_node(const crypto::public_key& pubkey, bool require_active) const
   {
-    return m_service_node_list.is_service_node(pubkey);
+    return m_service_node_list.is_service_node(pubkey, require_active);
   }
   //-----------------------------------------------------------------------------------------------
   const std::vector<service_nodes::key_image_blacklist_entry> &core::get_service_node_blacklisted_key_images() const

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -947,7 +947,7 @@ namespace cryptonote
         continue;
       }
 
-      if (tx_info[n].tx->get_type() != transaction::type_standard)
+      if (tx_info[n].tx->type != txtype::standard)
         continue;
       const rct::rctSig &rv = tx_info[n].tx->rct_signatures;
       switch (rv.type) {
@@ -1146,11 +1146,11 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::check_tx_semantic(const transaction& tx, bool keeped_by_block) const
   {
-    if (tx.get_type() != transaction::type_standard)
+    if (tx.type != txtype::standard)
     {
       if (tx.vin.size() != 0)
       {
-        MERROR_VER("tx type: " << transaction::type_to_string(tx.type) << " must have 0 inputs, received: " << tx.vin.size() << ", rejected for tx id = " << get_transaction_hash(tx));
+        MERROR_VER("tx type: " << tx.type << " must have 0 inputs, received: " << tx.vin.size() << ", rejected for tx id = " << get_transaction_hash(tx));
         return false;
       }
     }
@@ -1172,7 +1172,7 @@ namespace cryptonote
       return false;
     }
 
-    if (tx.version >= transaction::version_2)
+    if (tx.version >= txversion::v2_ringct)
     {
       if (tx.rct_signatures.outPk.size() != tx.vout.size())
       {
@@ -1187,7 +1187,7 @@ namespace cryptonote
       return false;
     }
 
-    if (tx.version == transaction::version_1)
+    if (tx.version == txversion::v1)
     {
       uint64_t amount_in = 0;
       get_inputs_money_amount(tx, amount_in);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -800,13 +800,15 @@ namespace cryptonote
      std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
 
      /**
-       * @brief get whether `pubkey` is known as a service node
+       * @brief get whether `pubkey` is known as a service node.
        *
        * @param pubkey the public key to test
+       * @param require_active if true also require that the service node is active (fully funded
+       * and not decommissioned).
        *
-       * @return whether `pubkey` is known as a service node
+       * @return whether `pubkey` is known as a (optionally active) service node
        */
-     bool is_service_node(const crypto::public_key& pubkey) const;
+     bool is_service_node(const crypto::public_key& pubkey, bool require_active) const;
 
 
      uint32_t get_service_node_public_ip() const {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -30,6 +30,8 @@
 #include <random>
 #include <algorithm>
 
+#include <boost/endian/conversion.hpp>
+
 #include "ringct/rctSigs.h"
 #include "wallet/wallet2.h"
 #include "cryptonote_tx_utils.h"
@@ -51,16 +53,7 @@ namespace service_nodes
 {
   static int get_min_service_node_info_version_for_hf(int hf_version)
   {
-    if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_9_service_nodes)
-      return service_node_info::version_0;
-
-    if (hf_version == cryptonote::network_version_10_bulletproofs)
-      return service_node_info::version_1_swarms;
-
-    if (hf_version == cryptonote::network_version_11_infinite_staking)
-      return service_node_info::version_2_infinite_staking;
-
-    return service_node_info::version_3_checkpointing;
+    return service_node_info::version_0_checkpointing; // Versioning reset with the full SN rescan in 4.0.0
   }
 
   service_node_list::service_node_list(cryptonote::Blockchain& blockchain)
@@ -120,18 +113,27 @@ namespace service_nodes
     LOG_PRINT_L0("Done recalculating service nodes list");
   }
 
-  std::vector<crypto::public_key> service_node_list::get_service_nodes_pubkeys() const
-  {
-    std::vector<crypto::public_key> result;
-    for (const auto& iter : m_transient_state.service_nodes_infos)
-      if (iter.second.is_fully_funded())
-        result.push_back(iter.first);
+  template <typename UnaryPredicate>
+  static std::vector<service_nodes::pubkey_and_sninfo> sort_and_filter(const service_nodes_infos_t &sns_infos, UnaryPredicate p, bool reserve = true) {
+    std::vector<pubkey_and_sninfo> result;
+    if (reserve) result.reserve(sns_infos.size());
+    for (const pubkey_and_sninfo &key_info : sns_infos)
+      if (p(key_info.second))
+        result.push_back(key_info);
 
     std::sort(result.begin(), result.end(),
-      [](const crypto::public_key &a, const crypto::public_key &b) {
+      [](const pubkey_and_sninfo &a, const pubkey_and_sninfo &b) {
         return memcmp(reinterpret_cast<const void*>(&a), reinterpret_cast<const void*>(&b), sizeof(a)) < 0;
       });
     return result;
+  }
+
+  std::vector<pubkey_and_sninfo> service_node_list::transient_state::active_service_nodes_infos() const {
+    return sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_active(); });
+  }
+
+  std::vector<pubkey_and_sninfo> service_node_list::transient_state::decommissioned_service_nodes_infos() const {
+    return sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_decommissioned() && info.is_fully_funded(); }, /*reserve=*/ false);
   }
 
   std::shared_ptr<const testing_quorum> service_node_list::get_testing_quorum(quorum_type type, uint64_t height) const
@@ -140,8 +142,8 @@ namespace service_nodes
     const auto &it = m_transient_state.quorum_states.find(height);
     if (it != m_transient_state.quorum_states.end())
     {
-      if (type == quorum_type::deregister)
-        return it->second.deregister;
+      if (type == quorum_type::obligations)
+        return it->second.obligations;
       else if (type == quorum_type::checkpointing)
         return it->second.checkpointing;
       else
@@ -202,10 +204,11 @@ namespace service_nodes
     m_service_node_pubkey = pub_key;
   }
 
-  bool service_node_list::is_service_node(const crypto::public_key& pubkey) const
+  bool service_node_list::is_service_node(const crypto::public_key& pubkey, bool require_active) const
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
-    return m_transient_state.service_nodes_infos.find(pubkey) != m_transient_state.service_nodes_infos.end();
+    auto it = m_transient_state.service_nodes_infos.find(pubkey);
+    return it != m_transient_state.service_nodes_infos.end() && (!require_active || it->second.is_active());
   }
 
   bool service_node_list::is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height, service_node_info::contribution_t *the_locked_contribution) const
@@ -295,70 +298,120 @@ namespace service_nodes
     return money_transferred;
   }
 
-  bool service_node_list::process_deregistration_tx(const cryptonote::transaction& tx, uint64_t block_height)
+  bool service_node_list::process_state_change_tx(const cryptonote::transaction& tx, uint64_t block_height)
   {
-    if (tx.type != cryptonote::txtype::deregister)
+    if (tx.type != cryptonote::txtype::state_change)
       return false;
 
-    cryptonote::tx_extra_service_node_deregister deregister;
-    if (!cryptonote::get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+    uint8_t hard_fork_version = m_blockchain.get_hard_fork_version(block_height);
+
+    cryptonote::tx_extra_service_node_state_change state_change;
+    if (!cryptonote::get_service_node_state_change_from_tx_extra(tx.extra, state_change, hard_fork_version))
     {
-      MERROR("Transaction deregister did not have deregister data in tx extra, possibly corrupt tx in blockchain");
+      MERROR("Transaction did not have valid state change data in tx extra, possibly corrupt tx in blockchain");
       return false;
     }
 
-    const auto state = get_testing_quorum(quorum_type::deregister, deregister.block_height);
+    const auto state = get_testing_quorum(quorum_type::obligations, state_change.block_height);
     if (!state)
     {
       // TODO(loki): Not being able to find a quorum is fatal! We want better caching abilities.
-      MERROR("Uptime quorum for height: " << deregister.block_height << ", was not stored by the daemon");
+      MERROR("Uptime quorum for height: " << state_change.block_height << ", was not stored by the daemon");
       return false;
     }
 
-    if (deregister.service_node_index >= state->workers.size())
+    if (state_change.service_node_index >= state->workers.size())
     {
       MERROR("Service node index to vote off has become invalid, quorum rules have changed without a hardfork.");
       return false;
     }
 
-    const crypto::public_key& key = state->workers[deregister.service_node_index];
+    const crypto::public_key& key = state->workers[state_change.service_node_index];
 
     auto iter = m_transient_state.service_nodes_infos.find(key);
-    if (iter == m_transient_state.service_nodes_infos.end())
+    if (iter == m_transient_state.service_nodes_infos.end()) {
+      LOG_PRINT_L2("Received state change tx for non-registered service node " << key << " (perhaps a delayed tx?)");
       return false;
-
-    if (m_service_node_pubkey && *m_service_node_pubkey == key)
-    {
-      MGINFO_RED("Deregistration for service node (yours): " << key);
-    }
-    else
-    {
-      LOG_PRINT_L1("Deregistration for service node: " << key);
     }
 
-    m_transient_state.rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_change(block_height, key, iter->second)));
+    auto &info = iter->second;
+    bool is_me = m_service_node_pubkey && *m_service_node_pubkey == key;
 
-    int hard_fork_version = m_blockchain.get_hard_fork_version(block_height);
-    if (hard_fork_version >= cryptonote::network_version_11_infinite_staking)
-    {
-      for (const auto &contributor : iter->second.contributors)
-      {
-        for (const auto &contribution : contributor.locked_contributions)
+    switch (state_change.state) {
+      case new_state::deregister:
+        if (is_me)
+          MGINFO_RED("Deregistration for service node (yours): " << key);
+        else
+          LOG_PRINT_L1("Deregistration for service node: " << key);
+
+        if (hard_fork_version >= cryptonote::network_version_11_infinite_staking)
         {
-          key_image_blacklist_entry entry = {};
-          entry.version                   = get_min_service_node_info_version_for_hf(hard_fork_version);
-          entry.key_image                 = contribution.key_image;
-          entry.unlock_height             = block_height + staking_num_lock_blocks(m_blockchain.nettype());
-          m_transient_state.key_image_blacklist.push_back(entry);
+          for (const auto &contributor : info.contributors)
+          {
+            for (const auto &contribution : contributor.locked_contributions)
+            {
+              key_image_blacklist_entry entry = {};
+              entry.version                   = get_min_service_node_info_version_for_hf(hard_fork_version);
+              entry.key_image                 = contribution.key_image;
+              entry.unlock_height             = block_height + staking_num_lock_blocks(m_blockchain.nettype());
+              m_transient_state.key_image_blacklist.push_back(entry);
 
-          const bool adding_to_blacklist = true;
-          m_transient_state.rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_key_image_blacklist(block_height, entry, adding_to_blacklist)));
+              const bool adding_to_blacklist = true;
+              m_transient_state.rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_key_image_blacklist(block_height, entry, adding_to_blacklist)));
+            }
+          }
         }
-      }
-    }
 
-    m_transient_state.service_nodes_infos.erase(iter);
-    return true;
+        m_transient_state.rollback_events.emplace_back(new rollback_change(block_height, key, info));
+        m_transient_state.service_nodes_infos.erase(iter);
+        return true;
+
+      case new_state::decommission:
+        if (hard_fork_version < cryptonote::network_version_12_checkpointing) {
+          MERROR("Invalid decommission transaction seen before network v12");
+          return false;
+        }
+
+        if (info.is_decommissioned()) {
+          LOG_PRINT_L2("Received decommission tx for already-decommissioned service node " << key << "; ignoring");
+          return false;
+        }
+
+        if (is_me)
+          MGINFO_RED("Temporary decommission for service node (yours): " << key);
+        else
+          LOG_PRINT_L1("Temporary decommission for service node: " << key);
+
+        m_transient_state.rollback_events.emplace_back(new rollback_change(block_height, key, info));
+        info.active_since_height = -info.active_since_height;
+        info.last_decommission_height = block_height;
+        info.decommission_count++;
+        return true;
+
+      case new_state::recommission:
+        if (hard_fork_version < cryptonote::network_version_12_checkpointing) {
+          MERROR("Invalid recommission transaction seen before network v12");
+          return false;
+        }
+
+        if (!info.is_decommissioned()) {
+          LOG_PRINT_L2("Received recommission tx for already-active service node " << key << "; ignoring");
+          return false;
+        }
+
+        if (is_me)
+          MGINFO_GREEN("Recommission for service node (yours): " << key);
+        else
+          LOG_PRINT_L1("Recommission for service node: " << key);
+
+        m_transient_state.rollback_events.emplace_back(new rollback_change(block_height, key, info));
+        info.active_since_height = block_height;
+        return true;
+      default:
+        // dev bug!
+        MERROR("BUG: Service node state change tx has unknown state " << static_cast<uint16_t>(state_change.state));
+        return false;
+    }
   }
 
   void service_node_list::update_swarms(uint64_t height) {
@@ -370,12 +423,8 @@ namespace service_nodes
     /// Gather existing swarms from infos
     swarm_snode_map_t existing_swarms;
 
-    const std::vector<crypto::public_key> sorted_sn_pubkeys = get_service_nodes_pubkeys();
-
-    for (const crypto::public_key& pk : sorted_sn_pubkeys) {
-      const service_node_info& info = m_transient_state.service_nodes_infos.at(pk);
-      existing_swarms[info.swarm_id].push_back(pk);
-    }
+    for (const auto &key_info : m_transient_state.active_service_nodes_infos())
+      existing_swarms[key_info.second.swarm_id].push_back(key_info.first);
 
     calc_swarm_changes(existing_swarms, seed);
 
@@ -590,12 +639,13 @@ namespace service_nodes
     info.registration_height = block_height;
     info.last_reward_block_height = block_height;
     info.last_reward_transaction_index = index;
+    info.active_since_height = 0;
+    info.last_decommission_height = 0;
+    info.decommission_count = 0;
     info.total_contributed = 0;
     info.total_reserved = 0;
     info.version = get_min_service_node_info_version_for_hf(hf_version);
-
-    if (info.version >= service_node_info::version_1_swarms)
-      info.swarm_id = UNASSIGNED_SWARM_ID;
+    info.swarm_id = UNASSIGNED_SWARM_ID;
 
     info.contributors.clear();
 
@@ -690,19 +740,19 @@ namespace service_nodes
     return true;
   }
 
-  void service_node_list::process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index)
+  bool service_node_list::process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index)
   {
     crypto::public_key pubkey;
 
     if (!cryptonote::get_service_node_pubkey_from_tx_extra(tx.extra, pubkey))
-      return; // Is not a contribution TX don't need to check it.
+      return false; // Is not a contribution TX don't need to check it.
 
     parsed_tx_contribution parsed_contribution = {};
     const int hf_version = m_blockchain.get_hard_fork_version(block_height);
     if (!get_contribution(m_blockchain.nettype(), hf_version, tx, block_height, parsed_contribution))
     {
       LOG_PRINT_L1("Contribution TX: Could not decode contribution for service node: " << pubkey << " on height: " << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
-      return;
+      return false;
     }
 
     /// Service node must be registered
@@ -713,7 +763,7 @@ namespace service_nodes
                    ", but could not be found in the service node list on height: " << block_height <<
                    " for tx: " << cryptonote::get_transaction_hash(tx )<< "\n"
                    "This could mean that the service node was deregistered before the contribution was processed.");
-      return;
+      return false;
     }
 
     service_node_info& info = iter->second;
@@ -722,13 +772,13 @@ namespace service_nodes
       LOG_PRINT_L1("Contribution TX: Service node: " << pubkey <<
                    " is already fully funded, but contribution received on height: "  << block_height <<
                    " for tx: " << cryptonote::get_transaction_hash(tx));
-      return;
+      return false;
     }
 
     if (!cryptonote::get_tx_secret_key_from_tx_extra(tx.extra, parsed_contribution.tx_key))
     {
       LOG_PRINT_L1("Contribution TX: Failed to get tx secret key from contribution received on height: "  << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
-      return;
+      return false;
     }
 
     auto& contributors = info.contributors;
@@ -745,7 +795,7 @@ namespace service_nodes
                      " for service node: " << pubkey <<
                      " on height: "  << block_height <<
                      " for tx: " << cryptonote::get_transaction_hash(tx));
-        return;
+        return false;
       }
 
       /// Check that the contribution is large enough
@@ -758,7 +808,7 @@ namespace service_nodes
                      " for service node: " << pubkey <<
                      " on height: "  << block_height <<
                      " for tx: " << cryptonote::get_transaction_hash(tx));
-        return;
+        return false;
       }
     }
 
@@ -817,6 +867,11 @@ namespace service_nodes
     }
 
     LOG_PRINT_L1("Contribution of " << parsed_contribution.transferred << " received for service node " << pubkey);
+    if (info.is_fully_funded()) {
+      info.active_since_height = block_height;
+      return true;
+    }
+    return false;
   }
 
   void service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
@@ -834,6 +889,8 @@ namespace service_nodes
 
     if (hard_fork_version < 9)
       return;
+
+    bool need_swarm_update = false;
 
     //
     // Remove old rollback events
@@ -869,7 +926,6 @@ namespace service_nodes
     //
     // Expire Nodes
     //
-    size_t expired_count = 0;
     for (const crypto::public_key& pubkey : update_and_get_expired_nodes(txs, block_height))
     {
       auto i = m_transient_state.service_nodes_infos.find(pubkey);
@@ -886,7 +942,7 @@ namespace service_nodes
 
         m_transient_state.rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_change(block_height, pubkey, i->second)));
 
-        expired_count++;
+        need_swarm_update += i->second.is_active();
         m_transient_state.service_nodes_infos.erase(i);
       }
     }
@@ -912,22 +968,17 @@ namespace service_nodes
     //
     // Process TXs in the Block
     //
-    size_t registrations = 0;
-    size_t deregistrations = 0;
     for (uint32_t index = 0; index < txs.size(); ++index)
     {
       const cryptonote::transaction& tx = txs[index];
       if (tx.type == cryptonote::txtype::standard)
       {
-        if (process_registration_tx(tx, block.timestamp, block_height, index))
-          registrations++;
-
-        process_contribution_tx(tx, block_height, index);
+        process_registration_tx(tx, block.timestamp, block_height, index);
+        need_swarm_update += process_contribution_tx(tx, block_height, index);
       }
-      else if (tx.type == cryptonote::txtype::deregister)
+      else if (tx.type == cryptonote::txtype::state_change)
       {
-        if (process_deregistration_tx(tx, block_height))
-          deregistrations++;
+        need_swarm_update += process_state_change_tx(tx, block_height);
       }
       else if (tx.type == cryptonote::txtype::key_image_unlock)
       {
@@ -984,7 +1035,7 @@ namespace service_nodes
       }
     }
 
-    if (registrations || deregistrations || expired_count) {
+    if (need_swarm_update) {
       update_swarms(block_height);
     }
 
@@ -1273,16 +1324,33 @@ namespace service_nodes
     return true;
   }
 
-  std::vector<size_t> generate_shuffled_service_node_index_list(std::vector<crypto::public_key> const &snode_list, crypto::hash const &block_hash, quorum_type type)
+  std::vector<size_t> generate_shuffled_service_node_index_list(
+      size_t list_size,
+      crypto::hash const &block_hash,
+      quorum_type type,
+      size_t sublist_size = 0,
+      size_t sublist_up_to = 0)
   {
-    std::vector<size_t> result(snode_list.size());
-    for (size_t i = 0; i < snode_list.size(); i++) result[i] = i;
+    std::vector<size_t> result(list_size);
+    std::iota(result.begin(), result.end(), 0);
 
     uint64_t seed = 0;
     std::memcpy(&seed, block_hash.data, std::min(sizeof(seed), sizeof(block_hash.data)));
+    boost::endian::little_to_native_inplace(seed);
 
     seed += static_cast<uint64_t>(type);
-    loki_shuffle(result, seed);
+    // If we have a list [0,Z) but we need a shuffled sublist of the first N values that only
+    // includes values from [0,Y) then we do this using two shuffles: first of the [0,Y) sublist,
+    // then of the [N,Z) sublist (which is already partially shuffled, but that doesn't matter).  We
+    // reuse the same seed for both partial shuffles, but again, that isn't an issue.
+    if ((0 < sublist_size && sublist_size < list_size) && (0 < sublist_up_to && sublist_up_to < list_size)) {
+      assert(sublist_size <= sublist_up_to); // Can't select N random items from M items when M < N
+      loki_shuffle(result.begin(), result.begin() + sublist_up_to, seed);
+      loki_shuffle(result.begin() + sublist_size, result.end(), seed);
+    }
+    else {
+      loki_shuffle(result.begin(), result.end(), seed);
+    }
     return result;
   }
 
@@ -1297,28 +1365,40 @@ namespace service_nodes
       return;
     }
 
-    std::vector<crypto::public_key> const snode_list = get_service_nodes_pubkeys();
-    quorum_manager &manager                          = m_transient_state.quorum_states[height];
-    for (int type_int = 0; type_int < (int)quorum_type::count; type_int++)
+    // The two quorums here have different selection criteria: the entire checkpoint quorum and the
+    // state change *validators* want only active service nodes, but the state change *workers*
+    // (i.e. the nodes to be tested) also include decommissioned service nodes.  (Prior to v12 there
+    // are no decommissioned nodes, so this distinction is irrelevant for network concensus).
+    auto active_snode_list = m_transient_state.active_service_nodes_infos();
+    decltype(active_snode_list) decomm_snode_list;
+    if (hf_version >= cryptonote::network_version_12_checkpointing)
+      decomm_snode_list = m_transient_state.decommissioned_service_nodes_infos();
+
+    quorum_manager &manager = m_transient_state.quorum_states[height];
+    for (int type_int = 0; type_int < static_cast<int>(quorum_type::count); type_int++)
     {
       auto type             = static_cast<quorum_type>(type_int);
       size_t num_validators = 0, num_workers = 0;
-      auto quorum                                = std::make_shared<testing_quorum>();
-      std::vector<size_t> const pub_keys_indexes = generate_shuffled_service_node_index_list(snode_list, block_hash, type);
+      auto quorum           = std::make_shared<testing_quorum>();
+      std::vector<size_t> pub_keys_indexes;
 
-      if (type == quorum_type::deregister)
+      if (type == quorum_type::obligations)
       {
         if (hf_version >= cryptonote::network_version_9_service_nodes)
         {
-          num_validators             = std::min(pub_keys_indexes.size(), DEREGISTER_QUORUM_SIZE);
-          size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
-          num_workers                = std::max(num_remaining_nodes/DEREGISTER_NTH_OF_THE_NETWORK_TO_TEST, std::min(DEREGISTER_MIN_NODES_TO_TEST, num_remaining_nodes));
+          size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
+          num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
+          pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, block_hash, type, num_validators, active_snode_list.size());
+          manager.obligations        = quorum;
+          size_t num_remaining_nodes = total_nodes - num_validators;
+          num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
         }
       }
       else if (type == quorum_type::checkpointing)
       {
         if (hf_version >= cryptonote::network_version_12_checkpointing)
         {
+          manager.checkpointing      = quorum;
           num_validators             = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
           size_t num_remaining_nodes = pub_keys_indexes.size() - num_validators;
           num_workers                = std::min(num_remaining_nodes, CHECKPOINT_QUORUM_SIZE);
@@ -1330,30 +1410,23 @@ namespace service_nodes
         continue;
       }
 
+      quorum->validators.reserve(num_validators);
+      quorum->workers.reserve(num_workers);
+
+      size_t i = 0;
+      for (; i < num_validators; i++)
       {
-        quorum->validators.resize(num_validators);
-        for (size_t i = 0; i < quorum->validators.size(); i++)
-        {
-          size_t node_index             = pub_keys_indexes[i];
-          const crypto::public_key &key = snode_list[node_index];
-          quorum->validators[i]         = key;
-        }
+        quorum->validators.push_back(active_snode_list[pub_keys_indexes[i]].first);
       }
 
+      for (; i < num_validators + num_workers; i++)
       {
-        quorum->workers.resize(num_workers);
-        for (size_t i = 0; i < quorum->workers.size(); i++)
-        {
-          size_t node_index             = pub_keys_indexes[quorum->validators.size() + i];
-          const crypto::public_key &key = snode_list[node_index];
-          quorum->workers[i]            = key;
-        }
+        size_t j = pub_keys_indexes[i];
+        if (j < active_snode_list.size())
+          quorum->workers.push_back(active_snode_list[j].first);
+        else
+          quorum->workers.push_back(decomm_snode_list[j - active_snode_list.size()].first);
       }
-
-      if (type == quorum_type::deregister)
-        manager.deregister = quorum;
-      else
-        manager.checkpointing = quorum;
     }
   }
 
@@ -1403,14 +1476,11 @@ namespace service_nodes
         quorum.height                   = kv_pair.first;
         quorum_manager const &manager   = kv_pair.second;
 
-        if (manager.deregister)
-          quorum.quorums[(int)quorum_type::deregister] = *manager.deregister;
+        if (manager.obligations)
+          quorum.quorums[static_cast<uint8_t>(quorum_type::obligations)] = *manager.obligations;
 
-        if (quorum.version >= service_node_info::version_3_checkpointing)
-        {
-          if (manager.checkpointing)
-            quorum.quorums[(int)quorum_type::checkpointing] = *manager.checkpointing;
-        }
+        if (manager.checkpointing)
+          quorum.quorums[static_cast<uint8_t>(quorum_type::checkpointing)] = *manager.checkpointing;
 
         data_to_store.quorum_states.push_back(quorum);
       }
@@ -1457,28 +1527,21 @@ namespace service_nodes
     return true;
   }
 
-  void service_node_list::get_all_service_nodes_public_keys(std::vector<crypto::public_key>& keys, bool fully_funded_nodes_only) const
+  void service_node_list::get_all_service_nodes_public_keys(std::vector<crypto::public_key>& keys, bool require_active) const
   {
     keys.clear();
-    keys.resize(m_transient_state.service_nodes_infos.size());
+    keys.reserve(m_transient_state.service_nodes_infos.size());
 
-    size_t i = 0;
-    if (fully_funded_nodes_only)
-    {
-      for (const auto &it : m_transient_state.service_nodes_infos)
-      {
-        service_node_info const &info = it.second;
-        if (info.is_fully_funded())
-          keys[i++] = it.first;
-      }
+    if (require_active) {
+      for (const auto &key_info : m_transient_state.service_nodes_infos)
+        if (key_info.second.is_active())
+          keys.push_back(key_info.first);
     }
-    else
-    {
-      for (const auto &it : m_transient_state.service_nodes_infos)
-        keys[i++] = it.first;
+    else {
+      for (const auto &key_info : m_transient_state.service_nodes_infos)
+        keys.push_back(key_info.first);
     }
   }
-
 
   void service_node_list::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) {
 
@@ -1523,16 +1586,11 @@ namespace service_nodes
 
     for (const auto& states : data_in.quorum_states)
     {
-      {
-        testing_quorum const &deregister = states.quorums[(int)quorum_type::deregister];
-        m_transient_state.quorum_states[states.height].deregister = std::make_shared<testing_quorum>(deregister);
-      }
+      testing_quorum const &obligations = states.quorums[static_cast<uint8_t>(quorum_type::obligations)];
+      m_transient_state.quorum_states[states.height].obligations = std::make_shared<testing_quorum>(obligations);
 
-      if (states.version >= service_node_info::version_3_checkpointing)
-      {
-        testing_quorum const &checkpointing = states.quorums[(int)quorum_type::checkpointing];
-        m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
-      }
+      testing_quorum const &checkpointing = states.quorums[static_cast<uint8_t>(quorum_type::checkpointing)];
+      m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
     }
 
     for (const auto& info : data_in.infos)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -297,7 +297,7 @@ namespace service_nodes
 
   bool service_node_list::process_deregistration_tx(const cryptonote::transaction& tx, uint64_t block_height)
   {
-    if (tx.get_type() != cryptonote::transaction::type_deregister)
+    if (tx.type != cryptonote::txtype::deregister)
       return false;
 
     cryptonote::tx_extra_service_node_deregister deregister;
@@ -475,7 +475,7 @@ namespace service_nodes
         bool has_correct_unlock_time = false;
         {
           uint64_t unlock_time = tx.unlock_time;
-          if (tx.version >= cryptonote::transaction::version_3_per_output_unlock_times)
+          if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
             unlock_time = tx.output_unlock_times[i];
 
           uint64_t min_height = block_height + staking_num_lock_blocks(nettype);
@@ -916,21 +916,20 @@ namespace service_nodes
     size_t deregistrations = 0;
     for (uint32_t index = 0; index < txs.size(); ++index)
     {
-      const cryptonote::transaction& tx             = txs[index];
-      const cryptonote::transaction::type_t tx_type = tx.get_type();
-      if (tx_type == cryptonote::transaction::type_standard)
+      const cryptonote::transaction& tx = txs[index];
+      if (tx.type == cryptonote::txtype::standard)
       {
         if (process_registration_tx(tx, block.timestamp, block_height, index))
           registrations++;
 
         process_contribution_tx(tx, block_height, index);
       }
-      else if (tx_type == cryptonote::transaction::type_deregister)
+      else if (tx.type == cryptonote::txtype::deregister)
       {
         if (process_deregistration_tx(tx, block_height))
           deregistrations++;
       }
-      else if (tx_type == cryptonote::transaction::type_key_image_unlock)
+      else if (tx.type == cryptonote::txtype::key_image_unlock)
       {
         crypto::public_key snode_key;
         if (!cryptonote::get_service_node_pubkey_from_tx_extra(tx.extra, snode_key))

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -159,7 +159,7 @@ namespace service_nodes
 
             for (; m_uptime_proof_height < (height - REORG_SAFETY_BUFFER_IN_BLOCKS); m_uptime_proof_height++)
             {
-              if (m_core.get_hard_fork_version(m_uptime_proof_height) < 9) continue;
+              if (m_core.get_hard_fork_version(m_uptime_proof_height) < cryptonote::network_version_9_service_nodes) continue;
 
               const std::shared_ptr<const testing_quorum> quorum =
                   m_core.get_testing_quorum(quorum_type::deregister, m_uptime_proof_height);
@@ -338,7 +338,7 @@ namespace service_nodes
           {
             int hf_version        = m_core.get_blockchain_storage().get_current_hard_fork_version();
             deregister_tx.version = cryptonote::transaction::get_max_version_for_hf(hf_version, m_core.get_nettype());
-            deregister_tx.type    = cryptonote::transaction::type_deregister;
+            deregister_tx.type    = cryptonote::txtype::deregister;
 
             cryptonote::tx_verification_context tvc = {};
             cryptonote::blobdata const tx_blob      = cryptonote::tx_to_blob(deregister_tx);

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -41,6 +41,8 @@ namespace cryptonote
 
 namespace service_nodes
 {
+  struct service_node_info;
+
   struct proof_info
   {
       uint64_t timestamp;
@@ -60,7 +62,7 @@ namespace service_nodes
 
   struct quorum_manager
   {
-    std::shared_ptr<const testing_quorum> deregister;
+    std::shared_ptr<const testing_quorum> obligations;
     std::shared_ptr<const testing_quorum> checkpointing;
   };
 
@@ -87,12 +89,16 @@ namespace service_nodes
     proof_info get_uptime_proof(const crypto::public_key &pubkey) const;
     void       generate_uptime_proof_request(cryptonote::NOTIFY_UPTIME_PROOF::request& req) const;
 
+    static int64_t calculate_decommission_credit(const service_node_info &info, uint64_t current_height);
+
+    bool check_service_node(const crypto::public_key &pubkey, const service_node_info &info) const;
+
   private:
     void process_quorums(cryptonote::block const &block);
 
     cryptonote::core& m_core;
     voting_pool       m_vote_pool;
-    uint64_t          m_uptime_proof_height;
+    uint64_t          m_obligations_height;
     uint64_t          m_last_checkpointed_height;
 
     std::unordered_map<crypto::public_key, proof_info> m_uptime_proof_seen;

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -41,6 +41,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/endian/conversion.hpp>
+
 #undef LOKI_DEFAULT_LOG_CATEGORY
 #define LOKI_DEFAULT_LOG_CATEGORY "service_nodes"
 
@@ -48,11 +50,11 @@ namespace service_nodes
 {
   bool convert_deregister_vote_to_legacy(quorum_vote_t const &vote, legacy_deregister_vote &legacy_vote)
   {
-    if (vote.type != quorum_type::deregister)
+    if (vote.type != quorum_type::obligations || vote.state_change.state != new_state::deregister)
       return false;
 
     legacy_vote.block_height           = vote.block_height;
-    legacy_vote.service_node_index     = vote.deregister.worker_index;
+    legacy_vote.service_node_index     = vote.state_change.worker_index;
     legacy_vote.voters_quorum_index    = vote.index_in_group;
     legacy_vote.signature              = vote.signature;
     return true;
@@ -60,26 +62,36 @@ namespace service_nodes
 
   quorum_vote_t convert_legacy_deregister_vote(legacy_deregister_vote const &vote)
   {
-    quorum_vote_t result           = {};
-    result.type                    = quorum_type::deregister;
-    result.block_height            = vote.block_height;
-    result.signature               = vote.signature;
-    result.group                   = quorum_group::validator;
-    result.index_in_group          = vote.voters_quorum_index;
-    result.deregister.worker_index = vote.service_node_index;
+    quorum_vote_t result             = {};
+    result.type                      = quorum_type::obligations;
+    result.block_height              = vote.block_height;
+    result.signature                 = vote.signature;
+    result.group                     = quorum_group::validator;
+    result.index_in_group            = vote.voters_quorum_index;
+    result.state_change.worker_index = vote.service_node_index;
+    result.state_change.state        = new_state::deregister;
     return result;
   }
 
-  static crypto::hash make_deregister_vote_hash(uint64_t block_height, uint32_t service_node_index)
+  static crypto::hash make_state_change_vote_hash(uint64_t block_height, uint32_t service_node_index, new_state state)
   {
-    const int buf_size = sizeof(block_height) + sizeof(service_node_index);
-    char buf[buf_size];
+    uint16_t state_int = static_cast<uint16_t>(state);
 
-    memcpy(buf, reinterpret_cast<void *>(&block_height), sizeof(block_height));
-    memcpy(buf + sizeof(block_height), reinterpret_cast<void *>(&service_node_index), sizeof(service_node_index));
+    char buf[sizeof(block_height) + sizeof(service_node_index) + sizeof(state_int)];
+
+    boost::endian::native_to_little_inplace(block_height);
+    boost::endian::native_to_little_inplace(service_node_index);
+    boost::endian::native_to_little_inplace(state_int);
+    memcpy(buf,                                                     &block_height,       sizeof(block_height));
+    memcpy(buf + sizeof(block_height),                              &service_node_index, sizeof(service_node_index));
+    memcpy(buf + sizeof(block_height) + sizeof(service_node_index), &state_int,          sizeof(state_int));
+
+    auto size = sizeof(buf);
+    if (state == new_state::deregister)
+        size -= sizeof(uint16_t); // Don't include state value for deregs (to be backwards compatible with pre-v12 dereg votes)
 
     crypto::hash result;
-    crypto::cn_fast_hash(buf, buf_size, result);
+    crypto::cn_fast_hash(buf, size, result);
     return result;
   }
 
@@ -95,9 +107,9 @@ namespace service_nodes
         return result;
       };
 
-      case quorum_type::deregister:
+      case quorum_type::obligations:
       {
-        crypto::hash hash = make_deregister_vote_hash(vote.block_height, vote.deregister.worker_index);
+        crypto::hash hash = make_state_change_vote_hash(vote.block_height, vote.state_change.worker_index, vote.state_change.state);
         crypto::generate_signature(hash, pub, sec, result);
       }
       break;
@@ -113,15 +125,15 @@ namespace service_nodes
     return result;
   }
 
-  crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec)
+  crypto::signature make_signature_from_tx_state_change(cryptonote::tx_extra_service_node_state_change const &state_change, crypto::public_key const &pub, crypto::secret_key const &sec)
   {
     crypto::signature result;
-    crypto::hash hash = make_deregister_vote_hash(deregister.block_height, deregister.service_node_index);
+    crypto::hash hash = make_state_change_vote_hash(state_change.block_height, state_change.service_node_index, state_change.state);
     crypto::generate_signature(hash, pub, sec, result);
     return result;
   }
 
-  static bool bounds_check_worker_index(service_nodes::testing_quorum const &quorum, size_t worker_index, cryptonote::vote_verification_context &vvc)
+  static bool bounds_check_worker_index(service_nodes::testing_quorum const &quorum, uint32_t worker_index, cryptonote::vote_verification_context &vvc)
   {
     if (worker_index >= quorum.workers.size())
     {
@@ -132,7 +144,7 @@ namespace service_nodes
     return true;
   }
 
-  static bool bounds_check_validator_index(service_nodes::testing_quorum const &quorum, size_t validator_index, cryptonote::vote_verification_context &vvc)
+  static bool bounds_check_validator_index(service_nodes::testing_quorum const &quorum, uint32_t validator_index, cryptonote::vote_verification_context &vvc)
   {
     if (validator_index >= quorum.validators.size())
     {
@@ -143,29 +155,42 @@ namespace service_nodes
     return true;
   }
 
-  bool verify_tx_deregister(const cryptonote::tx_extra_service_node_deregister &deregister,
-                            cryptonote::vote_verification_context &vvc,
-                            const service_nodes::testing_quorum &quorum)
+  bool verify_tx_state_change(const cryptonote::tx_extra_service_node_state_change &state_change,
+                              cryptonote::vote_verification_context &vvc,
+                              const service_nodes::testing_quorum &quorum,
+                              const uint8_t hf_version)
   {
-    if (deregister.votes.size() < service_nodes::DEREGISTER_MIN_VOTES_TO_KICK_SERVICE_NODE)
+    if (state_change.state != new_state::deregister && hf_version < cryptonote::network_version_12_checkpointing)
+    {
+      LOG_PRINT_L1("Non-deregister state changes are invalid before v12");
+      return false;
+    }
+
+    if (state_change.state > new_state::recommission)
+    {
+      LOG_PRINT_L1("Unknown state change to new state: " << static_cast<uint16_t>(state_change.state));
+      return false;
+    }
+
+    if (state_change.votes.size() < service_nodes::STATE_CHANGE_MIN_VOTES_TO_CHANGE_STATE)
     {
       LOG_PRINT_L1("Not enough votes");
       vvc.m_not_enough_votes = true;
       return false;
     }
 
-    if (deregister.votes.size() > service_nodes::DEREGISTER_QUORUM_SIZE)
+    if (state_change.votes.size() > service_nodes::STATE_CHANGE_QUORUM_SIZE)
     {
       LOG_PRINT_L1("Too many votes");
       return false;
     }
 
-    if (!bounds_check_worker_index(quorum, deregister.service_node_index, vvc))
+    if (!bounds_check_worker_index(quorum, state_change.service_node_index, vvc))
       return false;
 
-    crypto::hash const hash = make_deregister_vote_hash(deregister.block_height, deregister.service_node_index);
-    std::array<int, service_nodes::DEREGISTER_QUORUM_SIZE> validator_set = {};
-    for (const cryptonote::tx_extra_service_node_deregister::vote& vote : deregister.votes)
+    crypto::hash const hash = make_state_change_vote_hash(state_change.block_height, state_change.service_node_index, state_change.state);
+    std::array<int, service_nodes::STATE_CHANGE_QUORUM_SIZE> validator_set = {};
+    for (const auto &vote : state_change.votes)
     {
       if (!bounds_check_validator_index(quorum, vote.validator_index, vvc))
         return false;
@@ -189,15 +214,16 @@ namespace service_nodes
     return true;
   }
 
-  quorum_vote_t make_deregister_vote(uint64_t block_height, uint16_t validator_index, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &sec_key)
+  quorum_vote_t make_state_change_vote(uint64_t block_height, uint16_t validator_index, uint16_t worker_index, new_state state, crypto::public_key const &pub_key, crypto::secret_key const &sec_key)
   {
-    quorum_vote_t result           = {};
-    result.type                    = quorum_type::deregister;
-    result.block_height            = block_height;
-    result.group                   = quorum_group::validator;
-    result.index_in_group          = validator_index;
-    result.deregister.worker_index = worker_index;
-    result.signature               = make_signature_from_vote(result, pub_key, sec_key);
+    quorum_vote_t result             = {};
+    result.type                      = quorum_type::obligations;
+    result.block_height              = block_height;
+    result.group                     = quorum_group::validator;
+    result.index_in_group            = validator_index;
+    result.state_change.worker_index = worker_index;
+    result.state_change.state        = state;
+    result.signature                 = make_signature_from_vote(result, pub_key, sec_key);
     return result;
   }
 
@@ -228,7 +254,7 @@ namespace service_nodes
           return false;
         };
 
-        case quorum_type::deregister:
+        case quorum_type::obligations:
         {
           if (vote.group != quorum_group::validator)
           {
@@ -238,10 +264,10 @@ namespace service_nodes
           }
 
           key          = quorum.validators[vote.index_in_group];
-          max_vote_age = service_nodes::DEREGISTER_VOTE_LIFETIME;
-          hash         = make_deregister_vote_hash(vote.block_height, vote.deregister.worker_index);
+          max_vote_age = service_nodes::STATE_CHANGE_VOTE_LIFETIME;
+          hash         = make_state_change_vote_hash(vote.block_height, vote.state_change.worker_index, vote.state_change.state);
 
-          bool result = bounds_check_worker_index(quorum, vote.deregister.worker_index, vvc);
+          bool result = bounds_check_worker_index(quorum, vote.state_change.worker_index, vvc);
           if (!result)
             return result;
         }
@@ -304,6 +330,34 @@ namespace service_nodes
     return result;
   }
 
+  template <typename T>
+  static std::vector<pool_vote_entry> *find_vote_in_pool(std::vector<T> &pool, const quorum_vote_t &vote, bool create) {
+    T typed_vote{vote};
+    auto it = std::find(pool.begin(), pool.end(), typed_vote);
+    if (it != pool.end())
+      return &it->votes;
+    if (!create)
+      return nullptr;
+    pool.push_back(std::move(typed_vote));
+    return &pool.back().votes;
+  }
+
+  std::vector<pool_vote_entry> *voting_pool::find_vote_pool(const quorum_vote_t &find_vote, bool create_if_not_found) {
+    switch(find_vote.type)
+    {
+      default:
+        LOG_PRINT_L1("Unhandled find_vote type with value: " << (int)find_vote.type);
+        assert("Unhandled find_vote type" == 0);
+        return nullptr;
+
+      case quorum_type::obligations:
+        return find_vote_in_pool(m_obligations_pool, find_vote, create_if_not_found);
+
+      case quorum_type::checkpointing:
+        return find_vote_in_pool(m_checkpoint_pool, find_vote, create_if_not_found);
+    }
+  }
+
   void voting_pool::set_relayed(const std::vector<quorum_vote_t>& votes)
   {
     CRITICAL_REGION_LOCAL(m_lock);
@@ -311,47 +365,11 @@ namespace service_nodes
 
     for (const quorum_vote_t &find_vote : votes)
     {
-      std::vector<pool_vote_entry> *vote_pool = nullptr;
-      switch(find_vote.type)
-      {
-        default:
-        {
-          LOG_PRINT_L1("Unhandled find_vote type with value: " << (int)find_vote.type);
-          assert("Unhandled find_vote type" == 0);
-          break;
-        };
-
-        case quorum_type::deregister:
-        {
-          auto it = std::find_if(m_deregister_pool.begin(), m_deregister_pool.end(), [find_vote](deregister_pool_entry const &entry) {
-              return (entry.height == find_vote.block_height &&
-                      entry.worker_index == find_vote.deregister.worker_index);
-          });
-
-          if (it == m_deregister_pool.end())
-            break;
-
-          vote_pool = &it->votes;
-        }
-        break;
-
-        case quorum_type::checkpointing:
-        {
-          auto it = std::find_if(m_checkpoint_pool.begin(), m_checkpoint_pool.end(), [find_vote](checkpoint_pool_entry const &entry) {
-              return (entry.height == find_vote.block_height && entry.hash == find_vote.checkpoint.block_hash);
-          });
-
-          if (it == m_checkpoint_pool.end())
-            break;
-
-          vote_pool = &it->votes;
-        }
-        break;
-      }
+      std::vector<pool_vote_entry> *vote_pool = find_vote_pool(find_vote);
 
       if (vote_pool) // We found the group that this vote belongs to
       {
-        auto vote = std::find_if(vote_pool->begin(), vote_pool->end(), [find_vote](pool_vote_entry const &entry) {
+        auto vote = std::find_if(vote_pool->begin(), vote_pool->end(), [&find_vote](pool_vote_entry const &entry) {
             return (find_vote.index_in_group == entry.vote.index_in_group);
         });
 
@@ -361,6 +379,14 @@ namespace service_nodes
         }
       }
     }
+  }
+
+  template <typename T>
+  static void append_relayable_votes(std::vector<quorum_vote_t> &result, const T &pool, const time_t now, const time_t threshold) {
+    for (const auto &pool_entry : pool)
+      for (const auto &vote_entry : pool_entry.votes)
+        if (now > (time_t)vote_entry.time_last_sent_p2p + threshold)
+          result.push_back(vote_entry.vote);
   }
 
   std::vector<quorum_vote_t> voting_pool::get_relayable_votes() const
@@ -376,48 +402,26 @@ namespace service_nodes
 
     time_t const now = time(nullptr);
     std::vector<quorum_vote_t> result;
-    for (deregister_pool_entry const &pool_entry : m_deregister_pool)
-    {
-      for (pool_vote_entry const &vote_entry : pool_entry.votes)
-      {
-        const time_t last_sent = now - vote_entry.time_last_sent_p2p;
-        if (last_sent > TIME_BETWEEN_RELAY)
-          result.push_back(vote_entry.vote);
-      }
-    }
-
-    for (checkpoint_pool_entry const &pool_entry : m_checkpoint_pool)
-    {
-      for (pool_vote_entry const &vote_entry : pool_entry.votes)
-      {
-        const time_t last_sent = now - vote_entry.time_last_sent_p2p;
-        if (last_sent > TIME_BETWEEN_RELAY)
-          result.push_back(vote_entry.vote);
-      }
-    }
-
+    append_relayable_votes(result, m_obligations_pool, now, TIME_BETWEEN_RELAY);
+    append_relayable_votes(result, m_checkpoint_pool,   now, TIME_BETWEEN_RELAY);
     return result;
   }
 
   // return: True if the vote was unique
-  template <typename T>
-  static bool add_vote_to_pool_if_unique(T &vote_pool, quorum_vote_t const &vote)
+  static bool add_vote_to_pool_if_unique(std::vector<pool_vote_entry> &votes, quorum_vote_t const &vote)
   {
-    auto vote_it = std::find_if(vote_pool.votes.begin(), vote_pool.votes.end(), [&vote](pool_vote_entry const &pool_entry) {
+    auto vote_it = std::find_if(votes.begin(), votes.end(), [&vote](pool_vote_entry const &pool_entry) {
         assert(pool_entry.vote.group == vote.group);
         return (pool_entry.vote.index_in_group == vote.index_in_group);
     });
 
-    bool result = false;
-    if (vote_it == vote_pool.votes.end())
+    if (vote_it == votes.end())
     {
-      pool_vote_entry entry = {};
-      entry.vote            = vote;
-      vote_pool.votes.push_back(entry);
-      result                = true;
+      votes.push_back({vote});
+      return true;
     }
 
-    return result;
+    return false;
   }
 
   std::vector<pool_vote_entry> voting_pool::add_pool_vote_if_unique(uint64_t latest_height,
@@ -425,115 +429,67 @@ namespace service_nodes
                                                                     cryptonote::vote_verification_context& vvc,
                                                                     const service_nodes::testing_quorum &quorum)
   {
-    std::vector<pool_vote_entry> result = {};
-
     if (!verify_vote(vote, latest_height, vvc, quorum))
     {
       LOG_PRINT_L1("Signature verification failed for deregister vote");
-      return result;
+      return {};
     }
 
     CRITICAL_REGION_LOCAL(m_lock);
-    switch(vote.type)
-    {
-      default:
-      {
-        LOG_PRINT_L1("Unhandled vote type with value: " << (int)vote.type);
-        assert("Unhandled vote type" == 0);
-        return result;
-      };
+    auto *votes = find_vote_pool(vote, /*create_if_not_found=*/ true);
+    if (!votes)
+      return {};
 
-      case quorum_type::deregister:
-      {
-        time_t const now = time(NULL);
-        auto it = std::find_if(m_deregister_pool.begin(), m_deregister_pool.end(), [&vote](deregister_pool_entry const &entry) {
-            return (entry.height == vote.block_height && entry.worker_index == vote.deregister.worker_index);
-        });
-
-        if (it == m_deregister_pool.end())
-        {
-          m_deregister_pool.emplace_back(vote.block_height, vote.deregister.worker_index);
-          it = (m_deregister_pool.end() - 1);
-        }
-
-        deregister_pool_entry &pool_entry = (*it);
-        vvc.m_added_to_pool               = add_vote_to_pool_if_unique(pool_entry, vote);
-        result                            = pool_entry.votes;
-      }
-      break;
-
-      case quorum_type::checkpointing:
-      {
-        // Get Matching Checkpoint
-        auto it = std::find_if(m_checkpoint_pool.begin(), m_checkpoint_pool.end(), [&vote](checkpoint_pool_entry const &entry) {
-            return (entry.height == vote.block_height && entry.hash == vote.checkpoint.block_hash);
-        });
-
-        if (it == m_checkpoint_pool.end())
-        {
-          m_checkpoint_pool.emplace_back(vote.block_height, vote.checkpoint.block_hash);
-          it = (m_checkpoint_pool.end() - 1);
-        }
-
-        checkpoint_pool_entry &pool_entry = (*it);
-        vvc.m_added_to_pool               = add_vote_to_pool_if_unique(pool_entry, vote);
-        result                            = pool_entry.votes;
-      }
-      break;
-    }
-
-    return result;
+    vvc.m_added_to_pool = add_vote_to_pool_if_unique(*votes, vote);
+    return *votes;
   }
 
-  void voting_pool::remove_used_votes(std::vector<cryptonote::transaction> const &txs)
+  void voting_pool::remove_used_votes(std::vector<cryptonote::transaction> const &txs, uint8_t hard_fork_version)
   {
     // TODO(doyle): Cull checkpoint votes
     CRITICAL_REGION_LOCAL(m_lock);
-    if (m_deregister_pool.empty())
+    if (m_obligations_pool.empty())
       return;
 
-    for (const cryptonote::transaction &tx : txs)
+    for (const auto &tx : txs)
     {
-      if (tx.type != cryptonote::txtype::deregister)
+      if (tx.type != cryptonote::txtype::state_change)
         continue;
 
-      cryptonote::tx_extra_service_node_deregister deregister;
-      if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+      cryptonote::tx_extra_service_node_state_change state_change;
+      if (!get_service_node_state_change_from_tx_extra(tx.extra, state_change, hard_fork_version))
       {
-        LOG_ERROR("Could not get deregister from tx, possibly corrupt tx");
+        LOG_ERROR("Could not get state change from tx, possibly corrupt tx");
         continue;
       }
 
-      auto it = std::find_if(m_deregister_pool.begin(), m_deregister_pool.end(), [&deregister](deregister_pool_entry const &entry){
-          return (entry.height == deregister.block_height) && (entry.worker_index == deregister.service_node_index);
-      });
+      auto it = std::find(m_obligations_pool.begin(), m_obligations_pool.end(), state_change);
 
-      if (it != m_deregister_pool.end())
-        m_deregister_pool.erase(it);
+      if (it != m_obligations_pool.end())
+        m_obligations_pool.erase(it);
     }
   }
 
   template <typename T>
   static void cull_votes(std::vector<T> &vote_pool, uint64_t min_height, uint64_t max_height)
   {
-    for (auto it = vote_pool.begin(); it != vote_pool.end(); ++it)
+    for (auto it = vote_pool.begin(); it != vote_pool.end(); )
     {
       const T &pool_entry = *it;
       if (pool_entry.height < min_height || pool_entry.height > max_height)
-      {
         it = vote_pool.erase(it);
-        it--;
-      }
+      else
+        ++it;
     }
   }
 
   void voting_pool::remove_expired_votes(uint64_t height)
   {
     CRITICAL_REGION_LOCAL(m_lock);
-    uint64_t deregister_min_height = (height < DEREGISTER_VOTE_LIFETIME) ? 0 : height - DEREGISTER_VOTE_LIFETIME;
-    cull_votes(m_deregister_pool, deregister_min_height, height);
+    uint64_t deregister_min_height = (height < STATE_CHANGE_VOTE_LIFETIME) ? 0 : height - STATE_CHANGE_VOTE_LIFETIME;
+    cull_votes(m_obligations_pool, deregister_min_height, height);
 
-    uint64_t checkpoint_min_height = (height < CHECKPOINT_VOTE_LIFETIME) ? 0 : height - CHECKPOINT_VOTE_LIFETIME;
+    uint64_t checkpoint_min_height = (height < CHECKPOINT_VOTE_LIFETIME)   ? 0 : height - CHECKPOINT_VOTE_LIFETIME;
     cull_votes(m_checkpoint_pool, checkpoint_min_height, height);
   }
 }; // namespace service_nodes

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -494,7 +494,7 @@ namespace service_nodes
 
     for (const cryptonote::transaction &tx : txs)
     {
-      if (tx.get_type() != cryptonote::transaction::type_deregister)
+      if (tx.type != cryptonote::txtype::deregister)
         continue;
 
       cryptonote::tx_extra_service_node_deregister deregister;

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -63,14 +63,14 @@ namespace service_nodes
   struct checkpoint_vote { crypto::hash block_hash; };
   struct deregister_vote { uint16_t worker_index; };
 
-  enum struct quorum_type
+  enum struct quorum_type : uint8_t
   {
     deregister = 0,
     checkpointing,
     count,
   };
 
-  enum struct quorum_group { invalid, validator, worker };
+  enum struct quorum_group : uint8_t { invalid, validator, worker };
   struct quorum_vote_t
   {
     uint8_t           version = 0;

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -35,6 +35,7 @@
 #include "crypto/crypto.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/blobdatatype.h"
+#include "cryptonote_basic/tx_extra.h"
 
 #include "math_helper.h"
 #include "syncobj.h"
@@ -42,7 +43,6 @@
 namespace cryptonote
 {
   struct vote_verification_context;
-  struct tx_extra_service_node_deregister;
 };
 
 namespace service_nodes
@@ -61,11 +61,11 @@ namespace service_nodes
   };
 
   struct checkpoint_vote { crypto::hash block_hash; };
-  struct deregister_vote { uint16_t worker_index; };
+  struct state_change_vote { uint16_t worker_index; new_state state; };
 
   enum struct quorum_type : uint8_t
   {
-    deregister = 0,
+    obligations = 0,
     checkpointing,
     count,
   };
@@ -82,17 +82,17 @@ namespace service_nodes
 
     union
     {
-      deregister_vote deregister;
-      checkpoint_vote checkpoint;
+      state_change_vote state_change;
+      checkpoint_vote   checkpoint;
     };
   };
 
-  quorum_vote_t     make_deregister_vote(uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
+  quorum_vote_t     make_state_change_vote(uint64_t block_height, uint16_t index_in_group, uint16_t worker_index, new_state state, crypto::public_key const &pub_key, crypto::secret_key const &secret_key);
 
-  bool              verify_tx_deregister             (const cryptonote::tx_extra_service_node_deregister& deregister, cryptonote::vote_verification_context& vvc, const service_nodes::testing_quorum &quorum);
-  bool              verify_vote                      (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
-  crypto::signature make_signature_from_vote         (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
-  crypto::signature make_signature_from_tx_deregister(cryptonote::tx_extra_service_node_deregister const &deregister, crypto::public_key const &pub, crypto::secret_key const &sec);
+  bool              verify_tx_state_change             (const cryptonote::tx_extra_service_node_state_change& state_change, cryptonote::vote_verification_context& vvc, const service_nodes::testing_quorum &quorum, uint8_t hf_version);
+  bool              verify_vote                        (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
+  crypto::signature make_signature_from_vote           (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
+  crypto::signature make_signature_from_tx_state_change(cryptonote::tx_extra_service_node_state_change const &state_change, crypto::public_key const &pub, crypto::secret_key const &sec);
 
   // NOTE: This preserves the deregister vote format pre-checkpointing so that
   // up to the hardfork, we can still deserialize and serialize until we switch
@@ -125,25 +125,37 @@ namespace service_nodes
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                         set_relayed         (const std::vector<quorum_vote_t>& votes);
     void                         remove_expired_votes(uint64_t height);
-    void                         remove_used_votes   (std::vector<cryptonote::transaction> const &txs);
+    void                         remove_used_votes   (std::vector<cryptonote::transaction> const &txs, uint8_t hard_fork_version);
     std::vector<quorum_vote_t>   get_relayable_votes () const;
 
   private:
-    struct deregister_pool_entry
+    std::vector<pool_vote_entry> *find_vote_pool(const quorum_vote_t &vote, bool create_if_not_found = false);
+
+    struct obligations_pool_entry
     {
-      deregister_pool_entry(uint64_t height, uint32_t worker_index): height(height), worker_index(worker_index) {}
+      explicit obligations_pool_entry(const quorum_vote_t &vote)
+          : height{vote.block_height}, worker_index{vote.state_change.worker_index}, state{vote.state_change.state} {}
+      obligations_pool_entry(const cryptonote::tx_extra_service_node_state_change &sc)
+          : height{sc.block_height}, worker_index{sc.service_node_index}, state{sc.state} {}
+
       uint64_t                     height;
       uint32_t                     worker_index;
+      new_state                    state;
       std::vector<pool_vote_entry> votes;
+
+      bool operator==(const obligations_pool_entry &e) const { return height == e.height && worker_index == e.worker_index && state == e.state; }
     };
-    std::vector<deregister_pool_entry> m_deregister_pool;
+    std::vector<obligations_pool_entry> m_obligations_pool;
 
     struct checkpoint_pool_entry
     {
+      explicit checkpoint_pool_entry(const quorum_vote_t &vote) : height{vote.block_height}, hash{vote.checkpoint.block_hash} {}
       checkpoint_pool_entry(uint64_t height, crypto::hash const &hash): height(height), hash(hash) {}
       uint64_t                     height;
       crypto::hash                 hash;
       std::vector<pool_vote_entry> votes;
+
+      bool operator==(const checkpoint_pool_entry &e) const { return height == e.height && hash == e.hash; }
     };
     std::vector<checkpoint_pool_entry> m_checkpoint_pool;
 

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -461,7 +461,7 @@ namespace cryptonote
      * @return true if it already exists
      *
      */
-    bool have_duplicated_non_standard_tx(transaction const &tx) const;
+    bool have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version) const;
 
     /**
      * @brief check if any spent key image in a transaction is in the pool

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -493,7 +493,7 @@ namespace tx {
     auto & tsx_data = m_ct.tsx_data;
     auto & tx = cur_tx();
 
-    m_ct.tx.version = 2;
+    m_ct.tx.version = cryptonote::txversion::v2_ringct;
     m_ct.tx.unlock_time = tx.unlock_time;
     m_client_version = (m_aux_data->client_version ? m_aux_data->client_version.get() : 1);
 

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -233,7 +233,7 @@ namespace nodetool
       return false;
 
     peers_indexed::index<by_time>::type& by_time_index = m_peers_white.get<by_time>();
-    p = *epee::misc_utils::move_it_backward(--by_time_index.end(), i);    
+    p = *epee::misc_utils::move_it_backward(std::prev(by_time_index.end()), i);
     return true;
   }
   //--------------------------------------------------------------------------------------------------
@@ -245,7 +245,7 @@ namespace nodetool
       return false;
 
     peers_indexed::index<by_time>::type& by_time_index = m_peers_gray.get<by_time>();
-    p = *epee::misc_utils::move_it_backward(--by_time_index.end(), i);    
+    p = *epee::misc_utils::move_it_backward(std::prev(by_time_index.end()), i);
     return true;
   }
   //--------------------------------------------------------------------------------------------------
@@ -418,7 +418,7 @@ namespace nodetool
     size_t random_index = crypto::rand_idx(m_peers_gray.size());
 
     peers_indexed::index<by_time>::type& by_time_index = m_peers_gray.get<by_time>();
-    pe = *epee::misc_utils::move_it_backward(--by_time_index.end(), random_index);
+    pe = *epee::misc_utils::move_it_backward(std::prev(by_time_index.end()), random_index);
 
     return true;
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -324,7 +324,7 @@ private:
     bool check_core_ready();
 
     template<typename response>
-    void fill_sn_response_entry(response &entry, const service_nodes::service_node_pubkey_info &sn_info);
+    void fill_sn_response_entry(response &entry, const service_nodes::service_node_pubkey_info &sn_info, uint64_t current_height);
     
     //utils
     uint64_t get_block_reward(const block& blk);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2777,6 +2777,9 @@ namespace cryptonote
         uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
+        bool                      active;                        // True if fully funded and not currently decommissioned
+        uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
+        int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
         std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
         std::vector<contributor>  contributors;                  // Array of contributors, contributing to this Service Node.
         uint64_t                  total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
@@ -2795,6 +2798,9 @@ namespace cryptonote
             KV_SERIALIZE(last_reward_block_height)
             KV_SERIALIZE(last_reward_transaction_index)
             KV_SERIALIZE(last_uptime_proof)
+            KV_SERIALIZE(active)
+            KV_SERIALIZE(decommission_count)
+            KV_SERIALIZE(earned_downtime_blocks)
             KV_SERIALIZE(service_node_version)
             KV_SERIALIZE(contributors)
             KV_SERIALIZE(total_contributed)
@@ -2846,6 +2852,9 @@ namespace cryptonote
       bool last_reward_block_height;
       bool last_reward_transaction_index;
       bool last_uptime_proof;
+      bool active;
+      bool decommission_count;
+      bool earned_downtime_blocks;
 
       bool service_node_version;
       bool contributors;
@@ -2868,6 +2877,9 @@ namespace cryptonote
       KV_SERIALIZE_OPT2(last_reward_block_height, false)
       KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
       KV_SERIALIZE_OPT2(last_uptime_proof, false)
+      KV_SERIALIZE_OPT2(active, false)
+      KV_SERIALIZE_OPT2(decommission_count, false)
+      KV_SERIALIZE_OPT2(earned_downtime_blocks, false)
       KV_SERIALIZE_OPT2(service_node_version, false)
       KV_SERIALIZE_OPT2(contributors, false)
       KV_SERIALIZE_OPT2(total_contributed, false)
@@ -2916,6 +2928,9 @@ namespace cryptonote
         uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
+        bool                      active;                        // True if fully funded and not currently decommissioned
+        uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
+        int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
         std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
         std::vector<contributor>  contributors;                  // Array of contributors, contributing to this Service Node.
         uint64_t                  total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
@@ -2934,6 +2949,9 @@ namespace cryptonote
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_block_height);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_transaction_index);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_uptime_proof);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(active);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(decommission_count);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(earned_downtime_blocks);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(service_node_version);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(contributors);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(total_contributed);

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -219,10 +219,10 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::transaction& tx, ra
 {
   val.SetObject();
 
-  INSERT_INTO_JSON_OBJECT(val, doc, version, tx.version);
+  INSERT_INTO_JSON_OBJECT(val, doc, version, static_cast<uint16_t>(tx.version));
   INSERT_INTO_JSON_OBJECT(val, doc, unlock_time, tx.unlock_time);
   INSERT_INTO_JSON_OBJECT(val, doc, output_unlock_times, tx.output_unlock_times);
-  INSERT_INTO_JSON_OBJECT(val, doc, type, tx.type);
+  INSERT_INTO_JSON_OBJECT(val, doc, type, static_cast<uint16_t>(tx.type));
   INSERT_INTO_JSON_OBJECT(val, doc, inputs, tx.vin);
   INSERT_INTO_JSON_OBJECT(val, doc, outputs, tx.vout);
   INSERT_INTO_JSON_OBJECT(val, doc, extra, tx.extra);
@@ -238,15 +238,24 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::transaction& tx)
     throw WRONG_TYPE("json object");
   }
 
-  GET_FROM_JSON_OBJECT(val, tx.version, version);
+  uint16_t tx_ver, tx_type;
+
+  GET_FROM_JSON_OBJECT(val, tx_ver, version);
   GET_FROM_JSON_OBJECT(val, tx.unlock_time, unlock_time);
   GET_FROM_JSON_OBJECT(val, tx.output_unlock_times, output_unlock_times);
-  GET_FROM_JSON_OBJECT(val, tx.type, type);
+  GET_FROM_JSON_OBJECT(val, tx_type, type);
   GET_FROM_JSON_OBJECT(val, tx.vin, inputs);
   GET_FROM_JSON_OBJECT(val, tx.vout, outputs);
   GET_FROM_JSON_OBJECT(val, tx.extra, extra);
   GET_FROM_JSON_OBJECT(val, tx.signatures, signatures);
   GET_FROM_JSON_OBJECT(val, tx.rct_signatures, ringct);
+
+  tx.version = static_cast<txversion>(tx_ver);
+  tx.type    = static_cast<txtype>(tx_type);
+  if (tx.version == txversion::v0 || tx.version >= txversion::_count)
+    throw BAD_INPUT();
+  if (tx.type >= txtype::_count)
+    throw BAD_INPUT();
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::block& b, rapidjson::Value& val)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6580,7 +6580,7 @@ bool simple_wallet::sweep_main_internal(sweep_type_t sweep_type, std::vector<too
 
     if (sweep_type == sweep_type_t::stake || sweep_type == sweep_type_t::register_stake)
     {
-      ptx_vector[n].tx.version = std::max((size_t)transaction::version_3_per_output_unlock_times, ptx_vector[n].tx.version);
+      ptx_vector[n].tx.version = std::max(txversion::v4_tx_types, ptx_vector[n].tx.version);
       total_sent -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
     }
   }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5945,6 +5945,7 @@ bool wallet2::is_transfer_unlocked(uint64_t unlock_time, uint64_t block_height, 
   binary_buf.reserve(sizeof(crypto::key_image));
   {
     boost::optional<std::string> failed;
+    // FIXME: can just check one here by adding a is_key_image_blacklisted
     std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::entry> blacklist = m_node_rpc_proxy.get_service_node_blacklisted_key_images(failed);
     if (failed)
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1753,7 +1753,7 @@ void wallet2::cache_tx_data(const cryptonote::transaction& tx, const crypto::has
 //----------------------------------------------------------------------------------------------------
 void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote::transaction& tx, const std::vector<uint64_t> &o_indices, uint64_t height, uint64_t ts, bool miner_tx, bool pool, bool double_spend_seen, const tx_cache_data &tx_cache_data, std::map<std::pair<uint64_t, uint64_t>, size_t> *output_tracker_cache)
 {
-  if (tx.get_type() != transaction::type_standard)
+  if (tx.type != txtype::standard)
     return;
 
   PERF_TIMER(process_new_transaction);
@@ -1997,7 +1997,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
               td.m_mask = tx_scan_info[o].mask;
               td.m_rct = true;
             }
-            else if (miner_tx && tx.version >= 2)
+            else if (miner_tx && tx.version >= txversion::v2_ringct)
             {
               td.m_mask = rct::identity();
               td.m_rct = true;
@@ -2125,7 +2125,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
               td.m_mask = tx_scan_info[o].mask;
               td.m_rct = true;
             }
-            else if (miner_tx && tx.version >= 2)
+            else if (miner_tx && tx.version >= txversion::v2_ringct)
             {
               td.m_mask = rct::identity();
               td.m_rct = true;
@@ -2234,7 +2234,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
     }
   }
 
-  uint64_t fee = miner_tx ? 0 : tx.version == 1 ? tx_money_spent_in_ins - get_outs_money_amount(tx) : tx.rct_signatures.txnFee;
+  uint64_t fee = miner_tx ? 0 : tx.version == txversion::v1 ? tx_money_spent_in_ins - get_outs_money_amount(tx) : tx.rct_signatures.txnFee;
 
   if (tx_money_spent_in_ins > 0 && !pool)
   {
@@ -2388,7 +2388,7 @@ void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::trans
     // wallet (eg, we're a cold wallet and the hot wallet sent it). For RCT transactions,
     // we only see 0 input amounts, so have to deduce amount out from other parameters.
     entry.first->second.m_amount_in = spent;
-    if (tx.version == 1)
+    if (tx.version == txversion::v1)
       entry.first->second.m_amount_out = get_outs_money_amount(tx);
     else
       entry.first->second.m_amount_out = spent - tx.rct_signatures.txnFee;
@@ -7949,12 +7949,8 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
 wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const crypto::public_key &sn_key)
 {
   request_stake_unlock_result result = {};
-  result.ptx.tx.version              = cryptonote::transaction::version_4_tx_types;
-  if (!result.ptx.tx.set_type(cryptonote::transaction::type_key_image_unlock))
-  {
-    result.msg = tr("Failed to construct a key image unlock transaction");
-    return result;
-  }
+  result.ptx.tx.version = cryptonote::txversion::v4_tx_types;
+  result.ptx.tx.type    = cryptonote::txtype::key_image_unlock;
 
   std::string const sn_key_as_str = epee::string_tools::pod_to_hex(sn_key);
   {
@@ -10556,7 +10552,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
       fund_found = true;
       if (below == 0 || td.amount() < below)
       {
-        if (td.m_tx.version <= transaction::version_1 && sweep_style != sweep_style_t::use_v1_tx)
+        if (td.m_tx.version <= txversion::v1 && sweep_style != sweep_style_t::use_v1_tx)
           continue;
 
         if ((td.is_rct()) || is_valid_decomposed_amount(td.amount()))
@@ -11497,7 +11493,7 @@ void wallet2::check_tx_key_helper(const cryptonote::transaction &tx, const crypt
     if (found)
     {
       uint64_t amount;
-      if (tx.version == 1 || tx.rct_signatures.type == rct::RCTTypeNull)
+      if (tx.version == txversion::v1 || tx.rct_signatures.type == rct::RCTTypeNull)
       {
         amount = tx.vout[n].amount;
       }


### PR DESCRIPTION
This pulls out the relax deregistration mechanism from #655 leaving behind most of the data structure changes until after 4.0 launches.

I've also added extra commits adding RPC reporting and some debugging of how SNs vote.