### PR TITLE
Make various msgs clearer

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2528,7 +2528,7 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     if (entry.storage_server_reachable_timestamp == 0)
       stream << "Awaiting first test";
     else
-      stream << get_human_time_ago(entry.storage_server_reachable_timestamp, now);
+      stream << "Last checked: " << get_human_time_ago(entry.storage_server_reachable_timestamp, now);
     stream << ")\n";
 
     stream << indent2 <<  "Checkpoint Participation [Height: Voted]: ";


### PR DESCRIPTION
Also don't print self-test failures too early, check that your can be voted on before reporting an error (i.e. if you re-register quickly after deregistration you may still be in the old quorums. Other nodes are unable to vote for this, so you can't fail the test for that height).

@jagerman