### PR TITLE
Checkpoints: Avoid race updating checkpoint with a potentially older checkpoint

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3871,6 +3871,7 @@ void BlockchainLMDB::remove_block_checkpoint(uint64_t height)
 
 bool BlockchainLMDB::get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const
 {
+  check_open();
   TXN_PREFIX_RDONLY();
   RCURSOR(block_checkpoints);
 
@@ -3908,7 +3909,6 @@ bool BlockchainLMDB::get_block_checkpoint_internal(uint64_t height, checkpoint_t
 bool BlockchainLMDB::get_block_checkpoint(uint64_t height, checkpoint_t &checkpoint) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  check_open();
   bool result = get_block_checkpoint_internal(height, checkpoint, MDB_SET_KEY);
   return result;
 }
@@ -3916,7 +3916,6 @@ bool BlockchainLMDB::get_block_checkpoint(uint64_t height, checkpoint_t &checkpo
 bool BlockchainLMDB::get_top_checkpoint(checkpoint_t &checkpoint) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  check_open();
   bool result = get_block_checkpoint_internal(0, checkpoint, MDB_LAST);
   return result;
 }

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -110,12 +110,12 @@ namespace cryptonote
     return true;
   }
 
-  static bool get_checkpoint_from_db_safe(BlockchainDB *db, uint64_t height, checkpoint_t &checkpoint)
+  bool checkpoints::get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const
   {
     try
     {
-      auto guard = db_rtxn_guard(db);
-      return db->get_block_checkpoint(height, checkpoint);
+      auto guard = db_rtxn_guard(m_db);
+      return m_db->get_block_checkpoint(height, checkpoint);
     }
     catch (const std::exception &e)
     {
@@ -131,7 +131,7 @@ namespace cryptonote
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse checkpoint hash string into binary representation!");
 
     checkpoint_t checkpoint = {};
-    if (get_checkpoint_from_db_safe(m_db, height, checkpoint))
+    if (get_checkpoint(height, checkpoint))
     {
       crypto::hash const &curr_hash = checkpoint.block_hash;
       CHECK_AND_ASSERT_MES(h == curr_hash, false, "Checkpoint at given height already exists, and hash for new checkpoint was different!");
@@ -269,7 +269,7 @@ namespace cryptonote
   bool checkpoints::check_block(uint64_t height, const crypto::hash& h, bool* is_a_checkpoint, bool *rejected_by_service_node) const
   {
     checkpoint_t checkpoint;
-    bool found = get_checkpoint_from_db_safe(m_db, height, checkpoint);
+    bool found = get_checkpoint(height, checkpoint);
     if (is_a_checkpoint) *is_a_checkpoint = found;
 
     if(!found)

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -120,6 +120,7 @@ namespace cryptonote
     void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs) override;
     void blockchain_detached(uint64_t height) override;
 
+    bool get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const;
     /**
      * @brief adds a checkpoint to the container
      *
@@ -133,13 +134,6 @@ namespace cryptonote
     bool add_checkpoint(uint64_t height, const std::string& hash_str);
 
     bool update_checkpoint(checkpoint_t const &checkpoint);
-
-    /*
-       @brief Remove checkpoints that should not be stored persistently, i.e.
-       any checkpoint whose height is not divisible by
-       service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL
-     */
-    void prune_checkpoints(uint64_t height) const;
 
     /**
      * @brief checks if there is a checkpoint in the future

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1246,6 +1246,7 @@ namespace cryptonote
       bufPtr += snprintf(bufPtr, bufEnd - bufPtr, ", ");
     }
     if (vvc.m_invalid_vote_type)             bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Vote type has invalid value: %s, ", vote ? std::to_string((uint8_t)vote->type).c_str() : "??");
+    if (vvc.m_votes_not_sorted)              bufPtr += snprintf(bufPtr, bufEnd - bufPtr, "Votes are not stored in ascending order");
 
     if (bufPtr != buf)
     {

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -48,6 +48,7 @@ namespace cryptonote
     bool m_not_enough_votes;
     bool m_incorrect_voting_group;
     bool m_invalid_vote_type;
+    bool m_votes_not_sorted;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(m_verification_failed)
@@ -60,6 +61,7 @@ namespace cryptonote
       KV_SERIALIZE(m_not_enough_votes)
       KV_SERIALIZE(m_incorrect_voting_group)
       KV_SERIALIZE(m_invalid_vote_type)
+      KV_SERIALIZE(m_votes_not_sorted)
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2055,7 +2055,7 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
       try
       {
         checkpoint_t checkpoint;
-        if (m_db->get_block_checkpoint(block_height, checkpoint))
+        if (get_checkpoint(block_height, checkpoint))
           e.checkpoint = t_serializable_object_to_blob(checkpoint);
       }
       catch (const std::exception &e)
@@ -4201,7 +4201,7 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
     uint64_t block_height = get_block_height(bl);
     try
     {
-      if (m_db->get_block_checkpoint(block_height, existing_checkpoint))
+      if (get_checkpoint(block_height, existing_checkpoint))
       {
         if (checkpoint->signatures.size() < existing_checkpoint.signatures.size())
           checkpoint = nullptr;
@@ -4328,6 +4328,12 @@ bool Blockchain::update_checkpoint(cryptonote::checkpoint_t const &checkpoint)
   // checkpointing stopping it.
   bool result = m_checkpoints.update_checkpoint(checkpoint);
   return result;
+}
+//------------------------------------------------------------------
+bool Blockchain::get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const
+{
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  return m_checkpoints.get_checkpoint(height, checkpoint);
 }
 //------------------------------------------------------------------
 void Blockchain::block_longhash_worker(uint64_t height, const epee::span<const block> &blocks, std::unordered_map<crypto::hash, crypto::hash> &map) const

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -706,6 +706,8 @@ namespace cryptonote
 
     bool update_checkpoint(checkpoint_t const &checkpoint);
 
+    bool get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const;
+
     // user options, must be called before calling init()
 
     /**

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -166,7 +166,7 @@ namespace cryptonote
       * @return false if loading new checkpoints fails, or the block is not
       * added, otherwise true
       */
-     bool handle_incoming_block(const blobdata& block_blob, const block *b, block_verification_context& bvc, checkpoint_t const *checkpoint, bool update_miner_blocktemplate = true);
+     bool handle_incoming_block(const blobdata& block_blob, const block *b, block_verification_context& bvc, checkpoint_t *checkpoint, bool update_miner_blocktemplate = true);
 
      /**
       * @copydoc Blockchain::prepare_handle_incoming_blocks

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1321,6 +1321,13 @@ namespace cryptonote
                   return false;
                 }
 
+                std::sort(
+                    checkpoint->signatures.begin(),
+                    checkpoint->signatures.end(),
+                    [](service_nodes::voter_to_signature const &lhs, service_nodes::voter_to_signature const &rhs) {
+                      return lhs.voter_index < rhs.voter_index;
+                    });
+
                 // TODO(doyle): If we are receiving alternative blocks, we won't
                 // have the quorum for the alternative chain meaning we will not
                 // be able to verify the checkpoint. For now always accept

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1321,13 +1321,6 @@ namespace cryptonote
                   return false;
                 }
 
-                std::sort(
-                    checkpoint->signatures.begin(),
-                    checkpoint->signatures.end(),
-                    [](service_nodes::voter_to_signature const &lhs, service_nodes::voter_to_signature const &rhs) {
-                      return lhs.voter_index < rhs.voter_index;
-                    });
-
                 // TODO(doyle): If we are receiving alternative blocks, we won't
                 // have the quorum for the alternative chain meaning we will not
                 // be able to verify the checkpoint. For now always accept

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -197,7 +197,7 @@ bool tests::proxy_core::handle_incoming_txs(const std::vector<blobdata>& tx_blob
     return true;
 }
 
-bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block_, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t const *checkpoint, bool update_miner_blocktemplate) {
+bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block_, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t *checkpoint, bool update_miner_blocktemplate) {
     block b = AUTO_VAL_INIT(b);
 
     if(!parse_and_validate_block_from_blob(block_blob, b)) {

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -78,7 +78,7 @@ namespace tests
     void get_blockchain_top(uint64_t& height, crypto::hash& top_id);
     bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blobs, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
-    bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t const *checkpoint, bool update_miner_blocktemplate = true);
+    bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t *checkpoint, bool update_miner_blocktemplate = true);
     bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
     void pause_mine(){}
     void resume_mine(){}


### PR DESCRIPTION
Race when updating checkpoints in quorum cop since there are multiple network threads receiving and processing votes.

``` 
          // NOTE: Multiple network threads are going to try and update the
          // checkpoint, blockchain.update_checkpoint does NOT do any
          // validation- that is done here since we want to keep code for
          // converting votes to data suitable for the DB in service node land.

          // So then, multiple threads can race to update the checkpoint. One
          // thread could retrieve an outdated checkpoint whilst another has
          // already updated it. i.e. we could replace a checkpoint with lesser
          // votes prematurely. The actual update in the DB is an atomic
          // operation, but this check and validation step is NOT, taking the
          // lock here makes it so.
```
@jagerman

We also enforce ordering of votes in state changes and checkpoints after HF13. This is so we have some sane ordering to the data we store in the blockchain and has a side benefit of appending new votes to checkpoints nicer.

Side note: I don't think this fixes the corruption bug. I can't see anything here that would influence that.