### PR TITLE
Disable stack trace at log level 0

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -100,7 +100,7 @@ static const char *get_default_categories(int level)
   switch (level)
   {
     case 0:
-      categories = "*:WARNING,net:FATAL,net.http:FATAL,net.ssl:FATAL,net.p2p:FATAL,net.cn:FATAL,global:INFO,verify:FATAL,serialization:FATAL,stacktrace:INFO,logging:INFO,msgwriter:INFO";
+      categories = "*:WARNING,net:FATAL,net.http:FATAL,net.ssl:FATAL,net.p2p:FATAL,net.cn:FATAL,global:INFO,verify:FATAL,serialization:FATAL,logging:INFO,msgwriter:INFO";
       break;
     case 1:
       categories = "*:INFO,global:INFO,stacktrace:INFO,logging:INFO,msgwriter:INFO,perf.*:DEBUG";


### PR DESCRIPTION
This bit of code may once have been useful, but is currently mostly just
noise as there are various places in the code base that legitimately
throw and catch exceptions which *are not errors*.  As such the log
files are full of these useless exception stack traces which look scary
but actually provide no useful information at all (because they are
*expected* and *caught*).

I'd personally rather just rip this code out entirely (exception
catching is a bog standard way of handling errors), but at the very
least we can disable it for release builds.