### PR TITLE
Revert to manually serializing checkpoints/quorum

### DIFF
--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -59,7 +59,7 @@ namespace cryptonote
     uint64_t                                       height;
     crypto::hash                                   block_hash;
     std::vector<service_nodes::voter_to_signature> signatures; // Only service node checkpoints use signatures
-    uint64_t                                       prev_height;
+    uint64_t                                       prev_height; // TODO(doyle): Unused
 
     bool               check         (crypto::hash const &block_hash) const;
     static char const *type_to_string(checkpoint_type type)
@@ -80,20 +80,6 @@ namespace cryptonote
       FIELD(signatures)
       FIELD(prev_height)
     END_SERIALIZE()
-
-    BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(version)
-      KV_SERIALIZE(height)
-
-      std::string type = checkpoint_t::type_to_string(this_ref.type);
-      KV_SERIALIZE_VALUE(type);
-
-      std::string block_hash = epee::string_tools::pod_to_hex(this_ref.block_hash);
-      KV_SERIALIZE_VALUE(block_hash);
-
-      KV_SERIALIZE(signatures)
-      KV_SERIALIZE(prev_height)
-    END_KV_SERIALIZE_MAP()
   };
 
   struct height_to_hash

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -45,7 +45,6 @@ namespace service_nodes
 {
   struct service_node_info;
 
-  LOKI_RPC_DOC_INTROSPECT
   struct testing_quorum
   {
     std::vector<crypto::public_key> validators; // Array of public keys identifying service nodes which are being tested for the queried height.
@@ -55,16 +54,6 @@ namespace service_nodes
       FIELD(validators)
       FIELD(workers)
     END_SERIALIZE()
-
-    BEGIN_KV_SERIALIZE_MAP()
-      std::vector<std::string> validators(this_ref.validators.size());
-      for (size_t i = 0; i < this_ref.validators.size(); i++) validators[i] = epee::string_tools::pod_to_hex(this_ref.validators[i]);
-      KV_SERIALIZE_VALUE(validators);
-
-      std::vector<std::string> workers(this_ref.workers.size());
-      for (size_t i = 0; i < this_ref.workers.size(); i++) workers[i] = epee::string_tools::pod_to_hex(this_ref.workers[i]);
-      KV_SERIALIZE_VALUE(workers);
-    END_KV_SERIALIZE_MAP()
   };
 
   struct quorum_manager

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -61,12 +61,6 @@ namespace service_nodes
       FIELD(voter_index)
       FIELD(signature)
     END_SERIALIZE()
-
-    BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(voter_index)
-      std::string signature = epee::string_tools::pod_to_hex(this_ref.signature);
-      KV_SERIALIZE_VALUE(signature)
-    END_KV_SERIALIZE_MAP()
   };
 
   struct checkpoint_vote { crypto::hash block_hash; };

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -276,14 +276,15 @@ bool t_rpc_command_executor::print_checkpoints(uint64_t start_height, uint64_t e
   }
 
   std::string entry;
+  if (print_json) entry.append("{\n\"checkpoints\": [");
   for (size_t i = 0; i < res.checkpoints.size(); i++)
   {
-    cryptonote::checkpoint_t &checkpoint = res.checkpoints[i];
+    cryptonote::COMMAND_RPC_GET_CHECKPOINTS::checkpoint_serialized &checkpoint = res.checkpoints[i];
     if (print_json)
     {
-      entry.append("{\n");
-      entry.append(obj_to_json_str(checkpoint));
-      entry.append("\n}\n");
+      entry.append("\n");
+      entry.append(epee::serialization::store_t_to_json(checkpoint));
+      entry.append(",\n");
     }
     else
     {
@@ -292,22 +293,27 @@ bool t_rpc_command_executor::print_checkpoints(uint64_t start_height, uint64_t e
       entry.append("]");
 
       entry.append(" Type: ");
-      entry.append(cryptonote::checkpoint_t::type_to_string(checkpoint.type));
+      entry.append(checkpoint.type);
 
       entry.append(" Height: ");
       entry.append(std::to_string(checkpoint.height));
 
       entry.append(" Hash: ");
-      entry.append(epee::string_tools::pod_to_hex(checkpoint.block_hash));
+      entry.append(checkpoint.block_hash);
       entry.append("\n");
     }
   }
 
-  if (entry.empty())
+  if (print_json)
   {
-    if (print_json) entry.append("{\n}\n");
-    else            entry.append("No Checkpoints");
+    entry.append("]\n}");
   }
+  else
+  {
+    if (entry.empty())
+      entry.append("No Checkpoints");
+  }
+
   tools::success_msg_writer() << entry;
   return true;
 }
