### PR TITLE
Allow state changes if non conflicting states

### DIFF
--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -67,7 +67,8 @@ namespace service_nodes {
     decommission,
     recommission,
     ip_change_penalty,
-    _count
+    _count,
+    null_state,
   };
 };
 

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -68,7 +68,6 @@ namespace service_nodes {
     recommission,
     ip_change_penalty,
     _count,
-    null_state,
   };
 };
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3280,15 +3280,14 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
             continue;
           }
 
-          crypto::public_key existing_state_change_service_node_pubkey;
-          if (!m_service_node_list.get_quorum_pubkey(quorum_type,
-                                                     service_nodes::quorum_group::worker,
-                                                     existing_state_change.block_height,
-                                                     existing_state_change.service_node_index,
-                                                     existing_state_change_service_node_pubkey))
+          const auto existing_quorum = m_service_node_list.get_testing_quorum(quorum_type, existing_state_change.block_height);
+          if (!existing_quorum)
+          {
+            MERROR_VER("Could not get obligations quorum for recent state change tx");
             continue;
+          }
 
-          if (existing_state_change_service_node_pubkey == state_change_service_node_pubkey)
+          if (existing_quorum->workers[existing_state_change.service_node_index] == state_change_service_node_pubkey)
           {
             MERROR_VER("Already seen this state change tx (aka double spend)");
             tvc.m_double_spend = true;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3233,14 +3233,14 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         std::vector<service_nodes::service_node_pubkey_info> service_node_array = m_service_node_list.get_service_node_list_state({state_change_service_node_pubkey});
         if (service_node_array.empty())
         {
-          MERROR_VER("Service Node no longer exists on the network, state change can be ignored");
+          LOG_PRINT_L2("Service Node no longer exists on the network, state change can be ignored");
           return false;
         }
 
         service_nodes::service_node_info const &service_node_info = service_node_array[0].info;
         if (!service_node_info.can_transition_to_state(state_change.state))
         {
-          MERROR_VER("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
+          LOG_PRINT_L2("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
           tvc.m_double_spend = true;
           return false;
         }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2171,11 +2171,14 @@ namespace service_nodes
 
   bool service_node_info::can_transition_to_state(new_state proposed_state) const
   {
-    new_state last_state = last_state_transition();
-    if (last_state == proposed_state)
+    if (is_decommissioned())
     {
-      // NOTE: But allow multiple ip_change_penalties
-      return (last_state == service_nodes::new_state::ip_change_penalty);
+      return proposed_state != new_state::decommission &&
+             proposed_state != new_state::ip_change_penalty;
+    }
+    else
+    {
+      return proposed_state != new_state::recommission;
     }
 
     return true;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2168,5 +2168,18 @@ namespace service_nodes
     cmd = stream.str();
     return true;
   }
+
+  bool service_node_info::can_transition_to_state(new_state proposed_state) const
+  {
+    new_state last_state = last_state_transition();
+    if (last_state == proposed_state)
+    {
+      // NOTE: But allow multiple ip_change_penalties
+      return (last_state == service_nodes::new_state::ip_change_penalty);
+    }
+
+    return true;
+  }
+
 }
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -122,18 +122,6 @@ namespace service_nodes
     bool is_active() const { return is_fully_funded() && !is_decommissioned(); }
 
     bool can_transition_to_state(new_state proposed_state) const;
-
-    new_state last_state_transition() const
-    {
-      if (is_decommissioned()) return new_state::decommission;
-      if (last_ip_change_height > static_cast<uint64_t>(active_since_height))
-        return new_state::ip_change_penalty;
-
-      if (decommission_count == 0)
-        return new_state::null_state;
-      return new_state::recommission;
-    }
-
     size_t total_num_locked_contributions() const;
 
     BEGIN_SERIALIZE_OBJECT()

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -120,6 +120,20 @@ namespace service_nodes
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
     bool is_decommissioned() const { return active_since_height < 0; }
     bool is_active() const { return is_fully_funded() && !is_decommissioned(); }
+
+    bool can_transition_to_state(new_state proposed_state) const;
+
+    new_state last_state_transition() const
+    {
+      if (is_decommissioned()) return new_state::decommission;
+      if (last_ip_change_height > static_cast<uint64_t>(active_since_height))
+        return new_state::ip_change_penalty;
+
+      if (decommission_count == 0)
+        return new_state::null_state;
+      return new_state::recommission;
+    }
+
     size_t total_num_locked_contributions() const;
 
     BEGIN_SERIALIZE_OBJECT()

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -157,20 +157,28 @@ namespace cryptonote
           continue;
         }
 
-        crypto::public_key service_node_to_change_in_the_pool;
-        bool specifying_same_service_node = false;
-        if (service_node_list.get_quorum_pubkey(quorum_type, quorum_group, pool_tx_state_change.block_height, pool_tx_state_change.service_node_index, service_node_to_change_in_the_pool))
+        if (hard_fork_version >= cryptonote::network_version_12_checkpointing)
         {
-          specifying_same_service_node = (service_node_to_change == service_node_to_change_in_the_pool);
+          crypto::public_key service_node_to_change_in_the_pool;
+          bool specifying_same_service_node = false;
+          if (service_node_list.get_quorum_pubkey(quorum_type, quorum_group, pool_tx_state_change.block_height, pool_tx_state_change.service_node_index, service_node_to_change_in_the_pool))
+          {
+            specifying_same_service_node = (service_node_to_change == service_node_to_change_in_the_pool);
+          }
+          else
+          {
+            MWARNING("Could not resolve the service node public key from the information in a pooled tx state change, falling back to primitive checking method");
+            specifying_same_service_node = (state_change == pool_tx_state_change);
+          }
+
+          if (specifying_same_service_node && pool_tx_state_change.state == state_change.state)
+            return true;
         }
         else
         {
-          MWARNING("Could not resolve the service node public key from the information in a pooled tx state change, falling back to primitive checking method");
-          specifying_same_service_node = (state_change == pool_tx_state_change);
+          if (state_change == pool_tx_state_change)
+            return true;
         }
-
-        if (specifying_same_service_node && pool_tx_state_change.state == state_change.state)
-          return true;
       }
     }
     else if (tx.type == txtype::key_image_unlock)

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -158,18 +158,19 @@ namespace cryptonote
         }
 
         crypto::public_key service_node_to_change_in_the_pool;
+        bool specifying_same_service_node = false;
         if (service_node_list.get_quorum_pubkey(quorum_type, quorum_group, pool_tx_state_change.block_height, pool_tx_state_change.service_node_index, service_node_to_change_in_the_pool))
         {
-          if (service_node_to_change == service_node_to_change_in_the_pool)
-            return true;
+          specifying_same_service_node = (service_node_to_change == service_node_to_change_in_the_pool);
         }
         else
         {
-          MWARNING("Could not resolve the service node public key from the information in a pooled tx state change, possibly corrupt tx in your blockchain, falling back to primitive checking method");
-          if (state_change == pool_tx_state_change)
-            return true;
+          MWARNING("Could not resolve the service node public key from the information in a pooled tx state change, falling back to primitive checking method");
+          specifying_same_service_node = (state_change == pool_tx_state_change);
         }
 
+        if (specifying_same_service_node && pool_tx_state_change.state == state_change.state)
+          return true;
       }
     }
     else if (tx.type == txtype::key_image_unlock)


### PR DESCRIPTION
This removes the historical block check and instead just try find the service node in the service node list and check if the state it wants to transition to is going to be valid.

@jagerman