### PR TITLE
Resolve pubkeys from state change in dupe check in the tx_pool

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -687,7 +687,7 @@ block Blockchain::pop_block_from_blockchain()
       // that might not be always true. Unlikely though, and always relaying
       // these again might cause a spike of traffic as many nodes re-relay
       // all the transactions in a popped block when a reorg happens.
-      bool r = m_tx_pool.add_tx(tx, tvc, true, true, false, version);
+      bool r = m_tx_pool.add_tx(tx, tvc, true, true, false, version, m_service_node_list);
       if (!r)
       {
         LOG_ERROR("Error returning transaction to tx_pool");
@@ -3208,29 +3208,34 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return false;
       }
 
-      auto quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::obligations, state_change.block_height);
-      if (!quorum)
+      auto const quorum_type  = service_nodes::quorum_type::obligations;
+      auto const quorum       = m_service_node_list.get_testing_quorum(quorum_type, state_change.block_height);
       {
-        MERROR_VER("State change TX could not get quorum for height: " << state_change.block_height);
-        return false;
+        if (!quorum)
+        {
+          MERROR_VER("could not get obligations quorum for recent state change tx");
+          return false;
+        }
+
+        if (!service_nodes::verify_tx_state_change(state_change, get_current_blockchain_height(), tvc, *quorum, hf_version))
+        {
+          // will be set by the above on serious failures (i.e. illegal value), but not for less
+          // serious ones like state change heights slightly outside of allowed bounds:
+          //tvc.m_verifivation_failed = true;
+          MERROR_VER("tx " << get_transaction_hash(tx) << ": state change tx could not be completely verified reason: " << print_vote_verification_context(tvc.m_vote_ctx));
+          return false;
+        }
       }
 
-      if (!service_nodes::verify_tx_state_change(state_change, get_current_blockchain_height(), tvc, *quorum, hf_version))
-      {
-        // will be set by the above on serious failures (i.e. illegal value), but not for less
-        // serious ones like state change heights slightly outside of allowed bounds:
-        //tvc.m_verifivation_failed = true;
-        MERROR_VER("tx " << get_transaction_hash(tx) << ": state change tx could not be completely verified reason: " << print_vote_verification_context(tvc.m_vote_ctx));
-        return false;
-      }
-
-      const uint64_t height                = state_change.block_height;
-      constexpr size_t num_blocks_to_check = service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS;
+      crypto::public_key const &state_change_service_node_pubkey = quorum->workers[state_change.service_node_index];
+      const uint64_t height                                      = state_change.block_height;
+      constexpr size_t num_blocks_to_check                       = service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS;
 
       std::vector<std::pair<cryptonote::blobdata,block>> blocks;
       std::vector<cryptonote::blobdata> txs;
       if (!get_blocks(height, num_blocks_to_check, blocks, txs))
       {
+        MERROR_VER("Failed to get historical blocks to check against previous state changes for de-duplication");
         return false;
       }
 
@@ -3253,15 +3258,15 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
           continue;
         }
 
-        const auto existing_quorum = m_service_node_list.get_testing_quorum(service_nodes::quorum_type::obligations, existing_state_change.block_height);
-        if (!existing_quorum)
-        {
-          MERROR_VER("could not get obligations quorum for recent state change tx");
+        crypto::public_key existing_state_change_service_node_pubkey;
+        if (!m_service_node_list.try_resolve_pubkey_in_quorum(quorum_type,
+                                                              service_nodes::quorum_group::worker,
+                                                              existing_state_change.block_height,
+                                                              existing_state_change.service_node_index,
+                                                              existing_state_change_service_node_pubkey))
           continue;
-        }
 
