### PR TITLE
Don't query the blockchain for hardfork which causes major slowdown

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1202,13 +1202,12 @@ namespace service_nodes
     }
     else
     {
+      const uint64_t hf11_height = m_blockchain.get_earliest_ideal_height_for_version(cryptonote::network_version_11_infinite_staking);
       for (auto it = m_state.service_nodes_infos.begin(); it != m_state.service_nodes_infos.end(); it++)
       {
         crypto::public_key const &snode_key = it->first;
         service_node_info &info             = it->second;
-        int const hf_version                = m_blockchain.get_hard_fork_version(info.registration_height);
-
-        if (hf_version >= cryptonote::network_version_11_infinite_staking)
+        if (info.registration_height >= hf11_height)
         {
           if (info.requested_unlock_height != KEY_IMAGE_AWAITING_UNLOCK_HEIGHT && block_height > info.requested_unlock_height)
             expired_nodes.push_back(snode_key);


### PR DESCRIPTION
This one line was causing a big slow down after doing some profiling.

Now the time to rescan appears to be more linear with the size of the Service Node List. Won't get these sorts of good numbers without the store every 10k improvement though as well.

@jagerman

```
2019-07-26 07:29:43.393 I Recalculating service nodes list, scanning blockchain from height: 101250 to: 321467                                                                                                                                                                                                              
2019-07-26 07:29:46.495 I ... scanning height 111250 (3.101s)                                                                                                                                                                                                                                                               
2019-07-26 07:29:50.296 I ... scanning height 121250 (3.8s)                                                                                                                                                                                                                                                                 
2019-07-26 07:29:54.808 I ... scanning height 131250 (4.512s)                                                                                                                                                                                                                                                               
2019-07-26 07:29:59.782 I ... scanning height 141250 (4.974s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:05.008 I ... scanning height 151250 (5.225s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:09.992 I ... scanning height 161250 (4.983s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:18.207 I ... scanning height 171250 (8.215s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:26.435 I ... scanning height 181250 (8.227s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:34.800 I ... scanning height 191250 (8.365s)                                                                                                                                                                                                                                                               
2019-07-26 07:30:44.361 I ... scanning height 201250 (9.56s)                                                                                                                                                                                                                                                                
2019-07-26 07:30:52.733 I ... scanning height 211250 (8.372s)                                                                                                                                                                                                                                                               
2019-07-26 07:31:01.969 I ... scanning height 221250 (9.236s)                                                                                                                                                                                                                                                               
2019-07-26 07:31:11.567 I ... scanning height 231250 (9.597s)                                                                                                                                                                                                                                                               
2019-07-26 07:31:25.429 I ... scanning height 241250 (13.861s)                                                                                                                                                                                                                                                              
2019-07-26 07:31:44.047 I ... scanning height 251250 (18.618s)                                                                                                                                                                                                                                                              
2019-07-26 07:32:00.698 I ... scanning height 261250 (16.65s)                                                                                                                                                                                                                                                               
2019-07-26 07:32:15.335 I ... scanning height 271250 (14.637s)                                                                                                                                                                                                                                                              
2019-07-26 07:32:29.187 I ... scanning height 281250 (13.851s)                                                                                                                                                                                                                                                              
2019-07-26 07:32:42.654 I ... scanning height 291250 (13.466s)                                                                                                                                                                                                                                                              
2019-07-26 07:32:56.564 I ... scanning height 301250 (13.91s)                                                                                                                                                                                                                                                               
2019-07-26 07:33:10.606 I ... scanning height 311250 (14.042s)                                                                                                                                                                                                                                                              
2019-07-26 07:33:27.399 I ... scanning height 321250 (16.792s)                                                                                                                                                                                                                                                              
2019-07-26 07:33:27.760 I Done recalculating service nodes list (224.366s)        
```                                                                                                                                                                                                                                          