### PR TITLE
Handle multi state changes in the pool

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -277,6 +277,7 @@ namespace cryptonote
     network_version_10_bulletproofs, // Bulletproofs, Service Node Grace Registration Period, Batched Governance
     network_version_11_infinite_staking, // Infinite Staking, CN-Turtle
     network_version_12_checkpointing, // Checkpointing, Relaxed Deregistration, RandomXL, Loki Storage Server
+    network_version_13,
 
     network_version_count,
   };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -490,9 +490,7 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   {
     m_timestamps_and_difficulties_height = 0;
     m_hardfork->reorganize_from_chain_height(get_current_blockchain_height());
-    uint64_t top_block_height;
-    crypto::hash top_block_hash = get_tail_id(top_block_height);
-    m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
+    m_tx_pool.on_blockchain_dec();
   }
 
   if (test_options && test_options->long_term_block_weight_window)
@@ -714,11 +712,8 @@ block Blockchain::pop_block_from_blockchain()
   m_check_txin_table.clear();
 
   CHECK_AND_ASSERT_THROW_MES(update_next_cumulative_weight_limit(), "Error updating next cumulative weight limit");
-  uint64_t top_block_height;
-  crypto::hash top_block_hash = get_tail_id(top_block_height);
-  m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
+  m_tx_pool.on_blockchain_dec();
   invalidate_block_template_cache();
-
   return popped_block;
 }
 //------------------------------------------------------------------
@@ -3268,77 +3263,23 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       }
 
       crypto::public_key const &state_change_service_node_pubkey = quorum->workers[state_change.service_node_index];
