### PR TITLE
Add a `state_height` to RPC

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2655,6 +2655,8 @@ namespace cryptonote
     entry.last_reward_transaction_index = sn_info.info.last_reward_transaction_index;
     entry.last_uptime_proof             = sn_info.info.proof.timestamp;
     entry.active                        = sn_info.info.is_active();
+    entry.state_height                  = sn_info.info.is_fully_funded()
+        ? (sn_info.info.is_decommissioned() ? sn_info.info.last_decommission_height : sn_info.info.active_since_height) : sn_info.info.last_reward_block_height;
     entry.earned_downtime_blocks        = service_nodes::quorum_cop::calculate_decommission_credit(sn_info.info, current_height);
     entry.decommission_count            = sn_info.info.decommission_count;
     entry.service_node_version          = {sn_info.info.proof.version_major, sn_info.info.proof.version_minor, sn_info.info.proof.version_patch};

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2655,6 +2655,7 @@ namespace cryptonote
     entry.last_reward_transaction_index = sn_info.info.last_reward_transaction_index;
     entry.last_uptime_proof             = sn_info.info.proof.timestamp;
     entry.active                        = sn_info.info.is_active();
+    entry.funded                        = sn_info.info.is_fully_funded();
     entry.state_height                  = sn_info.info.is_fully_funded()
         ? (sn_info.info.is_decommissioned() ? sn_info.info.last_decommission_height : sn_info.info.active_since_height) : sn_info.info.last_reward_block_height;
     entry.earned_downtime_blocks        = service_nodes::quorum_cop::calculate_decommission_credit(sn_info.info, current_height);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2781,7 +2781,8 @@ namespace cryptonote
         uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by at least 1 Service Node other than itself in unix epoch time.
-        bool                      active;                        // True if fully funded and not currently decommissioned
+        bool                      active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
+        bool                      funded;                        // True if the required stakes have been submitted to activate this Service Node
         uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
         uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
         int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
@@ -2804,6 +2805,7 @@ namespace cryptonote
             KV_SERIALIZE(last_reward_transaction_index)
             KV_SERIALIZE(last_uptime_proof)
             KV_SERIALIZE(active)
+            KV_SERIALIZE(funded)
             KV_SERIALIZE(state_height)
             KV_SERIALIZE(decommission_count)
             KV_SERIALIZE(earned_downtime_blocks)
@@ -2859,6 +2861,7 @@ namespace cryptonote
       bool last_reward_transaction_index;
       bool last_uptime_proof;
       bool active;
+      bool funded;
       bool state_height;
       bool decommission_count;
       bool earned_downtime_blocks;
@@ -2886,6 +2889,7 @@ namespace cryptonote
       KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
       KV_SERIALIZE_OPT2(last_uptime_proof, false)
       KV_SERIALIZE_OPT2(active, false)
+      KV_SERIALIZE_OPT2(funded, false)
       KV_SERIALIZE_OPT2(state_height, false)
       KV_SERIALIZE_OPT2(decommission_count, false)
       KV_SERIALIZE_OPT2(earned_downtime_blocks, false)
@@ -2938,7 +2942,8 @@ namespace cryptonote
         uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
-        bool                      active;                        // True if fully funded and not currently decommissioned
+        bool                      active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
+        bool                      funded;                        // True if the required stakes have been submitted to activate this Service Node
         uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
         uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
         int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
@@ -2961,6 +2966,7 @@ namespace cryptonote
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_transaction_index);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_uptime_proof);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(active);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(funded);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(state_height);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(decommission_count);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(earned_downtime_blocks);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2782,6 +2782,7 @@ namespace cryptonote
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by at least 1 Service Node other than itself in unix epoch time.
         bool                      active;                        // True if fully funded and not currently decommissioned
+        uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
         uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
         int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
         std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
@@ -2803,6 +2804,7 @@ namespace cryptonote
             KV_SERIALIZE(last_reward_transaction_index)
             KV_SERIALIZE(last_uptime_proof)
             KV_SERIALIZE(active)
+            KV_SERIALIZE(state_height)
             KV_SERIALIZE(decommission_count)
             KV_SERIALIZE(earned_downtime_blocks)
             KV_SERIALIZE(service_node_version)
@@ -2857,6 +2859,7 @@ namespace cryptonote
       bool last_reward_transaction_index;
       bool last_uptime_proof;
       bool active;
+      bool state_height;
       bool decommission_count;
       bool earned_downtime_blocks;
 
@@ -2883,6 +2886,7 @@ namespace cryptonote
       KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
       KV_SERIALIZE_OPT2(last_uptime_proof, false)
       KV_SERIALIZE_OPT2(active, false)
+      KV_SERIALIZE_OPT2(state_height, false)
       KV_SERIALIZE_OPT2(decommission_count, false)
       KV_SERIALIZE_OPT2(earned_downtime_blocks, false)
       KV_SERIALIZE_OPT2(service_node_version, false)
@@ -2935,6 +2939,7 @@ namespace cryptonote
         uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
         uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
         bool                      active;                        // True if fully funded and not currently decommissioned
+        uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
         uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
         int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
         std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
@@ -2956,6 +2961,7 @@ namespace cryptonote
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_reward_transaction_index);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_uptime_proof);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(active);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(state_height);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(decommission_count);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(earned_downtime_blocks);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(service_node_version);


### PR DESCRIPTION
The field contains the latest height at which the SN status changed:
that is, the height at which the last contribution was received (if
awaiting); the height of activation (if active and never
decommissioned); the height of decommissioning (if currently
decommissioned); or the height of last recommissioning if applicable.

This is need by the block explorer to be able to report useful
information on the current status.