### PR TITLE
make get_checkpoints_range faster by using lmdb cursor as iterator

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -425,47 +425,6 @@ void BlockchainDB::fixup(fixup_context const context)
   set_batch_transactions(true);
 }
 
-std::vector<checkpoint_t> BlockchainDB::get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints) const
-{
-  std::vector<checkpoint_t> result;
-  checkpoint_t top_checkpoint = {};
-  if (!get_top_checkpoint(top_checkpoint))
-    return result;
-
-  if (top_checkpoint.height < std::min(start, end))
-    return result;
-
-  if (end > start)
-    end = std::min(top_checkpoint.height, end);
-
-  if (num_desired_checkpoints == BlockchainDB::GET_ALL_CHECKPOINTS)
-    num_desired_checkpoints = std::numeric_limits<decltype(num_desired_checkpoints)>::max();
-  else
-    result.reserve(num_desired_checkpoints);
-
-  for (uint64_t height = start;
-       height != end && result.size() < num_desired_checkpoints;
-       )
-  {
-    checkpoint_t checkpoint;
-    if (get_block_checkpoint(height, checkpoint))
-      result.push_back(checkpoint);
-
-    if (end >= start) height++;
-    else height--;
-  }
-
-  if (result.size() < num_desired_checkpoints)
-  {
-    // NOTE: Inclusive of end height
-    checkpoint_t checkpoint;
-    if (get_block_checkpoint(end, checkpoint))
-      result.push_back(checkpoint);
-  }
-
-  return result;
-}
-
 bool BlockchainDB::get_immutable_checkpoint(checkpoint_t *immutable_checkpoint, uint64_t block_height) const
 {
   size_t constexpr NUM_CHECKPOINTS = service_nodes::CHECKPOINT_NUM_CHECKPOINTS_FOR_CHAIN_FINALITY;

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -840,7 +840,7 @@ public:
 
   // num_desired_checkpoints: set to GET_ALL_CHECKPOINTS to collect as many checkpoints as possible
   static constexpr size_t GET_ALL_CHECKPOINTS = 0;
-  virtual std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const;
+  virtual std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const = 0;
   virtual bool get_immutable_checkpoint(checkpoint_t *immutable_checkpoint, uint64_t block_height) const;
 
   /**

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3869,6 +3869,29 @@ void BlockchainLMDB::remove_block_checkpoint(uint64_t height)
   }
 }
 
+static checkpoint_t convert_mdb_val_to_checkpoint(MDB_val const value)
+{
+  checkpoint_t result = {};
+  auto const *header  = static_cast<blk_checkpoint_header const *>(value.mv_data);
+  auto const *signatures =
+      reinterpret_cast<service_nodes::voter_to_signature *>(static_cast<uint8_t *>(value.mv_data) + sizeof(*header));
+
+  boost::endian::little_to_native_inplace(header->height);
+  boost::endian::little_to_native_inplace(header->num_signatures);
+
+  result.height     = header->height;
+  result.type       = (header->num_signatures > 0) ? checkpoint_type::service_node : checkpoint_type::hardcoded;
+  result.block_hash = header->block_hash;
+  result.signatures.reserve(header->num_signatures);
+  for (size_t i = 0; i < header->num_signatures; ++i)
+  {
+    service_nodes::voter_to_signature const *signature = signatures + i;
+    result.signatures.push_back(*signature);
+  }
+
+  return result;
+}
+
 bool BlockchainLMDB::get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const
 {
   check_open();
@@ -3879,24 +3902,7 @@ bool BlockchainLMDB::get_block_checkpoint_internal(uint64_t height, checkpoint_t
   MDB_val value = {};
   int ret = mdb_cursor_get(m_cur_block_checkpoints, &key, &value, op);
   if (ret == MDB_SUCCESS)
-  {
-    auto const *header     = static_cast<blk_checkpoint_header const *>(value.mv_data);
-    auto const *signatures = reinterpret_cast<service_nodes::voter_to_signature *>(static_cast<uint8_t *>(value.mv_data) + sizeof(*header));
-
-    boost::endian::little_to_native_inplace(header->height);
-    boost::endian::little_to_native_inplace(header->num_signatures);
-
-    checkpoint            = {};
-    checkpoint.height     = header->height;
-    checkpoint.type       = (header->num_signatures > 0 ) ? checkpoint_type::service_node : checkpoint_type::hardcoded;
-    checkpoint.block_hash = header->block_hash;
-    checkpoint.signatures.reserve(header->num_signatures);
-    for (size_t i = 0; i < header->num_signatures; ++i)
-    {
-      service_nodes::voter_to_signature const *signature = signatures + i;
-      checkpoint.signatures.push_back(*signature);
-    }
-  }
+    checkpoint = convert_mdb_val_to_checkpoint(value);
 
   TXN_POSTFIX_RDONLY();
   if (ret != MDB_SUCCESS && ret != MDB_NOTFOUND)
@@ -3917,6 +3923,95 @@ bool BlockchainLMDB::get_top_checkpoint(checkpoint_t &checkpoint) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   bool result = get_block_checkpoint_internal(0, checkpoint, MDB_LAST);
+  return result;
+}
+
+std::vector<checkpoint_t> BlockchainLMDB::get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints) const
+{
+  std::vector<checkpoint_t> result;
+  checkpoint_t top_checkpoint    = {};
+  checkpoint_t bottom_checkpoint = {};
+  if (!get_top_checkpoint(top_checkpoint)) return result;
+  if (!get_block_checkpoint_internal(0, bottom_checkpoint, MDB_FIRST)) return result;
+
+  start = loki::clamp_u64(bottom_checkpoint.height, start, top_checkpoint.height);
+  end   = loki::clamp_u64(bottom_checkpoint.height, end, top_checkpoint.height);
+  if (start > end)
+  {
+    if (start < bottom_checkpoint.height) return result;
+  }
+  else
+  {
+    if (start > top_checkpoint.height) return result;
+  }
+
+  if (num_desired_checkpoints == BlockchainDB::GET_ALL_CHECKPOINTS)
+    num_desired_checkpoints = std::numeric_limits<decltype(num_desired_checkpoints)>::max();
+  else
+    result.reserve(num_desired_checkpoints);
+
+  // NOTE: Get the first checkpoint and then use LMDB's cursor as an iterator to
+  // find subsequent checkpoints so we don't waste time querying every-single-height
+  checkpoint_t first_checkpoint = {};
+  bool found_a_checkpoint       = false;
+  for (uint64_t height = start;
+       height != end && result.size() < num_desired_checkpoints;
+       )
+  {
+    if (get_block_checkpoint(height, first_checkpoint))
+    {
+      result.push_back(first_checkpoint);
+      found_a_checkpoint = true;
+      break;
+    }
+
+    if (end >= start) height++;
+    else height--;
+  }
+
+  // Get inclusive of end if we couldn't find a checkpoint in all the other heights leading up to the end height
+  if (!found_a_checkpoint && result.size() < num_desired_checkpoints && get_block_checkpoint(end, first_checkpoint))
+  {
+    result.push_back(first_checkpoint);
+    found_a_checkpoint = true;
+  }
+
+  if (found_a_checkpoint && result.size() < num_desired_checkpoints)
+  {
+    check_open();
+    TXN_PREFIX_RDONLY();
+    RCURSOR(block_checkpoints);
+
+    MDB_val_set(key, first_checkpoint.height);
+    int ret = mdb_cursor_get(m_cur_block_checkpoints, &key, nullptr, MDB_SET_KEY);
+    if (ret != MDB_SUCCESS)
+      throw0(DB_ERROR(lmdb_error("Unexpected failure to get checkpoint we just queried: ", ret).c_str()));
+
+    uint64_t min = start;
+    uint64_t max = end;
+    if (min > max) std::swap(min, max);
+    MDB_cursor_op const op = (end >= start) ? MDB_NEXT : MDB_PREV;
+
+    for (; result.size() < num_desired_checkpoints;)
+    {
+      MDB_val value = {};
+      ret           = mdb_cursor_get(m_cur_block_checkpoints, nullptr, &value, op);
+
+      if (ret == MDB_NOTFOUND) break;
+      if (ret != MDB_SUCCESS)
+        throw0(DB_ERROR(lmdb_error("Failed to query block checkpoint range: ", ret).c_str()));
+
+      auto const *header = static_cast<blk_checkpoint_header const *>(value.mv_data);
+      if (header->height >= min && header->height <= max)
+      {
+        checkpoint_t checkpoint = convert_mdb_val_to_checkpoint(value);
+        result.push_back(checkpoint);
+      }
+    }
+
+    TXN_POSTFIX_RDONLY();
+  }
+
   return result;
 }
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3934,8 +3934,8 @@ std::vector<checkpoint_t> BlockchainLMDB::get_checkpoints_range(uint64_t start, 
   if (!get_top_checkpoint(top_checkpoint)) return result;
   if (!get_block_checkpoint_internal(0, bottom_checkpoint, MDB_FIRST)) return result;
 
-  start = loki::clamp_u64(bottom_checkpoint.height, start, top_checkpoint.height);
-  end   = loki::clamp_u64(bottom_checkpoint.height, end, top_checkpoint.height);
+  start = loki::clamp_u64(start, bottom_checkpoint.height, top_checkpoint.height);
+  end   = loki::clamp_u64(end, bottom_checkpoint.height, top_checkpoint.height);
   if (start > end)
   {
     if (start < bottom_checkpoint.height) return result;

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -327,6 +327,7 @@ public:
   void remove_block_checkpoint(uint64_t height) override;
   bool get_block_checkpoint   (uint64_t height, checkpoint_t &checkpoint) const override;
   bool get_top_checkpoint     (checkpoint_t &checkpoint) const override;
+  std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const override;
 
   void set_batch_transactions(bool batch_transactions) override;
   bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0) override;

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -33,13 +33,11 @@
 #include <string>
 #include <vector>
 #include <map>
-
 #include "blockchain_db.h"
 
 namespace cryptonote
 {
   struct checkpoint_t;
-
 class BaseTestDB: public cryptonote::BlockchainDB {
 public:
   BaseTestDB() {}
@@ -162,6 +160,7 @@ public:
   virtual bool get_block_checkpoint   (uint64_t height, struct checkpoint_t &checkpoint) const override { return false; }
   virtual bool get_top_checkpoint     (struct checkpoint_t &checkpoint) const override { return false; }
   virtual void remove_block_checkpoint(uint64_t height) override { }
+  std::vector<cryptonote::checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = BlockchainDB::GET_ALL_CHECKPOINTS) const override { return {}; }
 
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }

--- a/src/common/loki.cpp
+++ b/src/common/loki.cpp
@@ -584,3 +584,12 @@ std::string loki::hex64_to_base32z(const std::string &src)
 
   return result;
 }
+
+uint64_t loki::clamp_u64(uint64_t min, uint64_t val, uint64_t max)
+{
+  assert(min <= max);
+  if (val < min) val = min;
+  else if (val > max) val = max;
+  return val;
+}
+

--- a/src/common/loki.cpp
+++ b/src/common/loki.cpp
@@ -585,7 +585,7 @@ std::string loki::hex64_to_base32z(const std::string &src)
   return result;
 }
 
-uint64_t loki::clamp_u64(uint64_t min, uint64_t val, uint64_t max)
+uint64_t loki::clamp_u64(uint64_t val, uint64_t min, uint64_t max)
 {
   assert(min <= max);
   if (val < min) val = min;

--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -37,6 +37,7 @@ namespace loki
 double      round           (double);
 double      exp2            (double);
 std::string hex64_to_base32z(std::string const& src);
+uint64_t    clamp_u64       (uint64_t min, uint64_t val, uint64_t max);
 
 template <typename lambda_t>
 struct defer
@@ -61,6 +62,7 @@ struct defer_helper
 
 template <typename T, size_t N>
 constexpr size_t array_count(T (&)[N]) { return N; }
+
 }; // namespace Loki
 
 #endif // LOKI_H

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -83,6 +83,48 @@ struct TestDB: public BaseTestDB
     return 1;
   }
 
+  std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints) const override
+  {
+    std::vector<checkpoint_t> result;
+    checkpoint_t top_checkpoint    = {};
+    if (!get_top_checkpoint(top_checkpoint)) return result;
+    checkpoint_t bottom_checkpoint = checkpoints.front();
+
+    start = loki::clamp_u64(bottom_checkpoint.height, start, top_checkpoint.height);
+    end   = loki::clamp_u64(bottom_checkpoint.height, end, top_checkpoint.height);
+    if (start > end)
+    {
+      if (start < bottom_checkpoint.height) return result;
+    }
+    else
+    {
+      if (start > top_checkpoint.height) return result;
+    }
+
+    if (num_desired_checkpoints == BlockchainDB::GET_ALL_CHECKPOINTS)
+      num_desired_checkpoints = std::numeric_limits<decltype(num_desired_checkpoints)>::max();
+    else
+      result.reserve(num_desired_checkpoints);
+
+    // NOTE: Get the first checkpoint and then use LMDB's cursor as an iterator to
+    // find subsequent checkpoints so we don't waste time querying every-single-height
+    for (uint64_t height = start; height != end && result.size() < num_desired_checkpoints;)
+    {
+      checkpoint_t checkpoint;
+      if (get_block_checkpoint(height, checkpoint))
+        result.push_back(checkpoint);
+
+      if (end >= start) height++;
+      else height--;
+    }
+
+    // Get inclusive of end if we couldn't find a checkpoint in all the other heights leading up to the end height
+    checkpoint_t end_checkpoint;
+    if (result.size() < num_desired_checkpoints && get_block_checkpoint(end, end_checkpoint))
+      result.push_back(end_checkpoint);
+    return result;
+  }
+
   virtual void remove_block_checkpoint(uint64_t block_height)
   {
     auto it = std::find_if(checkpoints.begin(), checkpoints.end(), [block_height](checkpoint_t const &entry) {

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -90,8 +90,8 @@ struct TestDB: public BaseTestDB
     if (!get_top_checkpoint(top_checkpoint)) return result;
     checkpoint_t bottom_checkpoint = checkpoints.front();
 
-    start = loki::clamp_u64(bottom_checkpoint.height, start, top_checkpoint.height);
-    end   = loki::clamp_u64(bottom_checkpoint.height, end, top_checkpoint.height);
+    start = loki::clamp_u64(start, bottom_checkpoint.height, top_checkpoint.height);
+    end   = loki::clamp_u64(end, bottom_checkpoint.height, top_checkpoint.height);
     if (start > end)
     {
       if (start < bottom_checkpoint.height) return result;

--- a/tests/unit_tests/testdb.h
+++ b/tests/unit_tests/testdb.h
@@ -77,6 +77,7 @@ public:
   virtual bool get_block_checkpoint   (uint64_t height, cryptonote::checkpoint_t &checkpoint) const override { return false; }
   virtual bool get_top_checkpoint     (cryptonote::checkpoint_t &checkpoint) const override { return false; }
   virtual void remove_block_checkpoint(uint64_t height) override { }
+  std::vector<checkpoint_t> get_checkpoints_range(uint64_t start, uint64_t end, size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const override { return {}; }
   virtual cryptonote::blobdata get_block_blob(const crypto::hash& h) const override { return cryptonote::blobdata(); }
   virtual uint64_t get_block_height(const crypto::hash& h) const override { return 0; }
   virtual cryptonote::block_header get_block_header(const crypto::hash& h) const override { return cryptonote::block_header(); }


### PR DESCRIPTION
There's still some undesirable behaviour if you query the range of checkpoints that's not from the tip or the start of the chain, in that you have to linearly check each height back until you find the first checkpoint, then use that as a iterator to access the remaining checkpoints.

But this is not common and only currently only necessary when checking validity of an alternative block.
@jagerman

We had some not nice behaviour on startup when recalculating the service node list state we're required to find the immutable checkpoint which was a linear scan back from 300k to 200k at HF12, since there were no checkpoints except the hardcoded ones which are spaced many blocks apart.