### PR TITLE
Enforce minimum storage server version since hardfork 13

### DIFF
--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -97,7 +97,7 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  constexpr int MIN_STORAGE_SERVER_VERSION[] = {1, 0, 6};
+  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION = {1, 0, 5};
 
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -97,8 +97,7 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  // Minimum version of Storage Server required
-  constexpr int MIN_STORAGE_SERVER_VERSION[3] = {1, 0, 6};
+  constexpr int MIN_STORAGE_SERVER_VERSION[] = {1, 0, 6};
 
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -97,6 +97,9 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
+  // Minimum version of Storage Server required
+  constexpr int MIN_STORAGE_SERVER_VERSION[3] = {1, 0, 6};
+
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2971,16 +2971,9 @@ namespace cryptonote
                                                const connection_context*)
   {
 
-    const uint8_t hf_version = m_core.get_hard_fork_version(m_core.get_current_blockchain_height());
+    const std::array<int, 3> cur_version = { req.version_major, req.version_minor, req.version_patch };
 
-    const int cur_version[] = { req.version_major, req.version_minor, req.version_patch };
-
-    const bool update_needed = std::lexicographical_compare(cur_version,
-                                                            cur_version + 3,
-                                                            service_nodes::MIN_STORAGE_SERVER_VERSION,
-                                                            service_nodes::MIN_STORAGE_SERVER_VERSION + 3);
-
-    if (hf_version >= network_version_13 && update_needed) {
+    if (cur_version < service_nodes::MIN_STORAGE_SERVER_VERSION) {
       std::stringstream status;
       status << "Outdated Storage Server. ";
       status << "Current: " << req.version_major << "." << req.version_minor << "." << req.version_patch << ". ";

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2965,36 +2965,20 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  // Parse version, return `true` on success.
-  static bool parse_version(int result[3], const std::string& str)
+  // Return `true` if the current version is out of date (or in case of error)
+  static bool update_required(const std::string cur_version_str[3], const int min_version[3])
   {
-    std::vector<std::string> strs;
-    strs.reserve(3);
-    boost::split(strs, str, boost::is_any_of("."));
-    if (strs.size() != 3) {
-      return false;
-    }
+    int cur_version[3];
 
     try {
-      result[0] = std::stoi(strs[0]);
-      result[1] = std::stoi(strs[1]);
-      result[2] = std::stoi(strs[2]);
+      cur_version[0] = std::stoi(cur_version_str[0]);
+      cur_version[1] = std::stoi(cur_version_str[1]);
+      cur_version[2] = std::stoi(cur_version_str[2]);
     } catch (const std::exception& e) {
-      return false;
-    }
-
-    return true;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  // Return `true` if the current version is out of date (or in case of error)
-  static bool update_required(const std::string cur_version, const int min_version[3])
-  {
-    int ss_version[3] = { 0 };
-    if (!parse_version(ss_version, cur_version)) {
       return true;
     }
 
-    return std::lexicographical_compare(ss_version, ss_version + 3, min_version, min_version + 3);
+    return std::lexicographical_compare(cur_version, cur_version + 3, min_version, min_version + 3);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_storage_server_ping(const COMMAND_RPC_STORAGE_SERVER_PING::request& req,
@@ -3005,10 +2989,14 @@ namespace cryptonote
 
     const uint8_t hf_version = m_core.get_hard_fork_version(m_core.get_current_blockchain_height());
 
+    std::string cur_version_str[] = { req.version_major, req.version_minor, req.version_patch };
+
     if (hf_version >= network_version_13 &&
-        update_required(req.version, service_nodes::MIN_STORAGE_SERVER_VERSION)) {
+        update_required(cur_version_str, service_nodes::MIN_STORAGE_SERVER_VERSION)) {
       std::stringstream status;
-      status << "Outdated Storage Server. Required: " << service_nodes::MIN_STORAGE_SERVER_VERSION[0] << "."
+      status << "Outdated Storage Server. ";
+      status << "Current: " << req.version_major << "." << req.version_minor << "." << req.version_patch << ". ";
+      status << "Required: " << service_nodes::MIN_STORAGE_SERVER_VERSION[0] << "."
              << service_nodes::MIN_STORAGE_SERVER_VERSION[1] << "." << service_nodes::MIN_STORAGE_SERVER_VERSION[2];
       res.status = status.str();
       MERROR(status.str());

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2981,9 +2981,9 @@ namespace cryptonote
   {
     struct request
     {
-      std::string version_major; // Storage Server Major version
-      std::string version_minor; // Storage Server Minor version
-      std::string version_patch; // Storage Server Patch version
+      int version_major; // Storage Server Major version
+      int version_minor; // Storage Server Minor version
+      int version_patch; // Storage Server Patch version
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(version_major);
         KV_SERIALIZE(version_minor);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2981,7 +2981,9 @@ namespace cryptonote
   {
     struct request
     {
+      std::string version; // Storage Server version
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(version);
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2981,9 +2981,13 @@ namespace cryptonote
   {
     struct request
     {
-      std::string version; // Storage Server version
+      std::string version_major; // Storage Server Major version
+      std::string version_minor; // Storage Server Minor version
+      std::string version_patch; // Storage Server Patch version
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(version);
+        KV_SERIALIZE(version_major);
+        KV_SERIALIZE(version_minor);
+        KV_SERIALIZE(version_patch);
       END_KV_SERIALIZE_MAP()
     };
 


### PR DESCRIPTION
Storage Server will start sending its version with every ping to Lokid (starting with version 1.0.6). This PR reads the version and compares it to `MIN_STORAGE_SERVER_VERSION` to decide if the storage server is up to date and whether an uptime proof should be sent. An error is printed if the version is below the required.