### PR TITLE
Changes to show checkpointedness of transactions

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -192,6 +192,12 @@ namespace cryptonote
     ++res.height; // turn top block height into blockchain height
     res.top_block_hash = string_tools::pod_to_hex(top_hash);
     res.target_height = m_core.get_target_blockchain_height();
+
+    res.immutable_height = 0;
+    cryptonote::checkpoint_t checkpoint;
+    if (m_core.get_blockchain_storage().get_db().get_immutable_checkpoint(&checkpoint, res.height - 1))
+      res.immutable_height = checkpoint.height;
+
     res.difficulty = m_core.get_blockchain_storage().get_difficulty_for_next_block();
     res.target = m_core.get_blockchain_storage().get_difficulty_target();
     res.tx_count = m_core.get_blockchain_storage().get_total_transactions() - res.height; //without coinbase

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -775,6 +775,7 @@ namespace cryptonote
       std::string status;                   // General RPC error code. "OK" means everything looks good.
       uint64_t height;                      // Current length of longest chain known to daemon.
       uint64_t target_height;               // The height of the next block in the chain.
+      uint64_t immutable_height;            // The latest height in the blockchain that can not be reorganized from (backed by atleast 2 Service Node, or 1 hardcoded checkpoint, 0 if N/A).
       uint64_t difficulty;                  // Network difficulty (analogous to the strength of the network).
       uint64_t target;                      // Current target for next proof of work.
       uint64_t tx_count;                    // Total number of non-coinbase transaction in the chain.
@@ -810,6 +811,7 @@ namespace cryptonote
         KV_SERIALIZE(status)
         KV_SERIALIZE(height)
         KV_SERIALIZE(target_height)
+        KV_SERIALIZE(immutable_height)
         KV_SERIALIZE(difficulty)
         KV_SERIALIZE(target)
         KV_SERIALIZE(tx_count)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7946,12 +7946,13 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
       }
     }
 
-    auto formatter = boost::format("%8.8llu %6.6s %8.8s %16.16s %20.20s %s %s %14.14s %s %s - %s");
+    auto formatter = boost::format("%8.8llu %6.6s %8.8s %12.12s %16.16s %20.20s %s %s %14.14s %s %s - %s");
 
     message_writer(color, false) << formatter
       % transfer.block
       % tools::pay_type_string(transfer.type)
       % transfer.lock_msg
+      % (transfer.checkpointed ? "checkpointed" : "no")
       % tools::get_human_readable_timestamp(transfer.timestamp)
       % print_money(transfer.amount)
       % string_tools::pod_to_hex(transfer.hash)
@@ -9265,6 +9266,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
         else
           success_msg_writer() << "locked for " << tools::get_human_readable_timespan(std::chrono::seconds(pd.m_unlock_time - threshold));
       }
+      success_msg_writer() << "Checkpointed: " << (pd.m_block_height <= m_wallet->get_immutable_height() ? "Yes" : "No");
       success_msg_writer() << "Address index: " << pd.m_subaddr_index.minor;
       success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
       return true;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -280,7 +280,7 @@ namespace cryptonote
     std::pair<std::string, std::string> show_outputs_line(const std::vector<uint64_t> &heights, uint64_t blockchain_height, uint64_t highlight_height = std::numeric_limits<uint64_t>::max()) const;
     bool freeze_thaw(const std::vector<std::string>& args, bool freeze);
 
