### PR TITLE
P2p fixes for slow synching issue

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -99,6 +99,8 @@ public:
   template<class callback_t>
   bool for_connection(const boost::uuids::uuid &connection_id, const callback_t &cb);
   size_t get_connections_count();
+  size_t get_out_connections_count();
+  size_t get_in_connections_count();
   void set_handler(levin_commands_handler<t_connection_context>* handler, void (*destroy)(levin_commands_handler<t_connection_context>*) = NULL);
 
   async_protocol_handler_config():m_pcommands_handler(NULL), m_pcommands_handler_destroy(NULL), m_max_packet_size(LEVIN_DEFAULT_MAX_PACKET_SIZE), m_invoke_timeout(LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
@@ -879,6 +881,28 @@ size_t async_protocol_handler_config<t_connection_context>::get_connections_coun
 {
   CRITICAL_REGION_LOCAL(m_connects_lock);
   return m_connects.size();
+}
+//------------------------------------------------------------------------------------------
+template<class t_connection_context>
+size_t async_protocol_handler_config<t_connection_context>::get_out_connections_count()
+{
+  CRITICAL_REGION_LOCAL(m_connects_lock);
+  size_t count = 0;
+  for (const auto &c: m_connects)
+    if (!c.second->m_connection_context.m_is_income)
+      ++count;
+  return count;
+}
+//------------------------------------------------------------------------------------------
+template<class t_connection_context>
+size_t async_protocol_handler_config<t_connection_context>::get_in_connections_count()
+{
+  CRITICAL_REGION_LOCAL(m_connects_lock);
+  size_t count = 0;
+  for (const auto &c: m_connects)
+    if (c.second->m_connection_context.m_is_income)
+      ++count;
+  return count;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -927,7 +927,11 @@ bool async_protocol_handler_config<t_connection_context>::close(boost::uuids::uu
 {
   CRITICAL_REGION_LOCAL(m_connects_lock);
   async_protocol_handler<t_connection_context>* aph = find_connection(connection_id);
-  return 0 != aph ? aph->close() : false;
+  if (aph) {
+    del_connection(aph);
+    return aph->close();
+  }
+  return false;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -134,7 +134,8 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define P2P_LOCAL_WHITE_PEERLIST_LIMIT                  1000
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000
 
-#define P2P_DEFAULT_CONNECTIONS_COUNT                   8
+#define P2P_DEFAULT_CONNECTIONS_COUNT_OUT               8
+#define P2P_DEFAULT_CONNECTIONS_COUNT_IN                32
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //secondes
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
 #define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -342,6 +342,11 @@ namespace cryptonote
 
     if(m_core.have_block(hshd.top_id))
     {
+      if (target > hshd.current_height)
+      {
+        MINFO(context << "peer is not ahead of us and we're syncing, disconnecting");
+        return false;
+      }
       context.m_state = cryptonote_connection_context::state_normal;
       if(is_inital && target == m_core.get_current_blockchain_height())
         on_connection_synchronized();

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -120,7 +120,7 @@ namespace {
 
     std::string id_str;
     std::string port_str;
-    std::string elapsed = epee::misc_utils::get_time_interval_string(now - last_seen);
+    std::string elapsed = peer.last_seen == 0 ? "never" : epee::misc_utils::get_time_interval_string(now - last_seen);
     std::string ip_str = epee::string_tools::get_ip_string_from_int32(peer.ip);
     std::stringstream peer_id_str;
     peer_id_str << std::hex << std::setw(16) << peer.id;

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -136,6 +136,7 @@ namespace nodetool
     const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the blockchain with other peers", false};
 
     const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
+    const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "delayed"};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
     const command_line::arg_descriptor<int64_t>     arg_in_peers = {"in-peers", "set max number of in peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -205,6 +205,13 @@ namespace nodetool
       }
     };
 
+    enum igd_t
+    {
+      no_igd,
+      igd,
+      delayed_igd,
+    };
+
   public:
     typedef t_payload_net_handler payload_net_handler;
 
@@ -214,7 +221,7 @@ namespace nodetool
         m_rpc_port(0),
         m_allow_local_ip(false),
         m_hide_my_port(false),
-        m_no_igd(false),
+        m_igd(no_igd),
         m_offline(false),
         m_save_graph(false),
         is_closing(false),
@@ -415,7 +422,7 @@ namespace nodetool
     uint16_t m_rpc_port;
     bool m_allow_local_ip;
     bool m_hide_my_port;
-    bool m_no_igd;
+    igd_t m_igd;
     bool m_offline;
     std::atomic<bool> m_save_graph;
     std::atomic<bool> is_closing;
@@ -490,6 +497,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<bool> arg_no_sync;
 
     extern const command_line::arg_descriptor<bool>        arg_no_igd;
+    extern const command_line::arg_descriptor<std::string> arg_igd;
     extern const command_line::arg_descriptor<bool>        arg_offline;
     extern const command_line::arg_descriptor<int64_t>     arg_out_peers;
     extern const command_line::arg_descriptor<int64_t>     arg_in_peers;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -937,7 +937,10 @@ namespace nodetool
       }
       if(!context.m_is_income)
         m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.set_peer_just_seen(context.peer_id, context.m_remote_address, context.m_pruning_seed, context.m_rpc_port);
-      m_payload_handler.process_payload_sync_data(rsp.payload_data, context, false);
+      if (!m_payload_handler.process_payload_sync_data(rsp.payload_data, context, false))
+      {
+        m_network_zones.at(context.m_remote_address.get_zone()).m_net_server.get_config_object().close(context.m_connection_id );
+      }
     });
 
     if(!r)
@@ -1083,6 +1086,7 @@ namespace nodetool
       LOG_PRINT_CC_PRIORITY_NODE(is_priority, *con, "Failed to HANDSHAKE with peer "
         << na.str()
         /*<< ", try " << try_count*/);
+      zone.m_net_server.get_config_object().close(con->m_connection_id);
       return false;
     }
 
