### PR TITLE
Fix 4.0.4 uptime proof transmission after recomm

### DIFF
--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -41,12 +41,16 @@ namespace service_nodes
 {
   struct proof_info
   {
-    uint64_t timestamp     = 0;
+    uint64_t timestamp           = 0; // The actual time we last received an uptime proof
+    uint64_t effective_timestamp = 0; // Typically the same, but on recommissions it is set to the recommission block time to fend off instant obligation checks
     uint16_t version_major = 0, version_minor = 0, version_patch = 0;
     std::array<bool, CHECKPOINT_MIN_QUORUMS_NODE_MUST_VOTE_IN_BEFORE_DEREGISTER_CHECK> votes;
     uint8_t vote_index = 0;
     std::array<std::pair<uint32_t, uint64_t>, 2> public_ips = {}; // (not serialized)
     proof_info() { votes.fill(true); }
+
+    // Called to update both actual and effective timestamp, i.e. when a proof is received
+    void update_timestamp(uint64_t ts) { timestamp = ts; effective_timestamp = ts; }
 
     // Unlike the above, these two *do* get serialized, but directly from state_t rather than as a subobject:
     uint32_t public_ip;
@@ -452,7 +456,7 @@ namespace service_nodes
     // Returns true if there was a successful contribution that fully funded a service node:
     bool process_contribution_tx(const cryptonote::transaction& tx, uint64_t block_height, uint32_t index);
     // Returns true if a service node changed state (deregistered, decommissioned, or recommissioned)
-    bool process_state_change_tx(const cryptonote::transaction& tx, uint64_t block_height);
+    bool process_state_change_tx(const cryptonote::transaction& tx, const cryptonote::block& block);
     void process_block(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
     void update_swarms(uint64_t height);
 

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -63,7 +63,7 @@ namespace service_nodes
     service_node_test_results result; // Defaults to true for individual tests
     uint64_t now                          = time(nullptr);
     proof_info const &proof               = *info.proof;
-    uint64_t time_since_last_uptime_proof = now - proof.timestamp;
+    uint64_t time_since_last_uptime_proof = now - std::max(proof.timestamp, proof.effective_timestamp);
 
     bool check_uptime_obligation     = true;
     bool check_checkpoint_obligation = true;


### PR DESCRIPTION
When a node gets recommissioned in 4.0.4 we reset its timestamp to the
current time to delay obligations checks for newly recommissioned nodes,
but this reset caused problems:

- the code runs not only when a fresh block is received, but also when
  syncing or rescanning, and so time(NULL) gets used to update the
  node's timestamp even if it is an old record, and since proof info is
  shared across states, the affects the current state.

- as a result of the above, a just-rescanned node that has been
  decommissioned at some point in the past will think it has just sent a
  proof, and so won't send any proofs for an hour.

- A just-rescanned node won't accept or relay any proofs for any node
  that was recommissioned in its scan for the first half an hour, but this
  lack of relaying can cause chaos in getting uptime proofs out across the
  network, especially while we still have 4.0.3 nodes that need it.

To address the first issue, this switches the recommissioning to use the
block timestamp rather than the current timestamp.  This *will* be
slightly delayed in the case of current blocks (since a block timestamp
is the time the pool *started* working on the block, which is generally
the time the previous block was found on the network), but even with an
exceptionally long block delay (e.g. 20 minutes) we are still fending
off obligations checks for 1h40m.

That would partially fix issues 2 and 3, but we actually don't want a
recommissioning to look like a received uptime proof for a couple
reasons:

- When we haven't actually received an uptime proof it's confusing to
  report that we have (at the recommission time) and may mask an
  underlying issue of a node that isn't actually sending proofs for some
  reason (which might be more common for a node that has just been
  decommissioned/recommissioned).  There's also a related weird state
  here for nodes that have come on recently: they think the SN is
  active, but have 0's for IP and storage server port.

- 4.0.3 nodes don't get the updated timestamp and so really need the
  proof to come through even when the 4.0.4 nodes don't think it's
  important/acceptable.

So to also fix these, this commits adds an "effective_timestamp" to the
proof info: if it is larger than the actual timestamp field, we use it
instead of the actual one for obligations checking.  On a recommission,
we update only the effective field so that we can delay obligations
checking for a couple of hours without delaying actual proofs info going
over the network.