### PR TITLE
Uptime proof relaying robustness

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1411,14 +1411,14 @@ namespace cryptonote
     NOTIFY_UPTIME_PROOF::request req = m_service_node_list.generate_uptime_proof(m_service_node_pubkey, m_service_node_key, m_sn_public_ip, m_storage_port);
 
     cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
-    bool relayed = get_protocol()->relay_uptime_proof(req, fake_context, true /*force_relay*/);
+    bool relayed = get_protocol()->relay_uptime_proof(req, fake_context);
     if (relayed)
       MGINFO("Submitted uptime-proof for Service Node (yours): " << m_service_node_pubkey);
 
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation)
+  bool core::handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool &my_uptime_proof_confirmation)
   {
     return m_service_node_list.handle_uptime_proof(proof, my_uptime_proof_confirmation);
   }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1413,7 +1413,7 @@ namespace cryptonote
     cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
     bool relayed = get_protocol()->relay_uptime_proof(req, fake_context, true /*force_relay*/);
     if (relayed)
-      MGINFO("Submitted uptime-proof for service node (yours): " << m_service_node_pubkey);
+      MGINFO("Submitted uptime-proof for Service Node (yours): " << m_service_node_pubkey);
 
     return true;
   }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1418,9 +1418,9 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof)
+  bool core::handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation)
   {
-    return m_service_node_list.handle_uptime_proof(proof);
+    return m_service_node_list.handle_uptime_proof(proof, my_uptime_proof_confirmation);
   }
   //-----------------------------------------------------------------------------------------------
   void core::on_transaction_relayed(const cryptonote::blobdata& tx_blob)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -117,7 +117,7 @@ namespace cryptonote
       *
       * @return true if we haven't seen it before and thus need to relay.
       */
-     bool handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation);
+     bool handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool &my_uptime_proof_confirmation);
 
      /**
       * @brief handles an incoming transaction

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -117,7 +117,7 @@ namespace cryptonote
       *
       * @return true if we haven't seen it before and thus need to relay.
       */
-     bool handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof);
+     bool handle_uptime_proof(const NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation);
 
      /**
       * @brief handles an incoming transaction

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1893,7 +1893,7 @@ namespace service_nodes
     return result;
   }
 
-  bool service_node_list::handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool *my_uptime_proof_confirmation)
+  bool service_node_list::handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation)
   {
     uint8_t const hf_version = m_blockchain.get_current_hard_fork_version();
     uint64_t const now       = time(nullptr);
@@ -1964,12 +1964,12 @@ namespace service_nodes
 
     if (m_service_node_pubkey && (proof.pubkey == *m_service_node_pubkey))
     {
-      *my_uptime_proof_confirmation = true;
+      my_uptime_proof_confirmation = true;
       MGINFO("Received uptime-proof confirmation back from network for Service Node (yours): " << proof.pubkey);
     }
     else
     {
-      *my_uptime_proof_confirmation = false;
+      my_uptime_proof_confirmation = false;
       LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
     }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1893,7 +1893,7 @@ namespace service_nodes
     return result;
   }
 
-  bool service_node_list::handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof)
+  bool service_node_list::handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool *my_uptime_proof_confirmation)
   {
     uint8_t const hf_version = m_blockchain.get_current_hard_fork_version();
     uint64_t const now       = time(nullptr);
@@ -1963,9 +1963,15 @@ namespace service_nodes
     }
 
     if (m_service_node_pubkey && (proof.pubkey == *m_service_node_pubkey))
+    {
+      *my_uptime_proof_confirmation = true;
       MGINFO("Received uptime-proof confirmation back from network for Service Node (yours): " << proof.pubkey);
+    }
     else
+    {
+      *my_uptime_proof_confirmation = false;
       LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
+    }
 
     auto &iproof = *info.proof;
     iproof.update_timestamp(now);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1962,7 +1962,11 @@ namespace service_nodes
       return false;
     }
 
-    LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
+    if (m_service_node_pubkey && (proof.pubkey == *m_service_node_pubkey))
+      MGINFO("Received uptime-proof confirmation back from network for Service Node (yours): " << proof.pubkey);
+    else
+      LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
+
     auto &iproof = *info.proof;
     iproof.update_timestamp(now);
     iproof.version_major = proof.snode_version_major;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -281,7 +281,7 @@ namespace service_nodes
 
     /// Record public ip and storage port and add them to the service node list
     cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(crypto::public_key const &pubkey, crypto::secret_key const &key, uint32_t public_ip, uint16_t storage_port) const;
-    bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool *my_uptime_proof_confirmation);
+    bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation);
     void record_checkpoint_vote     (crypto::public_key const &pubkey, bool voted);
 
     bool set_storage_server_peer_reachable(crypto::public_key const &pubkey, bool value);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -281,7 +281,7 @@ namespace service_nodes
 
     /// Record public ip and storage port and add them to the service node list
     cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(crypto::public_key const &pubkey, crypto::secret_key const &key, uint32_t public_ip, uint16_t storage_port) const;
-    bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof);
+    bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool *my_uptime_proof_confirmation);
     void record_checkpoint_vote     (crypto::public_key const &pubkey, bool voted);
 
     bool set_storage_server_peer_reachable(crypto::public_key const &pubkey, bool value);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -159,7 +159,7 @@ namespace cryptonote
 
     virtual bool relay_block(NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
-    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context, bool force_relay);
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -727,10 +727,34 @@ namespace cryptonote
   int t_cryptonote_protocol_handler<t_core>::handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context)
   {
     MLOG_P2P_MESSAGE("Received NOTIFY_UPTIME_PROOF");
-    if(context.m_state != cryptonote_connection_context::state_normal)
+    if(context.m_state <= cryptonote_connection_context::state_synchronizing)
       return 1;
-    if (m_core.handle_uptime_proof(arg))
-      relay_uptime_proof(arg, context, false /*force_relay*/);
+
+    // NOTE: Don't relay your own uptime proof, otherwise we have the following situation
+
+    // Node1 sends uptime ->
+    // Node2 receives uptime and relays it back to Node1 for acknowledgement ->
+    // Node1 receives it, handle_uptime_proof returns true to acknowledge, Node1 tries to resend to the same peers again
+
+    // Instead, if we receive our own uptime proof, then acknowledge but don't
+    // send on. If the we are missing an uptime proof it will have been
+    // submitted automatically by the daemon itself instead of
+    // using my own proof relayed by other nodes.
+
+    (void)context;
+    bool my_uptime_proof_confirmation = false;
+    if (m_core.handle_uptime_proof(arg, &my_uptime_proof_confirmation))
+    {
+      if (!my_uptime_proof_confirmation)
+      {
+        // NOTE: The default exclude context contains the peer who sent us this
+        // uptime proof, we want to ensure we relay it back so they know that the
+        // peer they relayed to received their uptime and confirm it, so send in an
+        // empty context so we don't omit the source peer from the relay back.
+        cryptonote_connection_context empty_context = {};
+        relay_uptime_proof(arg, empty_context, false /*force_relay*/);
+      }
+    }
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------  

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -727,9 +727,6 @@ namespace cryptonote
   int t_cryptonote_protocol_handler<t_core>::handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context)
   {
     MLOG_P2P_MESSAGE("Received NOTIFY_UPTIME_PROOF");
-    if(context.m_state <= cryptonote_connection_context::state_synchronizing)
-      return 1;
-
     // NOTE: Don't relay your own uptime proof, otherwise we have the following situation
 
     // Node1 sends uptime ->
@@ -743,7 +740,7 @@ namespace cryptonote
 
     (void)context;
     bool my_uptime_proof_confirmation = false;
-    if (m_core.handle_uptime_proof(arg, &my_uptime_proof_confirmation))
+    if (m_core.handle_uptime_proof(arg, my_uptime_proof_confirmation))
     {
       if (!my_uptime_proof_confirmation)
       {
@@ -752,7 +749,7 @@ namespace cryptonote
         // peer they relayed to received their uptime and confirm it, so send in an
         // empty context so we don't omit the source peer from the relay back.
         cryptonote_connection_context empty_context = {};
-        relay_uptime_proof(arg, empty_context, false /*force_relay*/);
+        relay_uptime_proof(arg, empty_context);
       }
     }
     return 1;
@@ -2231,11 +2228,8 @@ skip:
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>
-  bool t_cryptonote_protocol_handler<t_core>::relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context, bool force_relay)
+  bool t_cryptonote_protocol_handler<t_core>::relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)
   {
-    if (!is_synchronized() && !force_relay)
-      return false;
-
     bool result = relay_to_synchronized_peers<NOTIFY_UPTIME_PROOF>(arg, exclude_context);
     return result;
   }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -42,7 +42,7 @@ namespace cryptonote
   {
     virtual bool relay_block(NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& exclude_context)=0;
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)=0;
-    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context, bool force_relay)=0;
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
@@ -64,7 +64,7 @@ namespace cryptonote
     {
       return false;
     }
