### PR TITLE
Update soft-forking checks to be effective HF13

### DIFF
--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -164,11 +164,11 @@ namespace cryptonote
      *         true if the passed parameters match the stored checkpoint,
      *         false otherwise
      */
-    bool check_block(uint64_t height, const crypto::hash& h, bool *is_a_checkpoint = nullptr, bool *rejected_by_service_node = nullptr) const;
+    bool check_block(uint64_t height, const crypto::hash& h, bool *is_a_checkpoint = nullptr, bool *service_node_checkpoint = nullptr) const;
 
     /**
      * @brief checks if alternate chain blocks should be kept for a given height and updates
-     * m_oldest_allowable_alternative_block based on the available checkpoints
+     * m_immutable_height based on the available checkpoints
      *
      * this basically says if the blockchain is smaller than the first
      * checkpoint then alternate blocks are allowed.  Alternatively, if the
@@ -181,7 +181,7 @@ namespace cryptonote
      * @return true if alternate blocks are allowed given the parameters,
      *         otherwise false
      */
-    bool is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height, bool *rejected_by_service_node = nullptr);
+    bool is_alternative_block_allowed(uint64_t blockchain_height, uint64_t block_height, bool *service_node_checkpoint = nullptr);
 
     /**
      * @brief gets the highest checkpoint height
@@ -201,7 +201,7 @@ namespace cryptonote
   private:
     network_type m_nettype = UNDEFINED;
     uint64_t m_last_cull_height = 0;
-    uint64_t m_oldest_allowable_alternative_block = 0;
+    uint64_t m_immutable_height = 0;
     BlockchainDB *m_db;
   };
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -160,8 +160,7 @@ static_assert(STAKING_PORTIONS % 3 == 0, "Use a multiple of three, so that it di
 #define HF_VERSION_SMALLER_BP                   cryptonote::network_version_11_infinite_staking
 #define HF_VERSION_LONG_TERM_BLOCK_WEIGHT       cryptonote::network_version_11_infinite_staking
 #define HF_VERSION_INCREASE_FEE                 cryptonote::network_version_12_checkpointing
-#define HF_VERSION_PER_OUTPUT_FEE               cryptonote::network_version_13
-#define HF_VERSION_12_CHECKPOINTING_SOFT_FORK_HEIGHT ((uint64_t)(-1))
+#define HF_VERSION_PER_OUTPUT_FEE               cryptonote::network_version_13_enforce_checkpoints
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 
@@ -260,7 +259,7 @@ namespace cryptonote
     network_version_10_bulletproofs, // Bulletproofs, Service Node Grace Registration Period, Batched Governance
     network_version_11_infinite_staking, // Infinite Staking, CN-Turtle
     network_version_12_checkpointing, // Checkpointing, Relaxed Deregistration, RandomXL, Loki Storage Server
-    network_version_13,
+    network_version_13_enforce_checkpoints,
 
     network_version_count,
   };

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1582,17 +1582,6 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::add_new_block(const block& b, block_verification_context& bvc, checkpoint_t const *checkpoint)
   {
-    // TODO(loki): Temporary soft-fork code can be removed
-    uint64_t latest_height = std::max(get_current_blockchain_height(), get_target_blockchain_height());
-    if (get_nettype() == cryptonote::MAINNET &&
-        latest_height >= HF_VERSION_12_CHECKPOINTING_SOFT_FORK_HEIGHT &&
-        get_block_height(b) < HF_VERSION_12_CHECKPOINTING_SOFT_FORK_HEIGHT)
-    {
-      // NOTE: After the soft fork, ignore all checkpoints from before the fork so we
-      // only create and enforce checkpoints from after the soft-fork.
-      checkpoint = nullptr;
-    }
-
     bool result = m_blockchain_storage.add_new_block(b, bvc, checkpoint);
     if (result)
     {
@@ -1661,7 +1650,7 @@ namespace cryptonote
     // quorums are implemented and merged
     if (checkpoint)
     {
-      if (b->major_version >= network_version_13)
+      if (b->major_version >= network_version_13_enforce_checkpoints)
       {
         if (checkpoint->signatures.size() > 1)
         {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -489,7 +489,7 @@ namespace service_nodes
         info.last_decommission_height = block_height;
         info.decommission_count++;
 
-        if (hf_version >= cryptonote::network_version_13) {
+        if (hf_version >= cryptonote::network_version_13_enforce_checkpoints) {
           // Assigning invalid swarm id effectively kicks the node off
           // its current swarm; it will be assigned a new swarm id when it
           // gets recommissioned. Prior to HF13 this step was incorrectly
@@ -2234,7 +2234,7 @@ namespace service_nodes
 
   bool service_node_info::can_transition_to_state(uint8_t hf_version, uint64_t height, new_state proposed_state) const
   {
-    if (hf_version >= cryptonote::network_version_13 && !can_be_voted_on(height))
+    if (hf_version >= cryptonote::network_version_13_enforce_checkpoints && !can_be_voted_on(height))
       return false;
 
     if (proposed_state == new_state::deregister)

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -93,7 +93,7 @@ namespace service_nodes
 
   private:
     void process_quorums(cryptonote::block const &block);
-    service_node_test_results check_service_node(const crypto::public_key &pubkey, const service_node_info &info) const;
+    service_node_test_results check_service_node(uint8_t hf_version, const crypto::public_key &pubkey, const service_node_info &info) const;
 
     cryptonote::core& m_core;
     voting_pool       m_vote_pool;

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -204,7 +204,7 @@ namespace service_nodes
     uint64_t validator_index_tracker                                       = -1;
     for (const auto &vote : state_change.votes)
     {
-      if (hf_version >= cryptonote::network_version_13) // NOTE: After HF13, votes must be stored in ascending order
+      if (hf_version >= cryptonote::network_version_13_enforce_checkpoints) // NOTE: After HF13, votes must be stored in ascending order
       {
         if (validator_index_tracker >= vote.validator_index)
         {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1189,7 +1189,7 @@ namespace cryptonote
 
           // Once we hard fork to v13 we can just use the blk major version
           // whole sale.
-          uint8_t enforce_hf_version = std::max((uint8_t)cryptonote::network_version_13, blk.major_version);
+          uint8_t enforce_hf_version = std::max((uint8_t)cryptonote::network_version_13_enforce_checkpoints, blk.major_version);
 
           if (service_node_array.empty() ||
               !service_node_array[0].info->can_transition_to_state(enforce_hf_version, state_change.block_height, state_change.state))


### PR DESCRIPTION
This disables checkpointing on testnet again, but we can just fork it to HF13 prematurely to get it active again, better than introducing `nettype() == mainnet && hf_version > ..` sort of jazz.

@jagerman