### PR TITLE
Service node data optimizations and code cleanups/simplifications

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3274,7 +3274,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         return hf_version < cryptonote::network_version_12_checkpointing; // NOTE: Used to be allowed pre HF12.
       }
 
-      service_nodes::service_node_info const &service_node_info = service_node_array[0].info;
+      service_nodes::service_node_info const &service_node_info = *service_node_array[0].info;
       if (!service_node_info.can_transition_to_state(hf_version, state_change.block_height, state_change.state))
       {
         MERROR_VER("State change trying to vote Service Node into the same state it already is in, (aka double spend)");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2002,10 +2002,11 @@ bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std
   if(start_offset >= height)
     return false;
 
-  blocks.reserve(blocks.size() + height - start_offset);
-  for(size_t i = start_offset; i < start_offset + count && i < height;i++)
+  const size_t num_blocks = std::min<uint64_t>(height - start_offset, count);
+  blocks.reserve(blocks.size() + num_blocks);
+  for(size_t i = 0; i < num_blocks; i++)
   {
-    blocks.push_back(std::make_pair(m_db->get_block_blob_from_height(i), block()));
+    blocks.emplace_back(m_db->get_block_blob_from_height(start_offset + i), block{});
     if (!parse_and_validate_block_from_blob(blocks.back().first, blocks.back().second))
     {
       LOG_ERROR("Invalid block");
@@ -2446,7 +2447,7 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
       cryptonote::blobdata tx;
       if (m_db->get_tx_blob(tx_hash, tx))
       {
-        txs.push_back(transaction());
+        txs.emplace_back();
         if (!parse_and_validate_tx_from_blob(tx, txs.back()))
         {
           LOG_ERROR("Invalid transaction");
@@ -3048,7 +3049,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       //
       if (hf_version >= cryptonote::network_version_11_infinite_staking)
       {
-        const std::vector<service_nodes::key_image_blacklist_entry> &blacklist = m_service_node_list.get_blacklisted_key_images();
+        const auto &blacklist = m_service_node_list.get_blacklisted_key_images();
         for (const auto &entry : blacklist)
         {
           if (in_to_key.k_image == entry.key_image) // Check if key image is on the blacklist

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2183,20 +2183,17 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   const std::vector<service_nodes::key_image_blacklist_entry> &core::get_service_node_blacklisted_key_images() const
   {
-    const auto &result = m_service_node_list.get_blacklisted_key_images();
-    return result;
+    return m_service_node_list.get_blacklisted_key_images();
   }
   //-----------------------------------------------------------------------------------------------
   std::vector<service_nodes::service_node_pubkey_info> core::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
-    std::vector<service_nodes::service_node_pubkey_info> result = m_service_node_list.get_service_node_list_state(service_node_pubkeys);
-    return result;
+    return m_service_node_list.get_service_node_list_state(service_node_pubkeys);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::add_service_node_vote(const service_nodes::quorum_vote_t& vote, vote_verification_context &vvc)
   {
-    bool result = m_quorum_cop.handle_vote(vote, vvc);
-    return result;
+    return m_quorum_cop.handle_vote(vote, vvc);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::get_service_node_keys(crypto::public_key &pub_key, crypto::secret_key &sec_key) const

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1792,12 +1792,11 @@ namespace cryptonote
     // wait one block before starting uptime proofs.
     std::vector<service_nodes::service_node_pubkey_info> const states = get_service_node_list_state({ m_service_node_pubkey });
 
-    if (!states.empty() && (states[0].info.registration_height + 1) < get_current_blockchain_height())
+    if (!states.empty() && (states[0].info->registration_height + 1) < get_current_blockchain_height())
     {
-      // Code snippet from Github @Jagerman
-      service_nodes::service_node_info const &info = states[0].info;
+      service_nodes::service_node_info const &info = *states[0].info;
       m_check_uptime_proof_interval.do_call([&info, this]() {
-        if (info.proof.timestamp <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS))
+        if (info.proof->timestamp <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS))
         {
           uint8_t hf_version = get_blockchain_storage().get_current_hard_fork_version();
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -77,9 +77,11 @@ namespace service_nodes
 
     MGINFO("Recalculating service nodes list, scanning blockchain from height: " << m_state.height << " to: " << current_height);
     std::vector<std::pair<cryptonote::blobdata, cryptonote::block>> blocks;
+    std::vector<cryptonote::transaction> txs;
+    std::vector<crypto::hash> missed_txs;
+    auto work_start = std::chrono::high_resolution_clock::now();
     for (uint64_t i = 0; m_state.height < current_height; i++)
     {
-      static auto work_start = std::chrono::high_resolution_clock::now();
       if (i > 0 && i % 10 == 0)
       {
         if (store_to_disk) store();
@@ -95,9 +97,9 @@ namespace service_nodes
         MERROR("Unable to initialize service nodes list");
         return;
       }
+      if (blocks.empty())
+        break;
 
-      std::vector<cryptonote::transaction> txs;
-      std::vector<crypto::hash> missed_txs;
       for (const auto& block_pair : blocks)
       {
         txs.clear();
@@ -181,15 +183,10 @@ namespace service_nodes
     quorum_manager const *quorums = nullptr;
     if (height == m_state.height)
       quorums = &m_state.quorums;
-
-    if (!quorums) // NOTE: Search m_state_history
+    else // NOTE: Search m_state_history
     {
-      auto it = std::lower_bound(m_state_history.begin(),
-                                 m_state_history.end(),
-                                 height,
-                                 [](state_t const &state, uint64_t height) { return state.height < height; });
-
-      if (it != m_state_history.end() && it->height == height)
+      auto it = m_state_history.find(height);
+      if (it != m_state_history.end())
         quorums = &it->quorums;
     }
 
@@ -255,27 +252,17 @@ namespace service_nodes
     {
       result.reserve(m_state.service_nodes_infos.size());
 
-      for (const auto &it : m_state.service_nodes_infos)
-      {
-        service_node_pubkey_info entry = {};
-        entry.pubkey                   = it.first;
-        entry.info                     = it.second;
-        result.push_back(entry);
-      }
+      for (const auto &info : m_state.service_nodes_infos)
+        result.emplace_back(info);
     }
     else
     {
       result.reserve(service_node_pubkeys.size());
       for (const auto &it : service_node_pubkeys)
       {
-        const auto &find_it = m_state.service_nodes_infos.find(it);
-        if (find_it == m_state.service_nodes_infos.end())
-          continue;
-
-        service_node_pubkey_info entry = {};
-        entry.pubkey                   = (*find_it).first;
-        entry.info                     = (*find_it).second;
-        result.push_back(entry);
+        auto find_it = m_state.service_nodes_infos.find(it);
+        if (find_it != m_state.service_nodes_infos.end())
+          result.emplace_back(*find_it);
       }
     }
 
@@ -338,8 +325,11 @@ namespace service_nodes
 
     addresses.clear();
     addresses.reserve(registration.m_public_spend_keys.size());
-    for (size_t i = 0; i < registration.m_public_spend_keys.size(); i++)
-      addresses.push_back(cryptonote::account_public_address{ registration.m_public_spend_keys[i], registration.m_public_view_keys[i] });
+    for (size_t i = 0; i < registration.m_public_spend_keys.size(); i++) {
+      addresses.emplace_back();
+      addresses.back().m_spend_public_key = registration.m_public_spend_keys[i];
+      addresses.back().m_view_public_key = registration.m_public_view_keys[i];
+    }
 
     portions_for_operator = registration.m_portions_for_operator;
     portions = registration.m_portions;
@@ -434,12 +424,10 @@ namespace service_nodes
           {
             for (const auto &contribution : contributor.locked_contributions)
             {
-              key_image_blacklist_entry entry = {};
-              entry.version                   = get_min_service_node_info_version_for_hf(hard_fork_version);
-              entry.key_image                 = contribution.key_image;
-              entry.unlock_height             = block_height + staking_num_lock_blocks(m_blockchain.nettype());
-              m_state.key_image_blacklist.push_back(entry);
-              const bool adding_to_blacklist = true;
+              m_state.key_image_blacklist.emplace_back(
+                  get_min_service_node_info_version_for_hf(hard_fork_version),
+                  contribution.key_image,
+                  block_height + staking_num_lock_blocks(m_blockchain.nettype()));
             }
           }
         }
@@ -618,12 +606,13 @@ namespace service_nodes
           if (!crypto::check_ring_signature((const crypto::hash &)(proof->key_image), proof->key_image, &ephemeral_pub_key_ptr, 1, &proof->signature))
             continue;
 
-          service_node_info::contribution_t entry = {};
-          entry.key_image_pub_key                 = ephemeral_pub_key;
-          entry.key_image                         = proof->key_image;
-          entry.amount                            = transferred;
+          parsed_contribution.locked_contributions.emplace_back(
+              service_node_info::version_0_checkpointing,
+              ephemeral_pub_key,
+              proof->key_image,
+              transferred
+          );
 
-          parsed_contribution.locked_contributions.push_back(entry);
           parsed_contribution.transferred += transferred;
           key_image_proofs.proofs.erase(proof);
           break;
@@ -779,11 +768,11 @@ namespace service_nodes
       lo = mul128(info.staking_requirement, service_node_portions[i], &hi);
       div128_64(hi, lo, STAKING_PORTIONS, &resulthi, &resultlo);
 
-      service_node_info::contributor_t contributor = {};
+      info.contributors.emplace_back();
+      auto &contributor = info.contributors.back();
       contributor.version                          = get_min_service_node_info_version_for_hf(hf_version);
       contributor.reserved                         = resultlo;
       contributor.address                          = service_node_addresses[i];
-      info.contributors.push_back(contributor);
       info.total_reserved += resultlo;
     }
 
@@ -925,18 +914,13 @@ namespace service_nodes
                      " for tx: " << cryptonote::get_transaction_hash(tx));
         return false;
       }
-    }
 
-    //
-    // Successfully Validated
-    //
-    if (new_contributor)
-    {
-      service_node_info::contributor_t new_contributor = {};
-      new_contributor.version                          = get_min_service_node_info_version_for_hf(hf_version);
-      new_contributor.address                          = parsed_contribution.address;
-      info.contributors.push_back(new_contributor);
-      contrib_iter = --contributors.end();
+      //
+      // Successfully Validated
+      //
+      contrib_iter = info.contributors.emplace(contributors.end());
+      contrib_iter->version = get_min_service_node_info_version_for_hf(hf_version);
+      contrib_iter->address = parsed_contribution.address;
     }
 
     service_node_info::contributor_t& contributor = *contrib_iter;
@@ -962,8 +946,6 @@ namespace service_nodes
     const size_t max_contributions_per_node = service_nodes::MAX_KEY_IMAGES_PER_CONTRIBUTOR * MAX_NUMBER_OF_CONTRIBUTORS;
     if (hf_version >= cryptonote::network_version_11_infinite_staking)
     {
-      std::vector<service_node_info::contribution_t> &locked_contributions = contributor.locked_contributions;
-
       for (const service_node_info::contribution_t &contribution : parsed_contribution.locked_contributions)
       {
         if (info.total_num_locked_contributions() < max_contributions_per_node)
@@ -1140,7 +1122,7 @@ namespace service_nodes
 
     assert(m_state.height == block_height);
     bool need_swarm_update = false;
-    m_state_history.push_back(m_state);
+    m_state_history.insert(m_state_history.end(), m_state);
     m_state.quorums = {};
     ++m_state.height;
 
@@ -1148,24 +1130,15 @@ namespace service_nodes
     // Cull old history
     //
     {
-      uint64_t start_height = (block_height < MAX_SHORT_TERM_STATE_HISTORY) ? 0 : block_height - MAX_SHORT_TERM_STATE_HISTORY;
-      auto it =
-          std::lower_bound(m_state_history.begin(),
-                           m_state_history.end(),
-                           start_height,
-                           [](state_t const &state, uint64_t start_height) { return state.height < start_height; });
+      uint64_t cull_height = (block_height < MAX_SHORT_TERM_STATE_HISTORY) ? 0 : block_height - MAX_SHORT_TERM_STATE_HISTORY;
+      auto it = m_state_history.find(cull_height);
 
-      while (it != m_state_history.end() && it->height <= start_height)
+      // TODO(loki): Don't keep state migrated from serialized v4.0.3s since they are incomplete. Remove after everyone has upgraded
+      if (it != m_state_history.end() && (it->height % STORE_LONG_TERM_STATE_INTERVAL != 0 || it->is_migrated_from_v403()))
       {
-        // TODO(loki): Don't keep state migrated from serialized v4.0.3s since they are incomplete. Remove after everyone has upgraded
-        if (it->height % STORE_LONG_TERM_STATE_INTERVAL == 0 && !it->is_migrated_from_v403())
-          it++;
-        else
-        {
-          if (m_store_quorum_history)
-            m_old_quorum_states.emplace_back(it->height, it->quorums);
-          it = m_state_history.erase(it);
-        }
+        if (m_store_quorum_history)
+          m_old_quorum_states.emplace_back(it->height, it->quorums);
+        it = m_state_history.erase(it);
       }
 
       if (m_old_quorum_states.size() > m_store_quorum_history)
@@ -1178,10 +1151,7 @@ namespace service_nodes
     for (auto entry = m_state.key_image_blacklist.begin(); entry != m_state.key_image_blacklist.end();)
     {
       if (block_height >= entry->unlock_height)
-      {
-        const bool adding_to_blacklist = false;
         entry = m_state.key_image_blacklist.erase(entry);
-      }
       else
         entry++;
     }
@@ -1261,36 +1231,27 @@ namespace service_nodes
         }
 
         uint64_t unlock_height = get_locked_key_image_unlock_height(m_blockchain.nettype(), node_info.registration_height, block_height);
-        bool early_exit        = false;
 
-        for (auto contributor = node_info.contributors.begin();
-             contributor     != node_info.contributors.end() && !early_exit;
-             contributor++)
+        for (const auto &contributor : node_info.contributors)
         {
-          for (auto locked_contribution = contributor->locked_contributions.begin();
-               locked_contribution     != contributor->locked_contributions.end() && !early_exit;
-               locked_contribution++)
+          auto it = std::find_if(contributor.locked_contributions.begin(), contributor.locked_contributions.end(),
+              [&unlock](const service_node_info::contribution_t &contribution) { return unlock.key_image == contribution.key_image; });
+          if (it != contributor.locked_contributions.end())
           {
-            if (unlock.key_image != locked_contribution->key_image)
-              continue;
-
             // NOTE(loki): This should be checked in blockchain check_tx_inputs already
             crypto::hash const hash = service_nodes::generate_request_stake_unlock_hash(unlock.nonce);
-            if (!crypto::check_signature(hash, locked_contribution->key_image_pub_key, unlock.signature))
-            {
+            if (crypto::check_signature(hash, it->key_image_pub_key, unlock.signature))
+              node_info.requested_unlock_height = unlock_height;
+            else
               LOG_PRINT_L1("Unlock TX: Couldn't verify key image unlock in the tx_extra, rejected on height: " << block_height << " for tx: " << get_transaction_hash(tx));
-              early_exit = true;
-              break;
-            }
 
-            node_info.requested_unlock_height = unlock_height;
-            early_exit = true;
+            break;
           }
         }
       }
     }
 
-    m_state_history.back().quorums = generate_quorums(m_blockchain.nettype(), m_state, block);
+    m_state_history.rbegin()->quorums = generate_quorums(m_blockchain.nettype(), m_state, block);
     if (need_swarm_update)
       update_swarms(block_height);
   }
@@ -1302,10 +1263,7 @@ namespace service_nodes
     if (m_state.height == height)
       return;
 
-    auto it = std::lower_bound(
-        m_state_history.begin(), m_state_history.end(), height, [](state_t const &state, uint64_t start_height) {
-          return state.height < start_height;
-        });
+    auto it = m_state_history.lower_bound(height);
 
     bool reinitialise = false;
     if (it == m_state_history.end())
@@ -1314,8 +1272,10 @@ namespace service_nodes
     {
       m_state_history.erase(it, m_state_history.end());
       // TODO(loki): If historical state is serialized from v4.0.3 they are incomplete, need a full rescan. Delete code block after everyone has upgraded
-      if (m_state_history.size())
-        reinitialise = (m_state_history.back().is_migrated_from_v403() || m_state_history.back().height > height);
+      if (m_state_history.size()) {
+        auto &latest = *m_state_history.rbegin();
+        reinitialise = (latest.is_migrated_from_v403() || latest.height > height);
+      }
       else
         reinitialise = true;
     }
@@ -1323,7 +1283,7 @@ namespace service_nodes
     if (reinitialise)
     {
       // TODO(loki): If historical state is serialized from v4.0.3 they are incomplete, need a full rescan. Delete code block after everyone has upgraded
-      if (m_state_history.back().is_migrated_from_v403())
+      if (m_state_history.rbegin()->is_migrated_from_v403())
         reset(true);
 
       m_state_history.clear();
@@ -1331,8 +1291,9 @@ namespace service_nodes
       return;
     }
 
-    m_state = m_state_history.back();
-    m_state_history.pop_back();
+    it = std::prev(m_state_history.end());
+    m_state = std::move(*it);
+    m_state_history.erase(it);
 
     if (m_state.height != height)
       rescan_starting_from_curr_state(false /*store_to_disk*/);
@@ -1431,7 +1392,7 @@ namespace service_nodes
       if (contributor.address == info.operator_address)
         resultlo += info.portions_for_operator;
 
-      winners.push_back(std::make_pair(contributor.address, resultlo));
+      winners.emplace_back(contributor.address, resultlo);
     }
     return winners;
   }
@@ -1557,14 +1518,9 @@ namespace service_nodes
     service_node_list::state_serialized result = {};
     result.version                             = get_min_service_node_info_version_for_hf(hf_version);
 
-    service_node_pubkey_info info;
     result.infos.reserve(state.service_nodes_infos.size());
     for (const auto &kv_pair : state.service_nodes_infos)
-    {
-      info.pubkey = kv_pair.first;
-      info.info   = kv_pair.second;
-      result.infos.push_back(info);
-    }
+      result.infos.emplace_back(kv_pair);
 
     result.key_image_blacklist = state.key_image_blacklist;
     result.height              = state.height;
@@ -1586,38 +1542,30 @@ namespace service_nodes
     data.version = get_min_service_node_info_version_for_hf(hf_version);
     {
       std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
+      data.quorum_states.reserve(m_old_quorum_states.size());
       for (const quorums_by_height &entry : m_old_quorum_states)
-      {
-        quorum_for_serialization quorum = serialize_quorum_state(hf_version, entry.height, entry.quorums);
-        data.quorum_states.push_back(std::move(quorum));
-      }
+        data.quorum_states.push_back(serialize_quorum_state(hf_version, entry.height, entry.quorums));
 
+      data.states.reserve(m_state_history.size());
       if (m_state_history.size() == 1)
       {
-        data.states.emplace_back(serialize_service_node_state_object(hf_version, m_state_history[0]));
+        data.states.push_back(serialize_service_node_state_object(hf_version, *m_state_history.begin()));
       }
       else if (m_state_history.size() >= 2)
       {
-        for (size_t i = 0; i < (m_state_history.size() - 1); i++)
+        for (auto it = m_state_history.cbegin(), nextit = std::next(it); nextit != m_state_history.cend(); it = nextit++)
         {
-          state_t const &curr = m_state_history[i];
-          state_t const &next = m_state_history[i + 1];
+          state_t const &curr = *it, &next = *nextit;
 
-          if (next.height <= curr.height)
-          {
-            LOG_PRINT_L0("States to serialise are not stored in ascending order by height in DB, failed to store to DB");
-            return false;
-          }
-
-          data.states.emplace_back(serialize_service_node_state_object(hf_version, curr));
+          data.states.push_back(serialize_service_node_state_object(hf_version, curr));
           uint64_t height_delta = next.height - curr.height;
           if (height_delta != STORE_LONG_TERM_STATE_INTERVAL)
           {
             // TODO(loki): Preserve the quorum state from v403 until they all get purged from storage then we can remove that check.
-            if (next.is_migrated_from_v403() && next.height != m_state_history.back().height)
+            if (next.is_migrated_from_v403() && next.height != m_state_history.rbegin()->height)
               continue;
 
-            data.states.emplace_back(serialize_service_node_state_object(hf_version, next));
+            data.states.push_back(serialize_service_node_state_object(hf_version, next));
             break;
           }
         }
@@ -1814,6 +1762,15 @@ namespace service_nodes
     return result;
   }
 
+  service_node_list::state_t::state_t(state_serialized &&state)
+      : height{state.height}, key_image_blacklist{std::move(state.key_image_blacklist)}
+  {
+    for (auto &pubkey_info : state.infos)
+      service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));
+    
+    quorums = quorum_for_serialization_to_quorum_manager(state.quorums);
+  }
+
   bool service_node_list::load(const uint64_t current_height)
   {
     LOG_PRINT_L1("service_node_list::load()");
@@ -1899,34 +1856,10 @@ namespace service_nodes
 
     {
       assert(new_data_in.states.size() > 0);
-      size_t const start_index = new_data_in.states.size() >= (MAX_SHORT_TERM_STATE_HISTORY + 1) ? new_data_in.states.size() - (MAX_SHORT_TERM_STATE_HISTORY - 1): 0;
       size_t const last_index  = new_data_in.states.size() - 1;
-      m_state_history.reserve(MAX_SHORT_TERM_STATE_HISTORY);
-      uint64_t last_loaded_height = 0;
-      for (size_t i = start_index; i <= last_index; i++)
-      {
-        state_serialized &source = new_data_in.states[i];
-        state_t *dest            = &m_state;
-        if (i != last_index)
-        {
-          m_state_history.emplace_back();
-          dest = &m_state_history.back();
-        }
-
-        dest->height              = source.height;
-        dest->key_image_blacklist = std::move(source.key_image_blacklist);
-        dest->quorums             = quorum_for_serialization_to_quorum_manager(source.quorums);
-
-        for (auto &pubkey_info : source.infos)
-          dest->service_nodes_infos[pubkey_info.pubkey] = std::move(pubkey_info.info);
-
-        if (source.height <= last_loaded_height)
-        {
-          LOG_PRINT_L0("Serialised state is not stored in ascending order by height in DB, failed to load from DB");
-          return false;
-        }
-        last_loaded_height = source.height;
-      }
+      for (size_t i = 0; i < last_index; i++)
+        m_state_history.emplace_hint(m_state_history.end(), std::move(new_data_in.states[i]));
+      m_state = std::move(new_data_in.states[last_index]);
     }
 
     MGINFO("Service node data loaded successfully, height: " << m_state.height);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1562,13 +1562,18 @@ namespace service_nodes
       for (const quorums_by_height &entry : m_old_quorum_states)
         data.quorum_states.push_back(serialize_quorum_state(hf_version, entry.height, entry.quorums));
 
-      data.states.reserve(m_state_history.size());
       if (m_state_history.size() == 1)
       {
         data.states.push_back(serialize_service_node_state_object(hf_version, *m_state_history.begin()));
       }
       else if (m_state_history.size() >= 2)
       {
+        size_t num_to_reserve = 1; // recent state
+        if (m_state_history.size() > MAX_SHORT_TERM_STATE_HISTORY)
+          // + 10k historic blocks (-1 because the oldest short-term history might also be historic)
+          num_to_reserve += m_state_history.size() - (MAX_SHORT_TERM_STATE_HISTORY - 1);
+        data.states.reserve(num_to_reserve);
+
         for (auto it = m_state_history.cbegin(), nextit = std::next(it); nextit != m_state_history.cend(); it = nextit++)
         {
           state_t const &curr = *it, &next = *nextit;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -58,10 +58,14 @@ namespace service_nodes
 
     struct contribution_t
     {
-      uint8_t            version;
+      uint8_t            version{version_0_checkpointing};
       crypto::public_key key_image_pub_key;
       crypto::key_image  key_image;
       uint64_t           amount;
+
+      contribution_t() = default;
+      contribution_t(uint8_t version, const crypto::public_key &pubkey, const crypto::key_image &key_image, uint64_t amount)
+        : version{version}, key_image_pub_key{pubkey}, key_image{key_image}, amount{amount} {}
 
       BEGIN_SERIALIZE_OBJECT()
         VARINT_FIELD(version)
@@ -153,6 +157,10 @@ namespace service_nodes
     crypto::public_key pubkey;
     service_node_info  info;
 
+    service_node_pubkey_info() = default;
+    service_node_pubkey_info(const std::pair<const crypto::public_key, service_node_info> &pair)
+      : pubkey{pair.first}, info{pair.second} {}
+
     BEGIN_SERIALIZE_OBJECT()
       FIELD(pubkey)
       FIELD(info)
@@ -161,9 +169,16 @@ namespace service_nodes
 
   struct key_image_blacklist_entry
   {
-    uint8_t           version;
+    uint8_t           version{0};
     crypto::key_image key_image;
     uint64_t          unlock_height;
+
+    key_image_blacklist_entry() = default;
+    key_image_blacklist_entry(uint8_t version, const crypto::key_image &key_image, uint64_t unlock_height)
+        : version{version}, key_image{key_image}, unlock_height{unlock_height} {}
+
+    bool operator==(const key_image_blacklist_entry &other) const { return key_image == other.key_image; }
+    bool operator==(const crypto::key_image &image) const { return key_image == image; }
 
     BEGIN_SERIALIZE()
       VARINT_FIELD(version)
@@ -405,8 +420,12 @@ namespace service_nodes
 
       service_nodes_infos_t service_nodes_infos;
       std::vector<key_image_blacklist_entry> key_image_blacklist;
-      block_height                           height;
-      quorum_manager                         quorums;
+      block_height                           height{0};
+      mutable quorum_manager                 quorums; // Mutable because we are allowed to (and need to) change it via std::set iterator
+
+      state_t() = default;
+      state_t(block_height height) : height{height} {}
+      state_t(state_serialized &&state);
 
       // Returns a filtered, pubkey-sorted vector of service nodes that are active (fully funded and
       // *not* decommissioned).
@@ -445,14 +464,18 @@ namespace service_nodes
     struct quorums_by_height
     {
       quorums_by_height() = default;
-      quorums_by_height(uint64_t height, quorum_manager quorums) : height(height), quorums(quorums) {}
+      quorums_by_height(uint64_t height, quorum_manager quorums) : height(height), quorums(std::move(quorums)) {}
       uint64_t       height;
       quorum_manager quorums;
     };
 
-    std::deque<quorums_by_height>  m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
-    std::vector<state_t>           m_state_history;
-    state_t                        m_state;
+    struct state_t_less {
+        constexpr bool operator()(const state_t &lhs, const state_t &rhs) const { return lhs.height < rhs.height; }
+    };
+
+    std::deque<quorums_by_height>   m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
+    std::set<state_t, state_t_less> m_state_history;
+    state_t                         m_state;
   };
 
   bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1162,7 +1162,7 @@ namespace cryptonote
           uint8_t enforce_hf_version = std::max((uint8_t)cryptonote::network_version_13, blk.major_version);
 
           if (service_node_array.empty() ||
-              !service_node_array[0].info.can_transition_to_state(enforce_hf_version, state_change.block_height, state_change.state))
+              !service_node_array[0].info->can_transition_to_state(enforce_hf_version, state_change.block_height, state_change.state))
           {
             transaction tx;
             cryptonote::blobdata blob;

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -58,7 +58,7 @@ void block_queue::add_blocks(uint64_t height, std::vector<cryptonote::block_comp
   boost::unique_lock<boost::recursive_mutex> lock(mutex);
   std::vector<crypto::hash> hashes;
   bool has_hashes = remove_span(height, &hashes);
-  blocks.insert(span(height, std::move(bcel), connection_id, rate, size));
+  blocks.emplace(height, std::move(bcel), connection_id, rate, size);
   if (has_hashes)
   {
     for (const crypto::hash &h: hashes)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2672,26 +2672,27 @@ namespace cryptonote
   template<typename response>
   void core_rpc_server::fill_sn_response_entry(response &entry, const service_nodes::service_node_pubkey_info &sn_info, uint64_t current_height) {
 
+    const auto &info = *sn_info.info;
     entry.service_node_pubkey           = string_tools::pod_to_hex(sn_info.pubkey);
-    entry.registration_height           = sn_info.info.registration_height;
-    entry.requested_unlock_height       = sn_info.info.requested_unlock_height;
-    entry.last_reward_block_height      = sn_info.info.last_reward_block_height;
-    entry.last_reward_transaction_index = sn_info.info.last_reward_transaction_index;
-    entry.last_uptime_proof             = sn_info.info.proof.timestamp;
-    entry.active                        = sn_info.info.is_active();
-    entry.funded                        = sn_info.info.is_fully_funded();
-    entry.state_height                  = sn_info.info.is_fully_funded()
-        ? (sn_info.info.is_decommissioned() ? sn_info.info.last_decommission_height : sn_info.info.active_since_height) : sn_info.info.last_reward_block_height;
-    entry.earned_downtime_blocks        = service_nodes::quorum_cop::calculate_decommission_credit(sn_info.info, current_height);
-    entry.decommission_count            = sn_info.info.decommission_count;
-    entry.service_node_version          = {sn_info.info.proof.version_major, sn_info.info.proof.version_minor, sn_info.info.proof.version_patch};
-    entry.public_ip                     = string_tools::get_ip_string_from_int32(sn_info.info.public_ip);
-    entry.storage_port                  = sn_info.info.storage_port;
+    entry.registration_height           = info.registration_height;
+    entry.requested_unlock_height       = info.requested_unlock_height;
+    entry.last_reward_block_height      = info.last_reward_block_height;
+    entry.last_reward_transaction_index = info.last_reward_transaction_index;
+    entry.last_uptime_proof             = info.proof->timestamp;
+    entry.active                        = info.is_active();
+    entry.funded                        = info.is_fully_funded();
+    entry.state_height                  = info.is_fully_funded()
+        ? (info.is_decommissioned() ? info.last_decommission_height : info.active_since_height) : info.last_reward_block_height;
+    entry.earned_downtime_blocks        = service_nodes::quorum_cop::calculate_decommission_credit(info, current_height);
+    entry.decommission_count            = info.decommission_count;
+    entry.service_node_version          = {info.proof->version_major, info.proof->version_minor, info.proof->version_patch};
+    entry.public_ip                     = string_tools::get_ip_string_from_int32(info.proof->public_ip);
+    entry.storage_port                  = info.proof->storage_port;
 
-    entry.contributors.reserve(sn_info.info.contributors.size());
+    entry.contributors.reserve(info.contributors.size());
 
     using namespace service_nodes;
-    for (service_node_info::contributor_t const &contributor : sn_info.info.contributors)
+    for (service_node_info::contributor_t const &contributor : info.contributors)
     {
       entry.contributors.push_back({});
       auto &new_contributor = entry.contributors.back();
@@ -2710,12 +2711,12 @@ namespace cryptonote
       }
     }
 
-    entry.total_contributed             = sn_info.info.total_contributed;
-    entry.total_reserved                = sn_info.info.total_reserved;
-    entry.staking_requirement           = sn_info.info.staking_requirement;
-    entry.portions_for_operator         = sn_info.info.portions_for_operator;
-    entry.operator_address              = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, sn_info.info.operator_address);
-    entry.swarm_id                      = sn_info.info.swarm_id;
+    entry.total_contributed             = info.total_contributed;
+    entry.total_reserved                = info.total_reserved;
+    entry.staking_requirement           = info.staking_requirement;
+    entry.portions_for_operator         = info.portions_for_operator;
+    entry.operator_address              = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, info.operator_address);
+    entry.swarm_id                      = info.swarm_id;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
@@ -2775,7 +2776,7 @@ namespace cryptonote
     if (req.active_only) {
       const auto end =
         std::remove_if(sn_infos.begin(), sn_infos.end(), [](const service_nodes::service_node_pubkey_info& snpk_info) {
-          return !snpk_info.info.is_active();
+          return !snpk_info.info->is_active();
         });
       
       sn_infos.erase(end, sn_infos.end());

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2617,16 +2617,16 @@ namespace cryptonote
   bool core_rpc_server::on_get_service_node_blacklisted_key_images(const COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::request& req, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx)
   {
     PERF_TIMER(on_get_service_node_blacklisted_key_images);
-    const std::vector<service_nodes::key_image_blacklist_entry> &blacklist = m_core.get_service_node_blacklisted_key_images();
+    auto &blacklist = m_core.get_service_node_blacklisted_key_images();
 
     res.status = CORE_RPC_STATUS_OK;
     res.blacklist.reserve(blacklist.size());
     for (const service_nodes::key_image_blacklist_entry &entry : blacklist)
     {
-      COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::entry new_entry = {};
+      res.blacklist.emplace_back();
+      auto &new_entry = res.blacklist.back();
       new_entry.key_image     = epee::string_tools::pod_to_hex(entry.key_image);
       new_entry.unlock_height = entry.unlock_height;
-      res.blacklist.push_back(std::move(new_entry));
     }
     return true;
   }


### PR DESCRIPTION
This pair of commits speeds up service node scanning by 42% and applies various other code cleanups/optimizations/tweaks.

I divided it into two commits, which really should be reviewed sequentially rather than at once (the second builds on the first, but is quite different in logical purpose).

(This is likely to conflict with #786; I will rebase after it is merged).

# Commit 1: Optimizations and simplifications

This commit makes various simplifications and optimizations, mainly in the service node list code.

All in all, this shaves about 5% of the CPU time used for re-processing the entire service node list.  It's a small gain, but the changes here are data structure improvements.

In particular:

- changed m_state_history from a std::vector to a std::set that sorts on height.  This is responsible for the bulk of the CPU reduction by significant reducing the amount of work required for checkpoint culling, which has to shuffle a lot of `state_t`s around when removing from the midde of a vector.

- the above also allows replacing the binary-search `std::lower_bound` complexity with a much simpler `find()`.

- since the history is now always sorted, removed the error messages related to sorting that either can't happen (on store) or don't matter (on load).

- Added some converting constructors to simplify code (for example, a `state_t` can now be very usefully constructed from an rvalue `state_serialized`).

- Many construct + moves (and a couple construct + copy) were replaced with in-place constructions.

- removed some unused variables

# Commit 2: Use shared_ptr storage for service_node_info

This commit is the bulk of the performance improvement, but unlike the above does make the code slightly more complicated (though not hugely so).

This commit converts the stored service_node_info value into a `shared_ptr<const service_node_info>` rather than a plain `service_node_info`.  This yields a huge performance benefit by significantly eliminating the vast majority of `service_node_info` construction, destruction, and copying.

Most of the time when we copy a service_node_info nothing in it has changed, which means we're storing exactly the same thing; this means an extra construction for every SN info on every block *and* an extra destruction when we cull old stored history.  By using a shared_ptr, the vast majority of those constructions and destructions are eliminated.

The immediately previous commit (upon which this one builds) already reduced a full rescan from 180s to 171s; this commit further reduces that time to 104s, or about 42% reduced from the rescan time required before this pair of commits.  (All timings are from the dev.lokinet.org box, tested over multiple runs with the entire lmdb cached in memory).

With the shared_ptr approach, we only make a copy when a change is actually needed: because of infrequent (at the per-SN level) events like a state_change, received reward, contribution, etc.  The contained reference is deliberately `const` so that values are not changeable; there's a new function that does an explicit copying duplication, returning the new non-const and storing the const ref in the shared pointer.

Related to this is a small change (and fix) to how proof info and public_ip/storage_port are stored: rather than store the values in the service_node_info struct itself, they now gets stored in a shared_ptr inside the service_node_info that intentionally gets shared among all copies of the service_node_info (that is, a SN info copy deliberately copies the pointer rather than the values).  This also moves the ip/port values into the proof struct, since that seemed much easier than maintaining a separate shared_ptr for each value.

Previously, because these were stored as values in the service_node_info they would actually get rolled back in the event of a reorg, but that seems highly undesirable: you would end up rolling back to the old values of the uptime proof and ip address (for example), but that should not happen: those values are not dependent on the blockchain and so should not be affected by a reorg/rollback.  With this change they aren't since there is only one actual proof stored.

Note that the shared storage here only applies to in-memory states; states loaded from the db will still be duplicated.