### PR TITLE
Use quorums N-MAX_REORG_BLOCKS_POST_HF12 for checkpointing

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -170,7 +170,7 @@ namespace cryptonote
     uint64_t start_cull_height     = (end_cull_height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL)
                                      ? 0
                                      : end_cull_height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;
-    start_cull_height += (start_cull_height % service_nodes::CHECKPOINT_INTERVAL);
+    start_cull_height += (service_nodes::CHECKPOINT_INTERVAL - (start_cull_height % service_nodes::CHECKPOINT_INTERVAL));
     m_last_cull_height = std::max(m_last_cull_height, start_cull_height);
 
     auto guard = db_wtxn_guard(m_db);

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -170,10 +170,12 @@ namespace cryptonote
     uint64_t start_cull_height     = (end_cull_height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL)
                                      ? 0
                                      : end_cull_height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;
-    start_cull_height += (service_nodes::CHECKPOINT_INTERVAL - (start_cull_height % service_nodes::CHECKPOINT_INTERVAL));
-    m_last_cull_height = std::max(m_last_cull_height, start_cull_height);
 
-    auto guard = db_wtxn_guard(m_db);
+    if ((start_cull_height % service_nodes::CHECKPOINT_INTERVAL) > 0)
+      start_cull_height += (service_nodes::CHECKPOINT_INTERVAL - (start_cull_height % service_nodes::CHECKPOINT_INTERVAL));
+
+    m_last_cull_height = std::max(m_last_cull_height, start_cull_height);
+    auto guard         = db_wtxn_guard(m_db);
     for (; m_last_cull_height < end_cull_height; m_last_cull_height += service_nodes::CHECKPOINT_INTERVAL)
     {
       if (m_last_cull_height % service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -312,7 +312,7 @@ namespace service_nodes
             start_checkpointing_height += (CHECKPOINT_INTERVAL - (start_checkpointing_height % CHECKPOINT_INTERVAL));
 
           m_last_checkpointed_height = std::max(start_checkpointing_height, m_last_checkpointed_height);
-          for (m_last_checkpointed_height += (CHECKPOINT_INTERVAL - (m_last_checkpointed_height % CHECKPOINT_INTERVAL));
+          for (;
                m_last_checkpointed_height <= height;
                m_last_checkpointed_height += CHECKPOINT_INTERVAL)
           {

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -116,8 +116,24 @@ namespace service_nodes
 
   void quorum_cop::blockchain_detached(uint64_t height)
   {
-    m_obligations_height       = std::min(m_obligations_height, height);
-    m_last_checkpointed_height = std::min(m_last_checkpointed_height, height);
+    uint8_t hf_version                        = m_core.get_hard_fork_version(height);
+    uint64_t const REORG_SAFETY_BUFFER_BLOCKS = (hf_version >= cryptonote::network_version_12_checkpointing)
+                                                    ? REORG_SAFETY_BUFFER_BLOCKS_POST_HF12
+                                                    : REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12;
+    if (m_obligations_height >= height)
+    {
+      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes for obligations up to " << m_obligations_height);
+      LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_BLOCKS << ". This should rarely happen! Please report this to the devs.");
+      m_obligations_height = height;
+    }
+
+    if (m_last_checkpointed_height >= height)
+    {
+      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes for checkpointing up to " << m_last_checkpointed_height);
+      LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_BLOCKS << ". This should rarely happen! Please report this to the devs.");
+      m_last_checkpointed_height = height;
+    }
+
     m_vote_pool.remove_expired_votes(height);
   }
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -116,14 +116,8 @@ namespace service_nodes
 
   void quorum_cop::blockchain_detached(uint64_t height)
   {
-    // TODO(doyle): Assumes large reorgs that are no longer possible with checkpointing
-    if (m_obligations_height >= height)
-    {
-      LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes up to " << m_obligations_height);
-      LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_IN_BLOCKS << ". This should never happen! Please report this to the devs.");
-      m_obligations_height = height;
-    }
-    m_last_checkpointed_height = height;
+    m_obligations_height       = std::min(m_obligations_height, height);
+    m_last_checkpointed_height = std::min(m_last_checkpointed_height, height);
     m_vote_pool.remove_expired_votes(height);
   }
 
@@ -152,6 +146,9 @@ namespace service_nodes
     if (hf_version < cryptonote::network_version_9_service_nodes)
       return;
 
+    uint64_t const MAX_REORG_BLOCKS = (hf_version >= cryptonote::network_version_12_checkpointing)
+                                          ? MAX_REORG_BLOCKS_POST_HF12
+                                          : MAX_REORG_BLOCKS_PRE_HF12;
     crypto::public_key my_pubkey;
     crypto::secret_key my_seckey;
     if (!m_core.get_service_node_keys(my_pubkey, my_seckey))
@@ -197,7 +194,7 @@ namespace service_nodes
             break;
 
           m_obligations_height = std::max(m_obligations_height, start_voting_from_height);
-          for (; m_obligations_height < (height - REORG_SAFETY_BUFFER_IN_BLOCKS); m_obligations_height++)
+          for (; m_obligations_height < (height - MAX_REORG_BLOCKS); m_obligations_height++)
           {
             if (m_core.get_hard_fork_version(m_obligations_height) < cryptonote::network_version_9_service_nodes) continue;
 
@@ -311,6 +308,7 @@ namespace service_nodes
         case quorum_type::checkpointing:
         {
           m_last_checkpointed_height = std::max(start_voting_from_height, m_last_checkpointed_height);
+
           for (m_last_checkpointed_height += (m_last_checkpointed_height % CHECKPOINT_INTERVAL);
                m_last_checkpointed_height <= height;
                m_last_checkpointed_height += CHECKPOINT_INTERVAL)
@@ -318,8 +316,11 @@ namespace service_nodes
             if (m_core.get_hard_fork_version(m_last_checkpointed_height) <= cryptonote::network_version_11_infinite_staking)
               continue;
 
+            if (m_last_checkpointed_height < MAX_REORG_BLOCKS)
+              continue;
+
             const std::shared_ptr<const testing_quorum> quorum =
-                m_core.get_testing_quorum(quorum_type::checkpointing, m_last_checkpointed_height);
+                m_core.get_testing_quorum(quorum_type::checkpointing, m_last_checkpointed_height - MAX_REORG_BLOCKS);
             if (!quorum)
             {
               // TODO(loki): Fatal error

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -307,8 +307,11 @@ namespace service_nodes
 
         case quorum_type::checkpointing:
         {
-          m_last_checkpointed_height = std::max(start_voting_from_height, m_last_checkpointed_height);
+          uint64_t start_checkpointing_height = start_voting_from_height;
+          if ((start_checkpointing_height % CHECKPOINT_INTERVAL) > 0)
+            start_checkpointing_height += (CHECKPOINT_INTERVAL - (start_checkpointing_height % CHECKPOINT_INTERVAL));
 
+          m_last_checkpointed_height = std::max(start_checkpointing_height, m_last_checkpointed_height);
           for (m_last_checkpointed_height += (CHECKPOINT_INTERVAL - (m_last_checkpointed_height % CHECKPOINT_INTERVAL));
                m_last_checkpointed_height <= height;
                m_last_checkpointed_height += CHECKPOINT_INTERVAL)

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -61,9 +61,10 @@ namespace service_nodes {
   static_assert(CHECKPOINT_MIN_VOTES <= CHECKPOINT_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
   // NOTE: We can reorg up to last 2 checkpoints + the number of extra blocks before the next checkpoint is set
-  constexpr uint64_t  MAX_REORG_BLOCKS_POST_HF12    = (CHECKPOINT_INTERVAL * 2) + (CHECKPOINT_INTERVAL - 1);
-  constexpr uint64_t  REORG_SAFETY_BUFFER_IN_BLOCKS = 20;
-  static_assert(REORG_SAFETY_BUFFER_IN_BLOCKS < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
+  constexpr uint64_t  MAX_REORG_BLOCKS_POST_HF12 = (CHECKPOINT_INTERVAL * 2) + (CHECKPOINT_INTERVAL - 1);
+  constexpr uint64_t  MAX_REORG_BLOCKS_PRE_HF12  = 20;
+  static_assert(MAX_REORG_BLOCKS_POST_HF12 < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
+  static_assert(MAX_REORG_BLOCKS_PRE_HF12  < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
 
   constexpr uint64_t  IP_CHANGE_WINDOW_IN_SECONDS     = 24*60*60; // How far back an obligations quorum looks for multiple IPs (unless the following buffer is more recent)
   constexpr uint64_t  IP_CHANGE_BUFFER_IN_SECONDS     = 2*60*60; // After we bump a SN for an IP change we don't bump again for changes within this time period

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -61,10 +61,10 @@ namespace service_nodes {
   static_assert(CHECKPOINT_MIN_VOTES <= CHECKPOINT_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
   // NOTE: We can reorg up to last 2 checkpoints + the number of extra blocks before the next checkpoint is set
-  constexpr uint64_t  MAX_REORG_BLOCKS_POST_HF12 = (CHECKPOINT_INTERVAL * 2) + (CHECKPOINT_INTERVAL - 1);
-  constexpr uint64_t  MAX_REORG_BLOCKS_PRE_HF12  = 20;
-  static_assert(MAX_REORG_BLOCKS_POST_HF12 < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
-  static_assert(MAX_REORG_BLOCKS_PRE_HF12  < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
+  constexpr uint64_t  REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 = (CHECKPOINT_INTERVAL * 2) + (CHECKPOINT_INTERVAL - 1);
+  constexpr uint64_t  REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12  = 20;
+  static_assert(REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
+  static_assert(REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12  < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
 
   constexpr uint64_t  IP_CHANGE_WINDOW_IN_SECONDS     = 24*60*60; // How far back an obligations quorum looks for multiple IPs (unless the following buffer is more recent)
   constexpr uint64_t  IP_CHANGE_BUFFER_IN_SECONDS     = 2*60*60; // After we bump a SN for an IP change we don't bump again for changes within this time period


### PR DESCRIPTION
Nodes on an alternative chain will generate quorums reflecting those on
the alternate chain. Since checkpointing prevents reorgs up to
MAX_REORG_BLOCKS_POST_HF12, use quorums exactly that many blocks old to
ensure that at any point, all nodes will be working in quorums that are
consistent between each other.

This will cause a fork most likely on testnet. @jagerman