### PR TITLE
Filter vote age before querying quorum

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1235,9 +1235,17 @@ namespace cryptonote
     {
       bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Incorrect voting group specified");
       if (vote)
-        bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ": %s", (vote->group == service_nodes::quorum_group::validator) ? "validator" : "worker");
+      {
+        if (vote->group == service_nodes::quorum_group::validator)
+          bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ": %s", "validator");
+        else if (vote->group == service_nodes::quorum_group::worker)
+          bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ": %s", "worker");
+        else
+          bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ": %d", (uint8_t)vote->group);
+      }
       bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ", ");
     }
+    if (vvc.m_invalid_vote_type)             bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Vote type has invalid value: %s, ", vote ? std::to_string((uint8_t)vote->type) : "??");
 
     if (bufPtr != buf)
     {

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1245,7 +1245,7 @@ namespace cryptonote
       }
       bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ", ");
     }
-    if (vvc.m_invalid_vote_type)             bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Vote type has invalid value: %s, ", vote ? std::to_string((uint8_t)vote->type) : "??");
+    if (vvc.m_invalid_vote_type)             bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Vote type has invalid value: %s, ", vote ? std::to_string((uint8_t)vote->type).c_str() : "??");
 
     if (bufPtr != buf)
     {

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -47,6 +47,7 @@ namespace cryptonote
     bool m_added_to_pool;
     bool m_not_enough_votes;
     bool m_incorrect_voting_group;
+    bool m_invalid_vote_type;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(m_verification_failed)
@@ -58,6 +59,7 @@ namespace cryptonote
       KV_SERIALIZE(m_added_to_pool)
       KV_SERIALIZE(m_not_enough_votes)
       KV_SERIALIZE(m_incorrect_voting_group)
+      KV_SERIALIZE(m_invalid_vote_type)
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -316,12 +316,53 @@ namespace service_nodes
     return result;
   }
 
-  bool verify_vote(const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum)
+  bool verify_vote_age(const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc)
+  {
+    bool result           = true;
+    bool height_in_buffer = false;
+    if (latest_height > vote.block_height + VOTE_LIFETIME)
+    {
+      height_in_buffer = latest_height <= vote.block_height + (VOTE_LIFETIME + VERIFY_HEIGHT_BUFFER);
+      LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is older than: " << VOTE_LIFETIME
+                                                << " blocks and has been rejected.");
+      vvc.m_invalid_block_height = true;
+    }
+    else if (vote.block_height > latest_height)
+    {
+      height_in_buffer = vote.block_height <= latest_height + VERIFY_HEIGHT_BUFFER;
+      LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is newer than: " << latest_height
+                                                << " (latest block height) and has been rejected.");
+      vvc.m_invalid_block_height = true;
+    }
+
+    if (vvc.m_invalid_block_height)
+    {
+      vvc.m_verification_failed = !height_in_buffer;
+      result = false;
+    }
+
+    return result;
+  }
+
+  bool verify_vote_against_quorum(const quorum_vote_t &vote, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum)
   {
     bool result = true;
-    if (vote.group == quorum_group::invalid)
+    if (vote.type >= quorum_type::count)
+    {
+      vvc.m_invalid_vote_type = true;
       result = false;
-    else if (vote.group == quorum_group::validator)
+    }
+
+    if (vote.group > quorum_group::worker || vote.group < quorum_group::validator)
+    {
+      vvc.m_incorrect_voting_group = true;
+      result = false;
+    }
+
+    if (!result)
+      return result;
+
+    if (vote.group == quorum_group::validator)
       result = bounds_check_validator_index(quorum, vote.index_in_group, &vvc);
     else
       result = bounds_check_worker_index(quorum, vote.index_in_group, &vvc);
@@ -329,92 +370,59 @@ namespace service_nodes
     if (!result)
       return result;
 
-    //
-    // NOTE: Validate vote age
-    //
+    crypto::public_key key = crypto::null_pkey;
+    crypto::hash hash      = crypto::null_hash;
+
+    switch(vote.type)
     {
-      bool height_in_buffer = false;
-      if (latest_height > vote.block_height + VOTE_LIFETIME)
+      default:
       {
-        height_in_buffer = latest_height <= vote.block_height + (VOTE_LIFETIME + VERIFY_HEIGHT_BUFFER);
-        LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is older than: " << VOTE_LIFETIME
-                                                  << " blocks and has been rejected.");
-        vvc.m_invalid_block_height = true;
-      }
-      else if (vote.block_height > latest_height)
-      {
-        height_in_buffer = vote.block_height <= latest_height + VERIFY_HEIGHT_BUFFER;
-        LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is newer than: " << latest_height
-                                                  << " (latest block height) and has been rejected.");
-        vvc.m_invalid_block_height = true;
-      }
+        LOG_PRINT_L1("Unhandled vote type with value: " << (int)vote.type);
+        assert("Unhandled vote type" == 0);
+        return false;
+      };
 