@@ -913,7 +919,16 @@ bool t_rpc_command_executor::print_quorum_state(uint64_t start_height, uint64_t 
     }
   }
 
-  tools::msg_writer() << "{\n" << obj_to_json_str(res.quorums) << "\n}";
+  std::string output;
+  output.append("{\n\"quorums\": [");
+  for (cryptonote::COMMAND_RPC_GET_QUORUM_STATE::quorum_for_height const &quorum : res.quorums)
+  {
+    output.append("\n");
+    output.append(epee::serialization::store_t_to_json(quorum));
+    output.append(",\n");
+  }
+  output.append("]\n}");
+  tools::success_msg_writer() << output;
   return true;
 }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2501,9 +2501,14 @@ namespace cryptonote
             COMMAND_RPC_GET_QUORUM_STATE::quorum_for_height entry = {};
             entry.height                                          = height;
             entry.quorum_type                                     = static_cast<uint8_t>(quorum_int);
-            entry.quorum                                          = *quorum;
-            at_least_one_succeeded                                = true;
+
+            entry.quorum.validators.reserve(quorum->validators.size());
+            entry.quorum.workers.reserve(quorum->workers.size());
+            for (crypto::public_key const &key : quorum->validators) entry.quorum.validators.push_back(epee::string_tools::pod_to_hex(key));
+            for (crypto::public_key const &key : quorum->workers)    entry.quorum.workers.push_back(epee::string_tools::pod_to_hex(key));
+
             res.quorums.push_back(entry);
+            at_least_one_succeeded = true;
           }
         }
       }
@@ -2941,28 +2946,31 @@ namespace cryptonote
     res.status             = CORE_RPC_STATUS_OK;
     BlockchainDB const &db = m_core.get_blockchain_storage().get_db();
 
+    std::vector<checkpoint_t> checkpoints;
     if (req.start_height == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE &&
         req.end_height   == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE)
     {
       checkpoint_t top_checkpoint;
       if (db.get_top_checkpoint(top_checkpoint))
-        res.checkpoints = db.get_checkpoints_range(top_checkpoint.height, 0, req.count);
-      return true;
+        checkpoints = db.get_checkpoints_range(top_checkpoint.height, 0, req.count);
     }
-
-    if (req.start_height == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE)
+    else if (req.start_height == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE)
     {
-      res.checkpoints = db.get_checkpoints_range(req.end_height, 0, req.count);
-      return true;
+      checkpoints = db.get_checkpoints_range(req.end_height, 0, req.count);
     }
-
-    if (req.end_height == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE)
+    else if (req.end_height == COMMAND_RPC_GET_CHECKPOINTS::HEIGHT_SENTINEL_VALUE)
     {
-      res.checkpoints = db.get_checkpoints_range(req.start_height, UINT64_MAX, req.count);
-      return true;
+      checkpoints = db.get_checkpoints_range(req.start_height, UINT64_MAX, req.count);
+    }
+    else
+    {
+      checkpoints = db.get_checkpoints_range(req.start_height, req.end_height);
     }
 
-    res.checkpoints = db.get_checkpoints_range(req.start_height, req.end_height);
+    res.checkpoints.reserve(checkpoints.size());
+    for (checkpoint_t const &checkpoint : checkpoints)
+      res.checkpoints.push_back(checkpoint);
+
     return true;
   }
 


### PR DESCRIPTION
KV_SERIALIZE doesn't handle non-primitive types well and requires adding
in extra deserialize/reserialize code. It's more straightforward to
manually serialize the output, rather than add serialization overloads.
Furthermore, KV_SERIALIZE doesn't support serializing enums in a sane
way.

@jagerman