### PR TITLE
Fix off by one in deleting checkpoints on detach

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -236,7 +236,7 @@ namespace cryptonote
     {
       uint64_t start_height = top_checkpoint.height;
       for (size_t delete_height = start_height;
-           delete_height > height;
+           delete_height >= height;
            delete_height -= service_nodes::CHECKPOINT_INTERVAL)
       {
         try


### PR DESCRIPTION
The height returned in blockchain_detached is the chain height not the
height of the latest block we have, so deletion should be inclusive of
the height not exclusive.

@jagerman

Side note: Logic to handle not being able to pop checkpoints off greater than the immutability checkpoint is done at the caller's site, because, for example pop_blocks should be able to remove any number of blocks irrespective of the immutable checkpoints, but reorg code would restrict the height to the immutable checkpoint and detach to that point.