### PR TITLE
Store state upto the (2nd oldest checkpoint or height - 360)

### DIFF
--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -373,10 +373,11 @@ namespace service_nodes
     };
 
     std::deque<quorums_by_height>          m_old_quorum_states; // Store all old quorum history only if run with --store-full-quorum-history
-    std::set<state_t, state_t_less>        m_state_history;
+    std::set<state_t, state_t_less>        m_state_history; // Store state_t's from MIN(2nd oldest checkpoint | height - DEFAULT_SHORT_TERM_STATE_HISTORY) up to the block height
+    std::set<state_t, state_t_less>        m_state_archive; // Store state_t's where ((height < m_state_history.first()) && (height % STORE_LONG_TERM_STATE_INTERVAL))
     state_t                                m_state;
 
-    bool                                   m_long_term_states_added_to;
+    bool                                   m_state_added_to_archive;
     data_for_serialization                 m_cache_long_term_data;
     data_for_serialization                 m_cache_short_term_data;
     std::string                            m_cache_data_blob;


### PR DESCRIPTION
This makes us store service node list state to the min(2nd oldest checkpoint height, height - 360). I've split the storage into m_state_history and m_state_archive, where archive is for long term storage (i.e. 10k blocks) and history is the recent portion (360 most recent blocks).

This simplifies the need to try and micromanage which height to start culling state from.

@jagerman

Should address the 2 issues

* SN rescans should not be possible to trigger by any network adversary. Essentially, rollbacks to the second-oldest chain must always be possible without triggering a rescan of the SN status. This likely means that we change how much rollback data is stored to always store back to the second-oldest checkpoint on the current chain (and #740 needs to be fixed so that the second-oldest checkpoint can never get older).
* incoming checkpoints must be considered even if they are old as long as they are not older than the 2nd-oldest checkpoint along the current chain. Currently if a node gets too far ahead on a chain without checkpoints it rejects new checkpoints (because it doesn't have them in the cache). This is likely related to the above point and to #740.

From #742