### PR TITLE
Make cosmetic changes for RPC declarations for the documentation generator

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2549,7 +2549,7 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     buffer.append("\n");
     for (size_t j = 0; j < entry.contributors.size(); ++j)
     {
-      const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::contributor &contributor = entry.contributors[j];
+      const cryptonote::service_node_contributor &contributor = entry.contributors[j];
 
       buffer.append(indent2);
       buffer.append("[");

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2696,6 +2696,8 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  LOKI_RPC_DOC_INTROSPECT
+  // TODO: Undocumented, -- unused
   struct COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST
   {
     struct request
@@ -2722,6 +2724,36 @@ namespace cryptonote
   };
 
   LOKI_RPC_DOC_INTROSPECT
+  struct service_node_contribution
+  {
+    std::string key_image;         // The contribution's key image that is locked on the network.
+    std::string key_image_pub_key; // The contribution's key image, public key component
+    uint64_t    amount;            // The amount that is locked in this contribution.
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(key_image)
+      KV_SERIALIZE(key_image_pub_key)
+      KV_SERIALIZE(amount)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  LOKI_RPC_DOC_INTROSPECT
+  struct service_node_contributor
+  {
+    uint64_t amount;                                             // The total amount of locked Loki in atomic units for this contributor.
+    uint64_t reserved;                                           // The amount of Loki in atomic units reserved by this contributor for this Service Node.
+    std::string address;                                         // The wallet address for this contributor rewards are sent to and contributions came from.
+    std::vector<service_node_contribution> locked_contributions; // Array of contributions from this contributor.
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(amount)
+      KV_SERIALIZE(reserved)
+      KV_SERIALIZE(address)
+      KV_SERIALIZE(locked_contributions)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  LOKI_RPC_DOC_INTROSPECT
   // Get information on Service Nodes.
   struct COMMAND_RPC_GET_SERVICE_NODES
   {
@@ -2739,57 +2771,29 @@ namespace cryptonote
 
     struct response_t
     {
-      struct contribution
-      {
-        std::string key_image;         // The contribution's key image that is locked on the network.
-        std::string key_image_pub_key; // The contribution's key image, public key component
-        uint64_t    amount;            // The amount that is locked in this contribution.
-
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(key_image)
-          KV_SERIALIZE(key_image_pub_key)
-          KV_SERIALIZE(amount)
-        END_KV_SERIALIZE_MAP()
-      };
-
-      struct contributor
-      {
-        uint64_t amount;                                // The total amount of locked Loki in atomic units for this contributor.
-        uint64_t reserved;                              // The amount of Loki in atomic units reserved by this contributor for this Service Node.
-        std::string address;                            // The wallet address for this contributor rewards are sent to and contributions came from.
-        std::vector<contribution> locked_contributions; // Array of contributions from this contributor.
-
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(amount)
-          KV_SERIALIZE(reserved)
-          KV_SERIALIZE(address)
-          KV_SERIALIZE(locked_contributions)
-        END_KV_SERIALIZE_MAP()
-      };
-
       struct entry
       {
-        std::string               service_node_pubkey;           // The public key of the Service Node.
-        uint64_t                  registration_height;           // The height at which the registration for the Service Node arrived on the blockchain.
-        uint64_t                  requested_unlock_height;       // The height at which contributions will be released and the Service Node expires. 0 if not requested yet.
-        uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
-        uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
-        uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by at least 1 Service Node other than itself in unix epoch time.
-        bool                      active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
-        bool                      funded;                        // True if the required stakes have been submitted to activate this Service Node
-        uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
-        uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
-        int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
-        std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
-        std::vector<contributor>  contributors;                  // Array of contributors, contributing to this Service Node.
-        uint64_t                  total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
-        uint64_t                  total_reserved;                // The total amount of Loki in atomic units reserved in this Service Node.
-        uint64_t                  staking_requirement;           // The staking requirement in atomic units that is required to be contributed to become a Service Node.
-        uint64_t                  portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
-        uint64_t                  swarm_id;                      // The identifier of the Service Node's current swarm.
-        std::string               operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
-        std::string               public_ip;                     // The public ip address of the service node
-        uint16_t                  storage_port;                  // The port number associated with the storage server
+        std::string                           service_node_pubkey;           // The public key of the Service Node.
+        uint64_t                              registration_height;           // The height at which the registration for the Service Node arrived on the blockchain.
+        uint64_t                              requested_unlock_height;       // The height at which contributions will be released and the Service Node expires. 0 if not requested yet.
+        uint64_t                              last_reward_block_height;      // The last height at which this Service Node received a reward.
+        uint32_t                              last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
+        uint64_t                              last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by at least 1 Service Node other than itself in unix epoch time.
+        bool                                  active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
+        bool                                  funded;                        // True if the required stakes have been submitted to activate this Service Node
+        uint64_t                              state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
+        uint32_t                              decommission_count;            // The number of times the Service Node has been decommissioned since registration
+        int64_t                               earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
+        std::vector<uint16_t>                 service_node_version;          // The major, minor, patch version of the Service Node respectively.
+        std::vector<service_node_contributor> contributors;                  // Array of contributors, contributing to this Service Node.
+        uint64_t                              total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
+        uint64_t                              total_reserved;                // The total amount of Loki in atomic units reserved in this Service Node.
+        uint64_t                              staking_requirement;           // The staking requirement in atomic units that is required to be contributed to become a Service Node.
+        uint64_t                              portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
+        uint64_t                              swarm_id;                      // The identifier of the Service Node's current swarm.
+        std::string                           operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
+        std::string                           public_ip;                     // The public ip address of the service node
+        uint16_t                              storage_port;                  // The port number associated with the storage server
 
         BEGIN_KV_SERIALIZE_MAP()
             KV_SERIALIZE(service_node_pubkey)
@@ -2877,36 +2881,33 @@ namespace cryptonote
       bool hardfork;
 
       BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE_OPT2(service_node_pubkey, false)
-      KV_SERIALIZE_OPT2(registration_height, false)
-      KV_SERIALIZE_OPT2(requested_unlock_height, false)
-      KV_SERIALIZE_OPT2(last_reward_block_height, false)
-      KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
-      KV_SERIALIZE_OPT2(last_uptime_proof, false)
-      KV_SERIALIZE_OPT2(active, false)
-      KV_SERIALIZE_OPT2(funded, false)
-      KV_SERIALIZE_OPT2(state_height, false)
-      KV_SERIALIZE_OPT2(decommission_count, false)
-      KV_SERIALIZE_OPT2(earned_downtime_blocks, false)
-      KV_SERIALIZE_OPT2(service_node_version, false)
-      KV_SERIALIZE_OPT2(contributors, false)
-      KV_SERIALIZE_OPT2(total_contributed, false)
-      KV_SERIALIZE_OPT2(total_reserved, false)
-      KV_SERIALIZE_OPT2(staking_requirement, false)
-      KV_SERIALIZE_OPT2(portions_for_operator, false)
-      KV_SERIALIZE_OPT2(swarm_id, false)
-      KV_SERIALIZE_OPT2(operator_address, false)
-      KV_SERIALIZE_OPT2(public_ip, false)
-      KV_SERIALIZE_OPT2(storage_port, false)
-      KV_SERIALIZE_OPT2(block_hash, false)
-      KV_SERIALIZE_OPT2(height, false)
-      KV_SERIALIZE_OPT2(target_height, false)
-      KV_SERIALIZE_OPT2(hardfork, false)
+        KV_SERIALIZE_OPT2(service_node_pubkey, false)
+        KV_SERIALIZE_OPT2(registration_height, false)
+        KV_SERIALIZE_OPT2(requested_unlock_height, false)
+        KV_SERIALIZE_OPT2(last_reward_block_height, false)
+        KV_SERIALIZE_OPT2(last_reward_transaction_index, false)
+        KV_SERIALIZE_OPT2(last_uptime_proof, false)
+        KV_SERIALIZE_OPT2(active, false)
+        KV_SERIALIZE_OPT2(funded, false)
+        KV_SERIALIZE_OPT2(state_height, false)
+        KV_SERIALIZE_OPT2(decommission_count, false)
+        KV_SERIALIZE_OPT2(earned_downtime_blocks, false)
+        KV_SERIALIZE_OPT2(service_node_version, false)
+        KV_SERIALIZE_OPT2(contributors, false)
+        KV_SERIALIZE_OPT2(total_contributed, false)
+        KV_SERIALIZE_OPT2(total_reserved, false)
+        KV_SERIALIZE_OPT2(staking_requirement, false)
+        KV_SERIALIZE_OPT2(portions_for_operator, false)
+        KV_SERIALIZE_OPT2(swarm_id, false)
+        KV_SERIALIZE_OPT2(operator_address, false)
+        KV_SERIALIZE_OPT2(public_ip, false)
+        KV_SERIALIZE_OPT2(storage_port, false)
+        KV_SERIALIZE_OPT2(block_hash, false)
+        KV_SERIALIZE_OPT2(height, false)
+        KV_SERIALIZE_OPT2(target_height, false)
+        KV_SERIALIZE_OPT2(hardfork, false)
       END_KV_SERIALIZE_MAP()
     };
-
-    using contribution = COMMAND_RPC_GET_SERVICE_NODES::response_t::contribution;
-    using contributor = COMMAND_RPC_GET_SERVICE_NODES::response_t::contributor;
 
     struct request_t
     {
@@ -2915,9 +2916,9 @@ namespace cryptonote
       requested_fields_t fields;
 
       BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(limit)
-      KV_SERIALIZE(active_only)
-      KV_SERIALIZE(fields)
+        KV_SERIALIZE(limit)
+        KV_SERIALIZE(active_only)
+        KV_SERIALIZE(fields)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -2932,27 +2933,27 @@ namespace cryptonote
           : requested_fields(res)
         {}
 
-        std::string               service_node_pubkey;           // The public key of the Service Node.
-        uint64_t                  registration_height;           // The height at which the registration for the Service Node arrived on the blockchain.
-        uint64_t                  requested_unlock_height;       // The height at which contributions will be released and the Service Node expires. 0 if not requested yet.
-        uint64_t                  last_reward_block_height;      // The last height at which this Service Node received a reward.
-        uint32_t                  last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
-        uint64_t                  last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
-        bool                      active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
-        bool                      funded;                        // True if the required stakes have been submitted to activate this Service Node
-        uint64_t                  state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
-        uint32_t                  decommission_count;            // The number of times the Service Node has been decommissioned since registration
-        int64_t                   earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
-        std::vector<uint16_t>     service_node_version;          // The major, minor, patch version of the Service Node respectively.
-        std::vector<contributor>  contributors;                  // Array of contributors, contributing to this Service Node.
-        uint64_t                  total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
-        uint64_t                  total_reserved;                // The total amount of Loki in atomic units reserved in this Service Node.
-        uint64_t                  staking_requirement;           // The staking requirement in atomic units that is required to be contributed to become a Service Node.
-        uint64_t                  portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
-        uint64_t                  swarm_id;                      // The identifier of the Service Node's current swarm.
-        std::string               operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
-        std::string               public_ip;                     // The public ip address of the service node
-        uint16_t                  storage_port;                  // The port number associated with the storage server
+        std::string                           service_node_pubkey;           // The public key of the Service Node.
+        uint64_t                              registration_height;           // The height at which the registration for the Service Node arrived on the blockchain.
+        uint64_t                              requested_unlock_height;       // The height at which contributions will be released and the Service Node expires. 0 if not requested yet.
+        uint64_t                              last_reward_block_height;      // The last height at which this Service Node received a reward.
+        uint32_t                              last_reward_transaction_index; // When multiple Service Nodes register on the same height, the order the transaction arrive dictate the order you receive rewards.
+        uint64_t                              last_uptime_proof;             // The last time this Service Node's uptime proof was relayed by atleast 1 Service Node other than itself in unix epoch time.
+        bool                                  active;                        // True if fully funded and not currently decommissioned (and so `active && !funded` implicitly defines decommissioned)
+        bool                                  funded;                        // True if the required stakes have been submitted to activate this Service Node
+        uint64_t                              state_height;                  // If active: the state at which registration was completed; if decommissioned: the decommissioning height; if awaiting: the last contribution (or registration) height
+        uint32_t                              decommission_count;            // The number of times the Service Node has been decommissioned since registration
+        int64_t                               earned_downtime_blocks;        // The number of blocks earned towards decommissioning, or the number of blocks remaining until deregistration if currently decommissioned
+        std::vector<uint16_t>                 service_node_version;          // The major, minor, patch version of the Service Node respectively.
+        std::vector<service_node_contributor> contributors;                  // Array of contributors, contributing to this Service Node.
+        uint64_t                              total_contributed;             // The total amount of Loki in atomic units contributed to this Service Node.
+        uint64_t                              total_reserved;                // The total amount of Loki in atomic units reserved in this Service Node.
+        uint64_t                              staking_requirement;           // The staking requirement in atomic units that is required to be contributed to become a Service Node.
+        uint64_t                              portions_for_operator;         // The operator percentage cut to take from each reward expressed in portions, see cryptonote_config.h's STAKING_PORTIONS.
+        uint64_t                              swarm_id;                      // The identifier of the Service Node's current swarm.
+        std::string                           operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
+        std::string                           public_ip;                     // The public ip address of the service node
+        uint16_t                              storage_port;                  // The port number associated with the storage server
 
         BEGIN_KV_SERIALIZE_MAP()
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(service_node_pubkey);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6321,7 +6321,7 @@ bool simple_wallet::query_locked_stakes(bool print_result)
     for (COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info : response)
     {
       bool only_once = true;
-      for (COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : node_info.contributors)
+      for (service_node_contributor const &contributor : node_info.contributors)
       {
         address_parse_info address_info = {};
         if (!cryptonote::get_account_address_from_str(address_info, m_wallet->nettype(), contributor.address))
@@ -6335,7 +6335,7 @@ bool simple_wallet::query_locked_stakes(bool print_result)
 
         for (size_t i = 0; i < contributor.locked_contributions.size(); ++i)
         {
-          COMMAND_RPC_GET_SERVICE_NODES::response::contribution const &contribution = contributor.locked_contributions[i];
+          service_node_contribution const &contribution = contributor.locked_contributions[i];
           has_locked_stakes = true;
 
           if (!print_result)

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -374,7 +374,7 @@ std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> NodeRPCP
           [&contributor](const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry &e)
           {
             return std::any_of(e.contributors.begin(), e.contributors.end(),
-                [&contributor](const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::contributor &c) { return contributor == c.address; });
+                [&contributor](const cryptonote::service_node_contributor &c) { return contributor == c.address; });
           }
       );
       m_contributed_service_nodes_cached_height = height;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5983,12 +5983,12 @@ bool wallet2::is_transfer_unlocked(uint64_t unlock_time, uint64_t block_height, 
 
     for (cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry const &entry : service_nodes_states)
     {
-      for (cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : entry.contributors)
+      for (cryptonote::service_node_contributor const &contributor : entry.contributors)
       {
         if (primary_address != contributor.address)
           continue;
 
-        for (cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::contribution const &contribution : contributor.locked_contributions)
+        for (cryptonote::service_node_contribution const &contribution : contributor.locked_contributions)
         {
           binary_buf.clear();
           if(!string_tools::parse_hexstr_to_binbuff(contribution.key_image, binary_buf) || binary_buf.size() != sizeof(crypto::key_image))
@@ -7537,7 +7537,7 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
   if (amount == 0) amount = snode_info.staking_requirement * fraction;
 
   size_t total_num_locked_contributions = 0;
-  for (COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : snode_info.contributors)
+  for (service_node_contributor const &contributor : snode_info.contributors)
     total_num_locked_contributions += contributor.locked_contributions.size();
 
   uint8_t const hf_version   = *res;
@@ -7977,9 +7977,9 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
     }
 
     cryptonote::account_public_address const primary_address = get_address();
-    std::vector<COMMAND_RPC_GET_SERVICE_NODES::response::contribution> const *contributions = nullptr;
-    COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info                         = response[0];
-    for (COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : node_info.contributors)
+    std::vector<service_node_contribution> const *contributions     = nullptr;
+    COMMAND_RPC_GET_SERVICE_NODES::response::entry const &node_info = response[0];
+    for (service_node_contributor const &contributor : node_info.contributors)
     {
       address_parse_info address_info = {};
       cryptonote::get_account_address_from_str(address_info, nettype(), contributor.address);
@@ -8017,7 +8017,7 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
       }
 
       result.msg.reserve(1024);
-      COMMAND_RPC_GET_SERVICE_NODES::response::contribution const &contribution = (*contributions)[0];
+      service_node_contribution const &contribution = (*contributions)[0];
       if (node_info.requested_unlock_height != 0)
       {
         result.msg.append("Key image: ");


### PR DESCRIPTION
The doc generator doesn't know how to parse using statements, so upgrade
contributor/contributions to global scope in the RPC definitions file so
it's able to parse it for both service node RPC calls.

The best option will be to eventually deprecate the various ways to
query the network down to 1 call that doesn't duplicate functionality.