### PR TITLE
Enforce checkpoint quorums min size and soft fork it for testnet

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1215,6 +1215,11 @@ namespace service_nodes
         if (nettype == cryptonote::TESTNET && state.height < 85357)
           total_nodes = active_snode_list.size() + decomm_snode_list.size();
 
+
+        // TODO(loki): We can remove after switching to V13 since we delete all V12 and below checkpoints where we introduced this kind of quorum
+        if (hf_version >= cryptonote::network_version_13_enforce_checkpoints && total_nodes < CHECKPOINT_QUORUM_SIZE)
+          continue;
+
         pub_keys_indexes     = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
         result.checkpointing = quorum;
         num_workers          = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -104,6 +104,8 @@ namespace service_nodes {
 
   inline quorum_type max_quorum_type_for_hf(uint8_t hf_version)
   {
+    // TODO(loki): After switching to V13, we can change checkpointing quorums to activate on V13 since we delete all
+    // v12 checkpoints so we don't need quorum data for it and save some space
     quorum_type result = (hf_version <= cryptonote::network_version_11_infinite_staking) ? quorum_type::obligations
                                                                                          : quorum_type::checkpointing;
     assert(result != quorum_type::count);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -120,6 +120,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(loki_core_test_deregister_on_split);
     GENERATE_AND_PLAY(loki_core_test_state_change_ip_penalty_disallow_dupes);
     GENERATE_AND_PLAY(loki_service_nodes_alt_quorums);
+    GENERATE_AND_PLAY(loki_service_nodes_checkpoint_quorum_size);
     GENERATE_AND_PLAY(loki_service_nodes_gen_nodes);
     GENERATE_AND_PLAY(loki_service_nodes_test_rollback);
     GENERATE_AND_PLAY(loki_service_nodes_test_swarms_basic);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -847,6 +847,58 @@ bool loki_service_nodes_alt_quorums::generate(std::vector<test_event_entry>& eve
   return true;
 }
 
+bool loki_service_nodes_checkpoint_quorum_size::generate(std::vector<test_event_entry>& events)
+{
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = generate_sequential_hard_fork_table();
+  loki_chain_generator gen(events, hard_forks);
+
+  gen.add_blocks_until_version(hard_forks.back().first);
+  gen.add_n_blocks(40);
+  gen.add_mined_money_unlock_blocks();
+
+  std::vector<cryptonote::transaction> registration_txs(service_nodes::CHECKPOINT_QUORUM_SIZE - 1);
+  for (auto i = 0u; i < service_nodes::CHECKPOINT_QUORUM_SIZE - 1; ++i)
+    registration_txs[i] = gen.create_and_add_registration_tx(gen.first_miner());
+  gen.add_block(registration_txs);
+
+  int const MAX_TRIES = 16;
+  int tries           = 0;
+  for (; tries < MAX_TRIES; tries++)
+    gen.add_blocks_until_next_checkpointable_height();
+
+  uint64_t check_height_1 = gen.height();
+  loki_register_callback(events, "check_checkpoint_quorum_should_be_empty", [&events, check_height_1](cryptonote::core &c, size_t ev_index)
+  {
+    DEFINE_TESTS_ERROR_CONTEXT("check_checkpoint_quorum_should_be_empty");
+    std::shared_ptr<const service_nodes::testing_quorum> quorum = c.get_testing_quorum(service_nodes::quorum_type::checkpointing, check_height_1);
+    CHECK_TEST_CONDITION(quorum == nullptr);
+    return true;
+  });
+
+  cryptonote::transaction new_registration_tx = gen.create_and_add_registration_tx(gen.first_miner());
+  gen.add_block({new_registration_tx});
+
+  for (tries = 0; tries < MAX_TRIES; tries++)
+  {
+    gen.add_blocks_until_next_checkpointable_height();
+    std::shared_ptr<const service_nodes::testing_quorum> quorum = gen.get_testing_quorum(service_nodes::quorum_type::checkpointing, gen.height());
+    if (quorum && quorum->workers.size()) break;
+  }
+  assert(tries != MAX_TRIES);
+
+  uint64_t check_height_2 = gen.height();
+  loki_register_callback(events, "check_checkpoint_quorum_should_be_populated", [&events, check_height_2](cryptonote::core &c, size_t ev_index)
+  {
+    DEFINE_TESTS_ERROR_CONTEXT("check_checkpoint_quorum_should_be_populated");
+    std::shared_ptr<const service_nodes::testing_quorum> quorum = c.get_testing_quorum(service_nodes::quorum_type::checkpointing, check_height_2);
+    CHECK_TEST_CONDITION(quorum != nullptr);
+    CHECK_TEST_CONDITION(quorum->workers.size() > 0);
+    return true;
+  });
+
+  return true;
+}
+
 bool loki_service_nodes_gen_nodes::generate(std::vector<test_event_entry> &events)
 {
   const std::vector<std::pair<uint8_t, uint64_t>> hard_forks = generate_sequential_hard_fork_table(cryptonote::network_version_9_service_nodes);

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -48,6 +48,7 @@ struct loki_core_test_deregister_zero_fee                                       
 struct loki_core_test_deregister_on_split                                            : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_test_state_change_ip_penalty_disallow_dupes                         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_alt_quorums                                                : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct loki_service_nodes_checkpoint_quorum_size                                     : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_gen_nodes                                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_test_rollback                                              : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_test_swarms_basic                                          : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };


### PR DESCRIPTION
Enforce the minimum size for checkpoint quorums, so that the super majority (13) is a super majority of the expected size (20) and not just the min available size.

@jagerman