### PR TITLE
Hf12 cleanup code

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1547,7 +1547,7 @@ namespace cryptonote
     add_new_block(b, bvc, nullptr /*checkpoint*/);
     cleanup_handle_incoming_blocks(true);
     //anyway - update miner template
-    update_miner_block_template();
+    m_miner.on_block_chain_update();
     m_miner.resume();
 
 
@@ -1662,7 +1662,7 @@ namespace cryptonote
     }
     add_new_block(*b, bvc, checkpoint);
     if(update_miner_blocktemplate && bvc.m_added_to_main_chain)
-       update_miner_block_template();
+       m_miner.on_block_chain_update();
     return true;
 
     CATCH_ENTRY_L0("core::handle_incoming_block()", false);
@@ -1775,12 +1775,6 @@ namespace cryptonote
   std::string core::print_pool(bool short_format) const
   {
     return m_mempool.print_pool(short_format);
-  }
-  //-----------------------------------------------------------------------------------------------
-  bool core::update_miner_block_template()
-  {
-    m_miner.on_block_chain_update();
-    return true;
   }
   //-----------------------------------------------------------------------------------------------
   static bool check_storage_server_ping(time_t last_time_storage_server_pinged)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -980,15 +980,6 @@ namespace cryptonote
      bool handle_incoming_tx_accumulated_batch(std::vector<tx_verification_batch_info> &tx_info, bool keeped_by_block);
 
      /**
-      * @copydoc miner::on_block_chain_update
-      *
-      * @note see miner::on_block_chain_update
-      *
-      * @return true
-      */
-     bool update_miner_block_template();
-
-     /**
       * @brief act on a set of command line options given
       *
       * @param vm the command line options

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -49,32 +49,6 @@
 
 namespace service_nodes
 {
-  bool convert_deregister_vote_to_legacy(quorum_vote_t const &vote, legacy_deregister_vote &legacy_vote)
-  {
-    if (vote.type != quorum_type::obligations || vote.state_change.state != new_state::deregister)
-      return false;
-
-    legacy_vote.block_height           = vote.block_height;
-    legacy_vote.service_node_index     = vote.state_change.worker_index;
-    legacy_vote.voters_quorum_index    = vote.index_in_group;
-    legacy_vote.signature              = vote.signature;
-    return true;
-  }
-
-  // TODO(loki): Post HF12 remove legacy votes, no longer should be propagated
-  quorum_vote_t convert_legacy_deregister_vote(legacy_deregister_vote const &vote)
-  {
-    quorum_vote_t result             = {};
-    result.type                      = quorum_type::obligations;
-    result.block_height              = vote.block_height;
-    result.signature                 = vote.signature;
-    result.group                     = quorum_group::validator;
-    result.index_in_group            = vote.voters_quorum_index;
-    result.state_change.worker_index = vote.service_node_index;
-    result.state_change.state        = new_state::deregister;
-    return result;
-  }
-
   static crypto::hash make_state_change_vote_hash(uint64_t block_height, uint32_t service_node_index, new_state state)
   {
     uint16_t state_int = static_cast<uint16_t>(state);

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -120,9 +120,6 @@ namespace service_nodes
     crypto::signature signature;
   };
 
-  bool           convert_deregister_vote_to_legacy(quorum_vote_t const &vote, legacy_deregister_vote &legacy);
-  quorum_vote_t  convert_legacy_deregister_vote   (legacy_deregister_vote const &vote);
-
   struct pool_vote_entry
   {
     quorum_vote_t vote;

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -294,25 +294,6 @@ namespace cryptonote
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
-  struct NOTIFY_NEW_DEREGISTER_VOTE
-  {
-    // TODO(doyle): We need to remove this code post fork, pre checkpointing
-    // fork which revamps the voting system, we need to continue accepting
-    // deregisters using the old system.
-    const static int ID = BC_COMMANDS_POOL_BASE + 10;
-
-    struct request
-    {
-      std::vector<service_nodes::legacy_deregister_vote> votes;
-      BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(votes)
-      END_KV_SERIALIZE_MAP()
-    };
-  };
-    
-  /************************************************************************/
-  /*                                                                      */
-  /************************************************************************/
   struct NOTIFY_UPTIME_PROOF
   {
     const static int ID = BC_COMMANDS_POOL_BASE + 11;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -92,7 +92,6 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_CHAIN_ENTRY, &cryptonote_protocol_handler::handle_response_chain_entry)
       HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)
-      HANDLE_NOTIFY_T2(NOTIFY_NEW_DEREGISTER_VOTE, &cryptonote_protocol_handler::handle_notify_new_deregister_vote)
       HANDLE_NOTIFY_T2(NOTIFY_UPTIME_PROOF, &cryptonote_protocol_handler::handle_uptime_proof)
       HANDLE_NOTIFY_T2(NOTIFY_NEW_SERVICE_NODE_VOTE, &cryptonote_protocol_handler::handle_notify_new_service_node_vote)
     END_INVOKE_MAP2()
@@ -128,7 +127,6 @@ namespace cryptonote
     int handle_response_chain_entry(int command, NOTIFY_RESPONSE_CHAIN_ENTRY::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_fluffy_block(int command, NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& context);
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
-    int handle_notify_new_deregister_vote(int command, NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& context);
     int handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_service_node_vote(int command, NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& context);
 
@@ -154,7 +152,6 @@ namespace cryptonote
 
     virtual bool relay_block(NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
-    virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -44,7 +44,6 @@ namespace cryptonote
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)=0;
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
-    virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
 
@@ -58,10 +57,6 @@ namespace cryptonote
       return false;
     }
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)
-    {
-      return false;
-    }
-    virtual bool relay_deregister_votes(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)
     {
       return false;
     }


### PR DESCRIPTION
* Remove NOTIFY_NEW_DEREGISTER_VOTE_CODE
* Inline update_miner_block_template as it's declared publicly but only used in cryptonote_core
* Remove legacy P2P vote conversion methods

@jagerman