### PR TITLE
Don't verify checkpoints until after HF13

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -62,7 +62,7 @@ namespace service_nodes
     uint64_t result =
         (block_height < DEFAULT_SHORT_TERM_STATE_HISTORY) ? 0 : block_height - DEFAULT_SHORT_TERM_STATE_HISTORY;
 
-    if (hf_version >= cryptonote::network_version_12_checkpointing)
+    if (hf_version >= cryptonote::network_version_13_enforce_checkpoints)
     {
       uint64_t latest_height = db->height() - 1;
       cryptonote::checkpoint_t checkpoint;
@@ -1106,7 +1106,7 @@ namespace service_nodes
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
     process_block(block, txs);
 
-    if (checkpoint)
+    if (block.major_version >= cryptonote::network_version_13_enforce_checkpoints && checkpoint)
     {
       std::shared_ptr<const testing_quorum> quorum = get_testing_quorum(quorum_type::checkpointing, checkpoint->height);
       if (!quorum)


### PR DESCRIPTION
Originally checkpointing was enabled without verification due to missing alternative quorums. There are some invalid checkpoints in HF12 on mainnet and testnet because of this.

Since we discard all HF12 checkpoints after HF13, we can continue to keep not verifying them until the switchover point.

@jagerman

Also add in missing >= v13 change that was meant to be in code review for AlternativeQuorums pr.