### PR TITLE
Reward fudge factor

### DIFF
--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -114,6 +114,5 @@ namespace cryptonote
     bool m_verifivation_failed; //bad block, should drop connection
     bool m_marked_as_orphaned;
     bool m_already_exists;
-    bool m_partial_block_reward;
   };
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1291,6 +1291,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     return false;
   }
 
+  CHECK_AND_ASSERT_MES(money_in_use >= fee, false, "base reward calculation bug");
   base_reward = money_in_use - fee;
 
   return true;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1203,14 +1203,13 @@ bool Blockchain::prevalidate_miner_transaction(const block& b, uint64_t height)
 }
 //------------------------------------------------------------------
 // This function validates the miner transaction reward
-bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_block_weight, uint64_t fee, uint64_t& base_reward, uint64_t already_generated_coins, bool &partial_block_reward, uint8_t version)
+bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_block_weight, uint64_t fee, uint64_t& base_reward, uint64_t already_generated_coins, uint8_t version)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   //validate reward
   uint64_t money_in_use = 0;
   for (auto& o: b.miner_tx.vout)
     money_in_use += o.amount;
-  partial_block_reward = false;
 
   if (b.miner_tx.vout.size() == 0) {
     MERROR_VER("miner tx has no outputs");
@@ -1289,12 +1288,6 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     return false;
   }
 
-  // since a miner can claim less than the full block reward, we update the base_reward
-  // to show the amount of coins that were actually generated, the remainder will be pushed back for later
-  // emission. This modifies the emission curve very slightly.
-  CHECK_AND_ASSERT_MES(money_in_use - fee <= base_reward + 1, false, "base reward calculation bug");
-  if(base_reward != money_in_use)
-    partial_block_reward = true;
   base_reward = money_in_use - fee;
 
   return true;
@@ -3941,7 +3934,7 @@ leave:
   TIME_MEASURE_START(vmt);
   uint64_t base_reward = 0;
   uint64_t already_generated_coins = blockchain_height ? m_db->get_block_already_generated_coins(blockchain_height - 1) : 0;
-  if(!validate_miner_transaction(bl, cumulative_block_weight, fee_summary, base_reward, already_generated_coins, bvc.m_partial_block_reward, m_hardfork->get_current_version()))
+  if(!validate_miner_transaction(bl, cumulative_block_weight, fee_summary, base_reward, already_generated_coins, m_hardfork->get_current_version()))
   {
     MERROR_VER("Block with id: " << id << " has incorrect miner transaction");
     bvc.m_verifivation_failed = true;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1282,7 +1282,8 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   }
 
   base_reward = reward_parts.base_miner + reward_parts.governance_paid + reward_parts.service_node_paid;
-  if(base_reward + fee < money_in_use)
+  // Allow a 1 atomic unit error in the calculation (which can happen because of the rounding mode changes randomx does)
+  if(base_reward + 1 + fee < money_in_use)
   {
     MERROR_VER("coinbase transaction spend too much money (" << print_money(money_in_use) << "). Block reward is " << print_money(base_reward) << "(" << print_money(base_reward) << "+" << print_money(fee) << ")");
     return false;
@@ -1291,7 +1292,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   // since a miner can claim less than the full block reward, we update the base_reward
   // to show the amount of coins that were actually generated, the remainder will be pushed back for later
   // emission. This modifies the emission curve very slightly.
-  CHECK_AND_ASSERT_MES(money_in_use - fee <= base_reward, false, "base reward calculation bug");
+  CHECK_AND_ASSERT_MES(money_in_use - fee <= base_reward + 1, false, "base reward calculation bug");
   if(base_reward != money_in_use)
     partial_block_reward = true;
   base_reward = money_in_use - fee;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1280,11 +1280,14 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     }
   }
 
