### PR TITLE
Add --backup-service-node flag to reduce proof timeout

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -67,6 +67,8 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define UPTIME_PROOF_FREQUENCY_IN_SECONDS               (60*60)
 #define UPTIME_PROOF_MAX_TIME_IN_SECONDS                (UPTIME_PROOF_FREQUENCY_IN_SECONDS * 2 + UPTIME_PROOF_BUFFER_IN_SECONDS)
 
+#define BACKUP_UPTIME_PROOF_DELAY_SECONDS               (45*60) // If running in --backup-service-node then wait until the usual FREQUENCY plus this time before sending a proof
+
 #define STORAGE_SERVER_PING_LIFETIME                    UPTIME_PROOF_FREQUENCY_IN_SECONDS
 
 // MONEY_SUPPLY - total number coins to be generated

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1147,6 +1147,7 @@ namespace cryptonote
      std::atomic_flag m_checkpoints_updating; //!< set if checkpoints are currently updating to avoid multiple threads attempting to update at once
 
      bool m_service_node;
+     bool m_backup_service_node;
      crypto::secret_key m_service_node_key;
      crypto::public_key m_service_node_pubkey;
 


### PR DESCRIPTION
This is designed to allow people to still run backup service nodes
*without* a race condition between the main and backup SNs that triggers
an undesirable and unnecessary service node IP switch on the network.

A SN running in backup mode won't submit uptime proofs until it has gone
1h45m without seeing an uptime proof on the network for the SN with the
same pubkey in the past 1h45m.  (Which means it also has to have been
alive for at least 1h45m, and the SN must have been registered for ~1h45
worth of blocks).