### PR TITLE
Only store service node list every 10k AND Height-N blocks

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -81,6 +81,7 @@ namespace service_nodes
       static auto work_start = std::chrono::high_resolution_clock::now();
       if (i > 0 && i % 10 == 0)
       {
+        store();
         auto work_end = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(work_end - work_start);
         MGINFO("... scanning height " << m_state.height << " (" << duration.count() / 1000.f << "s)");
@@ -1863,7 +1864,7 @@ namespace service_nodes
       }
     }
 
-    if (new_data_in.states.empty() || new_data_in.quorum_states.empty())
+    if (new_data_in.states.empty())
       return false;
 
     {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -190,7 +190,10 @@ namespace service_nodes
                                  [](state_t const &state, uint64_t height) { return state.height < height; });
 
       if (it != m_state_history.end())
-        quorums = &it->quorums;
+      {
+        if (it->height == height)
+          quorums = &it->quorums;
+      }
     }
 
     if (!quorums && include_old) // NOTE: Search m_old_quorum_states
@@ -202,7 +205,10 @@ namespace service_nodes
                            [](quorums_by_height const &entry, uint64_t height) { return entry.height < height; });
 
       if (it != m_old_quorum_states.end())
-        quorums = &it->quorums;
+      {
+        if (it->height == height)
+          quorums = &it->quorums;
+      }
     }
 
     if (!quorums)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -49,13 +49,14 @@
 #include "service_node_swarm.h"
 #include "version.h"
 
-size_t constexpr MAX_SHORT_TERM_STATE_HISTORY = BLOCKS_EXPECTED_IN_HOURS(2);
-
 #undef LOKI_DEFAULT_LOG_CATEGORY
 #define LOKI_DEFAULT_LOG_CATEGORY "service_nodes"
 
 namespace service_nodes
 {
+  size_t constexpr MAX_SHORT_TERM_STATE_HISTORY   = 6 * STATE_CHANGE_TX_LIFETIME_IN_BLOCKS;
+  size_t constexpr STORE_LONG_TERM_STATE_INTERVAL = 10000;
+
   static int get_min_service_node_info_version_for_hf(uint8_t hf_version)
   {
     return service_node_info::version_0_checkpointing; // Versioning reset with the full SN rescan in 4.0.0

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -428,6 +428,8 @@ namespace service_nodes
 
     struct quorums_by_height
     {
+      quorums_by_height() = default;
+      quorums_by_height(uint64_t height, quorum_manager quorums) : height(height), quorums(quorums) {}
       uint64_t       height;
       quorum_manager quorums;
     };

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -403,7 +403,7 @@ namespace service_nodes
 
     // Note(maxim): private methods don't have to be protected the mutex
     // Returns true if there was a registration:
-    void rescan_starting_from_curr_state();
+    void rescan_starting_from_curr_state(bool store_to_disk);
     bool process_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index);
     // Returns true if there was a successful contribution that fully funded a service node:
     bool process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -355,14 +355,18 @@ namespace service_nodes
 
     struct state_serialized
     {
-      uint64_t height;
-      std::vector<service_node_pubkey_info> infos;
+      uint8_t                                version;
+      uint64_t                               height;
+      std::vector<service_node_pubkey_info>  infos;
       std::vector<key_image_blacklist_entry> key_image_blacklist;
+      quorum_for_serialization               quorums;
 
       BEGIN_SERIALIZE()
-        FIELD(height)
+        VARINT_FIELD(version)
+        VARINT_FIELD(height)
         FIELD(infos)
         FIELD(key_image_blacklist)
+        FIELD(quorums)
       END_SERIALIZE()
     };
 
@@ -386,6 +390,7 @@ namespace service_nodes
       service_nodes_infos_t                  service_nodes_infos;
       std::vector<key_image_blacklist_entry> key_image_blacklist;
       block_height                           height;
+      quorum_manager                         quorums;
 
       // Returns a filtered, pubkey-sorted vector of service nodes that are active (fully funded and
       // *not* decommissioned).
@@ -408,7 +413,6 @@ namespace service_nodes
     void update_swarms(uint64_t height);
 
     bool contribution_tx_output_has_correct_unlock_time(const cryptonote::transaction& tx, size_t i, uint64_t block_height) const;
-    void generate_quorums(cryptonote::block const &block);
 
     bool is_registration_tx(const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info) const;
     std::vector<crypto::public_key> update_and_get_expired_nodes(const std::vector<cryptonote::transaction> &txs, uint64_t block_height);
@@ -422,10 +426,15 @@ namespace service_nodes
     cryptonote::BlockchainDB      *m_db;
     uint64_t                       m_store_quorum_history;
 
-    std::map<block_height, quorum_manager> m_quorum_states;
-    decltype(m_quorum_states)              m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
-    std::vector<state_t>                   m_state_history;
-    state_t                                m_state;
+    struct quorums_by_height
+    {
+      uint64_t       height;
+      quorum_manager quorums;
+    };
+
+    std::deque<quorums_by_height>  m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
+    std::vector<state_t>           m_state_history;
+    state_t                        m_state;
   };
 
   bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -91,7 +91,6 @@ namespace service_nodes {
   constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
   constexpr uint64_t STATE_CHANGE_TX_LIFETIME_IN_BLOCKS = VOTE_LIFETIME;
-  constexpr size_t   QUORUM_LIFETIME                    = (6 * STATE_CHANGE_TX_LIFETIME_IN_BLOCKS);
 
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;


### PR DESCRIPTION
The biggest bottleneck in syncing after the historical change was serialising the states into memory every block, when trying to sync the blockchain i.e. 300,000 blocks this was adding around ~15ms per block which adds up when syncing large amounts.

So now we only store 1 of the recent states, around ~60 blocks back and rederive the rest at run-time so we only have to store states every 10k blocks and 1 recent one cutting down the time it takes to serialise state.

There's still one more improvement that will get us back to speed that will come in another PR, that is separating the serialising of long term and the current state in the DB. It's wasteful currently to serialise the long term states every block when they don't change until the next 10k interval.

@jagerman