-    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context, bool force_relay)
+    virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)
     {
       return false;
     }

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -223,7 +223,7 @@ bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_
     return true;
 }
 
-bool tests::proxy_core::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof)
+bool tests::proxy_core::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation)
 {
   // TODO: add tests for core uptime proof checking.
   return false; // never relay these for tests.

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -223,7 +223,7 @@ bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_
     return true;
 }
 
-bool tests::proxy_core::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation)
+bool tests::proxy_core::handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool &my_uptime_proof_confirmation)
 {
   // TODO: add tests for core uptime proof checking.
   return false; // never relay these for tests.

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -79,7 +79,7 @@ namespace tests
     bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blobs, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t *checkpoint, bool update_miner_blocktemplate = true);
-    bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof);
+    bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation);
     void pause_mine(){}
     void resume_mine(){}
     bool on_idle(){return true;}

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -79,7 +79,7 @@ namespace tests
     bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blobs, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay);
     bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t *checkpoint, bool update_miner_blocktemplate = true);
-    bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation);
+    bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool &my_uptime_proof_confirmation);
     void pause_mine(){}
     void resume_mine(){}
     bool on_idle(){return true;}

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -55,7 +55,7 @@ public:
   bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blob, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t const *checkpoint, bool update_miner_blocktemplate = true) { return true; }
-  bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) { return false; }
+  bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation) { return false; }
   void pause_mine(){}
   void resume_mine(){}
   bool on_idle(){return true;}

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -55,7 +55,7 @@ public:
   bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blob, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t const *checkpoint, bool update_miner_blocktemplate = true) { return true; }
-  bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool *my_uptime_proof_confirmation) { return false; }
+  bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, bool &my_uptime_proof_confirmation) { return false; }
   void pause_mine(){}
   void resume_mine(){}
   bool on_idle(){return true;}


### PR DESCRIPTION
- Upon receipt of an uptime proof, ensure it gets relayed back to the source peer so they get confirmation that the proof was received, rather than wait for a new set of peers to re-relay it back to you.

- Remove is_synchronized() check which can change inbetween handling the uptime proof and attempting to relay it by another thread.

- Change handle_uptime_proof to reject proofs from peers using `<= state_synchronizing` so it pairs up with relay_to_synchronized_peers which only relays to peers whose `state > state_synchronizing`

@jagerman