### PR TITLE
Don't use architecture dependent sizes in RPC calls

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3126,13 +3126,13 @@ namespace cryptonote
   // Query hardcoded/service node checkpoints stored for the blockchain. Omit all arguments to retrieve the latest "count" checkpoints.
   struct COMMAND_RPC_GET_CHECKPOINTS
   {
-    constexpr static size_t   NUM_CHECKPOINTS_TO_QUERY_BY_DEFAULT = 60;
+    constexpr static uint32_t NUM_CHECKPOINTS_TO_QUERY_BY_DEFAULT = 60;
     constexpr static uint64_t HEIGHT_SENTINEL_VALUE               = (UINT64_MAX - 1);
     struct request_t
     {
       uint64_t start_height; // Optional: Get the first count checkpoints starting from this height. Specify both start and end to get the checkpoints inbetween.
       uint64_t end_height;   // Optional: Get the first count checkpoints before end height. Specify both start and end to get the checkpoints inbetween.
-      size_t count;          // Optional: Number of checkpoints to query.
+      uint32_t count;        // Optional: Number of checkpoints to query.
 
       BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE_OPT(start_height, HEIGHT_SENTINEL_VALUE)


### PR DESCRIPTION
Try and appease the Mac CI