-      if (vvc.m_invalid_block_height)
+      case quorum_type::obligations:
       {
-        result                    = false;
-        vvc.m_verification_failed = !height_in_buffer;
-        return result;
-      }
-    }
-
-    {
-      crypto::public_key key = crypto::null_pkey;
-      crypto::hash hash      = crypto::null_hash;
-
-      switch(vote.type)
-      {
-        default:
+        if (vote.group != quorum_group::validator)
         {
-          LOG_PRINT_L1("Unhandled vote type with value: " << (int)vote.type);
-          assert("Unhandled vote type" == 0);
-          return false;
-        };
-
-        case quorum_type::obligations:
+          LOG_PRINT_L1("Vote received specifies incorrect voting group, expected vote from validator");
+          vvc.m_incorrect_voting_group = true;
+          result = false;
+        }
+        else
         {
-          if (vote.group != quorum_group::validator)
-          {
-            LOG_PRINT_L1("Vote received specifies incorrect voting group, expected vote from validator");
-            vvc.m_incorrect_voting_group = true;
-            return false;
-          }
-
           key = quorum.validators[vote.index_in_group];
           hash = make_state_change_vote_hash(vote.block_height, vote.state_change.worker_index, vote.state_change.state);
-
-          bool result = bounds_check_worker_index(quorum, vote.state_change.worker_index, &vvc);
-          if (!result)
-            return result;
+          result = bounds_check_worker_index(quorum, vote.state_change.worker_index, &vvc);
         }
-        break;
+      }
+      break;
 
-        case quorum_type::checkpointing:
+      case quorum_type::checkpointing:
+      {
+        if (vote.group != quorum_group::worker)
         {
-          if (vote.group != quorum_group::worker)
-          {
-            LOG_PRINT_L1("Vote received specifies incorrect voting group, expected vote from worker");
-            vvc.m_incorrect_voting_group = true;
-            return false;
-          }
-
+          LOG_PRINT_L1("Vote received specifies incorrect voting group, expected vote from worker");
+          vvc.m_incorrect_voting_group = true;
+          result = false;
+        }
+        else
+        {
           key  = quorum.workers[vote.index_in_group];
           hash = vote.checkpoint.block_hash;
         }
-        break;
       }
-
-      //
-      // NOTE: Validate vote signature
-      //
-      result = crypto::check_signature(hash, key, vote.signature);
-      if (!result)
-      {
-        vvc.m_signature_not_valid = true;
-        return result;
-      }
+      break;
     }
 
-    result = true;
+    if (!result)
+      return result;
+
+    result = crypto::check_signature(hash, key, vote.signature);
+    if (!result)
+      vvc.m_signature_not_valid = true;
+
     return result;
   }
 
@@ -514,17 +522,8 @@ namespace service_nodes
     return false;
   }
 
-  std::vector<pool_vote_entry> voting_pool::add_pool_vote_if_unique(uint64_t latest_height,
-                                                                    const quorum_vote_t& vote,
-                                                                    cryptonote::vote_verification_context& vvc,
-                                                                    const service_nodes::testing_quorum &quorum)
+  std::vector<pool_vote_entry> voting_pool::add_pool_vote_if_unique(const quorum_vote_t& vote, cryptonote::vote_verification_context& vvc)
   {
-    if (!verify_vote(vote, latest_height, vvc, quorum))
-    {
-      LOG_PRINT_L1("Signature verification failed for deregister vote");
-      return {};
-    }
-
     CRITICAL_REGION_LOCAL(m_lock);
     auto *votes = find_vote_pool(vote, /*create_if_not_found=*/ true);
     if (!votes)

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -105,7 +105,8 @@ namespace service_nodes
 
   bool              verify_checkpoint                  (cryptonote::checkpoint_t const &checkpoint, service_nodes::testing_quorum const &quorum);
   bool              verify_tx_state_change             (const cryptonote::tx_extra_service_node_state_change& state_change, uint64_t latest_height, cryptonote::tx_verification_context& vvc, const service_nodes::testing_quorum &quorum, uint8_t hf_version);
-  bool              verify_vote                        (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
+  bool              verify_vote_age                    (const quorum_vote_t& vote, uint64_t latest_height, cryptonote::vote_verification_context &vvc);
+  bool              verify_vote_against_quorum         (const quorum_vote_t& vote, cryptonote::vote_verification_context &vvc, const service_nodes::testing_quorum &quorum);
   crypto::signature make_signature_from_vote           (quorum_vote_t const &vote, const crypto::public_key& pub, const crypto::secret_key& sec);
   crypto::signature make_signature_from_tx_state_change(cryptonote::tx_extra_service_node_state_change const &state_change, crypto::public_key const &pub, crypto::secret_key const &sec);
 
@@ -132,10 +133,7 @@ namespace service_nodes
   struct voting_pool
   {
     // return: The vector of votes if the vote is valid (and even if it is not unique) otherwise nullptr
-    std::vector<pool_vote_entry> add_pool_vote_if_unique(uint64_t latest_height,
-                                                         const quorum_vote_t& vote,
-                                                         cryptonote::vote_verification_context& vvc,
-                                                         const service_nodes::testing_quorum &quorum);
+    std::vector<pool_vote_entry> add_pool_vote_if_unique(const quorum_vote_t &vote, cryptonote::vote_verification_context &vvc);
 
     // TODO(loki): Review relay behaviour and all the cases when it should be triggered
     void                         set_relayed         (const std::vector<quorum_vote_t>& votes);


### PR DESCRIPTION
Removes verification of votes outside of voting pool and into 2 steps. Verifying the vote age (which if its valid, then we should go ahead and try retrieve the quorum) then verifying the vote against the retrieved quorum.

Otherwise someone can willy nilly generate votes with invalid parameters and spam missing quorum error messages that are actually not a serious error.

@jagerman

This makes #768 redundant