### PR TITLE
Fix decommissioned snodes not leaving swarms

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -464,6 +464,14 @@ namespace service_nodes
         info.last_decommission_height = block_height;
         info.decommission_count++;
 
+        if (hard_fork_version >= cryptonote::network_version_13) {
+          // Assigning invalid swarm id effectively kicks the node off
+          // its current swarm; it will be assigned a new swarm id when it
+          // gets recommissioned. Prior to HF13 this step was incorrectly
+          // skipped.
+          info.swarm_id = UNASSIGNED_SWARM_ID;
+        }
+
         info.proof->update_timestamp(0);
         return true;
 


### PR DESCRIPTION
In HF12 decommissioned snodes don't have their swarm ids reset, and as a result they return to their previous swarms upon recommissioning, bypassing all swarm formation rules and limits. For example, a snode could return into a no longer existing swarm effectively creating a swarm of size 1. This PR fixes that for HF13 onward.