### PR TITLE
Another checkpoint quorum fix

### DIFF
--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -778,8 +778,9 @@ namespace cryptonote
       * @brief Get the deterministic quorum of service node's public keys responsible for the specified quorum type
       *
       * @param type The quorum type to retrieve
-      * @param height Block height to deterministically recreate the quorum list from
-      * @return Null shared ptr if quorum has not been determined yet for height
+      * @param height Block height to deterministically recreate the quorum list from (note that for
+      * a checkpointing quorum this value is automatically reduced by the correct buffer size).
+      * @return Null shared ptr if quorum has not been determined yet or is not defined for height
       */
      std::shared_ptr<const service_nodes::testing_quorum> get_testing_quorum(service_nodes::quorum_type type, uint64_t height) const;
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -139,6 +139,12 @@ namespace service_nodes
 
   std::shared_ptr<const testing_quorum> service_node_list::get_testing_quorum(quorum_type type, uint64_t height) const
   {
+    if (type == quorum_type::checkpointing) {
+        if (height < REORG_SAFETY_BUFFER_BLOCKS_POST_HF12)
+            return nullptr;
+        height -= REORG_SAFETY_BUFFER_BLOCKS_POST_HF12;
+    }
+
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
     const auto &it = m_transient_state.quorum_states.find(height);
     if (it != m_transient_state.quorum_states.end())

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -208,8 +208,11 @@ namespace service_nodes
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;
 
     /// Note(maxim): this should not affect thread-safety as the returned object is const
-    // For checkpointing, quorums are only generated when: ((height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL == 0)
-    // return: nullptr if the quorum is not cached in memory (pruned from memory).
+    ///
+    /// For checkpointing, quorums are only generated when height % CHECKPOINT_INTERVAL == 0 (and
+    /// the actual internal quorum used is for `height - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, i.e.
+    /// do no subtract off the buffer in advance)
+    /// return: nullptr if the quorum is not cached in memory (pruned from memory).
     std::shared_ptr<const testing_quorum> get_testing_quorum(quorum_type type, uint64_t height) const;
     bool                                  get_quorum_pubkey(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -220,7 +220,7 @@ namespace service_nodes
             // service nodes have fulfilled their checkpointing work
             if (m_core.get_hard_fork_version(m_obligations_height) >= cryptonote::network_version_12_checkpointing)
             {
-              if (std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(quorum_type::checkpointing, m_obligations_height - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12))
+              if (std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(quorum_type::checkpointing, m_obligations_height))
               {
                 for (size_t index_in_quorum = 0; index_in_quorum < quorum->workers.size(); index_in_quorum++)
                 {
@@ -357,7 +357,7 @@ namespace service_nodes
               continue;
 
             const std::shared_ptr<const testing_quorum> quorum =
-                m_core.get_testing_quorum(quorum_type::checkpointing, m_last_checkpointed_height - REORG_SAFETY_BUFFER_BLOCKS);
+                m_core.get_testing_quorum(quorum_type::checkpointing, m_last_checkpointed_height);
             if (!quorum)
             {
               // TODO(loki): Fatal error
@@ -425,25 +425,12 @@ namespace service_nodes
       return true;
     }
 
-    uint64_t quorum_height = vote.block_height;
-    if (vote.type == quorum_type::checkpointing)
-    {
-      if (vote.block_height < REORG_SAFETY_BUFFER_BLOCKS_POST_HF12)
-      {
-        vvc.m_invalid_block_height = true;
-        LOG_ERROR("Invalid vote height: " << vote.block_height << " would overflow after offsetting height to quorum");
-        return false;
-      }
-
-      quorum_height = vote.block_height - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12;
-    }
-
-    std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(vote.type, quorum_height);
+    std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(vote.type, vote.block_height);
     if (!quorum)
     {
       // TODO(loki): Fatal error
       vvc.m_invalid_block_height = true;
-      LOG_ERROR("Quorum state for height: " << quorum_height << " was not cached in daemon!");
+      LOG_ERROR("Quorum state for vote height " << vote.block_height << " was not cached in daemon!");
       return false;
     }
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -129,7 +129,7 @@ namespace service_nodes
       m_obligations_height = height;
     }
 
-    if (m_last_checkpointed_height >= height)
+    if (m_last_checkpointed_height >= height + REORG_SAFETY_BUFFER_BLOCKS)
     {
       LOG_ERROR("The blockchain was detached to height: " << height << ", but quorum cop has already processed votes for checkpointing up to " << m_last_checkpointed_height);
       LOG_ERROR("This implies a reorg occured that was over " << REORG_SAFETY_BUFFER_BLOCKS << ". This should rarely happen! Please report this to the devs.");

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -220,7 +220,7 @@ namespace service_nodes
             // service nodes have fulfilled their checkpointing work
             if (m_core.get_hard_fork_version(m_obligations_height) >= cryptonote::network_version_12_checkpointing)
             {
-              if (std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(quorum_type::checkpointing, m_obligations_height))
+              if (std::shared_ptr<const testing_quorum> quorum = m_core.get_testing_quorum(quorum_type::checkpointing, m_obligations_height - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12))
               {
                 for (size_t index_in_quorum = 0; index_in_quorum < quorum->workers.size(); index_in_quorum++)
                 {


### PR DESCRIPTION
Vote counting was still wrong here because the code was using the same height for the quorum and the vote pool.

The first commit fixes that (I left it for exposition), then the second commit replaces it completely by making all the callers of `get_testing_quorum` no longer have to worry about subtracting `REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`—it now just does it itself in one single place.  So now code that wants to get the quorum for voting at height H now writes:
```C++
    auto quorum = core.get_testing_quorum(quorum_type::checkpointing, H);
```
instead of having to worry about the subtraction:
```C++
    int quorum_height = H - REORG_SAFETY_BUFFER_BLOCKS_POST_HF12;
    auto quorum = core.get_testing_quorum(quorum_type::checkpointing, quorum_height);
```
The results are equivalent (the quorum is determined by the block at `H - BUFFER`), but this approach seems much less error prone.