### PR TITLE
Disallow recursive reorgs from the 2nd oldest checkpoint

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -258,7 +258,7 @@ namespace cryptonote
     return result;
   }
   //---------------------------------------------------------------------------
-  bool checkpoints::is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height) const
+  bool checkpoints::is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height)
   {
     if (0 == block_height)
       return false;
@@ -293,7 +293,8 @@ namespace cryptonote
       sentinel_reorg_height = checkpoints[0].height;
     }
 
-    bool result = sentinel_reorg_height < block_height;
+    m_oldest_allowable_alternative_block = std::max(sentinel_reorg_height, m_oldest_allowable_alternative_block);
+    bool result                          = block_height > m_oldest_allowable_alternative_block;
     return result;
   }
   //---------------------------------------------------------------------------

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -166,9 +166,10 @@ namespace cryptonote
     bool check_block(uint64_t height, const crypto::hash& h, bool *is_a_checkpoint = nullptr) const;
 
     /**
-     * @brief checks if alternate chain blocks should be kept for a given height
+     * @brief checks if alternate chain blocks should be kept for a given height and updates
+     * m_oldest_allowable_alternative_block based on the available checkpoints
      *
-     *m this basically says if the blockchain is smaller than the first
+     * this basically says if the blockchain is smaller than the first
      * checkpoint then alternate blocks are allowed.  Alternatively, if the
      * last checkpoint *before* the end of the current chain is also before
      * the block to be added, then this is fine.
@@ -179,7 +180,7 @@ namespace cryptonote
      * @return true if alternate blocks are allowed given the parameters,
      *         otherwise false
      */
-    bool is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height) const;
+    bool is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height);
 
     /**
      * @brief gets the highest checkpoint height
@@ -198,6 +199,7 @@ namespace cryptonote
 
   private:
     uint64_t m_last_cull_height = 0;
+    uint64_t m_oldest_allowable_alternative_block = 0;
     BlockchainDB *m_db;
   };
 


### PR DESCRIPTION
Checkpointing mandates that we can not reorganise back past the 2nd
oldest service node checkpoint. Ordinarily if we reorg back to the 2nd
oldest checkpoint, we could continually reorg the chain by introducing
alternative chains repeatedly with length less than the size of
the next 2 oldest checkpoint ranges and continually pop off blocks.