### PR TITLE
Don't cull checkpoints if they bleed into the finality zone

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -202,7 +202,7 @@ namespace cryptonote
 
     uint64_t end_cull_height = height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;
     {
-      uint64_t constexpr NUM_CHECKPOINTS = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY + 1;
+      uint64_t constexpr NUM_CHECKPOINTS = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY;
       std::vector<checkpoint_t> checkpoints = m_db->get_checkpoints_range(height, 0, NUM_CHECKPOINTS);
 
       if (checkpoints.size() != NUM_CHECKPOINTS)

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -202,13 +202,13 @@ namespace cryptonote
 
     uint64_t end_cull_height = height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;
     {
-      uint64_t constexpr num_desired_checkpoints = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY + 1;
-      std::vector<checkpoint_t> checkpoints = m_db->get_checkpoints_range(height, 0, num_desired_checkpoints);
+      uint64_t constexpr NUM_CHECKPOINTS = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY + 1;
+      std::vector<checkpoint_t> checkpoints = m_db->get_checkpoints_range(height, 0, NUM_CHECKPOINTS);
 
-      if (checkpoints.size() != num_desired_checkpoints)
+      if (checkpoints.size() != NUM_CHECKPOINTS)
         return; // NOTE: No checkpoints to cull, can't cull the last N as they are for securing the chain
 
-      checkpoint_t const &oldest_checkpoint = checkpoints[num_desired_checkpoints - 1];
+      checkpoint_t const &oldest_checkpoint = checkpoints.back();
       assert(oldest_checkpoint.height < checkpoints[0].height && "API for retrieving range of checkpoints has changed and is returning the checkpoints sorted in an order we did not expect" != nullptr);
       end_cull_height = std::min(oldest_checkpoint.height, end_cull_height);
     }
@@ -222,7 +222,7 @@ namespace cryptonote
 
     m_last_cull_height = std::max(m_last_cull_height, start_cull_height);
     auto guard         = db_wtxn_guard(m_db);
-    for (; m_last_cull_height <= end_cull_height; m_last_cull_height += service_nodes::CHECKPOINT_INTERVAL)
+    for (; m_last_cull_height < end_cull_height; m_last_cull_height += service_nodes::CHECKPOINT_INTERVAL)
     {
       if (m_last_cull_height % service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
         continue;

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -200,19 +200,7 @@ namespace cryptonote
       }
     }
 
-    uint64_t end_cull_height = height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;
-    {
-      uint64_t constexpr NUM_CHECKPOINTS = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY;
-      std::vector<checkpoint_t> checkpoints = m_db->get_checkpoints_range(height, 0, NUM_CHECKPOINTS);
-
-      if (checkpoints.size() != NUM_CHECKPOINTS)
-        return; // NOTE: No checkpoints to cull, can't cull the last N as they are for securing the chain
-
-      checkpoint_t const &oldest_checkpoint = checkpoints.back();
-      assert(oldest_checkpoint.height < checkpoints[0].height && "API for retrieving range of checkpoints has changed and is returning the checkpoints sorted in an order we did not expect" != nullptr);
-      end_cull_height = std::min(oldest_checkpoint.height, end_cull_height);
-    }
-
+    uint64_t end_cull_height = m_db->get_checkpoint_immutable_height();
     uint64_t start_cull_height = (end_cull_height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL)
                                      ? 0
                                      : end_cull_height - service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -27,7 +27,7 @@ namespace service_nodes {
 
   static_assert(DECOMMISSION_INITIAL_CREDIT <= DECOMMISSION_MAX_CREDIT, "Initial registration decommission credit cannot be larger than the maximum decommission credit");
 
-  constexpr uint64_t  CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY = 2;
+  constexpr uint64_t  CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY = 2;  // Number of consecutive checkpoints before, blocks preceeding the N checkpoints are locked in
   constexpr uint64_t  CHECKPOINT_INTERVAL                           = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
   constexpr uint64_t  CHECKPOINT_STORE_PERSISTENTLY_INTERVAL        = 60; // Persistently store the checkpoints at these intervals
   constexpr uint64_t  CHECKPOINT_VOTE_LIFETIME                      = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes


### PR DESCRIPTION
If we miss many checkpoints for whatever reason, we could accidentally
delete checkpoints due to the cull height not checking what checkpoints
we have available