### PR TITLE
Revert "cryptonote_protocol: drop peers we can't download from when s…

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -342,7 +342,7 @@ namespace cryptonote
 
     if(m_core.have_block(hshd.top_id))
     {
-      if (target > hshd.current_height)
+      if (target > m_core.get_current_blockchain_height())
       {
         MINFO(context << "peer is not ahead of us and we're syncing, disconnecting");
         return false;


### PR DESCRIPTION
…yncing"

This reverts commit a96c1a46d4b3854252de75cbe09458ad5d1aecb0.

The commit seems completely broken: if we have block `hshd.top_id` then it will basically *always* be the case that `target > hshd.current_height`, and so this basically just instantly disconnects any new peer that connects that is behind.

Just revert this for now.