### PR TITLE
Use pre-penalty base reward for non-miner block reward

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -117,7 +117,7 @@ namespace cryptonote {
   /************************************************************************/
   size_t get_min_block_weight(uint8_t version);
   size_t get_max_tx_size();
-  bool get_base_block_reward(size_t median_weight, size_t current_block_weight, uint64_t already_generated_coins, uint64_t &reward, uint8_t version, uint64_t height);
+  bool get_base_block_reward(size_t median_weight, size_t current_block_weight, uint64_t already_generated_coins, uint64_t &reward, uint64_t &reward_unpenalized, uint8_t version, uint64_t height);
   uint8_t get_account_address_checksum(const public_address_outer_blob& bl);
   uint8_t get_account_integrated_address_checksum(const public_integrated_address_outer_blob& bl);
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1249,15 +1249,15 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
 
   if (already_generated_coins != 0 && block_has_governance_output(nettype(), b))
   {
-    if (version >= network_version_10_bulletproofs && reward_parts.governance == 0)
+    if (version >= network_version_10_bulletproofs && reward_parts.governance_paid == 0)
     {
       MERROR("Governance reward should not be 0 after hardfork v10 if this height has a governance output because it is the batched payout height");
       return false;
     }
 
-    if (b.miner_tx.vout.back().amount != reward_parts.governance)
+    if (b.miner_tx.vout.back().amount != reward_parts.governance_paid)
     {
-      MERROR("Governance reward amount incorrect.  Should be: " << print_money(reward_parts.governance) << ", is: " << print_money(b.miner_tx.vout.back().amount));
+      MERROR("Governance reward amount incorrect.  Should be: " << print_money(reward_parts.governance_paid) << ", is: " << print_money(b.miner_tx.vout.back().amount));
       return false;
     }
 
@@ -1285,7 +1285,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     }
   }
 
-  base_reward = reward_parts.adjusted_base_reward;
+  base_reward = reward_parts.base_miner + reward_parts.governance_paid + reward_parts.service_node_paid;
   if(base_reward + fee < money_in_use)
   {
     MERROR_VER("coinbase transaction spend too much money (" << print_money(money_in_use) << "). Block reward is " << print_money(base_reward) << "(" << print_money(base_reward) << "+" << print_money(fee) << ")");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3428,8 +3428,8 @@ bool Blockchain::check_fee(size_t tx_weight, size_t tx_outs, uint64_t fee) const
 
   uint64_t median = m_current_block_cumul_weight_limit / 2;
   uint64_t already_generated_coins = blockchain_height ? m_db->get_block_already_generated_coins(blockchain_height - 1) : 0;;
-  uint64_t base_reward = 0;
-  if (!get_base_block_reward(median, 1, already_generated_coins, base_reward, version, blockchain_height))
+  uint64_t base_reward, base_reward_unpenalized;
+  if (!get_base_block_reward(median, 1, already_generated_coins, base_reward, base_reward_unpenalized, version, blockchain_height))
     return false;
 
   uint64_t needed_fee;
@@ -3483,8 +3483,8 @@ byte_and_output_fees Blockchain::get_dynamic_base_fee_estimate(uint64_t grace_bl
     median = min_block_weight;
 
   uint64_t already_generated_coins = db_height ? m_db->get_block_already_generated_coins(db_height - 1) : 0;
-  uint64_t base_reward;
-  if (!get_base_block_reward(median, 1, already_generated_coins, base_reward, version, m_db->height()))
+  uint64_t base_reward, base_reward_unpenalized;
+  if (!get_base_block_reward(median, 1, already_generated_coins, base_reward, base_reward_unpenalized, version, m_db->height()))
   {
     MERROR("Failed to determine block reward, using placeholder " << print_money(BLOCK_REWARD_OVERESTIMATE) << " as a high bound");
     base_reward = BLOCK_REWARD_OVERESTIMATE;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -75,20 +75,15 @@ namespace cryptonote
     uint64_t service_node_total;
     uint64_t service_node_paid;
 
-    uint64_t governance;
+    uint64_t governance_due;
+    uint64_t governance_paid;
+
     uint64_t base_miner;
     uint64_t base_miner_fee;
 
-    // NOTE: Post hardfork 10, adjusted base reward is the block reward with the
-    // governance amount removed. We still need the original base reward, so
-    // that we can calculate the 50% on the whole base amount, that should be
-    // allocated for the service node and fees.
-
-    // If this block contains the batched governance payment, this is
-    // included in the adjusted base reward.
-
-    // Before hardfork 10, this is the same value as original_base_reward
-    uint64_t adjusted_base_reward;
+    /// The base block reward from which non-miner amounts (i.e. SN rewards and governance fees) are
+    /// calculated.  Before HF 13 this was (mistakenly) reduced by the block size penalty for
+    /// exceeding the median block size; starting in HF 13 the miner pays the full penalty.
     uint64_t original_base_reward;
 
     uint64_t miner_reward() { return base_miner + base_miner_fee; }


### PR DESCRIPTION
The miner base reward can be optionally reduced if the block producer
chooses to take extra tx fees beyond the median block limit, but that
shouldn't affect SN or governance fees (since they receive none of the
tx fees, they shouldn't pay any penalty for adding extra txes).

This changes the code starting with HF13 to use the unpenalized base
reward for the SN and goverance fee calculations.