### PR TITLE
Difficulty workaround

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -4576,7 +4576,10 @@ void BlockchainLMDB::fixup(fixup_context const context)
         block_info.bi_diff           = prev_cumulative_diff + diff;
         prev_cumulative_diff         = block_info.bi_diff;
 
-        LOG_PRINT_L0("Height: " << curr_height << " prev difficulty: " << old_cumulative_diff <<  ", new difficulty: " << block_info.bi_diff);
+        if (old_cumulative_diff != block_info.bi_diff)
+          LOG_PRINT_L0("Height: " << curr_height << " prev difficulty: " << old_cumulative_diff <<  ", new difficulty: " << block_info.bi_diff);
+        else
+          LOG_PRINT_L2("Height: " << curr_height << " difficulty unchanged (" << old_cumulative_diff << ")");
 
         MDB_val_set(val, block_info);
         if (int result = mdb_cursor_put(m_cur_block_info, (MDB_val *)&zerokval, &val, MDB_CURRENT))

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1062,11 +1062,14 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
   // TODO(loki): This is a work around for sometimes reorganising the blockchain causing inconsistent difficulty values
   LOKI_DEFER
   {
-    uint64_t const FUDGE                             = 60;
-    cryptonote::BlockchainDB::fixup_context context  = {};
-    context.type                                     = cryptonote::BlockchainDB::fixup_type::calculate_difficulty;
-    context.calculate_difficulty_params.start_height = split_height < FUDGE ? 0 : split_height - FUDGE;
-    m_db->fixup(context);
+    if (nettype() == MAINNET)
+    {
+      uint64_t const FUDGE                             = 60;
+      cryptonote::BlockchainDB::fixup_context context  = {};
+      context.type                                     = cryptonote::BlockchainDB::fixup_type::calculate_difficulty;
+      context.calculate_difficulty_params.start_height = split_height < FUDGE ? 0 : split_height - FUDGE;
+      m_db->fixup(context);
+    }
   };
 
   for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1059,6 +1059,16 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
 
   auto split_height = m_db->height();
 
+  // TODO(loki): This is a work around for sometimes reorganising the blockchain causing inconsistent difficulty values
+  LOKI_DEFER
+  {
+    uint64_t const FUDGE                             = 60;
+    cryptonote::BlockchainDB::fixup_context context  = {};
+    context.type                                     = cryptonote::BlockchainDB::fixup_type::calculate_difficulty;
+    context.calculate_difficulty_params.start_height = split_height < FUDGE ? 0 : split_height - FUDGE;
+    m_db->fixup(context);
+  };
+
   for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
     hook->blockchain_detached(split_height);
 


### PR DESCRIPTION
This appears to only happen on reorg, popping blocks does not appear to have this issue so only add the recalculation when switching chains. I've added this behaviour only on mainnet so we have a reference point of whether or not we may have inadvertently fixed it, if it stops occuring on testnet or something. 

@jagerman