### PR TITLE
Fix rejection of ip changes state change txes

### DIFF
--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -180,7 +180,7 @@ namespace service_nodes
       return bad_tx(tvc);
     }
 
-    if (state_change.state > new_state::recommission)
+    if (state_change.state >= new_state::_count)
     {
       LOG_PRINT_L1("Unknown state change to new state: " << static_cast<uint16_t>(state_change.state));
       return bad_tx(tvc);


### PR DESCRIPTION
This one, annoyingly, is going to cause a split; we will need to coordinate so that it gets applied across most of the testnet nodes at once.