### PR TITLE
4.0.2 fixes: checkpointing dereg fix; pre-fork mainnet dereg vote relay fix

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1432,7 +1432,7 @@ namespace cryptonote
   {
     std::vector<service_nodes::quorum_vote_t> relayable_votes = m_quorum_cop.get_relayable_votes(get_current_blockchain_height());
     uint8_t hf_version = get_blockchain_storage().get_current_hard_fork_version();
-    if (hf_version < cryptonote::network_version_11_infinite_staking)
+    if (hf_version < cryptonote::network_version_12_checkpointing)
     {
       NOTIFY_NEW_DEREGISTER_VOTE::request req = {};
       for (service_nodes::quorum_vote_t const &vote : relayable_votes)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1457,6 +1457,14 @@ namespace service_nodes
       }
       else if (type == quorum_type::checkpointing)
       {
+        // Checkpoint quorums only exist every CHECKPOINT_INTERVAL blocks, but the height that gets
+        // used to generate the quorum (i.e. the `height` variable here) is actually `H -
+        // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, where H is divisible by CHECKPOINT_INTERVAL, but
+        // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 is not (it equals 11).  Hence the addition here to
+        // "undo" the lag before checking to see if we're on an interval multiple:
+        if ((height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL != 0)
+          continue; // Not on an interval multiple: no checkpointing quorum is defined.
+
         size_t total_nodes = active_snode_list.size();
 
         // TODO(loki): Soft fork, remove when testnet gets reset

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1838,7 +1838,10 @@ namespace service_nodes
       m_transient_state.quorum_states[states.height].obligations = std::make_shared<testing_quorum>(obligations);
 
       testing_quorum const &checkpointing = states.quorums[static_cast<uint8_t>(quorum_type::checkpointing)];
-      m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
+      // Don't load any checkpoints that shouldn't exist (see the comment in generate_quorums as to
+      // why the `+BUFFER` term is here).
+      if ((states.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL == 0)
+          m_transient_state.quorum_states[states.height].checkpointing = std::make_shared<testing_quorum>(checkpointing);
     }
 
     for (const auto& info : data_in.infos)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -225,7 +225,7 @@ namespace service_nodes
                 for (size_t index_in_quorum = 0; index_in_quorum < quorum->workers.size(); index_in_quorum++)
                 {
                   crypto::public_key const &key = quorum->workers[index_in_quorum];
-                  m_core.record_checkpoint_vote(key, m_vote_pool.received_checkpoint_vote(height, index_in_quorum));
+                  m_core.record_checkpoint_vote(key, m_vote_pool.received_checkpoint_vote(m_obligations_height, index_in_quorum));
                 }
               }
             }

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -133,7 +133,7 @@ namespace service_nodes
     {
       LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes for checkpointing up to " << m_last_checkpointed_height);
       LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_BLOCKS << ". This should rarely happen! Please report this to the devs.");
-      m_last_checkpointed_height = height;
+      m_last_checkpointed_height = height - (height % CHECKPOINT_INTERVAL);
     }
 
     m_vote_pool.remove_expired_votes(height);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -361,7 +361,7 @@ namespace service_nodes
             if (!quorum)
             {
               // TODO(loki): Fatal error
-              LOG_ERROR("Checkpoint quorum for height: " << m_last_checkpointed_height << " was not cached in daemon!");
+              LOG_ERROR("Checkpoint quorum for height: " << (m_last_checkpointed_height - REORG_SAFETY_BUFFER_BLOCKS) << " was not cached in daemon!");
               continue;
             }
 


### PR DESCRIPTION
These are fixing some issues that have appeared in the 4.0.2 release:

- testnet deregistrations.  The testnet self-destructs by deregistering itself pretty much instantly because of a pair of bugs: first it counted votes using the wrong current height instead of lagged height, and second checkpointing quorums were returned for all heights (instead of just every 4th height), and so (even with the above fix) 3/4 of votes appeared to be "missing" since they aren't supposed to be voted on.

- `NOTIFY_NEW_SERVICE_NODE_VOTE` was being used for v11 on 4.0.x, but shouldn't be used until v12 (because 3.0.x doesn't understand it).