### PR TITLE
Fix segfault on exit with bad SN args

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1506,11 +1506,13 @@ namespace service_nodes
 
   bool service_node_list::store()
   {
+    if (!m_db)
+        return false; // Haven't been initialized yet
+
     uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
     if (hf_version < cryptonote::network_version_9_service_nodes)
       return true;
 
-    CHECK_AND_ASSERT_MES(m_db != nullptr, false, "Failed to store service node info, m_db == nullptr");
     data_members_for_serialization data_to_store;
     {
       std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);


### PR DESCRIPTION
service_node_list::store() was called on destruction, but destruction
can happen before it is set up with the database pointer (hence the
segfault).  Fix it to just silently return if not set up yet.