### PR TITLE
Checkpointing votes using wrong quorum

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -406,7 +406,6 @@ namespace service_nodes
         info.decommission_count++;
 
         info.proof.timestamp = 0;
-        info.proof.votes.fill(true);
         return true;
 
       case new_state::recommission:
@@ -430,6 +429,7 @@ namespace service_nodes
         info.active_since_height = block_height;
 
         // Move the SN at the back of the list as if it had just registered (or just won)
+        info.proof.votes.fill(true);
         info.last_reward_block_height = block_height;
         info.last_reward_transaction_index = std::numeric_limits<uint32_t>::max();
         return true;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -431,7 +431,7 @@ namespace service_nodes
       if (vote.block_height < REORG_SAFETY_BUFFER_BLOCKS_POST_HF12)
       {
         vvc.m_invalid_block_height = true;
-        LOG_ERROR("Quorum state for height: " << vote.block_height << " was not cached in daemon!");
+        LOG_ERROR("Invalid vote height: " << vote.block_height << " would overflow after offsetting height to quorum");
         return false;
       }
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -414,6 +414,7 @@ namespace service_nodes
 
   bool quorum_cop::handle_vote(quorum_vote_t const &vote, cryptonote::vote_verification_context &vvc)
   {
+    vvc                  = {};
     uint64_t curr_height = m_core.get_blockchain_storage().get_current_blockchain_height();
     if (m_core.get_nettype() == cryptonote::MAINNET &&
         curr_height >= HF_VERSION_12_CHECKPOINTING_SOFT_FORK_HEIGHT &&
@@ -424,12 +425,25 @@ namespace service_nodes
       return true;
     }
 
-    vvc = {};
-    std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(vote.type, vote.block_height);
+    uint64_t quorum_height = vote.block_height;
+    if (vote.type == quorum_type::checkpointing)
+    {
+      if (vote.block_height < REORG_SAFETY_BUFFER_BLOCKS_POST_HF12)
+      {
+        vvc.m_invalid_block_height = true;
+        LOG_ERROR("Quorum state for height: " << vote.block_height << " was not cached in daemon!");
+        return false;
+      }
+
+      quorum_height = vote.block_height - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12;
+    }
+
+    std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(vote.type, quorum_height);
     if (!quorum)
     {
       // TODO(loki): Fatal error
-      LOG_ERROR("Quorum state for height: " << vote.block_height << " was not cached in daemon!");
+      vvc.m_invalid_block_height = true;
+      LOG_ERROR("Quorum state for height: " << quorum_height << " was not cached in daemon!");
       return false;
     }
 


### PR DESCRIPTION
1st bug. In quorum_cop the obligation quorum still counts votes received even if the service node is decommissioned. So refill the votes on recommission essentially ignoring any missed votes during the decommissioning phase.

2nd bug. Use the correct quorum height when processing votes, which is the `vote height - safety buffer`

@jagerman