### PR TITLE
Relax p2p connection restrictions for non-mainnet

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1393,7 +1393,7 @@ namespace nodetool
       size_t idx = 0, skipped = 0;
       for (int step = 0; step < 2; ++step)
       {
-        bool skip_duplicate_class_B = step == 0;
+        bool skip_duplicate_class_B = step == 0 && m_nettype == cryptonote::MAINNET;
         zone.m_peerlist.foreach (use_white_list, [&classB, &filtered, &idx, &skipped, skip_duplicate_class_B, limit, next_needed_pruning_stripe](const peerlist_entry &pe){
           if (filtered.size() >= limit)
             return false;
@@ -2520,7 +2520,7 @@ namespace nodetool
     if (address.get_zone() != epee::net_utils::zone::public_)
       return false; // Unable to determine how many connections from host
 
-    const size_t max_connections = 1;
+    const size_t max_connections = m_nettype == cryptonote::MAINNET ? 1 : 20;
     size_t count = 0;
 
     m_network_zones.at(epee::net_utils::zone::public_).m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)


### PR DESCRIPTION
Our testnet IP distribution is far from distributed: the 1-connection-per-IP and skipping duplicate class B IPs are more of a nuissance rather than anything useful on testnet.

This turns off both when not on mainnet: the class B checking is disabled, and the connections per IP becomes 20 instead of 1.