### PR TITLE
Increase the age of service node rollbacks we keep

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -957,9 +957,20 @@ namespace service_nodes
     {
       assert(m_transient_state.height == block_height);
       ++m_transient_state.height;
-      const size_t ROLLBACK_EVENT_EXPIRATION_BLOCKS = 30;
-      uint64_t cull_height = (block_height < ROLLBACK_EVENT_EXPIRATION_BLOCKS) ? block_height : block_height - ROLLBACK_EVENT_EXPIRATION_BLOCKS;
 
+      uint64_t cull_height = block_height;
+      std::vector<cryptonote::checkpoint_t> const &checkpoints = m_db->get_checkpoints_range(block_height, 0, CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY);
+      if (checkpoints.size() == CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY)
+      {
+        cryptonote::checkpoint_t const &oldest_checkpoint = checkpoints[CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY - 1];
+        cull_height = oldest_checkpoint.height;
+      }
+
+      uint64_t constexpr ROLLBACK_EVENT_EXPIRATION_BLOCKS = BLOCKS_EXPECTED_IN_DAYS(2);
+      uint64_t conservative_height =
+          block_height < ROLLBACK_EVENT_EXPIRATION_BLOCKS ? 0 : block_height - ROLLBACK_EVENT_EXPIRATION_BLOCKS;
+
+      cull_height = std::min(conservative_height, cull_height);
       while (!m_transient_state.rollback_events.empty() && m_transient_state.rollback_events.front()->m_block_height < cull_height)
       {
         m_transient_state.rollback_events.pop_front();

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -27,9 +27,10 @@ namespace service_nodes {
 
   static_assert(DECOMMISSION_INITIAL_CREDIT <= DECOMMISSION_MAX_CREDIT, "Initial registration decommission credit cannot be larger than the maximum decommission credit");
 
-  constexpr uint64_t  CHECKPOINT_INTERVAL                    = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
-  constexpr uint64_t  CHECKPOINT_STORE_PERSISTENTLY_INTERVAL = 60; // Persistently store the checkpoints at these intervals
-  constexpr uint64_t  CHECKPOINT_VOTE_LIFETIME               = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
+  constexpr uint64_t  CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY = 2;
+  constexpr uint64_t  CHECKPOINT_INTERVAL                           = 4;  // Checkpoint every 4 blocks and prune when too old except if (height % CHECKPOINT_STORE_PERSISTENTLY_INTERVAL == 0)
+  constexpr uint64_t  CHECKPOINT_STORE_PERSISTENTLY_INTERVAL        = 60; // Persistently store the checkpoints at these intervals
+  constexpr uint64_t  CHECKPOINT_VOTE_LIFETIME                      = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
 
   constexpr int16_t CHECKPOINT_MIN_QUORUMS_NODE_MUST_VOTE_IN_BEFORE_DEREGISTER_CHECK = 8;
   constexpr int16_t CHECKPOINT_MAX_MISSABLE_VOTES                                    = 4;
@@ -61,7 +62,7 @@ namespace service_nodes {
   static_assert(CHECKPOINT_MIN_VOTES <= CHECKPOINT_QUORUM_SIZE, "The number of votes required to kick can't exceed the actual quorum size, otherwise we never kick.");
 
   // NOTE: We can reorg up to last 2 checkpoints + the number of extra blocks before the next checkpoint is set
-  constexpr uint64_t  REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 = (CHECKPOINT_INTERVAL * 2) + (CHECKPOINT_INTERVAL - 1);
+  constexpr uint64_t  REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 = (CHECKPOINT_INTERVAL * CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY) + (CHECKPOINT_INTERVAL - 1);
   constexpr uint64_t  REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12  = 20;
   static_assert(REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");
   static_assert(REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12  < VOTE_LIFETIME, "Safety buffer should always be less than the vote lifetime");


### PR DESCRIPTION
Increase the range to mitigate frequent rescanning when reorganising,
technically with checkpointing we only need up to the 2nd oldest
checkpoint, but I'm sure there's some case we're forgetting that would
benefit from a larger rollback range.

Also considering there were only 160 events in the month with a mass
deregistration- keeping 2 days worth of rollbacks around is not going to
be too expensive.