-  base_reward = reward_parts.base_miner + reward_parts.governance_paid + reward_parts.service_node_paid;
-  // Allow a 1 atomic unit error in the calculation (which can happen because of the rounding mode changes randomx does)
-  if(base_reward + 1 + fee < money_in_use)
+  // +1 here to allow a 1 atomic unit error in the calculation (which can happen because of floating point errors or rounding)
+  // TODO(loki): eliminate all floating point math in reward calculations.
+  uint64_t max_base_reward = reward_parts.base_miner + reward_parts.governance_paid + reward_parts.service_node_paid + 1;
+  uint64_t max_money_in_use = max_base_reward + fee;
+  if (money_in_use > max_money_in_use)
   {
-    MERROR_VER("coinbase transaction spend too much money (" << print_money(money_in_use) << "). Block reward is " << print_money(base_reward) << "(" << print_money(base_reward) << "+" << print_money(fee) << ")");
+    MERROR_VER("coinbase transaction spends too much money (" << print_money(money_in_use) << "). Maximum block reward is "
+            << print_money(max_money_in_use) << " (= " << print_money(max_base_reward) << " base + " << print_money(fee) << " fees)");
     return false;
   }
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1291,12 +1291,11 @@ namespace cryptonote
      * @param fee the total fees collected in the block
      * @param base_reward return-by-reference the new block's generated coins
      * @param already_generated_coins the amount of currency generated prior to this block
-     * @param partial_block_reward return-by-reference true if miner accepted only partial reward
      * @param version hard fork version for that transaction
      *
      * @return false if anything is found wrong with the miner transaction, otherwise true
      */
-    bool validate_miner_transaction(const block& b, size_t cumulative_block_weight, uint64_t fee, uint64_t& base_reward, uint64_t already_generated_coins, bool &partial_block_reward, uint8_t version);
+    bool validate_miner_transaction(const block& b, size_t cumulative_block_weight, uint64_t fee, uint64_t& base_reward, uint64_t already_generated_coins, uint8_t version);
 
     /**
      * @brief reverts the blockchain to its previous state following a failed switch

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1619,6 +1619,11 @@ namespace service_nodes
     return result;
   }
 
+  template <typename T>
+  static constexpr bool within_one(T a, T b) {
+      return (a > b ? a - b : b - a) <= T{1};
+  }
+
   bool service_node_list::validate_miner_tx(const crypto::hash& prev_id, const cryptonote::transaction& miner_tx, uint64_t height, int hf_version, cryptonote::block_reward_parts const &reward_parts) const
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
@@ -1652,7 +1657,11 @@ namespace service_nodes
       payout_entry const &payout = winner.payouts[i];
       uint64_t reward            = cryptonote::get_portion_of_reward(payout.portions, total_service_node_reward);
 
-      if (miner_tx.vout[vout_index].amount != reward)
+      // Because FP math is involved in reward calculations (and compounded by CPUs, compilers,
+      // expression contraction, and RandomX fiddling with the rounding modes) we can end up with a
+      // 1 ULP difference in the reward calculations.
+      // TODO(loki): eliminate all FP math from reward calculations
+      if (!within_one(miner_tx.vout[vout_index].amount, reward))
       {
         MERROR("Service node reward amount incorrect. Should be " << cryptonote::print_money(reward) << ", is: " << cryptonote::print_money(miner_tx.vout[vout_index].amount));
         return false;

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -647,7 +647,7 @@ bool gen_block_invalid_binary_format::check_block_verification_context(const cry
   else
   {
     return (!bvc.m_added_to_main_chain && (bvc.m_already_exists || bvc.m_marked_as_orphaned || bvc.m_verifivation_failed))
-      || (bvc.m_added_to_main_chain && bvc.m_partial_block_reward);
+      || bvc.m_added_to_main_chain;
   }
 }
 


### PR DESCRIPTION
Adds a 1 atomic unit fudge factor.

The second commit is because I wasn't entirely sure how to handle the `partial_block_reward` variable when things are off by 1, but it turns out that it is not used at all so I just banished it completely.