-        if (existing_quorum->workers[existing_state_change.service_node_index] ==
-            quorum->workers[state_change.service_node_index])
+        if (existing_state_change_service_node_pubkey == state_change_service_node_pubkey)
         {
           MERROR_VER("Already seen this state change tx (aka double spend)");
           tvc.m_double_spend = true;
@@ -3625,7 +3630,7 @@ void Blockchain::return_tx_to_pool(std::vector<std::pair<transaction, blobdata>>
     // all the transactions in a popped block when a reorg happens.
     const size_t weight = get_transaction_weight(tx.first, tx.second.size());
     const crypto::hash tx_hash = get_transaction_hash(tx.first);
-    if (!m_tx_pool.add_tx(tx.first, tx_hash, tx.second, weight, tvc, true, true, false, version))
+    if (!m_tx_pool.add_tx(tx.first, tx_hash, tx.second, weight, tvc, true, true, false, version, m_service_node_list))
     {
       MERROR("Failed to return taken transaction with hash: " << get_transaction_hash(tx.first) << " to tx_pool");
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3259,11 +3259,11 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         }
 
         crypto::public_key existing_state_change_service_node_pubkey;
-        if (!m_service_node_list.try_resolve_pubkey_in_quorum(quorum_type,
-                                                              service_nodes::quorum_group::worker,
-                                                              existing_state_change.block_height,
-                                                              existing_state_change.service_node_index,
-                                                              existing_state_change_service_node_pubkey))
+        if (!m_service_node_list.get_quorum_pubkey(quorum_type,
+                                                   service_nodes::quorum_group::worker,
+                                                   existing_state_change.block_height,
+                                                   existing_state_change.service_node_index,
+                                                   existing_state_change_service_node_pubkey))
           continue;
 
         if (existing_state_change_service_node_pubkey == state_change_service_node_pubkey)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1372,7 +1372,7 @@ namespace cryptonote
     }
 
     uint8_t version = m_blockchain_storage.get_current_hard_fork_version();
-    return m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, keeped_by_block, relayed, do_not_relay, version);
+    return m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, keeped_by_block, relayed, do_not_relay, version, m_service_node_list);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::relay_txpool_transactions()

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -157,7 +157,7 @@ namespace service_nodes
     return nullptr;
   }
 
