### PR TITLE
Tweak decommission credit rules

### DIFF
--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -33,9 +33,9 @@ namespace service_nodes {
   // accumulated credit at the point of decommissioning) then a quorum will send a permanent
   // deregistration transaction to the network, starting a 30-day deregistration count down.
   constexpr int64_t DECOMMISSION_CREDIT_PER_DAY = BLOCKS_EXPECTED_IN_HOURS(24) / 30;
-  constexpr int64_t DECOMMISSION_INITIAL_CREDIT = BLOCKS_EXPECTED_IN_HOURS(0);
+  constexpr int64_t DECOMMISSION_INITIAL_CREDIT = BLOCKS_EXPECTED_IN_HOURS(2);
   constexpr int64_t DECOMMISSION_MAX_CREDIT     = BLOCKS_EXPECTED_IN_HOURS(24);
-  constexpr int64_t DECOMMISSION_MINIMUM        = BLOCKS_EXPECTED_IN_HOURS(8);
+  constexpr int64_t DECOMMISSION_MINIMUM        = BLOCKS_EXPECTED_IN_HOURS(2);
 
   static_assert(DECOMMISSION_INITIAL_CREDIT <= DECOMMISSION_MAX_CREDIT, "Initial registration decommission credit cannot be larger than the maximum decommission credit");
 


### PR DESCRIPTION
This starts everyone with 2 hours of credit at deregistration (instead
of none), and reduces the minimum required for decommissioning to 2
hours so that everyone can get some decommission right away.

Otherwise the credit accumulation rate and maximum remain unchanged: 24
blocks per day = 24 hours worth of blocks per 30 days, and a maximum
accumulated credit of 24 hours (which you'll now hit 27.5 days after
registration instead of 30 because of the initial 2 hour credit).