### PR TITLE
Report potential decommission recommission

### DIFF
--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -31,6 +31,9 @@
 
 #include <string>
 
+#define LOKI_HOUR(val) ((val) * LOKI_MINUTES(60))
+#define LOKI_MINUTES(val) val * 60
+
 #define LOKI_RPC_DOC_INTROSPECT
 namespace loki
 {

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -93,6 +93,21 @@ static constexpr HardFork::Params stagenet_hard_forks[] =
   { network_version_12_checkpointing,    213125, 0, 1561608000 }, // 2019-06-28 14:00 AEDT
 };
 
+uint64_t HardFork::get_hardcoded_hard_fork_height(network_type nettype, cryptonote::network_version version)
+{
+  uint64_t result = INVALID_HF_VERSION_HEIGHT;
+  for (const auto &record : cryptonote::HardFork::get_hardcoded_hard_forks(nettype))
+  {
+    if (record.version >= version)
+    {
+      result = record.height;
+      break;
+    }
+  }
+
+  return result;
+}
+
 HardFork::ParamsIterator HardFork::get_hardcoded_hard_forks(network_type nettype)
 {
   if (nettype == MAINNET)       return {mainnet_hard_forks, std::end(mainnet_hard_forks)};

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -47,6 +47,7 @@ namespace cryptonote
     };
 
     constexpr static uint8_t INVALID_HF_VERSION_FOR_HEIGHT = 255;
+    constexpr static uint64_t INVALID_HF_VERSION_HEIGHT    = static_cast<uint64_t>(-1);
     typedef enum {
       LikelyForked,
       UpdateNeeded,
@@ -66,6 +67,8 @@ namespace cryptonote
       constexpr Params const *end()   { return end_; };
     };
 
+    // NOTE: Returns INVALID_HF_VERSION_HEIGHT if version not specified for nettype
+    static uint64_t get_hardcoded_hard_fork_height(network_type nettype, cryptonote::network_version version);
     static ParamsIterator get_hardcoded_hard_forks(network_type nettype);
 
     /**

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -885,7 +885,7 @@ namespace cryptonote
      /**
       * @brief Record if the service node has checkpointed at this point in time
       */
-     void record_checkpoint_vote(crypto::public_key const &pubkey, bool voted) { m_service_node_list.record_checkpoint_vote(pubkey, voted); }
+     void record_checkpoint_vote(crypto::public_key const &pubkey, uint64_t height, bool voted) { m_service_node_list.record_checkpoint_vote(pubkey, height, voted); }
 
      /**
       * @brief Record the reachability status of node's storage server

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -80,6 +80,7 @@ namespace service_nodes
     bool voted_in_checkpoints     = true;
     bool storage_server_reachable = true;
 
+    char const *why() const;
     bool passed() const { return uptime_proved && voted_in_checkpoints && storage_server_reachable; }
   };
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -32,9 +32,9 @@ namespace service_nodes {
   constexpr uint64_t  CHECKPOINT_STORE_PERSISTENTLY_INTERVAL        = 60; // Persistently store the checkpoints at these intervals
   constexpr uint64_t  CHECKPOINT_VOTE_LIFETIME                      = CHECKPOINT_STORE_PERSISTENTLY_INTERVAL; // Keep the last 60 blocks worth of votes
 
-  constexpr int16_t CHECKPOINT_MIN_QUORUMS_NODE_MUST_VOTE_IN_BEFORE_DEREGISTER_CHECK = 8;
-  constexpr int16_t CHECKPOINT_MAX_MISSABLE_VOTES                                    = 4;
-  static_assert(CHECKPOINT_MAX_MISSABLE_VOTES < CHECKPOINT_MIN_QUORUMS_NODE_MUST_VOTE_IN_BEFORE_DEREGISTER_CHECK,
+  constexpr int16_t CHECKPOINT_NUM_QUORUMS_TO_PARTICIPATE_IN = 8;
+  constexpr int16_t CHECKPOINT_MAX_MISSABLE_VOTES            = 4;
+  static_assert(CHECKPOINT_MAX_MISSABLE_VOTES < CHECKPOINT_NUM_QUORUMS_TO_PARTICIPATE_IN,
                 "The maximum number of votes a service node can miss cannot be greater than the amount of checkpoint "
                 "quorums they must participate in before we check if they should be deregistered or not.");
 

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -131,13 +131,13 @@ t_command_server::t_command_server(
   m_command_lookup.set_handler(
       "print_sn"
     , std::bind(&t_command_parser_executor::print_sn, &m_parser, p::_1)
-    , "print_sn [<pubkey> [...]] [+json]"
+    , "print_sn [<pubkey> [...]] [+json|+detail]"
     , "Print service node registration info for the current height"
     );
   m_command_lookup.set_handler(
       "print_sn_status"
     , std::bind(&t_command_parser_executor::print_sn_status, &m_parser, p::_1)
-    , "print_sn_status [+json]"
+    , "print_sn_status [+json|+detail]"
     , "Print service node registration info for this service node"
     );
   m_command_lookup.set_handler(

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2739,7 +2739,6 @@ namespace cryptonote
     entry.requested_unlock_height       = info.requested_unlock_height;
     entry.last_reward_block_height      = info.last_reward_block_height;
     entry.last_reward_transaction_index = info.last_reward_transaction_index;
-    entry.last_uptime_proof             = info.proof->timestamp;
     entry.active                        = info.is_active();
     entry.funded                        = info.is_fully_funded();
     entry.state_height                  = info.is_fully_funded()
@@ -2779,6 +2778,16 @@ namespace cryptonote
     entry.portions_for_operator         = info.portions_for_operator;
     entry.operator_address              = cryptonote::get_account_address_as_str(m_core.get_nettype(), false/*is_subaddress*/, info.operator_address);
     entry.swarm_id                      = info.swarm_id;