@@ -1142,7 +1146,7 @@ namespace nodetool
       bool is_priority = is_priority_node(na);
 
       LOG_PRINT_CC_PRIORITY_NODE(is_priority, *con, "Failed to HANDSHAKE with peer " << na.str());
-
+      zone.m_net_server.get_config_object().close(con->m_connection_id);
       return false;
     }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -739,7 +739,10 @@ namespace nodetool
             }
             else
             {
-              ++number_of_out_peers;
+              // If this is a new (<10s) connection and we're still in before handshake mode then
+              // don't count it yet: it is probably a back ping connection that will be closed soon.
+              if (!(cntxt.m_state == p2p_connection_context::state_before_handshake && std::time(NULL) < cntxt.m_started + 10))
+                ++number_of_out_peers;
             }
             return true;
           }); // lambda

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1252,19 +1252,53 @@ namespace nodetool
       size_t random_index;
       const uint32_t next_needed_pruning_stripe = m_payload_handler.get_next_needed_pruning_stripe().second;
 
+      // build a set of all the /16 we're connected to, and prefer a peer that's not in that set
+      std::set<uint32_t> classB;
+      if (&zone == &m_network_zones.at(epee::net_utils::zone::public_)) // at returns reference, not copy
+      {
+        zone.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
+        {
+          if (cntxt.m_remote_address.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
+          {
+
+            const epee::net_utils::network_address na = cntxt.m_remote_address;
+            const uint32_t actual_ip = na.as<const epee::net_utils::ipv4_network_address>().ip();
+            classB.insert(actual_ip & 0x0000ffff);
+          }
+          return true;
+        });
+      }
+
       std::deque<size_t> filtered;
       const size_t limit = use_white_list ? 20 : std::numeric_limits<size_t>::max();
