### PR TITLE
Service node winner incorrect fix

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -2293,11 +2293,11 @@ void BlockchainBDB::fixup(fixup_context const context)
   BlockchainDB::fixup(context);
 }
 
-void BlockchainBDB::set_service_node_data(const std::string& data)
+void BlockchainBDB::set_service_node_data(const std::string& data, bool long_term)
 {
 }
 
-bool BlockchainBDB::get_service_node_data(std::string& data)
+bool BlockchainBDB::get_service_node_data(std::string& data, bool long_term)
 {
   return false;
 }

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -409,8 +409,8 @@ private:
   // fix up anything that may be wrong due to past bugs
   virtual void fixup(fixup_context const context);
 
-  virtual void set_service_node_data(const std::string& data);
-  virtual bool get_service_node_data(std::string& data);
+  virtual void set_service_node_data(const std::string& data, bool long_term);
+  virtual bool get_service_node_data(std::string& data, bool long_term);
   virtual void clear_service_node_data();
 
   bool m_run_checkpoint;

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1808,11 +1808,11 @@ public:
   };
   virtual void fixup(fixup_context const context = {});
 
-  virtual bool get_output_blacklist(std::vector<uint64_t> &blacklist) const = 0;
-  virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist) = 0;
-  virtual void set_service_node_data(const std::string& data)               = 0;
-  virtual bool get_service_node_data(std::string& data)                     = 0;
-  virtual void clear_service_node_data()                                    = 0;
+  virtual bool get_output_blacklist(std::vector<uint64_t> &blacklist) const   = 0;
+  virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist)   = 0;
+  virtual void set_service_node_data(const std::string& data, bool long_term) = 0;
+  virtual bool get_service_node_data(std::string &data, bool long_term)       = 0;
+  virtual void clear_service_node_data()                                      = 0;
 
   /**
    * @brief set whether or not to automatically remove logs

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -453,8 +453,8 @@ private:
   void cleanup_batch();
 
   bool get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const;
-  void set_service_node_data(const std::string& data) override;
-  bool get_service_node_data(std::string& data) override;
+  void set_service_node_data(const std::string& data, bool long_term) override;
+  bool get_service_node_data(std::string& data, bool long_term) override;
   void clear_service_node_data() override;
 
 private:

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -165,8 +165,8 @@ public:
 
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }
-  virtual void set_service_node_data  (const std::string& data)                      override { }
-  virtual bool get_service_node_data  (std::string& data)                            override { return false; }
+  virtual void set_service_node_data  (const std::string& data, bool long_term)      override { }
+  virtual bool get_service_node_data  (std::string& data, bool long_term)            override { return false; }
   virtual void clear_service_node_data()                                             override { }
 
   virtual void add_alt_block(const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata &blob) override {}

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1803,11 +1803,8 @@ namespace service_nodes
     bool deserialized                  = ::serialization::serialize(ba, data_in);
     CHECK_AND_ASSERT_MES(deserialized, false, "Failed to parse service node data from blob");
 
-    if (data_in.states.empty() ||
-        data_in.states[0].version <= state_serialized::version_t::version_0_v404_missing_state_changes)
-    {
+    if (data_in.states.empty())
       return false;
-    }
 
     {
       const uint64_t hist_state_from_height = current_height - m_store_quorum_history;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -197,19 +197,8 @@ namespace service_nodes
         result_ptr = &it->quorums;
     }
 
-    quorum_manager empty_result = {};
-    if (!result_ptr) result_ptr = &empty_result;
-
-    return *result_ptr;
-  }
-
-  std::shared_ptr<const testing_quorum> service_node_list::get_testing_quorum(quorum_type type, uint64_t height, bool include_old) const
-  {
-    if (type == quorum_type::checkpointing) {
-        if (height < REORG_SAFETY_BUFFER_BLOCKS_POST_HF12)
-            return nullptr;
-        height -= REORG_SAFETY_BUFFER_BLOCKS_POST_HF12;
-    }
+    if (!quorums)
+        return nullptr;
 
     quorum_manager quorums = get_quorum_manager(height, include_old);
     if (type == quorum_type::obligations)

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -372,6 +372,7 @@ namespace service_nodes
     std::deque<quorums_by_height>          m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
     std::set<state_t, state_t_less>        m_state_history;
     state_t                                m_state;
+    bool                                   m_long_term_states_added_to;
   };
 
   bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -273,13 +273,8 @@ namespace service_nodes
 
     struct state_serialized
     {
-      enum struct version_t
-      {
-        version_0_v404_missing_state_changes,
-        version_1_required_quorums_for_skipped_state_changes,
-        count,
-      };
-      static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_1_required_quorums_for_skipped_state_changes; }
+      enum struct version_t { version_0, count, };
+      static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_0; }
 
       version_t                              version;
       uint64_t                               height;
@@ -300,13 +295,8 @@ namespace service_nodes
 
     struct data_for_serialization
     {
-      enum struct version_t
-      {
-        version_0_v404_missing_state_changes,
-        version_1_store_historic_states_separate,
-        count,
-      };
-      static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_1_store_historic_states_separate; }
+      enum struct version_t { version_0, count, };
+      static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_0; }
 
       version_t version;
       std::vector<quorum_for_serialization> quorum_states;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -239,7 +239,6 @@ namespace service_nodes
     /// do no subtract off the buffer in advance)
     /// return: nullptr if the quorum is not cached in memory (pruned from memory).
     std::shared_ptr<const testing_quorum> get_testing_quorum(quorum_type type, uint64_t height, bool include_old = false) const;
-    quorum_manager                        get_quorum_manager(uint64_t height, bool include_old = false) const;
     bool                                  get_quorum_pubkey(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
 
     std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
@@ -273,7 +272,7 @@ namespace service_nodes
 
     struct state_serialized
     {
-      enum struct version_t { version_0, count, };
+      enum struct version_t : uint8_t { version_0, count, };
       static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_0; }
 
       version_t                              version;
@@ -295,7 +294,7 @@ namespace service_nodes
 
     struct data_for_serialization
     {
-      enum struct version_t { version_0, count, };
+      enum struct version_t : uint8_t { version_0, count, };
       static version_t get_version(uint8_t /*hf_version*/) { return version_t::version_0; }
 
       version_t version;
