### PR TITLE
Bump min SS version to 1.0.6

### DIFF
--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -97,7 +97,7 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION = {1, 0, 5};
+  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION = {1, 0, 6};
 
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;


### PR DESCRIPTION
Storage Server will be updated to 1.0.6 (PR up), so this should be changed accordingly in Lokid.