-      size_t idx = 0;
-      zone.m_peerlist.foreach (use_white_list, [&filtered, &idx, limit, next_needed_pruning_stripe](const peerlist_entry &pe){
-        if (filtered.size() >= limit)
-          return false;
-        if (next_needed_pruning_stripe == 0 || pe.pruning_seed == 0)
-          filtered.push_back(idx);
-        else if (next_needed_pruning_stripe == tools::get_pruning_stripe(pe.pruning_seed))
-          filtered.push_front(idx);
-        ++idx;
-        return true;
-      });
+      size_t idx = 0, skipped = 0;
+      for (int step = 0; step < 2; ++step)
+      {
+        bool skip_duplicate_class_B = step == 0;
+        zone.m_peerlist.foreach (use_white_list, [&classB, &filtered, &idx, &skipped, skip_duplicate_class_B, limit, next_needed_pruning_stripe](const peerlist_entry &pe){
+          if (filtered.size() >= limit)
+            return false;
+          bool skip = false;
+          if (skip_duplicate_class_B && pe.adr.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
+          {
+            const epee::net_utils::network_address na = pe.adr;
+            uint32_t actual_ip = na.as<const epee::net_utils::ipv4_network_address>().ip();
+            skip = classB.find(actual_ip & 0x0000ffff) != classB.end();
+          }
+          if (skip)
+            ++skipped;
+          else if (next_needed_pruning_stripe == 0 || pe.pruning_seed == 0)
+            filtered.push_back(idx);
+          else if (next_needed_pruning_stripe == tools::get_pruning_stripe(pe.pruning_seed))
+            filtered.push_front(idx);
+          ++idx;
+          return true;
+        });
+        if (skipped == 0 || !filtered.empty())
+          break;
+        if (skipped)
+          MGINFO("Skipping " << skipped << " possible peers as they share a class B with existing peers");
+      }
       if (filtered.empty())
       {
         MDEBUG("No available peer in " << (use_white_list ? "white" : "gray") << " list filtered by " << next_needed_pruning_stripe);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -106,6 +106,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_p2p_hide_my_port);
     command_line::add_arg(desc, arg_no_sync);
     command_line::add_arg(desc, arg_no_igd);
+    command_line::add_arg(desc, arg_igd);
     command_line::add_arg(desc, arg_out_peers);
     command_line::add_arg(desc, arg_in_peers);
     command_line::add_arg(desc, arg_tos_flag);
@@ -258,7 +259,35 @@ namespace nodetool
     public_zone.m_can_pingback = true;
     m_external_port = command_line::get_arg(vm, arg_p2p_external_port);
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
-    m_no_igd = command_line::get_arg(vm, arg_no_igd);
+    const bool has_no_igd = command_line::get_arg(vm, arg_no_igd);
+    const std::string sigd = command_line::get_arg(vm, arg_igd);
+    if (sigd == "enabled")
+    {
+      if (has_no_igd)
+      {
+        MFATAL("Cannot have both --" << arg_no_igd.name << " and --" << arg_igd.name << " enabled");
+        return false;
+      }
+      m_igd = igd;
+    }
+    else if (sigd == "disabled")
+    {
+      m_igd =  no_igd;
+    }
+    else if (sigd == "delayed")
+    {
+      if (has_no_igd && !command_line::is_arg_defaulted(vm, arg_igd))
+      {
+        MFATAL("Cannot have both --" << arg_no_igd.name << " and --" << arg_igd.name << " delayed");
+        return false;
+      }
+      m_igd = has_no_igd ? no_igd : delayed_igd;
+    }
+    else
+    {
+      MFATAL("Invalid value for --" << arg_igd.name << ", expected enabled, disabled or delayed");
+      return false;
+    }
     m_offline = command_line::get_arg(vm, cryptonote::arg_offline);
 
     if (command_line::has_arg(vm, arg_p2p_add_peer))
@@ -675,7 +704,7 @@ namespace nodetool
       MDEBUG("External port defined as " << m_external_port);
 
     // add UPnP port mapping
-    if(!m_no_igd)
+    if(m_igd == igd)
       add_upnp_port_mapping(m_listening_port);
 
     return res;
@@ -769,7 +798,7 @@ namespace nodetool
       for(auto& zone : m_network_zones)
         zone.second.m_net_server.deinit_server();
       // remove UPnP port mapping
-      if(!m_no_igd)
+      if(m_igd == igd)
         delete_upnp_port_mapping(m_listening_port);
     }
     return store_config();
