### PR TITLE
Improve print quorum state + rpc update

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -346,7 +346,7 @@ uint8_t HardFork::get(uint64_t height) const
   CRITICAL_REGION_LOCAL(lock);
   if (height > db.height()) {
     assert(false);
-    return 255;
+    return INVALID_HF_VERSION_FOR_HEIGHT;
   }
   if (height == db.height()) {
     return get_current_version();

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -38,6 +38,7 @@ namespace cryptonote
   class HardFork
   {
   public:
+    constexpr static uint8_t INVALID_HF_VERSION_FOR_HEIGHT = 255;
     typedef enum {
       LikelyForked,
       UpdateNeeded,

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -129,6 +129,7 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 
 #define COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT           1000
 #define COMMAND_RPC_GET_CHECKPOINTS_MAX_COUNT           256
+#define COMMAND_RPC_GET_QUORUM_STATE_MAX_COUNT          256
 
 #define P2P_LOCAL_WHITE_PEERLIST_LIMIT                  1000
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -59,11 +59,11 @@ namespace service_nodes
     BEGIN_KV_SERIALIZE_MAP()
       std::vector<std::string> validators(this_ref.validators.size());
       for (size_t i = 0; i < this_ref.validators.size(); i++) validators[i] = epee::string_tools::pod_to_hex(this_ref.validators[i]);
-      epee::serialization::selector<is_store>::serialize(validators, stg, hparent_section, "validators");
+      KV_SERIALIZE_VALUE(validators);
 
       std::vector<std::string> workers(this_ref.workers.size());
       for (size_t i = 0; i < this_ref.workers.size(); i++) workers[i] = epee::string_tools::pod_to_hex(this_ref.workers[i]);
-      epee::serialization::selector<is_store>::serialize(workers, stg, hparent_section, "workers");
+      KV_SERIALIZE_VALUE(workers);
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -33,6 +33,8 @@
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_core/service_node_voting.h"
 
+#include "common/loki.h"
+
 namespace cryptonote
 {
   class core;
@@ -43,15 +45,26 @@ namespace service_nodes
 {
   struct service_node_info;
 
+  LOKI_RPC_DOC_INTROSPECT
   struct testing_quorum
   {
-    std::vector<crypto::public_key> validators;
-    std::vector<crypto::public_key> workers;
+    std::vector<crypto::public_key> validators; // Array of public keys identifying service nodes which are being tested for the queried height.
+    std::vector<crypto::public_key> workers;    // Array of public keys identifying service nodes which are responsible for voting on the queried height.
 
     BEGIN_SERIALIZE()
       FIELD(validators)
       FIELD(workers)
     END_SERIALIZE()
+
+    BEGIN_KV_SERIALIZE_MAP()
+      std::vector<std::string> validators(this_ref.validators.size());
+      for (size_t i = 0; i < this_ref.validators.size(); i++) validators[i] = epee::string_tools::pod_to_hex(this_ref.validators[i]);
+      epee::serialization::selector<is_store>::serialize(validators, stg, hparent_section, "validators");
+
+      std::vector<std::string> workers(this_ref.workers.size());
+      for (size_t i = 0; i < this_ref.workers.size(); i++) workers[i] = epee::string_tools::pod_to_hex(this_ref.workers[i]);
+      epee::serialization::selector<is_store>::serialize(workers, stg, hparent_section, "workers");
+    END_KV_SERIALIZE_MAP()
   };
 
   struct quorum_manager

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -77,6 +77,7 @@ namespace service_nodes
     obligations = 0,
     checkpointing,
     count,
+    rpc_request_all_quorums_sentinel_value = 255, // Only valid for get_quorum_state RPC call
   };
 
   inline char const *quorum_type_to_string(quorum_type v)

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -208,14 +208,24 @@ bool t_command_parser_executor::print_blockchain_info(const std::vector<std::str
 
 bool t_command_parser_executor::print_quorum_state(const std::vector<std::string>& args)
 {
-  uint64_t height = UINT64_MAX;
-  if(args.size() >= 1 && !epee::string_tools::get_xtype_from_string(height, args[0]))
+  uint64_t start_height = cryptonote::COMMAND_RPC_GET_QUORUM_STATE::HEIGHT_SENTINEL_VALUE;
+  uint64_t end_height   = cryptonote::COMMAND_RPC_GET_QUORUM_STATE::HEIGHT_SENTINEL_VALUE;
+
+  std::forward_list<std::string> args_list(args.begin(), args.end());
+  if (!parse_if_present(args_list, start_height, "start height"))
+    return false;
+
+  if (!parse_if_present(args_list, end_height, "end height"))
+    return false;
+
+  if (!args_list.empty())
   {
-    std::cout << "wrong block height parameter" << std::endl;
+    std::cout << "use: print_quorum_state [start height] [end height]\n"
+              << "(omit arguments to print the latest quorums" << std::endl;
     return false;
   }
 
-  return m_executor.print_quorum_state(height);
+  return m_executor.print_quorum_state(start_height, end_height);
 }
 
 bool t_command_parser_executor::print_sn_key(const std::vector<std::string>& args)

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -208,14 +208,8 @@ bool t_command_parser_executor::print_blockchain_info(const std::vector<std::str
 
 bool t_command_parser_executor::print_quorum_state(const std::vector<std::string>& args)
 {
-  if(args.size() != 1)
-  {
-    std::cout << "need block height parameter" << std::endl;
-    return false;
-  }
-
-  uint64_t height = 0;
-  if(!epee::string_tools::get_xtype_from_string(height, args[0]))
+  uint64_t height = UINT64_MAX;
+  if(args.size() >= 1 && !epee::string_tools::get_xtype_from_string(height, args[0]))
   {
     std::cout << "wrong block height parameter" << std::endl;
     return false;

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -108,7 +108,7 @@ t_command_server::t_command_server(
       "print_quorum_state"
     , std::bind(&t_command_parser_executor::print_quorum_state, &m_parser, p::_1)
     , "print_quorum_state [height]"
-    , "Print the quorum state for the block height."
+    , "Print the quorum state for the block height, omit the height to print the latest quorum"
     );
   m_command_lookup.set_handler(
       "print_sn_key"

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -107,7 +107,7 @@ t_command_server::t_command_server(
   m_command_lookup.set_handler(
       "print_quorum_state"
     , std::bind(&t_command_parser_executor::print_quorum_state, &m_parser, p::_1)
-    , "print_quorum_state <height>"
+    , "print_quorum_state [height]"
     , "Print the quorum state for the block height."
     );
   m_command_lookup.set_handler(

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -107,8 +107,8 @@ t_command_server::t_command_server(
   m_command_lookup.set_handler(
       "print_quorum_state"
     , std::bind(&t_command_parser_executor::print_quorum_state, &m_parser, p::_1)
-    , "print_quorum_state [height]"
-    , "Print the quorum state for the block height, omit the height to print the latest quorum"
+    , "print_quorum_state [start height] [end height]"
+    , "Print the quorum state for the range of block heights, omit the height to print the latest quorum"
     );
   m_command_lookup.set_handler(
       "print_sn_key"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -884,7 +884,7 @@ bool t_rpc_command_executor::print_quorum_state(uint64_t height)
   cryptonote::COMMAND_RPC_GET_QUORUM_STATE::response res;
   epee::json_rpc::error error_resp;
 
-  req.height = height;
+  if (height != UINT64_MAX) req.heights = {height};
   std::string fail_message = "Unsuccessful";
 
   if (m_is_rpc)
@@ -903,21 +903,7 @@ bool t_rpc_command_executor::print_quorum_state(uint64_t height)
     }
   }
 
-  tools::msg_writer() << "Quorum Service Nodes [" << res.quorum_nodes.size() << "]";
-  for (size_t i = 0; i < res.quorum_nodes.size(); i++)
-  {
-    const std::string &entry = res.quorum_nodes[i];
-    tools::msg_writer() << "[" << i << "] " << entry;
-  }
-
-  tools::msg_writer() << "Service Nodes To Test [" << res.nodes_to_test.size() << "]";
-  for (size_t i = 0; i < res.nodes_to_test.size(); i++)
-  {
-    const std::string &entry = res.nodes_to_test[i];
-    tools::msg_writer() << "[" << i << "] " << entry;
-  }
-
-
+  tools::msg_writer() << "{\n" << obj_to_json_str(res.quorums) << "\n}";
   return true;
 }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -878,13 +878,16 @@ bool t_rpc_command_executor::print_blockchain_info(uint64_t start_block_index, u
   return true;
 }
 
-bool t_rpc_command_executor::print_quorum_state(uint64_t height)
+bool t_rpc_command_executor::print_quorum_state(uint64_t start_height, uint64_t end_height)
 {
   cryptonote::COMMAND_RPC_GET_QUORUM_STATE::request req;
   cryptonote::COMMAND_RPC_GET_QUORUM_STATE::response res;
   epee::json_rpc::error error_resp;
 
-  if (height != UINT64_MAX) req.heights = {height};
+  req.start_height = start_height;
+  req.end_height   = end_height;
+  req.quorum_type  = (decltype(req.quorum_type))service_nodes::quorum_type::rpc_request_all_quorums_sentinel_value;
+
   std::string fail_message = "Unsuccessful";
 
   if (m_is_rpc)

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -90,7 +90,7 @@ public:
 
   bool print_blockchain_info(uint64_t start_block_index, uint64_t end_block_index);
 
-  bool print_quorum_state(uint64_t height);
+  bool print_quorum_state(uint64_t start_height, uint64_t end_height);
 
   bool set_log_level(int8_t level);
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2448,8 +2448,10 @@ namespace cryptonote
       if (height > latest_height)
         continue;
 
-      uint8_t hf_version                         = m_core.get_hard_fork_version(height);
-      service_nodes::quorum_type max_quorum_type = service_nodes::max_quorum_type_for_hf(hf_version);
+      uint8_t hf_version                                     = m_core.get_hard_fork_version(height);
+      service_nodes::quorum_type max_quorum_type             = service_nodes::max_quorum_type_for_hf(hf_version);
+      COMMAND_RPC_GET_QUORUM_STATE::quorums_for_height entry = {};
+      entry.height                                           = height;
 
       for (int type_int = 0; type_int <= (int)max_quorum_type; type_int++)
       {
@@ -2459,8 +2461,6 @@ namespace cryptonote
         if (!quorum)
           continue;
 
-        COMMAND_RPC_GET_QUORUM_STATE::quorums_for_height entry                          = {};
-        entry.height                                                                    = height;
         if (type == service_nodes::quorum_type::obligations)        entry.obligation    = *quorum;
         else if (type == service_nodes::quorum_type::checkpointing) entry.checkpointing = *quorum;
         else
@@ -2470,9 +2470,9 @@ namespace cryptonote
           continue;
         }
 
-        res.quorums.push_back(entry);
         at_least_one_succeeded = true;
       }
+      res.quorums.push_back(entry);
     }
 
     if (at_least_one_succeeded)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2447,7 +2447,7 @@ namespace cryptonote
       uint64_t height    = heights[i];
       uint8_t hf_version = m_core.get_hard_fork_version(height);
 
-      for (int type_int = 0; type_int < (int)service_nodes::max_quorum_type_for_hf(hf_version); type_int++)
+      for (int type_int = 0; type_int <= (int)service_nodes::max_quorum_type_for_hf(hf_version); type_int++)
       {
         auto type                                                   = static_cast<service_nodes::quorum_type>(type_int);
         std::shared_ptr<const service_nodes::testing_quorum> quorum = m_core.get_testing_quorum(type, height);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -175,20 +175,19 @@ namespace cryptonote
         //
         // Loki
         //
-        MAP_JON_RPC_WE("get_quorum_state",                         on_get_quorum_state, COMMAND_RPC_GET_QUORUM_STATE)
-        MAP_JON_RPC_WE("get_quorum_state_batched",                 on_get_quorum_state_batched, COMMAND_RPC_GET_QUORUM_STATE_BATCHED)
-        MAP_JON_RPC_WE_IF("get_service_node_registration_cmd_raw", on_get_service_node_registration_cmd_raw, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW, !m_restricted)
-        MAP_JON_RPC_WE("get_service_node_blacklisted_key_images",  on_get_service_node_blacklisted_key_images, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES)
-        MAP_JON_RPC_WE_IF("get_service_node_registration_cmd",     on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD, !m_restricted)
-        MAP_JON_RPC_WE_IF("get_service_node_key",                  on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY, !m_restricted)
-        MAP_JON_RPC_WE("get_service_nodes",                        on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
-        MAP_JON_RPC_WE("get_all_service_nodes",                    on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
-        MAP_JON_RPC_WE("get_all_service_nodes_keys",               on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
-        MAP_JON_RPC_WE("get_n_service_nodes",                      on_get_n_service_nodes, COMMAND_RPC_GET_N_SERVICE_NODES)
-        MAP_JON_RPC_WE("get_staking_requirement",                  on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
+        MAP_JON_RPC_WE("get_quorum_state",                          on_get_quorum_state, COMMAND_RPC_GET_QUORUM_STATE)
+        MAP_JON_RPC_WE_IF("get_service_node_registration_cmd_raw",  on_get_service_node_registration_cmd_raw, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW, !m_restricted)
+        MAP_JON_RPC_WE("get_service_node_blacklisted_key_images",   on_get_service_node_blacklisted_key_images, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES)
+        MAP_JON_RPC_WE_IF("get_service_node_registration_cmd",      on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD, !m_restricted)
+        MAP_JON_RPC_WE_IF("get_service_node_key",                   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY, !m_restricted)
+        MAP_JON_RPC_WE("get_service_nodes",                         on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
+        MAP_JON_RPC_WE("get_all_service_nodes",                     on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
+        MAP_JON_RPC_WE("get_all_service_nodes_keys",                on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
+        MAP_JON_RPC_WE("get_n_service_nodes",                       on_get_n_service_nodes, COMMAND_RPC_GET_N_SERVICE_NODES)
+        MAP_JON_RPC_WE("get_staking_requirement",                   on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
         MAP_JON_RPC_WE("get_checkpoints",                          on_get_checkpoints, COMMAND_RPC_GET_CHECKPOINTS)
-        MAP_JON_RPC_WE_IF("perform_blockchain_test",               on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
-        MAP_JON_RPC_WE_IF("storage_server_ping",                   on_storage_server_ping, COMMAND_RPC_STORAGE_SERVER_PING, !m_restricted)
+        MAP_JON_RPC_WE_IF("perform_blockchain_test",                on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
+        MAP_JON_RPC_WE_IF("storage_server_ping",                    on_storage_server_ping, COMMAND_RPC_STORAGE_SERVER_PING, !m_restricted)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -265,7 +264,6 @@ namespace cryptonote
     // Loki
     //
     bool on_get_quorum_state(const COMMAND_RPC_GET_QUORUM_STATE::request& req, COMMAND_RPC_GET_QUORUM_STATE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
-    bool on_get_quorum_state_batched(const COMMAND_RPC_GET_QUORUM_STATE_BATCHED::request& req, COMMAND_RPC_GET_QUORUM_STATE_BATCHED::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_registration_cmd_raw(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD_RAW::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_registration_cmd(const COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::request& req, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_blacklisted_key_images(const COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::request& req, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2539,7 +2539,7 @@ namespace cryptonote
   {
     struct request_t
     {
-      std::vector<uint64_t> heights; // Array of heights to query the quorums for.
+      std::vector<uint64_t> heights; // Array of heights to query the quorums for, omit the height to request the latest quorum
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(heights)
       END_KV_SERIALIZE_MAP()
@@ -2548,7 +2548,7 @@ namespace cryptonote
 
     struct quorums_for_height
     {
-      uint64_t height;
+      uint64_t height;                             // The height the quorums are relevant for
       service_nodes::testing_quorum obligation;    // Quorum for checking Service Nodes have performed their duties and should not be voted off
       service_nodes::testing_quorum checkpointing; // Quorum for Service Nodes responsible for participating in making checkpoints
       BEGIN_KV_SERIALIZE_MAP()


### PR DESCRIPTION
Remove get_quorum_state_batched and just make the default able to handle multiple heights. Don't specify heights in range and prefer a more granular API and build helper functions if needed on top. 

review @jagerman

This will break lokiblocks as that is using the batched call.