### PR TITLE
Dont form invalid block_extended_infos

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5055,7 +5055,7 @@ std::list<std::pair<Blockchain::block_extended_info,std::vector<crypto::hash>>> 
     }
 
     checkpoint_t checkpoint = {};
-    if (checkpoint_blob)
+    if (data.checkpointed && checkpoint_blob)
     {
       if (!t_serializable_object_from_blob(checkpoint, *checkpoint_blob))
         MERROR("Failed to parse checkpoint from blob");
@@ -5064,7 +5064,7 @@ std::list<std::pair<Blockchain::block_extended_info,std::vector<crypto::hash>>> 
     cryptonote::block block;
     if (cryptonote::parse_and_validate_block_from_blob(*block_blob, block))
     {
-      block_extended_info bei(data, std::move(block), &checkpoint);
+      block_extended_info bei(data, std::move(block), data.checkpointed ? &checkpoint : nullptr);
       alt_blocks.insert(std::make_pair(cryptonote::get_block_hash(bei.bl), std::move(bei)));
     }
     else

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1073,7 +1073,7 @@ namespace cryptonote
     std::unique_ptr<boost::asio::io_service::work> m_async_work_idle;
 
     // some invalid blocks
-    blocks_ext_by_hash m_invalid_blocks;     // crypto::hash -> block_extended_info
+    std::set<crypto::hash> m_invalid_blocks;
 
     std::vector<BlockAddedHook*> m_block_added_hooks;
     std::vector<BlockchainDetachedHook*> m_blockchain_detached_hooks;
@@ -1357,20 +1357,7 @@ namespace cryptonote
      *
      * @return false if the block cannot be stored for some reason, otherwise true
      */
-    bool add_block_as_invalid(const block& bl, const crypto::hash& h);
-
-    /**
-     * @brief stores an invalid block in a separate container
-     *
-     * Storing invalid blocks allows quick dismissal of the same block
-     * if it is seen again.
-     *
-     * @param bei the invalid block (see ::block_extended_info)
-     * @param h the block's hash
-     *
-     * @return false if the block cannot be stored for some reason, otherwise true
-     */
-    bool add_block_as_invalid(const block_extended_info& bei, const crypto::hash& h);
+    bool add_block_as_invalid(const cryptonote::block &block);
 
     /**
      * @brief checks a block's timestamp


### PR DESCRIPTION
Don't try to add the empty checkpoint to a block_extended_info if it doesn't have a checkpoint in the first place.

Further minor change, only store block hashes for invalid blocks as we only need the hash to instantly reject blocks from P2P.

Fixes a crash I had on Mainnet over the weekend when trying to query the alt chains I had received where I was received non checkpointed blocks but the block_extended_info was being constructed with an empty checkpoint causes an assertion to trigger.

@jagerman