### PR TITLE
Check wallet is connected before entering trigger happy exception functions

### DIFF
--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -275,7 +275,7 @@ namespace net_utils
 			chunked_state m_chunked_state;
 			std::string m_chunked_cache;
 			bool m_auto_connect;
-			critical_section m_lock;
+			mutable critical_section m_lock;
 
 		public:
 			explicit http_simple_client_template()
@@ -342,7 +342,7 @@ namespace net_utils
 				return m_net_client.disconnect();
 			}
 			//---------------------------------------------------------------------------
-			bool is_connected(bool *ssl = NULL)
+			bool is_connected(bool *ssl = NULL) const
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				return m_net_client.is_connected(ssl);

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -389,7 +389,7 @@ namespace net_utils
 			return true;
 		}
 
-		bool is_connected(bool *ssl = NULL)
+		bool is_connected(bool *ssl = NULL) const
 		{
 			if (!m_connected || !m_ssl_socket->next_layer().is_open())
 				return false;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -918,6 +918,7 @@ private:
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);
     std::vector<pending_tx> create_unmixable_sweep_transactions();
     void discard_unmixable_outputs();
+    bool is_connected() const;
     bool check_connection(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 200000);
     void fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &txid, const crypto::hash &payment_id, const wallet2::payment_details &pd) const;
     void fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &txid, const tools::wallet2::confirmed_transfer_details &pd) const;


### PR DESCRIPTION
Soft locks the wallet when using `export_transfers` or `balance` on a wallet not connected to the daemon.

@jagerman