### PR TITLE
Rollback chain when receiving conflicting checkpoints

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -51,6 +51,14 @@ using namespace epee;
 
 namespace cryptonote
 {
+  bool checkpoint_t::check(crypto::hash const &hash) const
+  {
+    bool result = block_hash == hash;
+    if (result) MINFO   ("CHECKPOINT PASSED FOR HEIGHT " << height << " " << block_hash);
+    else        MWARNING("CHECKPOINT FAILED FOR HEIGHT " << height << ". EXPECTED HASH " << block_hash << "GIVEN HASH: " << hash);
+    return result;
+  }
+
   height_to_hash const HARDCODED_MAINNET_CHECKPOINTS[] =
   {
     {0,      "08ff156d993012b0bdf2816c4bee47c9bbc7930593b70ee02574edddf15ee933"},
@@ -234,9 +242,7 @@ namespace cryptonote
     if(!found)
       return true;
 
-    bool result = checkpoint.block_hash == h;
-    if (result) MINFO   ("CHECKPOINT PASSED FOR HEIGHT " << height << " " << h);
-    else        MWARNING("CHECKPOINT FAILED FOR HEIGHT " << height << ". EXPECTED HASH " << checkpoint.block_hash << "FETCHED HASH: " << h);
+    bool result = checkpoint.check(h);
     return result;
   }
   //---------------------------------------------------------------------------

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -61,6 +61,7 @@ namespace cryptonote
     std::vector<service_nodes::voter_to_signature> signatures; // Only service node checkpoints use signatures
     uint64_t                                       prev_height;
 
+    bool               check         (crypto::hash const &block_hash) const;
     static char const *type_to_string(checkpoint_type type)
     {
       switch(type)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4241,7 +4241,7 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
 // returns false if any of the checkpoints loading returns false.
 // That should happen only if a checkpoint is added that conflicts
 // with an existing checkpoint.
-bool Blockchain::update_checkpoints(const std::string& file_path)
+bool Blockchain::update_checkpoints_from_json_file(const std::string& file_path)
 {
   std::vector<height_to_hash> checkpoint_hashes;
   if (!cryptonote::load_checkpoints_from_json(file_path, checkpoint_hashes))
@@ -4313,6 +4313,20 @@ bool Blockchain::update_checkpoint(cryptonote::checkpoint_t const &checkpoint)
 {
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   bool result = m_checkpoints.update_checkpoint(checkpoint);
+  if (result)
+  {
+    if (checkpoint.height < m_db->height())
+    {
+      if (!checkpoint.check(m_db->get_block_hash_from_height(checkpoint.height)))
+      {
+        // roll back to a couple of blocks before the checkpoint
+        LOG_ERROR("Local blockchain failed to pass a checkpoint in: " << __func__ << ", rolling back!");
+        std::list<block> empty;
+        rollback_blockchain_switching(empty, checkpoint.height - 2);
+      }
+    }
+  }
+
   return result;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -702,7 +702,7 @@ namespace cryptonote
      *
      * @return false if any enforced checkpoint type fails to load, otherwise true
      */
-    bool update_checkpoints(const std::string& file_path);
+    bool update_checkpoints_from_json_file(const std::string& file_path);
 
     bool update_checkpoint(checkpoint_t const &checkpoint);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -254,7 +254,7 @@ namespace cryptonote
       m_pprotocol = &m_protocol_stub;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::update_checkpoints()
+  bool core::update_checkpoints_from_json_file()
   {
     if (m_nettype != MAINNET) return true;
     if (m_checkpoints_updating.test_and_set()) return true;
@@ -263,7 +263,7 @@ namespace cryptonote
     bool res = true;
     if (time(NULL) - m_last_json_checkpoints_update >= 600)
     {
-      res = m_blockchain_storage.update_checkpoints(m_checkpoints_path);
+      res = m_blockchain_storage.update_checkpoints_from_json_file(m_checkpoints_path);
       m_last_json_checkpoints_update = time(NULL);
     }
     m_checkpoints_updating.clear();
@@ -751,7 +751,7 @@ namespace cryptonote
       MERROR("Error --dblock-sync-size cannot be greater than " << BLOCKS_SYNCHRONIZING_MAX_COUNT);
 
     MGINFO("Loading checkpoints");
-    CHECK_AND_ASSERT_MES(update_checkpoints(), false, "One or more checkpoints loaded from json conflicted with existing checkpoints.");
+    CHECK_AND_ASSERT_MES(update_checkpoints_from_json_file(), false, "One or more checkpoints loaded from json conflicted with existing checkpoints.");
 
    // DNS versions checking
     if (check_updates_string == "disabled")
@@ -1649,7 +1649,7 @@ namespace cryptonote
     if (((size_t)-1) <= 0xffffffff && block_blob.size() >= 0x3fffffff)
       MWARNING("This block's size is " << block_blob.size() << ", closing on the 32 bit limit");
 
-    CHECK_AND_ASSERT_MES(update_checkpoints(), false, "One or more checkpoints loaded from json conflicted with existing checkpoints.");
+    CHECK_AND_ASSERT_MES(update_checkpoints_from_json_file(), false, "One or more checkpoints loaded from json conflicted with existing checkpoints.");
 
     block lb;
     if (!b)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -667,9 +667,9 @@ namespace cryptonote
       * its checkpoints if it is time.  If updating checkpoints fails,
       * the daemon is told to shut down.
       *
-      * @note see Blockchain::update_checkpoints()
+      * @note see Blockchain::update_checkpoints_from_json_file()
       */
-     bool update_checkpoints();
+     bool update_checkpoints_from_json_file();
 
      /**
       * @brief tells the daemon to wind down operations and stop running


### PR DESCRIPTION
Copy the rollback behaviour when you load checkpoints from json for service node checkpoints and retroactively realize you have synced the wrong chain.

@jagerman