-      if (1)
+      //
+      // NOTE: Query the Service Node List for the in question Service Node the state change is for and disallow if conflicting
+      //
+      std::vector<service_nodes::service_node_pubkey_info> service_node_array = m_service_node_list.get_service_node_list_state({state_change_service_node_pubkey});
+      if (service_node_array.empty())
       {
-        //
-        // NOTE: Query the Service Node List for the in question Service Node the state change is for and disallow if conflicting
-        //
-        std::vector<service_nodes::service_node_pubkey_info> service_node_array = m_service_node_list.get_service_node_list_state({state_change_service_node_pubkey});
-        if (service_node_array.empty())
-        {
-          LOG_PRINT_L2("Service Node no longer exists on the network, state change can be ignored");
-          return false;
-        }
-
-        service_nodes::service_node_info const &service_node_info = service_node_array[0].info;
-        if (!service_node_info.can_transition_to_state(hf_version, state_change.block_height, state_change.state))
-        {
-          MERROR_VER("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
-          tvc.m_double_spend = true;
-          return false;
-        }
-      }
-      else
-      {
-        // Check the inputs (votes) of the transaction have not already been
-        // submitted to the blockchain under another transaction using a different
-        // combination of votes.
-        const uint64_t height                = state_change.block_height;
-        constexpr size_t num_blocks_to_check = service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS;
-
-        std::vector<std::pair<cryptonote::blobdata,block>> blocks;
-        std::vector<cryptonote::blobdata> txs;
-        if (!get_blocks(height, num_blocks_to_check, blocks, txs))
-        {
-          MERROR_VER("Failed to get historical blocks to check against previous state changes for de-duplication");
-          return false;
-        }
-
-        for (blobdata const &blob : txs)
-        {
-          transaction existing_tx;
-          if (!parse_and_validate_tx_from_blob(blob, existing_tx))
-          {
-            MERROR_VER("tx could not be validated from blob, possibly corrupt blockchain");
-            continue;
-          }
-
-          if (existing_tx.type != txtype::state_change)
-            continue;
-
-          tx_extra_service_node_state_change existing_state_change;
-          if (!get_service_node_state_change_from_tx_extra(existing_tx.extra, existing_state_change, hf_version))
-          {
-            MERROR_VER("could not get service node state change from tx extra, possibly corrupt tx");
-            continue;
-          }
-
-          const auto existing_quorum = m_service_node_list.get_testing_quorum(quorum_type, existing_state_change.block_height);
-          if (!existing_quorum)
-          {
-            MERROR_VER("Could not get obligations quorum for recent state change tx");
-            continue;
-          }
-
-          if (existing_quorum->workers[existing_state_change.service_node_index] == state_change_service_node_pubkey)
-          {
-            MERROR_VER("Already seen this state change tx (aka double spend)");
-            tvc.m_double_spend = true;
-            return false;
-          }
-        }
+        MERROR_VER("Service Node no longer exists on the network, state change can be ignored");
+        return hf_version < cryptonote::network_version_12_checkpointing; // NOTE: Used to be allowed pre HF12.
       }
 
+      service_nodes::service_node_info const &service_node_info = service_node_array[0].info;
+      if (!service_node_info.can_transition_to_state(hf_version, state_change.block_height, state_change.state))
+      {
+        MERROR_VER("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
+        tvc.m_double_spend = true;
+        return false;
+      }
     }
     else if (tx.type == txtype::key_image_unlock)
     {
@@ -4103,8 +4044,7 @@ leave:
   bvc.m_added_to_main_chain = true;
   ++m_sync_counter;
 
-  // appears to be a NOP *and* is called elsewhere.  wat?
-  m_tx_pool.on_blockchain_inc(new_height, id);
+  m_tx_pool.on_blockchain_inc(m_service_node_list, bl);
   get_difficulty_for_next_block(); // just to cache it
   invalidate_block_template_cache();
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3268,7 +3268,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       }
 
       crypto::public_key const &state_change_service_node_pubkey = quorum->workers[state_change.service_node_index];
-      if (hf_version >= cryptonote::network_version_12_checkpointing)
+      if (1)
       {
         //
         // NOTE: Query the Service Node List for the in question Service Node the state change is for and disallow if conflicting
@@ -3281,9 +3281,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         }
 
         service_nodes::service_node_info const &service_node_info = service_node_array[0].info;
-        if (!service_node_info.can_transition_to_state(state_change.state))
+        if (!service_node_info.can_transition_to_state(hf_version, state_change.block_height, state_change.state))
         {
-          LOG_PRINT_L2("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
+          MERROR_VER("State change trying to vote Service Node into the same state it already is in, (aka double spend)");
           tvc.m_double_spend = true;
           return false;
         }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -122,7 +122,7 @@ namespace service_nodes
     bool is_decommissioned() const { return active_since_height < 0; }
     bool is_active() const { return is_fully_funded() && !is_decommissioned(); }
 
-    bool can_transition_to_state(new_state proposed_state) const;
+    bool can_transition_to_state(uint8_t hf_version, uint64_t block_height, new_state proposed_state) const;
     size_t total_num_locked_contributions() const;
 
     BEGIN_SERIALIZE_OBJECT()

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -123,6 +123,7 @@ namespace service_nodes
     bool is_active() const { return is_fully_funded() && !is_decommissioned(); }
 
     bool can_transition_to_state(uint8_t hf_version, uint64_t block_height, new_state proposed_state) const;
+    bool can_be_voted_on        (uint64_t block_height) const;
     size_t total_num_locked_contributions() const;
 
     BEGIN_SERIALIZE_OBJECT()

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1119,15 +1119,69 @@ namespace cryptonote
     }
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::on_blockchain_inc(uint64_t new_block_height, const crypto::hash& top_block_id)
+  bool tx_memory_pool::on_blockchain_inc(service_nodes::service_node_list const &service_node_list, block const &blk)
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     m_input_cache.clear();
     m_parsed_tx_cache.clear();
+
+    std::vector<transaction> pool_txs;
+    get_transactions(pool_txs);
+    if (pool_txs.empty()) return true;
+
+    // NOTE: For transactions in the pool, on new block received, if a Service
+    // Node changed state any older state changes that the node cannot
+    // transition to now are invalid and cannot be used, so take them out from
+    // the pool.
+
+    // Otherwise multiple state changes can queue up until they are applicable
+    // and be applied on the node.
+    for (transaction const &pool_tx : pool_txs)
+    {
+      tx_extra_service_node_state_change state_change;
+      crypto::public_key service_node_pubkey;
+      if (pool_tx.type == txtype::state_change &&
+          get_service_node_state_change_from_tx_extra(pool_tx.extra, state_change, blk.major_version))
+      {
+        if (service_node_list.get_quorum_pubkey(service_nodes::quorum_type::obligations,
+                                                service_nodes::quorum_group::worker,
+                                                state_change.block_height,
+                                                state_change.service_node_index,
+                                                service_node_pubkey))
+        {
+          std::vector<service_nodes::service_node_pubkey_info> service_node_array = service_node_list.get_service_node_list_state({service_node_pubkey});
+
+          // TODO(loki): Temporary HF12 code. We want to use HF13 code for
+          // detecting if a service node can change state for pruning from the
+          // pool, because changing the pool code here is not consensus, but we
+          // want this logic so as to improve the network behaviour regarding
+          // multiple queued up state changes without a hard fork.
+
+          // Once we hard fork to v13 we can just use the blk major version
+          // whole sale.
+          uint8_t enforce_hf_version = std::max((uint8_t)cryptonote::network_version_13, blk.major_version);
+
+          if (service_node_array.empty() ||
+              !service_node_array[0].info.can_transition_to_state(enforce_hf_version, state_change.block_height, state_change.state))
+          {
+            transaction tx;
+            cryptonote::blobdata blob;
+            size_t tx_weight;
+            uint64_t fee;
+            bool relayed, do_not_relay, double_spend_seen;
+
+            crypto::hash tx_hash;
+            if (get_transaction_hash(pool_tx, tx_hash))
+              take_tx(tx_hash, tx, blob, tx_weight, fee, relayed, do_not_relay, double_spend_seen);
+          }
+        }
+      }
+    }
+
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::on_blockchain_dec(uint64_t new_block_height, const crypto::hash& top_block_id)
+  bool tx_memory_pool::on_blockchain_dec()
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     m_input_cache.clear();

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -159,26 +159,22 @@ namespace cryptonote
     /**
      * @brief action to take when notified of a block added to the blockchain
      *
-     * Currently does nothing
-     *
      * @param new_block_height the height of the blockchain after the change
      * @param top_block_id the hash of the new top block
      *
      * @return true
      */
-    bool on_blockchain_inc(uint64_t new_block_height, const crypto::hash& top_block_id);
+    bool on_blockchain_inc(service_nodes::service_node_list const &service_node_list, block const &blk);
 
     /**
      * @brief action to take when notified of a block removed from the blockchain
      *
-     * Currently does nothing
-     *
      * @param new_block_height the height of the blockchain after the change
      * @param top_block_id the hash of the new top block
      *
      * @return true
      */
-    bool on_blockchain_dec(uint64_t new_block_height, const crypto::hash& top_block_id);
+    bool on_blockchain_dec();
 
     /**
      * @brief action to take periodically


### PR DESCRIPTION
Prune invalid state changes in the pool every block. Come hardfork 13 we will start enforcing this on the protocol level.

I believe this mitigates https://github.com/loki-project/loki/issues/765 and fixes it by hardfork 13 as well by not allowing decommissions to queue up in the pool and be used if you happen to re-register after the decommission and it gets reapplied on your newly stake node.

Addendum to that I also added a reset to the uptime proof on recommission so the network universally agrees that the node is online (if a super majority of the quorum decided so, then the rest of the network should as well).

@jagerman  

Also able to simplify check_tx_inputs removing the old code path for detecting dupe state changes with the new one. Is backwards compatible all the way back to the start of Service Nodes.