-  bool service_node_list::try_resolve_pubkey_in_quorum(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const
+  bool service_node_list::get_quorum_pubkey(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const
   {
     std::shared_ptr<const testing_quorum> quorum = get_testing_quorum(type, height);
     if (!quorum)
@@ -343,7 +343,7 @@ namespace service_nodes
     }
 
     crypto::public_key key;
-    if (!try_resolve_pubkey_in_quorum(quorum_type::obligations, quorum_group::worker, state_change.block_height, state_change.service_node_index, key))
+    if (!get_quorum_pubkey(quorum_type::obligations, quorum_group::worker, state_change.block_height, state_change.service_node_index, key))
       return false;
 
     auto iter = m_transient_state.service_nodes_infos.find(key);
@@ -1791,7 +1791,7 @@ namespace service_nodes
       return;
 
     crypto::public_key pubkey;
-    if (!try_resolve_pubkey_in_quorum(quorum_type::checkpointing, quorum_group::worker, vote.block_height, vote.index_in_group, pubkey))
+    if (!get_quorum_pubkey(quorum_type::checkpointing, quorum_group::worker, vote.block_height, vote.index_in_group, pubkey))
     {
       MERROR("Unexpected missing quorum for checkpointing vote at height: " << vote.block_height << ", current height: " << m_transient_state.height);
       return;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -178,7 +178,7 @@ namespace service_nodes
 
     if (quorum_index >= array->size())
     {
-      MERROR("Unexpected pre-existing vote in tx pool is indexing out of bounds, this TX should have failed validation");
+      MERROR("Quorum indexing out of bounds: " << quorum_index << ", quorum_size: " << array->size());
       return false;
     }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -157,6 +157,35 @@ namespace service_nodes
     return nullptr;
   }
 
+  bool service_node_list::try_resolve_pubkey_in_quorum(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const
+  {
+    std::shared_ptr<const testing_quorum> quorum = get_testing_quorum(type, height);
+    if (!quorum)
+    {
+      // TODO(loki): Not being able to find a quorum is fatal! We want better caching abilities.
+      MERROR("Quorum for height: " << height << ", was not stored by the daemon");
+      return false;
+    }
+
+    std::vector<crypto::public_key> const *array = nullptr;
+    if      (group == quorum_group::validator) array = &quorum->validators;
+    else if (group == quorum_group::worker)    array = &quorum->workers;
+    else
+    {
+      MERROR("Invalid quorum group specified");
+      return false;
+    }
+
+    if (quorum_index >= array->size())
+    {
+      MERROR("Unexpected pre-existing vote in tx pool is indexing out of bounds, this TX should have failed validation");
+      return false;
+    }
+
+    key = (*array)[quorum_index];
+    return true;
+  }
+
   std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
@@ -313,21 +342,9 @@ namespace service_nodes
       return false;
     }
 
-    const auto state = get_testing_quorum(quorum_type::obligations, state_change.block_height);
-    if (!state)
-    {
-      // TODO(loki): Not being able to find a quorum is fatal! We want better caching abilities.
-      MERROR("Obligation quorum for height: " << state_change.block_height << ", was not stored by the daemon");
+    crypto::public_key key;
+    if (!try_resolve_pubkey_in_quorum(quorum_type::obligations, quorum_group::worker, state_change.block_height, state_change.service_node_index, key))
       return false;
-    }
-
-    if (state_change.service_node_index >= state->workers.size())
-    {
-      MERROR("Service node index to vote off has become invalid, quorum rules have changed without a hardfork.");
-      return false;
-    }
-
-    const crypto::public_key& key = state->workers[state_change.service_node_index];
 
     auto iter = m_transient_state.service_nodes_infos.find(key);
     if (iter == m_transient_state.service_nodes_infos.end()) {
@@ -1773,21 +1790,14 @@ namespace service_nodes
     if (vote.type != quorum_type::checkpointing)
       return;
 
-    std::shared_ptr<const testing_quorum> quorum = get_testing_quorum(vote.type, vote.block_height);
-    if (!quorum)
+    crypto::public_key pubkey;
+    if (!try_resolve_pubkey_in_quorum(quorum_type::checkpointing, quorum_group::worker, vote.block_height, vote.index_in_group, pubkey))
     {
       MERROR("Unexpected missing quorum for checkpointing vote at height: " << vote.block_height << ", current height: " << m_transient_state.height);
       return;
     }
 
-    if (vote.index_in_group >= quorum->workers.size())
-    {
-      MERROR("Unexpected vote indexing out of bounds, vote should have already been validated previously.");
-      return;
-    }
-
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
-    crypto::public_key const &pubkey = quorum->workers[vote.index_in_group];
     auto it = m_transient_state.service_nodes_infos.find(pubkey);
     if (it == m_transient_state.service_nodes_infos.end())
       return;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -205,8 +205,8 @@ namespace service_nodes
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;
 
     /// Note(maxim): this should not affect thread-safety as the returned object is const
-    std::shared_ptr<const testing_quorum> get_testing_quorum          (quorum_type type, uint64_t height) const;
-    bool                                  try_resolve_pubkey_in_quorum(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
+    std::shared_ptr<const testing_quorum> get_testing_quorum(quorum_type type, uint64_t height) const;
+    bool                                  get_quorum_pubkey(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
 
     std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
     const std::vector<key_image_blacklist_entry> &get_blacklisted_key_images() const { return m_transient_state.key_image_blacklist; }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -205,7 +205,8 @@ namespace service_nodes
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;
 
     /// Note(maxim): this should not affect thread-safety as the returned object is const
-    std::shared_ptr<const testing_quorum> get_testing_quorum(quorum_type type, uint64_t height) const;
+    std::shared_ptr<const testing_quorum> get_testing_quorum          (quorum_type type, uint64_t height) const;
+    bool                                  try_resolve_pubkey_in_quorum(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
 
     std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
     const std::vector<key_image_blacklist_entry> &get_blacklisted_key_images() const { return m_transient_state.key_image_blacklist; }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -37,6 +37,7 @@
 #include "tx_pool.h"
 #include "cryptonote_tx_utils.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
+#include "cryptonote_core/service_node_list.h"
 #include "cryptonote_config.h"
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
@@ -119,7 +120,7 @@ namespace cryptonote
 
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version) const
+  bool tx_memory_pool::have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version, service_nodes::service_node_list const &service_node_list) const
   {
     if (tx.type == txtype::standard)
       return false;
@@ -130,6 +131,15 @@ namespace cryptonote
       if (!get_service_node_state_change_from_tx_extra(tx.extra, state_change, hard_fork_version))
       {
         MERROR("Could not get service node state change from tx, possibly corrupt tx in your blockchain, rejecting malformed state change");
+        return true;
+      }
+
+      auto const quorum_type = service_nodes::quorum_type::obligations;
+      auto const quorum_group = service_nodes::quorum_group::worker;
+      crypto::public_key service_node_to_change;
+      if (!service_node_list.try_resolve_pubkey_in_quorum(quorum_type, quorum_group, state_change.block_height, state_change.service_node_index, service_node_to_change))
+      {
+        MERROR("Could not resolve the service node public key from the information in the state change, possibly corrupt tx in your blockchain, rejecting malformed state change");
         return true;
       }
 
@@ -147,8 +157,19 @@ namespace cryptonote
           continue;
         }
 
-        if (state_change == pool_tx_state_change)
-          return true;
+        crypto::public_key service_node_to_change_in_the_pool;
+        if (service_node_list.try_resolve_pubkey_in_quorum(quorum_type, quorum_group, pool_tx_state_change.block_height, pool_tx_state_change.service_node_index, service_node_to_change_in_the_pool))
+        {
+          if (service_node_to_change == service_node_to_change_in_the_pool)
+            return true;
+        }
+        else
+        {
+          MERROR("Could not resolve the service node public key from the information in a pooled tx state change, possibly corrupt tx in your blockchain, falling back to primitive checking method");
+          if (state_change == pool_tx_state_change)
+            return true;
+        }
+
       }
     }
     else if (tx.type == txtype::key_image_unlock)
@@ -192,7 +213,7 @@ namespace cryptonote
     return false;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::add_tx(transaction &tx, /*const crypto::hash& tx_prefix_hash,*/ const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version)
+  bool tx_memory_pool::add_tx(transaction &tx, /*const crypto::hash& tx_prefix_hash,*/ const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version, service_nodes::service_node_list const &service_node_list)
   {
     // this should already be called with that lock, but let's make it explicit for clarity
     CRITICAL_REGION_LOCAL(m_transactions_lock);
@@ -287,7 +308,7 @@ namespace cryptonote
         tvc.m_double_spend = true;
         return false;
       }
-      if (have_duplicated_non_standard_tx(tx, version))
+      if (have_duplicated_non_standard_tx(tx, version, service_node_list))
       {
         mark_double_spend(tx);
         LOG_PRINT_L1("Transaction with id= "<< id << " already has a duplicate tx for height");
@@ -332,7 +353,7 @@ namespace cryptonote
         meta.last_relayed_time = time(NULL);
         meta.relayed = relayed;
         meta.do_not_relay = do_not_relay;
-        meta.double_spend_seen = (have_tx_keyimges_as_spent(tx) || have_duplicated_non_standard_tx(tx, version));
+        meta.double_spend_seen = (have_tx_keyimges_as_spent(tx) || have_duplicated_non_standard_tx(tx, version, service_node_list));
         meta.bf_padding = 0;
         memset(meta.padding, 0, sizeof(meta.padding));
         try
@@ -414,7 +435,7 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::add_tx(transaction &tx, tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay, uint8_t version)
+  bool tx_memory_pool::add_tx(transaction &tx, tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay, uint8_t version, service_nodes::service_node_list const &service_node_list)
   {
     crypto::hash h = null_hash;
     size_t blob_size = 0;
@@ -422,7 +443,7 @@ namespace cryptonote
     t_serializable_object_to_blob(tx, bl);
     if (bl.size() == 0 || !get_transaction_hash(tx, h))
       return false;
-    return add_tx(tx, h, bl, get_transaction_weight(tx, bl.size()), tvc, keeped_by_block, relayed, do_not_relay, version);
+    return add_tx(tx, h, bl, get_transaction_weight(tx, bl.size()), tvc, keeped_by_block, relayed, do_not_relay, version, service_node_list);
   }
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_txpool_weight() const

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -110,7 +110,7 @@ namespace cryptonote
      * @param id the transaction's hash
      * @param tx_weight the transaction's weight
      */
-    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version, service_nodes::service_node_list const &service_node_list);
+    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version, const service_nodes::service_node_list &service_node_list);
 
     /**
      * @brief add a transaction to the transaction pool

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -48,6 +48,11 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "rpc/message_data_structs.h"
 
+namespace service_nodes
+{
+  class service_node_list;
+};
+
 namespace cryptonote
 {
   class Blockchain;
@@ -105,7 +110,7 @@ namespace cryptonote
      * @param id the transaction's hash
      * @param tx_weight the transaction's weight
      */
-    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version);
+    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version, service_nodes::service_node_list const &service_node_list);
 
     /**
      * @brief add a transaction to the transaction pool
@@ -124,7 +129,7 @@ namespace cryptonote
      *
      * @return true if the transaction passes validations, otherwise false
      */
-    bool add_tx(transaction &tx, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version);
+    bool add_tx(transaction &tx, tx_verification_context& tvc, bool kept_by_block, bool relayed, bool do_not_relay, uint8_t version, service_nodes::service_node_list const &service_node_list);
 
     /**
      * @brief takes a transaction with the given hash from the pool
@@ -461,7 +466,7 @@ namespace cryptonote
      * @return true if it already exists
      *
      */
-    bool have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version) const;
+    bool have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version, service_nodes::service_node_list const &node_list) const;
 
     /**
      * @brief check if any spent key image in a transaction is in the pool


### PR DESCRIPTION
This will prevent the occasional massive blocks filled to the brim with state changes when the same node is being tested across multiple quorums and the pool is full