### PR TITLE
Enable dummy payment IDs

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -496,16 +496,7 @@ namespace cryptonote
     std::vector<tx_extra_field> tx_extra_fields;
     if (parse_tx_extra(tx.extra, tx_extra_fields))
     {
-      // TODO(doyle): FIXME(doyle): LOOK AT ME. Introduced in commmit
-      // c6d387184e05437d8f68a4227d739ad28568aa5e on Monero as part of the
-      // deprecating process of payment IDs. I've set it to false, but it was
-      // actually true before. If we want to take this route as the way to
-      // deprecate payment ID's by including it in every transaction, we should
-      // make this true.
-
-      // But if we have a better way, this may not be necessary.
-      //   - Jan 30, 2019
-      bool add_dummy_payment_id = false;
+      bool add_dummy_payment_id = true;
 
       tx_extra_nonce extra_nonce;
       if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))


### PR DESCRIPTION
This doesn't deprecate anything -- we still want to deprecate payment
IDs eventually in favour of subaddresses.  The main point here is just
to make all single-recipient transactions look identical (right now,
transactions into and out of TradeOgre stick out since they are the only
places payment IDs are being consistently used).

(This doesn't need to be network version guarded -- adding short payment
IDs to a tx is perfectly valid).