### PR TITLE
Don't do a full randomx build

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -80,4 +80,4 @@ endif()
 
 add_subdirectory(db_drivers)
 add_subdirectory(easylogging++)
-add_subdirectory(randomx)
+add_subdirectory(randomx EXCLUDE_FROM_ALL)


### PR DESCRIPTION
It builds the randomx test and benchmark binaries as part of the loki
build which isn't necessary (and isn't used).  We can test randomx on
its own.