-    bool get_transfers(std::vector<std::string>& args_, std::vector<tools::wallet2::transfer_view>& transfers);
+    bool get_transfers(std::vector<std::string>& args_, std::vector<tools::transfer_view>& transfers);
 
     /*!
      * \brief Prints the seed with a nice message

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -58,6 +58,7 @@ void NodeRPCProxy::invalidate()
   m_contributed_service_nodes.clear();
 
   m_height = 0;
+  m_immutable_height = 0;
   for (size_t n = 0; n < 256; ++n)
     m_earliest_height[n] = 0;
   m_dynamic_base_fee_estimate = {0, 0};
@@ -93,6 +94,8 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
 void NodeRPCProxy::set_height(uint64_t h)
 {
   m_height = h;
+  if (h < m_immutable_height)
+      m_immutable_height = 0;
 }
 
 boost::optional<std::string> NodeRPCProxy::get_info() const
@@ -115,6 +118,7 @@ boost::optional<std::string> NodeRPCProxy::get_info() const
     m_height = resp_t.height;
     m_target_height = resp_t.target_height;
     m_block_weight_limit = resp_t.block_weight_limit ? resp_t.block_weight_limit : resp_t.block_size_limit;
+    m_immutable_height = resp_t.immutable_height;
     m_get_info_time = now;
   }
   return boost::optional<std::string>();
@@ -135,6 +139,15 @@ boost::optional<std::string> NodeRPCProxy::get_target_height(uint64_t &height) c
   if (res)
     return res;
   height = m_target_height;
+  return boost::optional<std::string>();
+}
+
+boost::optional<std::string> NodeRPCProxy::get_immutable_height(uint64_t &height) const
+{
+  auto res = get_info();
+  if (res)
+    return res;
+  height = m_immutable_height;
   return boost::optional<std::string>();
 }
 

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -49,6 +49,7 @@ public:
   boost::optional<std::string> get_height(uint64_t &height) const;
   void set_height(uint64_t h);
   boost::optional<std::string> get_target_height(uint64_t &height) const;
+  boost::optional<std::string> get_immutable_height(uint64_t &height) const;
   boost::optional<std::string> get_block_weight_limit(uint64_t &block_weight_limit) const;
   boost::optional<std::string> get_earliest_height(uint8_t version, uint64_t &earliest_height) const;
   boost::optional<std::string> get_dynamic_base_fee_estimate(uint64_t grace_blocks, cryptonote::byte_and_output_fees &fees) const;
@@ -80,6 +81,7 @@ private:
   mutable std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> m_contributed_service_nodes;
 
   mutable uint64_t m_height;
+  mutable uint64_t m_immutable_height;
   mutable uint64_t m_earliest_height[256];
   mutable cryptonote::byte_and_output_fees m_dynamic_base_fee_estimate;
   mutable uint64_t m_dynamic_base_fee_estimate_cached_height;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5765,14 +5765,9 @@ void wallet2::get_transfers(wallet2::transfer_container& incoming_transfers) con
   incoming_transfers = m_transfers;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-static void set_confirmations(wallet2::transfer_view &entry, uint64_t blockchain_height, uint64_t block_reward)
+static void set_confirmations(transfer_view &entry, uint64_t blockchain_height, uint64_t block_reward)
 {
-  std::string block;
-  if (entry.block.type() == typeid(std::string))
-  {
-    block = boost::get<std::string>(entry.block);
-  }
-  if (entry.height >= blockchain_height || (entry.height == 0 && ((block != "pending") || (block != "pool"))))
+  if (entry.height >= blockchain_height || (entry.height == 0 && ((entry.type != "pending") || (entry.type != "pool"))))
     entry.confirmations = 0;
   else
     entry.confirmations = blockchain_height - entry.height;
@@ -5783,120 +5778,126 @@ static void set_confirmations(wallet2::transfer_view &entry, uint64_t blockchain
     entry.suggested_confirmations_threshold = (entry.amount + block_reward - 1) / block_reward;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &txid, const crypto::hash &payment_id, const tools::wallet2::payment_details &pd) const
+transfer_view wallet2::make_transfer_view(const crypto::hash &txid, const crypto::hash &payment_id, const tools::wallet2::payment_details &pd) const
 {
-  entry.txid = string_tools::pod_to_hex(pd.m_tx_hash);
-  entry.hash = txid;
-  entry.payment_id = string_tools::pod_to_hex(payment_id);
-  if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-    entry.payment_id = entry.payment_id.substr(0,16);
-  entry.height = pd.m_block_height;
-  entry.block = entry.height;
-  entry.timestamp = pd.m_timestamp;
-  entry.amount = pd.m_amount;
-  entry.unlock_time = pd.m_unlock_time;
-  entry.fee = pd.m_fee;
-  entry.note = get_tx_note(pd.m_tx_hash);
-  entry.type = pd.m_type;
-  entry.subaddr_index = pd.m_subaddr_index;
-  entry.subaddr_indices.push_back(pd.m_subaddr_index);
-  entry.address = get_subaddress_as_str(pd.m_subaddr_index);
-  entry.confirmed = true;
+  transfer_view result = {};
+  result.txid = string_tools::pod_to_hex(pd.m_tx_hash);
+  result.hash = txid;
+  result.payment_id = string_tools::pod_to_hex(payment_id);
+  if (result.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+    result.payment_id = result.payment_id.substr(0,16);
+  result.height = pd.m_block_height;
+  result.timestamp = pd.m_timestamp;
+  result.amount = pd.m_amount;
+  result.unlock_time = pd.m_unlock_time;
+  result.fee = pd.m_fee;
+  result.note = get_tx_note(pd.m_tx_hash);
+  result.pay_type = pd.m_type;
+  result.subaddr_index = pd.m_subaddr_index;
+  result.subaddr_indices.push_back(pd.m_subaddr_index);
+  result.address = get_subaddress_as_str(pd.m_subaddr_index);
+  result.confirmed = true;
   // TODO(sacha): is this just for in or also coinbase?
-  const bool unlocked = is_transfer_unlocked(entry.unlock_time, entry.height);
-  entry.lock_msg = unlocked ? "unlocked" : "locked";
-  set_confirmations(entry, get_blockchain_current_height(), get_last_block_reward());
-  entry.checkpointed = entry.height <= m_immutable_height;
+  const bool unlocked = is_transfer_unlocked(result.unlock_time, result.height);
+  result.lock_msg = unlocked ? "unlocked" : "locked";
+  set_confirmations(result, get_blockchain_current_height(), get_last_block_reward());
+  result.checkpointed = result.height <= m_immutable_height;
+  return result;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void wallet2::fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &txid, const tools::wallet2::confirmed_transfer_details &pd) const
+transfer_view wallet2::wallet2::make_transfer_view(const crypto::hash &txid, const tools::wallet2::confirmed_transfer_details &pd) const
 {
-  entry.txid = string_tools::pod_to_hex(txid);
-  entry.hash = txid;
-  entry.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
-  if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-    entry.payment_id = entry.payment_id.substr(0,16);
-  entry.height = pd.m_block_height;
-  entry.block = entry.height;
-  entry.timestamp = pd.m_timestamp;
-  entry.unlock_time = pd.m_unlock_time;
-  entry.fee = pd.m_amount_in - pd.m_amount_out;
+  transfer_view result = {};
+  result.txid = string_tools::pod_to_hex(txid);
+  result.hash = txid;
+  result.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
+  if (result.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+    result.payment_id = result.payment_id.substr(0,16);
+  result.height = pd.m_block_height;
+  result.timestamp = pd.m_timestamp;
+  result.unlock_time = pd.m_unlock_time;
+  result.fee = pd.m_amount_in - pd.m_amount_out;
   uint64_t change = pd.m_change == (uint64_t)-1 ? 0 : pd.m_change; // change may not be known
-  entry.amount = pd.m_amount_in - change - entry.fee;
-  entry.note = get_tx_note(txid);
+  result.amount = pd.m_amount_in - change - result.fee;
+  result.note = get_tx_note(txid);
 
   for (const auto &d: pd.m_dests) {
-    entry.destinations.push_back(wallet2::transfer_view::dest_output());
-    wallet2::transfer_view::dest_output &td = entry.destinations.back();
+    result.destinations.push_back({});
+    transfer_destination &td = result.destinations.back();
     td.amount = d.amount;
     td.address = d.original.empty() ? get_account_address_as_str(nettype(), d.is_subaddress, d.addr) : d.original;
   }
 
-  entry.type = pay_type::out;
-  entry.subaddr_index = { pd.m_subaddr_account, 0 };
+  result.pay_type = pay_type::out;
+  result.subaddr_index = { pd.m_subaddr_account, 0 };
   for (uint32_t i: pd.m_subaddr_indices)
-    entry.subaddr_indices.push_back({pd.m_subaddr_account, i});
-  entry.address = get_subaddress_as_str({pd.m_subaddr_account, 0});
-  entry.confirmed = true;
-  entry.checkpointed = entry.height <= m_immutable_height;
-  set_confirmations(entry, get_blockchain_current_height(), get_last_block_reward());
+    result.subaddr_indices.push_back({pd.m_subaddr_account, i});
+  result.address = get_subaddress_as_str({pd.m_subaddr_account, 0});
+  result.confirmed = true;
+  result.checkpointed = result.height <= m_immutable_height;
+  set_confirmations(result, get_blockchain_current_height(), get_last_block_reward());
+  return result;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void wallet2::fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &txid, const tools::wallet2::unconfirmed_transfer_details &pd) const
+transfer_view wallet2::make_transfer_view(const crypto::hash &txid, const tools::wallet2::unconfirmed_transfer_details &pd) const
 {
+  transfer_view result = {};
   bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
-  entry.txid = string_tools::pod_to_hex(txid);
-  entry.hash = txid;
-  entry.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
-  entry.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
-  if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-    entry.payment_id = entry.payment_id.substr(0,16);
-  entry.height = 0;
-  entry.timestamp = pd.m_timestamp;
-  entry.fee = pd.m_amount_in - pd.m_amount_out;
-  entry.amount = pd.m_amount_in - pd.m_change - entry.fee;
-  entry.unlock_time = pd.m_tx.unlock_time;
-  entry.note = get_tx_note(txid);
+  result.txid = string_tools::pod_to_hex(txid);
+  result.hash = txid;
+  result.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
+  result.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
+  if (result.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+    result.payment_id = result.payment_id.substr(0,16);
+  result.height = 0;
+  result.timestamp = pd.m_timestamp;
+  result.fee = pd.m_amount_in - pd.m_amount_out;
+  result.amount = pd.m_amount_in - pd.m_change - result.fee;
+  result.unlock_time = pd.m_tx.unlock_time;
+  result.note = get_tx_note(txid);
 
   for (const auto &d: pd.m_dests) {
-    entry.destinations.push_back(wallet2::transfer_view::dest_output());
-    wallet2::transfer_view::dest_output &td = entry.destinations.back();
+    result.destinations.push_back({});
+    transfer_destination &td = result.destinations.back();
     td.amount = d.amount;
     td.address = d.original.empty() ? get_account_address_as_str(nettype(), d.is_subaddress, d.addr) : d.original;
   }
 
-  entry.type = pay_type::unspecified;
-  entry.block = is_failed ? "failed" : "pending";
-  entry.subaddr_index = { pd.m_subaddr_account, 0 };
+  result.pay_type = pay_type::unspecified;
+  result.type = is_failed ? "failed" : "pending";
+  result.subaddr_index = { pd.m_subaddr_account, 0 };
   for (uint32_t i: pd.m_subaddr_indices)
-    entry.subaddr_indices.push_back({pd.m_subaddr_account, i});
-  entry.address = get_subaddress_as_str({pd.m_subaddr_account, 0});
-  entry.confirmed = false;
-  set_confirmations(entry, get_blockchain_current_height(), get_last_block_reward());
+    result.subaddr_indices.push_back({pd.m_subaddr_account, i});
+  result.address = get_subaddress_as_str({pd.m_subaddr_account, 0});
+  result.confirmed = false;
+  set_confirmations(result, get_blockchain_current_height(), get_last_block_reward());
+  return result;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void wallet2::fill_transfer_view(wallet2::transfer_view &entry, const crypto::hash &payment_id, const tools::wallet2::pool_payment_details &ppd) const
+transfer_view wallet2::make_transfer_view(const crypto::hash &payment_id, const tools::wallet2::pool_payment_details &ppd) const
 {
+  transfer_view result = {};
   const tools::wallet2::payment_details &pd = ppd.m_pd;
-  entry.txid = string_tools::pod_to_hex(pd.m_tx_hash);
-  entry.hash = pd.m_tx_hash;
-  entry.payment_id = string_tools::pod_to_hex(payment_id);
-  if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-    entry.payment_id = entry.payment_id.substr(0,16);
-  entry.height = 0;
-  entry.timestamp = pd.m_timestamp;
-  entry.amount = pd.m_amount;
-  entry.unlock_time = pd.m_unlock_time;
-  entry.fee = pd.m_fee;
-  entry.note = get_tx_note(pd.m_tx_hash);
-  entry.double_spend_seen = ppd.m_double_spend_seen;
-  entry.type = pay_type::unspecified;
-  entry.block = "pool";
-  entry.subaddr_index = pd.m_subaddr_index;
-  entry.subaddr_indices.push_back(pd.m_subaddr_index);
-  entry.address = get_subaddress_as_str(pd.m_subaddr_index);
-  entry.confirmed = true;
-  set_confirmations(entry, get_blockchain_current_height(), get_last_block_reward());
+  result.txid = string_tools::pod_to_hex(pd.m_tx_hash);
+  result.hash = pd.m_tx_hash;
+  result.payment_id = string_tools::pod_to_hex(payment_id);
+  if (result.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+    result.payment_id = result.payment_id.substr(0,16);
+  result.height = 0;
+  result.timestamp = pd.m_timestamp;
+  result.amount = pd.m_amount;
+  result.unlock_time = pd.m_unlock_time;
+  result.fee = pd.m_fee;
+  result.note = get_tx_note(pd.m_tx_hash);
+  result.double_spend_seen = ppd.m_double_spend_seen;
+  result.pay_type = pay_type::unspecified;
+  result.type = "pool";
+  result.subaddr_index = pd.m_subaddr_index;
+  result.subaddr_indices.push_back(pd.m_subaddr_index);
+  result.address = get_subaddress_as_str(pd.m_subaddr_index);
+  result.confirmed = true;
+  set_confirmations(result, get_blockchain_current_height(), get_last_block_reward());
+  return result;
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::get_transfers(get_transfers_args_t args, std::vector<transfer_view>& transfers)
@@ -5913,53 +5914,76 @@ void wallet2::get_transfers(get_transfers_args_t args, std::vector<transfer_view
     args.max_height = std::min<uint64_t>(args.max_height, CRYPTONOTE_MAX_BLOCK_NUMBER);
   }
 
+  std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> in;
+  std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> out;
+  std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> pending_or_failed;
+  std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> pool;
+
+  size_t size = 0;
   if (args.in)
   {
-    std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-    get_payments(payments, args.min_height, args.max_height, account_index, args.subaddr_indices);
-    for (auto i = payments.cbegin(); i != payments.cend(); ++i) {
-      transfers.push_back(wallet2::transfer_view());
-      fill_transfer_view(transfers.back(), i->second.m_tx_hash, i->first, i->second);
+    get_payments(in, args.min_height, args.max_height, account_index, args.subaddr_indices);
+    size += in.size();
+  }
+
+  if (args.out)
+  {
+    get_payments_out(out, args.min_height, args.max_height, account_index, args.subaddr_indices);
+    size += out.size();
+  }
+
+  if (args.pending || args.failed)
+  {
+    get_unconfirmed_payments_out(pending_or_failed, account_index, args.subaddr_indices);
+    size += pending_or_failed.size();
+  }
+
+  if (args.pool)
+  {
+    if (is_connected()) update_pool_state();
+    get_unconfirmed_payments(pool, account_index, args.subaddr_indices);
+    size += pool.size();
+  }
+
+  // Fill transfers
+  transfers.reserve(size);
+  if (args.in)
+  {
+    for (auto i = in.cbegin(); i != in.cend(); ++i)
+    {
+      transfers.push_back(make_transfer_view(i->second.m_tx_hash, i->first, i->second));
     }
   }
 
   if (args.out)
   {
-    std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments;
-    get_payments_out(payments, args.min_height, args.max_height, account_index, args.subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-      transfers.push_back(wallet2::transfer_view());
-      fill_transfer_view(transfers.back(), i->first, i->second);
+    for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = out.begin(); i != out.end(); ++i)
+    {
+      transfers.push_back(make_transfer_view(i->first, i->second));
     }
   }
 
-  if (args.pending || args.failed) {
-    std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> upayments;
-    get_unconfirmed_payments_out(upayments, account_index, args.subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = upayments.begin(); i != upayments.end(); ++i) {
+  if (args.pending || args.failed)
+  {
+    for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = pending_or_failed.begin(); i != pending_or_failed.end(); ++i)
+    {
       const wallet2::unconfirmed_transfer_details &pd = i->second;
       bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
       if (!((args.failed && is_failed) || (!is_failed && args.pending)))
         continue;
-      transfers.push_back(wallet2::transfer_view());
-      fill_transfer_view(transfers.back(), i->first, i->second);
+      transfers.push_back(make_transfer_view(i->first, i->second));
     }
   }
 
   if (args.pool)
   {
-    if (is_connected())
-      update_pool_state();
-
-    std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> payments;
-    get_unconfirmed_payments(payments, account_index, args.subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-      transfers.push_back(wallet2::transfer_view());
-      fill_transfer_view(transfers.back(), i->first, i->second);
+    for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = pool.begin(); i != pool.end(); ++i)
+    {
+      transfers.push_back(make_transfer_view(i->first, i->second));
     }
   }
 
-  std::sort(transfers.begin(), transfers.end(), [](const wallet2::transfer_view& a, const wallet2::transfer_view& b) -> bool {
+  std::sort(transfers.begin(), transfers.end(), [](const transfer_view& a, const transfer_view& b) -> bool {
     if (a.confirmed && !b.confirmed)
       return true;
     if (a.height != b.height)
@@ -5970,7 +5994,7 @@ void wallet2::get_transfers(get_transfers_args_t args, std::vector<transfer_view
   });
 }
 
-std::string wallet2::transfers_to_csv(const std::vector<wallet2::transfer_view>& transfers, bool formatting) const
+std::string wallet2::transfers_to_csv(const std::vector<transfer_view>& transfers, bool formatting) const
 {
   uint64_t running_balance = 0;
   auto data_formatter  = boost::format("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'%s',%s");
@@ -6012,7 +6036,7 @@ std::string wallet2::transfers_to_csv(const std::vector<wallet2::transfer_view>&
 
   for (const auto& transfer : transfers)
   {
-    switch (transfer.type)
+    switch (transfer.pay_type)
     {
       case tools::pay_type::in:
       case tools::pay_type::miner:
@@ -6032,8 +6056,8 @@ std::string wallet2::transfers_to_csv(const std::vector<wallet2::transfer_view>&
     }
 
     output << data_formatter
-      % transfer.block
-      % pay_type_string(transfer.type)
+      % (transfer.type.size() ? transfer.type : std::to_string(transfer.height))
+      % pay_type_string(transfer.pay_type)
       % transfer.lock_msg
       % (transfer.checkpointed ? "checkpointed" : "no")
       % tools::get_human_readable_timestamp(transfer.timestamp)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -494,6 +494,7 @@ private:
       bool double_spend_seen;                                    // True if the key image(s) for the transfer have been seen before.
       uint64_t confirmations;                                    // Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).
       uint64_t suggested_confirmations_threshold;
+      bool checkpointed = false; // If the transfer is backed by atleast (2 service node|| 1 hardcoded) checkpoints // TODO(loki): Make this count the number of checkpoints backing this transfer
     };
 
     typedef std::vector<transfer_details> transfer_container;
@@ -963,6 +964,7 @@ private:
 
     uint64_t get_last_block_reward() const { return m_last_block_reward; }
     uint64_t get_device_last_key_image_sync() const { return m_device_last_key_image_sync; }
+    uint64_t get_immutable_height() const { return m_immutable_height; }
 
     template <class t_archive>
     inline void serialize(t_archive &a, const unsigned int ver)
@@ -1077,6 +1079,9 @@ private:
       if(ver < 28)
         return;
       a & m_cold_key_images;
+      if(ver < 29)
+        return;
+      a & m_immutable_height;
     }
 
     /*!
@@ -1667,6 +1672,7 @@ private:
     std::string m_device_derivation_path;
     uint64_t m_device_last_key_image_sync;
     bool m_offline;
+    uint64_t m_immutable_height;
 
     // Aux transaction data from device
     std::unordered_map<crypto::hash, std::string> m_tx_device;
@@ -1721,7 +1727,7 @@ private:
   bool parse_priority          (const std::string& arg, uint32_t& priority);
 
 }
-BOOST_CLASS_VERSION(tools::wallet2, 28)
+BOOST_CLASS_VERSION(tools::wallet2, 29)
 BOOST_CLASS_VERSION(tools::wallet2::transfer_details, 12)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info, 1)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info::LR, 0)

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -267,7 +267,7 @@ namespace tools
           bool get_tx_key, Ts& tx_key, Tu &amount, Tu &fee, std::string &multisig_txset, std::string &unsigned_txset, bool do_not_relay,
           Ts &tx_hash, bool get_tx_hex, Ts &tx_blob, bool get_tx_metadata, Ts &tx_metadata, epee::json_rpc::error &er);
 
-      bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er);
+      bool validate_transfer(const std::list<transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er);
 
       void check_background_mining();
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -469,18 +469,6 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
-  struct transfer_destination
-  {
-    uint64_t amount;     // Amount to send to each destination, in atomic units.
-    std::string address; // Destination public address.
-
-    BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(amount)
-      KV_SERIALIZE(address)
-    END_KV_SERIALIZE_MAP()
-  };
-
-  LOKI_RPC_DOC_INTROSPECT
   // Send loki to a number of recipients. To preview the transaction fee, set do_not_relay to true and get_tx_metadata to true. 
   // Submit the response using the data in get_tx_metadata in the RPC call, relay_tx.
   struct COMMAND_RPC_TRANSFER
@@ -1452,77 +1440,6 @@ namespace wallet_rpc
   };
 
   LOKI_RPC_DOC_INTROSPECT
-  // 
-  struct transfer_entry
-  {
-    transfer_entry() = default;
-    transfer_entry(const wallet2::transfer_view& transfer)
-      : txid(transfer.txid)
-      , payment_id(transfer.payment_id)
-      , height(transfer.height)
-      , timestamp(transfer.timestamp)
-      , amount(transfer.amount)
-      , fee(transfer.fee)
-      , note(transfer.note)
-      // destinations
-      , type(tools::pay_type_string(transfer.type))
-      , unlock_time(transfer.unlock_time)
-      , subaddr_index(transfer.subaddr_index)
-      , subaddr_indices(transfer.subaddr_indices)
-      , address(transfer.address)
-      , double_spend_seen(transfer.double_spend_seen)
-      , confirmations(transfer.confirmations)
-      , suggested_confirmations_threshold(transfer.suggested_confirmations_threshold)
-    {
-      if (transfer.block.type() == typeid(std::string))
-      {
-          type = boost::get<std::string>(transfer.block);
-      }
-      for (const auto& dest : transfer.destinations)
-      {
-        destinations.push_back({std::move(dest.amount), std::move(dest.address)});
-      }
-    }
-    std::string txid;                                          // Transaction ID for this transfer.
-    std::string payment_id;                                    // Payment ID for this transfer.
-    uint64_t height;                                           // Height of the first block that confirmed this transfer (0 if not mined yet).
-    uint64_t timestamp;                                        // UNIX timestamp for when this transfer was first confirmed in a block (or timestamp submission if not mined yet).
-    uint64_t amount;                                           // Amount transferred.
-    uint64_t fee;                                              // Transaction fee for this transfer.
-    std::string note;                                          // Note about this transfer.
-    std::list<transfer_destination> destinations;              // Array of transfer destinations.
-    std::string type;                                          // Type of transfer, one of the following: "in", "out", "pending", "failed", "pool".
-    uint64_t unlock_time;                                      // Number of blocks until transfer is safely spendable.
-    cryptonote::subaddress_index subaddr_index;                // Major & minor index, account and subaddress index respectively.
-    std::vector<cryptonote::subaddress_index> subaddr_indices;
-    std::string address;                                       // Address that transferred the funds.
-    bool double_spend_seen;                                    // True if the key image(s) for the transfer have been seen before.
-    uint64_t confirmations;                                    // Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).
-    uint64_t suggested_confirmations_threshold;                // Estimation of the confirmations needed for the transaction to be included in a block.
-    uint64_t checkpointed;                                     // If transfer is backed by atleast 2 Service Node Checkpoints, 0 if it is not, see immutable_height in the daemon rpc call get_info
-
-    BEGIN_KV_SERIALIZE_MAP()
-      KV_SERIALIZE(txid);
-      KV_SERIALIZE(payment_id);
-      KV_SERIALIZE(height);
-      KV_SERIALIZE(timestamp);
-      KV_SERIALIZE(amount);
-      KV_SERIALIZE(fee);
-      KV_SERIALIZE(note);
-      KV_SERIALIZE(destinations);
-      KV_SERIALIZE(type);
-      KV_SERIALIZE(unlock_time)
-      KV_SERIALIZE(subaddr_index);
-      KV_SERIALIZE(subaddr_indices);
-      KV_SERIALIZE(address);
-      KV_SERIALIZE(double_spend_seen)
-      KV_SERIALIZE_OPT(confirmations, (uint64_t)0)
-      KV_SERIALIZE_OPT(suggested_confirmations_threshold, (uint64_t)0)
-      KV_SERIALIZE(checkpointed)
-    END_KV_SERIALIZE_MAP()
-  };
-
-  LOKI_RPC_DOC_INTROSPECT
   // Generate a signature to prove a spend. Unlike proving a transaction, it does not requires the destination public address.
   struct COMMAND_RPC_GET_SPEND_PROOF
   {
@@ -1679,11 +1596,11 @@ namespace wallet_rpc
 
     struct response_t
     {
-      std::list<transfer_entry> in;      // 
-      std::list<transfer_entry> out;     //
-      std::list<transfer_entry> pending; //
-      std::list<transfer_entry> failed;  //
-      std::list<transfer_entry> pool;    // 
+      std::list<transfer_view> in;      // 
+      std::list<transfer_view> out;     //
+      std::list<transfer_view> pending; //
+      std::list<transfer_view> failed;  //
+      std::list<transfer_view> pool;    // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(in);
@@ -1731,8 +1648,8 @@ namespace wallet_rpc
 
     struct response_t
     {
-      transfer_entry transfer;             // 
-      std::list<transfer_entry> transfers; // 
+      transfer_view transfer;             // 
+      std::list<transfer_view> transfers; // 
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(transfer);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1499,6 +1499,7 @@ namespace wallet_rpc
     bool double_spend_seen;                                    // True if the key image(s) for the transfer have been seen before.
     uint64_t confirmations;                                    // Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).
     uint64_t suggested_confirmations_threshold;                // Estimation of the confirmations needed for the transaction to be included in a block.
+    uint64_t checkpointed;                                     // If transfer is backed by atleast 2 Service Node Checkpoints, 0 if it is not, see immutable_height in the daemon rpc call get_info
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(txid);
@@ -1517,6 +1518,7 @@ namespace wallet_rpc
       KV_SERIALIZE(double_spend_seen)
       KV_SERIALIZE_OPT(confirmations, (uint64_t)0)
       KV_SERIALIZE_OPT(suggested_confirmations_threshold, (uint64_t)0)
+      KV_SERIALIZE(checkpointed)
     END_KV_SERIALIZE_MAP()
   };
 


### PR DESCRIPTION
With `show_transfers`
```
132272  miner   locked checkpointed 2019-10-02 07:34         23.533008373 67192cb1c75968511d2c888a1e9007a7b54da873eb6edfbb430b27559c6c3cb0 0000000000000000    0.000000000 - 0 -
132282  miner   locked           no 2019-10-02 07:52         23.531838962 7bc31379ba626ea73f105603689c0e2dc2d42934f2fca6f6277dc8296637bc41 0000000000000000    0.000000000 - 0 - 
```

With `show_transfer 67192cb1c75968511d2c888a1e9007a7b54da873eb6edfbb430b27559c6c3cb0`
```
Incoming transaction found
txid: <67192cb1c75968511d2c888a1e9007a7b54da873eb6edfbb430b27559c6c3cb0>
Height: 132272
Timestamp: 2019-10-02 07:34:33
Amount: 23.533008373
Payment ID: 0000000000000000
Locked: 23 blocks to unlock
Checkpointed: Yes
Address index: 0
Note:
```

In `export_transfers`
```
   block,     type,    lock,  checkpointed,       timestamp,              amount,     running balance,                                                            hash,      payment ID,           fee,                                                                                         destination,              amount,index,note
       1,    miner,unlocked,  checkpointed,2019-03-07 09:14,       116.603178672,       116.603178672,f8c621b85c86fc4e1f3c0f93954cd28a941ebe1ae5998d0bf0198ccf504c47ab,0000000000000000,   0.000000000,                                                                                                   -,                    ,"0",
       2,    miner,unlocked,  checkpointed,2019-03-07 09:14,       121.597967646,       238.201146318,dd4dd84f255c457bcf937e4a146193043f9e1318dabe00cd1cde60d8929f493b,0000000000000000,   0.000000000,                                                                                                   -,                    ,"0",
```

In `get_transfers`, new field is added, `checkpointed`
```
{
      "address": "T6UF17LpAFF64Agf5uPZp87FaHsSxGMKbJpF5RTqcoNCGMciaqKcw8bVv4p5XeY9kZ7RnRjVpdrtLMosWHH85Kt12qk5JVcrj",
      "amount": 56575491211,
      "checkpointed": 1,
      "confirmations": 130130,
      "double_spend_seen": false,
      "fee": 0,
      "height": 2153,
      "note": "",
      "payment_id": "0000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 0
      },
      "subaddr_indices": [{
        "major": 0,
        "minor": 0
      }],
      "suggested_confirmations_threshold": 2,
      "timestamp": 1552194104,
      "txid": "1dba532778b34453948808cd7e4638e4af1434196436d9396e3a491670c9b12a",
      "type": "miner",
      "unlock_time": 2183
    }
```

@jagerman

This also merges transfer_view and transfer_entry which are duplicated and server mostly the same purpose to one unified structure. Also fixes crash bug on get_transfers.