### PR TITLE
Make empty quorum if height is checkpointable but insufficient nodes

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1231,15 +1231,18 @@ namespace service_nodes
 
         // TODO(loki): We can remove after switching to V13 since we delete all V12 and below checkpoints where we introduced this kind of quorum
         if (hf_version >= cryptonote::network_version_13_enforce_checkpoints && total_nodes < CHECKPOINT_QUORUM_SIZE)
-          continue;
-
-        pub_keys_indexes     = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
-        result.checkpointing = quorum;
-
-        if ((state.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) >= hf13_height)
-          num_validators = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+        {
+          // NOTE: Although insufficient nodes, generate the empty quorum so we can distinguish between a height with
+          // insufficient service nodes for a quorum VS a height that shouldn't generate a quorum so that we can report
+          // an error to the user if they're missing a quorum
+        }
         else
-          num_workers = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+        {
+          pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
+          num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+        }
+
+        result.checkpointing = quorum;
       }
       else
       {

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -913,7 +913,8 @@ bool loki_service_nodes_checkpoint_quorum_size::generate(std::vector<test_event_
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_checkpoint_quorum_should_be_empty");
     std::shared_ptr<const service_nodes::testing_quorum> quorum = c.get_testing_quorum(service_nodes::quorum_type::checkpointing, check_height_1);
-    CHECK_TEST_CONDITION(quorum == nullptr);
+    CHECK_TEST_CONDITION(quorum != nullptr);
+    CHECK_TEST_CONDITION(quorum->validators.size() == 0);
     return true;
   });
 


### PR DESCRIPTION
This is so that we can validly print an error in quorum_cop on the
heights that are actually not being stored in the daemon VS a service
node network that has insufficient nodes to form the quorum.

Update core test to enforce this constraint

@jagerman