### PR TITLE
Regression core tests, missing txs on fork, segfault on detach

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1296,7 +1296,7 @@ namespace service_nodes
     if (reinitialise)
     {
       // TODO(loki): If historical state is serialized from v4.0.3 they are incomplete, need a full rescan. Delete code block after everyone has upgraded
-      if (m_state_history.rbegin()->is_migrated_from_v403())
+      if (m_state_history.size() && m_state_history.rbegin()->is_migrated_from_v403())
         reset(true);
 
       m_state_history.clear();
@@ -2172,6 +2172,12 @@ namespace service_nodes
   {
     if (hf_version >= cryptonote::network_version_13 && !can_be_voted_on(height))
       return false;
+
+    if (proposed_state == new_state::deregister)
+    {
+      if (height < this->registration_height)
+        return false;
+    }
 
     if (this->is_decommissioned())
     {

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -844,7 +844,6 @@ public:
   bool operator()(const cryptonote::transaction& tx) const
   {
     log_event("cryptonote::transaction");
-
     cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_txs_keeped_by_block, false, false);
@@ -857,7 +856,6 @@ public:
   bool operator()(const std::vector<cryptonote::transaction>& txs) const
   {
     log_event("cryptonote::transaction");
-
     std::vector<cryptonote::blobdata> tx_blobs;
     std::vector<cryptonote::tx_verification_context> tvcs;
      cryptonote::tx_verification_context tvc0 = AUTO_VAL_INIT(tvc0);
@@ -877,7 +875,6 @@ public:
   bool operator()(const cryptonote::block& b) const
   {
     log_event("cryptonote::block");
-
     cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
     cryptonote::blobdata bd = t_serializable_object_to_blob(b);
     std::vector<cryptonote::block> pblocks;

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(sn_test_rollback);
       GENERATE_AND_PLAY(test_swarms_basic);
 #else
-      GENERATE_AND_PLAY(test_prefer_deregisters);
+      GENERATE_AND_PLAY(gen_simple_chain_split_1);
 #endif
     }
 

--- a/tests/core_tests/service_nodes.cpp
+++ b/tests/core_tests/service_nodes.cpp
@@ -834,7 +834,7 @@ bool test_swarms_basic::test_initial_swarms(cryptonote::core& c, size_t ev_index
   std::map<service_nodes::swarm_id_t, std::vector<crypto::public_key>> swarms;
 
   for (const auto& entry : sn_list) {
-    const auto id = entry.info.swarm_id;
+    const auto id = entry.info->swarm_id;
     swarms[id].push_back(entry.pubkey);
   }
 
@@ -853,7 +853,7 @@ bool test_swarms_basic::test_with_one_more_sn(cryptonote::core& c, size_t ev_ind
   std::map<service_nodes::swarm_id_t, std::vector<crypto::public_key>> swarms;
 
   for (const auto& entry : sn_list) {
-    const auto id = entry.info.swarm_id;
+    const auto id = entry.info->swarm_id;
     swarms[id].push_back(entry.pubkey);
   }
 
@@ -871,7 +871,7 @@ bool test_swarms_basic::test_with_more_sn(cryptonote::core& c, size_t ev_index, 
   std::map<service_nodes::swarm_id_t, std::vector<crypto::public_key>> swarms;
 
   for (const auto& entry : sn_list) {
-    const auto id = entry.info.swarm_id;
+    const auto id = entry.info->swarm_id;
     swarms[id].push_back(entry.pubkey);
   }
 
@@ -889,7 +889,7 @@ bool test_swarms_basic::test_after_first_deregisters(cryptonote::core& c, size_t
   std::map<service_nodes::swarm_id_t, std::vector<crypto::public_key>> swarms;
 
   for (const auto& entry : sn_list) {
-    const auto id = entry.info.swarm_id;
+    const auto id = entry.info->swarm_id;
     swarms[id].push_back(entry.pubkey);
   }
 
@@ -907,7 +907,7 @@ bool test_swarms_basic::test_after_final_deregisters(cryptonote::core& c, size_t
   std::map<service_nodes::swarm_id_t, std::vector<crypto::public_key>> swarms;
 
   for (const auto& entry : sn_list) {
-    const auto id = entry.info.swarm_id;
+    const auto id = entry.info->swarm_id;
     swarms[id].push_back(entry.pubkey);
   }
 


### PR DESCRIPTION
We can't delete all state change TX's on blockchain increment incase the
state change came from an alternative block. We must keep them around
even if they would conflict with another state change because if we
switch chains, they need to be present for the block to still be
considered valid.

Add a .size() check when checking for is_migrated_from_v403 because when
reinitialise is true, m_state_history does not necessarily have any
elements (in tests atleast).

@jagerman

This should get all the current running core tests working.