@@ -1578,8 +1607,17 @@ namespace nodetool
       }
       else
       {
-        const el::Level level = el::Level::Warning;
-        MCLOG_RED(level, "global", "No incoming connections - check firewalls/routers allow port " << get_this_peer_port());
+        if (m_igd == delayed_igd)
+        {
+          MWARNING("No incoming connections, trying to setup IGD");
+          add_upnp_port_mapping(m_listening_port);
+          m_igd = igd;
+        }
+        else
+        {
+          const el::Level level = el::Level::Warning;
+          MCLOG_RED(level, "global", "No incoming connections - check firewalls/routers allow port " << get_this_peer_port());
+        }
       }
     }
     return true;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2285,6 +2285,7 @@ namespace nodetool
       public_zone->second.m_config.m_net_config.max_out_connection_count = count;
       if(current > count)
         public_zone->second.m_net_server.get_config_object().del_out_connections(current - count);
+      m_payload_handler.set_max_out_peers(count);
     }
   }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2281,7 +2281,7 @@ namespace nodetool
     auto public_zone = m_network_zones.find(epee::net_utils::zone::public_);
     if (public_zone != m_network_zones.end())
     {
-      const auto current = public_zone->second.m_config.m_net_config.max_out_connection_count;
+      const auto current = public_zone->second.m_net_server.get_config_object().get_out_connections_count();
       public_zone->second.m_config.m_net_config.max_out_connection_count = count;
       if(current > count)
         public_zone->second.m_net_server.get_config_object().del_out_connections(current - count);
@@ -2295,7 +2295,7 @@ namespace nodetool
     auto public_zone = m_network_zones.find(epee::net_utils::zone::public_);
     if (public_zone != m_network_zones.end())
     {
-      const auto current = public_zone->second.m_config.m_net_config.max_in_connection_count;
+      const auto current = public_zone->second.m_net_server.get_config_object().get_in_connections_count();
       public_zone->second.m_config.m_net_config.max_in_connection_count = count;
       if(current > count)
         public_zone->second.m_net_server.get_config_object().del_in_connections(current - count);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2260,10 +2260,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::set_max_out_peers(network_zone& zone, int64_t max)
   {
-    if(max == -1) {
-      zone.m_config.m_net_config.max_out_connection_count = P2P_DEFAULT_CONNECTIONS_COUNT;
-      return true;
-    }
+    if (max == -1)
+      max = P2P_DEFAULT_CONNECTIONS_COUNT_OUT;
     zone.m_config.m_net_config.max_out_connection_count = max;
     return true;
   }
@@ -2271,6 +2269,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::set_max_in_peers(network_zone& zone, int64_t max)
   {
+    if (max == -1)
+      max = P2P_DEFAULT_CONNECTIONS_COUNT_IN;
     zone.m_config.m_net_config.max_in_connection_count = max;
     return true;
   }

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -344,8 +344,14 @@ namespace nodetool
       trim_white_peerlist();
     }else
     {
-      //update record in white list 
-      m_peers_white.replace(by_addr_it_wt, ple);      
+      //update record in white list
+      peerlist_entry new_ple = ple;
+      if (by_addr_it_wt->pruning_seed && ple.pruning_seed == 0) // guard against older nodes not passing pruning info around
+        new_ple.pruning_seed = by_addr_it_wt->pruning_seed;
+      if (by_addr_it_wt->rpc_port && ple.rpc_port == 0) // guard against older nodes not passing RPC port around
+        new_ple.rpc_port = by_addr_it_wt->rpc_port;
+      new_ple.last_seen = by_addr_it_wt->last_seen; // do not overwrite the last seen timestamp, incoming peer list are untrusted
+      m_peers_white.replace(by_addr_it_wt, new_ple);
     }
     //remove from gray list, if need
     auto by_addr_it_gr = m_peers_gray.get<by_addr>().find(ple.adr);


### PR DESCRIPTION
Various p2p fixes ported from upstream monero + some other additional fixes for p2p issues.

The underlying issue we are suffering from is that epee's p2p locking monstrosity scales horribly and grounds to a halt once you have more than a few dozen peers; with the default unlimited in-peers this happens quite often (given our relatively large p2p network), so ths fix here changes the in peers limit to 32 instead of unlimited.

This also takes care of ping back connections not being properly deleted, which left a bunch of stale `before_handshake` connections behind, and fixes the status code not to treat the temporary ping back connections as outgoing connections.