@@ -372,7 +371,11 @@ namespace service_nodes
     std::deque<quorums_by_height>          m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
     std::set<state_t, state_t_less>        m_state_history;
     state_t                                m_state;
+
     bool                                   m_long_term_states_added_to;
+    data_for_serialization                 m_cache_long_term_data;
+    data_for_serialization                 m_cache_short_term_data;
+    std::string                            m_cache_data_blob;
   };
 
   bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature, crypto::public_key& tx_pub_key);

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -92,6 +92,11 @@ namespace service_nodes {
 
   constexpr uint64_t STATE_CHANGE_TX_LIFETIME_IN_BLOCKS = VOTE_LIFETIME;
 
+  // If we get an incoming vote of state change tx that is outside the acceptable range by this many
+  // blocks then ignore it but don't trigger a connection drop; the sending side could be a couple
+  // blocks out of sync and sending something that it thinks is legit.
+  constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
+
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;
 

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -131,11 +131,6 @@ namespace service_nodes
     return true;
   }
 
-  // If we get an incoming vote of state change tx that is outside the acceptable range by this many
-  // blocks then ignore it but don't trigger a connection drop; the sending side could be a couple
-  // blocks out of sync and sending something that it thinks is legit.
-  constexpr uint64_t VERIFY_HEIGHT_BUFFER = 5;
-
   static bool bad_tx(cryptonote::tx_verification_context &tvc) {
     tvc.m_verifivation_failed = true;
     return false;
@@ -185,7 +180,7 @@ namespace service_nodes
                      << ", is newer than current height: " << latest_height
                      << " blocks and has been rejected.");
         vvc.m_invalid_block_height = true;
-        if (state_change.block_height >= latest_height + VERIFY_HEIGHT_BUFFER)
+        if (state_change.block_height >= latest_height + VOTE_OR_TX_VERIFY_HEIGHT_BUFFER)
           tvc.m_verifivation_failed = true;
         return false;
       }
@@ -198,7 +193,7 @@ namespace service_nodes
                      << " (current height: " << latest_height << ") "
                      << "blocks and has been rejected.");
         vvc.m_invalid_block_height = true;
-        if (latest_height >= state_change.block_height + (service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS + VERIFY_HEIGHT_BUFFER))
+        if (latest_height >= state_change.block_height + (service_nodes::STATE_CHANGE_TX_LIFETIME_IN_BLOCKS + VOTE_OR_TX_VERIFY_HEIGHT_BUFFER))
           tvc.m_verifivation_failed = true;
         return false;
       }
@@ -309,14 +304,14 @@ namespace service_nodes
     bool height_in_buffer = false;
     if (latest_height > vote.block_height + VOTE_LIFETIME)
     {
-      height_in_buffer = latest_height <= vote.block_height + (VOTE_LIFETIME + VERIFY_HEIGHT_BUFFER);
+      height_in_buffer = latest_height <= vote.block_height + (VOTE_LIFETIME + VOTE_OR_TX_VERIFY_HEIGHT_BUFFER);
       LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is older than: " << VOTE_LIFETIME
                                                 << " blocks and has been rejected.");
       vvc.m_invalid_block_height = true;
     }
     else if (vote.block_height > latest_height)
     {
-      height_in_buffer = vote.block_height <= latest_height + VERIFY_HEIGHT_BUFFER;
+      height_in_buffer = vote.block_height <= latest_height + VOTE_OR_TX_VERIFY_HEIGHT_BUFFER;
       LOG_PRINT_L1("Received vote for height: " << vote.block_height << ", is newer than: " << latest_height
                                                 << " (latest block height) and has been rejected.");
       vvc.m_invalid_block_height = true;

--- a/tests/unit_tests/testdb.h
+++ b/tests/unit_tests/testdb.h
@@ -150,8 +150,8 @@ public:
 
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }
-  virtual void set_service_node_data  (const std::string& data)                      override { }
-  virtual bool get_service_node_data  (std::string& data)                            override { return false; }
+  virtual void set_service_node_data  (const std::string& data, bool long_term)      override { }
+  virtual bool get_service_node_data  (std::string& data, bool long_term)            override { return false; }
   virtual void clear_service_node_data()                                             override { }
 
   virtual cryptonote::transaction get_pruned_tx(const crypto::hash& h) const override { return {}; };


### PR DESCRIPTION
If we are re-deriving states we still also need the historical quorums
such that we can process incoming blocks with state changes. Without it,
state changes will be ignored and skipped causing inconsistent state in
the service node list.

This mandates a rescan and stores the most recent in state_ts, and only
just quorums for states preceeding 10k intervals. We can no longer store
the 1st most recent state in the DB as that will be missing quorums as
well for similar reason when rederiving on start-up.

@jagerman

We mandate a rescan for this change.