### PR TITLE
Cap difficulty at 30MH/s for first 60 v12 blocks

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -4347,7 +4347,7 @@ void BlockchainLMDB::fixup(fixup_context const context)
 
   if (context.type == fixup_type::calculate_difficulty)
   {
-    uint64_t const start_height = (context.calculate_difficulty_params.start_height == 0) ?
+    uint64_t start_height = (context.calculate_difficulty_params.start_height == 0) ?
       1 : context.calculate_difficulty_params.start_height;
 
     std::vector<uint64_t> timestamps;
@@ -4376,6 +4376,22 @@ void BlockchainLMDB::fixup(fixup_context const context)
     mdb_txn_cursors *m_cursors = &m_wcursors; // Necessary for macro
     CURSOR(block_info);
 
+    // The first blocks of v12 get an overridden difficulty, so if the start block is v12 we need to
+    // make sure it isn't in that initial window; if it *is*, check H-60 to see if that is v11; if
+    // it is, recalculate from there instead (so that we detect the v12 barrier).
+    uint8_t v12_initial_blocks_remaining = 0;
+    uint8_t start_version = get_hard_fork_version(start_height);
+    if (start_version < cryptonote::network_version_12_checkpointing) {
+      v12_initial_blocks_remaining = DIFFICULTY_WINDOW_V2;
+    } else if (start_version == cryptonote::network_version_12_checkpointing && start_height > DIFFICULTY_WINDOW_V2) {
+      uint8_t earlier_version = get_hard_fork_version(start_height - DIFFICULTY_WINDOW_V2);
+      if (earlier_version < cryptonote::network_version_12_checkpointing) {
+        start_height -= DIFFICULTY_WINDOW_V2;
+        v12_initial_blocks_remaining = DIFFICULTY_WINDOW_V2;
+        LOG_PRINT_L2("Using earlier recalculation start height " << start_height << " to include v12 fork height");
+      }
+    }
+
     uint64_t end_height = (height() - 1);
     uint64_t num_blocks = end_height - start_height;
 
@@ -4385,7 +4401,13 @@ void BlockchainLMDB::fixup(fixup_context const context)
       {
         uint64_t const curr_height = (start_height + i);
         uint8_t version            = get_hard_fork_version(curr_height);
-        difficulty_type diff       = next_difficulty_v2(timestamps, difficulties, DIFFICULTY_TARGET_V2, version <= cryptonote::network_version_9_service_nodes);
+        bool v12_initial_override = false;
+        if (version == cryptonote::network_version_12_checkpointing && v12_initial_blocks_remaining > 0) {
+          v12_initial_override = true;
+          v12_initial_blocks_remaining--;
+        }
+        difficulty_type diff = next_difficulty_v2(timestamps, difficulties, DIFFICULTY_TARGET_V2,
+            version <= cryptonote::network_version_9_service_nodes, v12_initial_override);
 
         MDB_val_set(key, curr_height);
         if (int result = mdb_cursor_get(m_cur_block_info, (MDB_val *)&zerokval, &key, MDB_GET_BOTH))

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -147,7 +147,8 @@ namespace cryptonote {
   // Cryptonote clones:  #define DIFFICULTY_BLOCKS_COUNT_V2 DIFFICULTY_WINDOW_V2 + 1
 
 
-  difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds, bool use_old_lwma) {
+  difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds,
+      bool use_old_lwma, bool v12_initial_override) {
 
     const int64_t T = static_cast<int64_t>(target_seconds);
 
@@ -204,6 +205,12 @@ namespace cryptonote {
 
     if (next_difficulty == 0)
         next_difficulty = 1;
+
+    // Rough estimate based on comparable coins, pre-merge-mining hashrate, and hashrate changes is
+    // that 30MH/s seems more or less right, so we cap it there for the first WINDOW blocks to
+    // prevent too-long blocks right after the fork.
+    if (v12_initial_override)
+      return std::min(next_difficulty, 30000000 * uint64_t(target_seconds));
 
     return next_difficulty;
   }

--- a/src/cryptonote_basic/difficulty.h
+++ b/src/cryptonote_basic/difficulty.h
@@ -53,5 +53,6 @@ namespace cryptonote
      */
     bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
 
-    difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds, bool use_old_lwma);
+    difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds,
+        bool use_old_lwma, bool v12_initial_override);
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -941,7 +941,13 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     m_difficulties = difficulties;
   }
   size_t target = get_difficulty_target();
-  difficulty_type diff = next_difficulty_v2(timestamps, difficulties, target, version <= cryptonote::network_version_9_service_nodes);
+
+  // HF12 switches to RandomX with a likely drastically reduced hashrate versus Turtle, so override
+  // difficulty for the first difficulty window blocks:
+  uint64_t hf12_height = m_hardfork->get_earliest_ideal_height_for_version(network_version_12_checkpointing);
+
+  difficulty_type diff = next_difficulty_v2(timestamps, difficulties, target, version <= cryptonote::network_version_9_service_nodes,
+          height >= hf12_height && height < hf12_height + DIFFICULTY_WINDOW_V2);
 
   CRITICAL_REGION_LOCAL1(m_difficulty_lock);
   m_difficulty_for_next_block_top_hash = top_hash;
@@ -1176,8 +1182,15 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // FIXME: This will fail if fork activation heights are subject to voting
   size_t target = DIFFICULTY_TARGET_V2;
 
+  // HF12 switches to RandomX with a likely drastically reduced hashrate versus Turtle, so override
+  // difficulty for the first difficulty window blocks:
+  uint64_t hf12_height = m_hardfork->get_earliest_ideal_height_for_version(network_version_12_checkpointing);
+
+  uint64_t height = (alt_chain.size() ? alt_chain.front().height : bei.height) + alt_chain.size() + 1;
+
   // calculate the difficulty target for the block and return it
-  return next_difficulty_v2(timestamps, cumulative_difficulties, target, get_current_hard_fork_version() <= cryptonote::network_version_9_service_nodes);
+  return next_difficulty_v2(timestamps, cumulative_difficulties, target, get_current_hard_fork_version() <= cryptonote::network_version_9_service_nodes,
+      height >= hf12_height && height < hf12_height + DIFFICULTY_WINDOW_V2);
 }
 //------------------------------------------------------------------
 // This function does a sanity check on basic things that all miner


### PR DESCRIPTION
We're going to be coming down off a ~300MH/s high, so add a difficulty
cap of 30MH/s for the first 60 blocks so that we don't end with
extremely long blocks.

(Obviously this requires #675 to also be merged).