### PR TITLE
Make testing_quorum JSON serialization work for input

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -355,5 +355,24 @@ namespace cryptonote
     return true;
   }
 
+  void transform_out(const crypto::hash &h, std::string &out) {
+    out = epee::string_tools::pod_to_hex(h);
+  }
+  void transform_in(crypto::hash &h, const std::string &in) {
+    epee::string_tools::hex_to_pod(in, h);
+  }
+  void transform_out(const checkpoint_type &t, std::string &out) {
+    out = checkpoint_t::type_to_string(t);
+  }
+  void transform_in(checkpoint_type &t, const std::string &in) {
+    for (auto i = static_cast<checkpoint_type>(0); i != checkpoint_type::count; i = static_cast<checkpoint_type>(static_cast<int>(i) + 1)) {
+      if (in == checkpoint_t::type_to_string(i)) {
+        t = i;
+        return;
+      }
+    }
+    t = checkpoint_type::count;
+  }
+
 }
 

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -52,6 +52,16 @@ namespace cryptonote
     count,
   };
 
+  // Overloads for copying values -> strings or vice versa when serializing out or in, respectively.
+  void transform_out(const crypto::hash &h, std::string &out);
+  void transform_in(crypto::hash &h, const std::string &in);
+  inline void transform_out(crypto::hash &, std::string &) {}
+  inline void transform_in(const crypto::hash &, const std::string &) {}
+  void transform_out(const checkpoint_type &t, std::string &out);
+  void transform_in(checkpoint_type &t, const std::string &in);
+  inline void transform_out(checkpoint_type &, std::string &) {}
+  inline void transform_in(const checkpoint_type &, const std::string &) {}
+
   struct checkpoint_t
   {
     uint8_t                                        version = 0;
@@ -85,11 +95,13 @@ namespace cryptonote
       KV_SERIALIZE(version)
       KV_SERIALIZE(height)
 
-      std::string type = checkpoint_t::type_to_string(this_ref.type);
+      std::string type, block_hash;
+      transform_out(this_ref.type, type);
+      transform_out(this_ref.block_hash, block_hash);
       KV_SERIALIZE_VALUE(type);
-
-      std::string block_hash = epee::string_tools::pod_to_hex(this_ref.block_hash);
       KV_SERIALIZE_VALUE(block_hash);
+      transform_in(this_ref.type, type);
+      transform_in(this_ref.block_hash, block_hash);
 
       KV_SERIALIZE(signatures)
       KV_SERIALIZE(prev_height)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -553,4 +553,16 @@ namespace service_nodes
 
     return credit;
   }
+
+  void transform_out(const std::vector<crypto::public_key> &pks, std::vector<std::string> &out) {
+    out.reserve(pks.size());
+    for (auto &pk : pks)
+      out.push_back(epee::string_tools::pod_to_hex(pk));
+  }
+
+  void transform_in(std::vector<crypto::public_key> &pks, const std::vector<std::string> &in) {
+    pks.resize(in.size());
+    for (size_t i = 0; i < in.size(); i++)
+      epee::string_tools::hex_to_pod(in[i], pks[i]);
+  }
 }

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -45,6 +45,12 @@ namespace service_nodes
 {
   struct service_node_info;
 
+  // Overloads for copying public keys -> hex strings or vice versa when serializing out or in, respectively.
+  void transform_out(const std::vector<crypto::public_key> &pks, std::vector<std::string> &out);
+  void transform_in(std::vector<crypto::public_key> &, const std::vector<std::string> &);
+  inline void transform_out(std::vector<crypto::public_key> &, std::vector<std::string> &out) {}
+  inline void transform_in(const std::vector<crypto::public_key> &pks, const std::vector<std::string> &in) {}
+
   LOKI_RPC_DOC_INTROSPECT
   struct testing_quorum
   {
@@ -57,13 +63,17 @@ namespace service_nodes
     END_SERIALIZE()
 
     BEGIN_KV_SERIALIZE_MAP()
-      std::vector<std::string> validators(this_ref.validators.size());
-      for (size_t i = 0; i < this_ref.validators.size(); i++) validators[i] = epee::string_tools::pod_to_hex(this_ref.validators[i]);
-      KV_SERIALIZE_VALUE(validators);
+      std::vector<std::string> validators, workers;
 
-      std::vector<std::string> workers(this_ref.workers.size());
-      for (size_t i = 0; i < this_ref.workers.size(); i++) workers[i] = epee::string_tools::pod_to_hex(this_ref.workers[i]);
+      transform_out(this_ref.validators, validators);
+      transform_out(this_ref.workers, workers);
+
+      KV_SERIALIZE_VALUE(validators);
       KV_SERIALIZE_VALUE(workers);
+
+      transform_in(this_ref.validators, validators);
+      transform_in(this_ref.workers, workers);
+
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -52,6 +52,12 @@ namespace service_nodes
 {
   struct testing_quorum;
 
+  // Overloads for copying signature -> strings or vice versa when serializing out or in, respectively.
+  inline void transform_out(const crypto::signature &h, std::string &out) { out = epee::string_tools::pod_to_hex(h); }
+  inline void transform_in(crypto::signature &h, const std::string &in) { epee::string_tools::hex_to_pod(in, h); }
+  inline void transform_out(crypto::signature &, std::string &) {}
+  inline void transform_in(const crypto::signature &, const std::string &) {}
+
   struct voter_to_signature
   {
     uint16_t          voter_index;
@@ -64,8 +70,10 @@ namespace service_nodes
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(voter_index)
-      std::string signature = epee::string_tools::pod_to_hex(this_ref.signature);
+      std::string signature;
+      transform_out(this_ref.signature, signature);
       KV_SERIALIZE_VALUE(signature)
+      transform_in(this_ref.signature, signature);
     END_KV_SERIALIZE_MAP()
   };
 


### PR DESCRIPTION
The block explorer uses loki's KV serialization structs for its RPC
commands, but testing_quorum was only doing outbound serialization of
validators/workers.  This adds the missing inbound serialization code.