+    entry.registration_hf_version       = info.registration_hf_version;
+
+    // NOTE: Service Node Testing
+    entry.last_uptime_proof                  = info.proof->timestamp;
+    entry.storage_server_reachable           = info.proof->storage_server_reachable;
+    entry.storage_server_reachable_timestamp = info.proof->storage_server_reachable_timestamp;
+    entry.version_major                      = info.proof->version_major;
+    entry.version_minor                      = info.proof->version_minor;
+    entry.version_patch                      = info.proof->version_patch;
+    entry.votes = std::vector<service_nodes::checkpoint_vote_record>(info.proof->votes.begin(), info.proof->votes.end());
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
@@ -2821,7 +2830,6 @@ namespace cryptonote
     {
       COMMAND_RPC_GET_SERVICE_NODES::response::entry entry = {};
       fill_sn_response_entry(entry, pubkey_info, height);
-
       res.service_node_states.push_back(entry);
     }
 


### PR DESCRIPTION
Commit on top of: https://github.com/loki-project/loki/pull/841

```
    Report portential decomission and recommission for your node

    When processing a quorum for a block, if you are not in the quorum to
    validate other nodes, check if you're a node that is going to be tested.
    If you are, check based on your current data if you're potentially
    a candidate to be decommissioned/deregistered and if so report it to the
    console log.

    Note that this is only a heuristic and ultimately the decision lies on
    what the the other Service Nodes perceive the current state of your node
    is (i.e. if they're acting malicious then you will be deregistered
    irrespectively).
```

@jagerman

I'm not sure if this is desired, I found it a bit helpful for debugging on testnet, but it is just a heuristic on why you might be getting decomm/deregistered. Maybe it will lead to more questions than answers by other operators if it says one thing but your node gets affected otherwise.

Also not sure if my reorganizing of the process quorum loop made it more complicated or easier to understand.

It prints something like

```
Service node (yours) is active but is not passing tests for quorum: 100000
Service Node is passing all tests, if decommissioned, you will be recommissioned if status is maintained by the next quorum
```

or 

```
2019-09-17 06:57:26.140	I Temporary decommission for service node (yours): <b4d5d5336107fff5878d339f8de296e92f1014b071bb8377196d9afa36cd6277>
2019-09-17 06:59:24.322	I Submitted uptime-proof for service node (yours): <b4d5d5336107fff5878d339f8de296e92f1014b071bb8377196d9afa36cd6277>
2019-09-17 07:00:58.516	W Service Node (yours) is currently decommissioned and being tested in quorum: 129195
2019-09-17 07:00:58.516	W Service Node is currently failing the following tests: Uptime proof missing. Note: Storage server may not be reachable. This is only testable by an external Service Node.
2019-09-17 07:04:24.366	I Submitted uptime-proof for service node (yours): <b4d5d5336107fff5878d339f8de296e92f1014b071bb8377196d9afa36cd6277>

```
etcetera

Also there might be some potential with further networking improvements that we could contact the nodes in the quorum to figure out exactly why they're failing us.