### PR TITLE
Fix the overflow test for fee and block_reward in blocks

### DIFF
--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -752,7 +752,7 @@ public:
     log_event("loki_blockchain_addable<cryptonote::checkpoint_t>");
     cryptonote::Blockchain &blockchain = m_c.get_blockchain_storage();
     bool added = blockchain.update_checkpoint(entry.data);
-    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, entry.fail_msg);
+    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, (entry.fail_msg.size() ? entry.fail_msg : "Failed to add checkpoint (no reason given)"));
     return true;
   }
 
@@ -761,7 +761,7 @@ public:
     log_event("loki_blockchain_addable<service_nodes::quorum_vote_t>");
     cryptonote::vote_verification_context vvc = {};
     bool added                                = m_c.add_service_node_vote(entry.data, vvc);
-    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, entry.fail_msg);
+    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, (entry.fail_msg.size() ? entry.fail_msg : "Failed to add service node vote (no reason given)"));
     return true;
   }
 
@@ -786,7 +786,7 @@ public:
       bvc.m_verifivation_failed = true;
 
     bool added = !bvc.m_verifivation_failed;
-    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, entry.fail_msg);
+    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, (entry.fail_msg.size() ? entry.fail_msg : "Failed to add block with checkpoint (no reason given)"));
     return true;
   }
   
@@ -807,7 +807,7 @@ public:
       bvc.m_verifivation_failed = true;
 
     bool added = !bvc.m_verifivation_failed;
-    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, entry.fail_msg);
+    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, (entry.fail_msg.size() ? entry.fail_msg : "Failed to add block (no reason given)"));
     return true;
   }
 
@@ -819,7 +819,7 @@ public:
     m_c.handle_incoming_tx(t_serializable_object_to_blob(entry.data.tx), tvc, entry.data.kept_by_block, false, false);
 
     bool added = (pool_size + 1) == m_c.get_pool_transactions_count();
-    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, entry.fail_msg);
+    CHECK_AND_NO_ASSERT_MES(added == entry.can_be_added_to_blockchain, false, (entry.fail_msg.size() ? entry.fail_msg : "Failed to add transaction (no reason given)"));
     return true;
   }
 
@@ -1331,11 +1331,11 @@ struct loki_chain_generator_db : public cryptonote::BaseTestDB
 {
   std::vector<loki_blockchain_entry>                        &blockchain;
   std::unordered_map<crypto::hash, cryptonote::transaction> &tx_table; // TODO(loki): I want to store pointers to transactions but I get some memory corruption somewhere. Pls fix.
-  std::unordered_map<crypto::hash, loki_blockchain_entry *> &block_table;
+  std::unordered_map<crypto::hash, loki_blockchain_entry> &block_table;
 
   loki_chain_generator_db(std::vector<loki_blockchain_entry> &blockchain,
                      std::unordered_map<crypto::hash, cryptonote::transaction> &tx_table,
-                     std::unordered_map<crypto::hash, loki_blockchain_entry *> &block_table)
+                     std::unordered_map<crypto::hash, loki_blockchain_entry> &block_table)
   : blockchain(blockchain)
   , tx_table(tx_table)
   , block_table(block_table)
@@ -1354,7 +1354,7 @@ struct loki_chain_generator
   // TODO(loki): I want to store pointers to transactions but I get some memory corruption somewhere. Pls fix.
   // We already store blockchain_entries in block_ vector which stores the actual backing transaction entries.
   std::unordered_map<crypto::hash, cryptonote::transaction>   tx_table_;
-  std::unordered_map<crypto::hash, loki_blockchain_entry *>   block_table_;
+  std::unordered_map<crypto::hash, loki_blockchain_entry>     block_table_; // TODO(loki): Hmm takes a copy. But its easier to work this way, particularly for storing alt blocks
   std::vector<loki_blockchain_entry>                          blocks_;
   loki_chain_generator_db                                     db_;
   uint8_t                                                     hf_version_ = cryptonote::network_version_7;
@@ -1374,28 +1374,31 @@ struct loki_chain_generator
   std::shared_ptr<const service_nodes::testing_quorum> get_testing_quorum(service_nodes::quorum_type type, uint64_t height) const;
 
   cryptonote::account_base                             add_account();
-  loki_blockchain_entry                               &add_block(const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
+  loki_blockchain_entry                               &add_block(loki_blockchain_entry const &entry, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
   void                                                 add_blocks_until_version(uint8_t hf_version);
   void                                                 add_n_blocks(int n);
   void                                                 add_blocks_until_next_checkpointable_height();
   void                                                 add_service_node_checkpoint(uint64_t block_height, size_t num_votes);
   void                                                 add_mined_money_unlock_blocks(); // NOTE: Unlock all Loki generated from mining prior to this call i.e. CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW
 
-  void                                                 add_tx(cryptonote::transaction const &tx, bool can_be_added_to_blockchain, std::string const &fail_msg = {}, bool kept_by_block = false);
+  void                                                 add_tx(cryptonote::transaction const &tx, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {}, bool kept_by_block = false);
 
   // NOTE: Add constructed TX to events_ and assume that it is valid to add to the blockchain. If the TX is meant to be unaddable to the blockchain use the individual create + add functions to
   // be able to mark the add TX event as something that should trigger a failure.
   cryptonote::transaction                              create_and_add_tx             (const cryptonote::account_base& src, const cryptonote::account_base& dest, uint64_t amount, uint64_t fee = TESTS_DEFAULT_FEE, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default")), bool kept_by_block = false);
+  loki_blockchain_entry                               &create_and_add_next_block(const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
 
   // NOTE: Create transactions but don't add to events_
+  cryptonote::transaction                              create_tx             (const cryptonote::account_base &src, const cryptonote::account_base &dest, uint64_t amount, uint64_t fee, bool kept_by_block, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {}) const;
   cryptonote::transaction                              create_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default"))) const;
   cryptonote::transaction                              create_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0) const;
   cryptonote::checkpoint_t                             create_service_node_checkpoint(uint64_t block_height, size_t num_votes) const;
 
   loki_blockchain_entry                                create_genesis_block(const cryptonote::account_base &miner, uint64_t timestamp);
-  bool                                                 create_loki_blockchain_entry(loki_blockchain_entry &entry, uint8_t hf_version, loki_blockchain_entry &prev, const cryptonote::account_base &miner_acc, uint64_t timestamp, std::vector<uint64_t> &block_weights, const std::vector<cryptonote::transaction> &tx_list, const service_nodes::block_winner &block_winner);
+  loki_blockchain_entry                                create_next_block(const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr);
+  bool                                                 create_block(loki_blockchain_entry &entry, uint8_t hf_version, loki_blockchain_entry const &prev, const cryptonote::account_base &miner_acc, uint64_t timestamp, std::vector<uint64_t> &block_weights, const std::vector<cryptonote::transaction> &tx_list, const service_nodes::block_winner &block_winner) const;
 
   uint8_t                                              get_hf_version_at(uint64_t height) const;
   std::vector<uint64_t>                                last_n_block_weights(uint64_t height, uint64_t num) const;

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -158,6 +158,8 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_block_has_invalid_tx);
     GENERATE_AND_PLAY(gen_block_is_too_big);
 
+    GENERATE_AND_PLAY(gen_uint_overflow_1);
+
     // TODO(loki): We also want to run these tx tests on deregistration tx's
     // as well because they special case and run under very different code
     // paths from the regular tx path
@@ -228,10 +230,8 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks<false>);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks<true>);
 
-      GENERATE_AND_PLAY(gen_uint_overflow_1);
-      GENERATE_AND_PLAY(gen_uint_overflow_2);
-
       GENERATE_AND_PLAY(gen_block_reward);
+      GENERATE_AND_PLAY(gen_uint_overflow_2);
 
       GENERATE_AND_PLAY(gen_v2_tx_mixable_0_mixin);
       GENERATE_AND_PLAY(gen_v2_tx_mixable_low_mixin);

--- a/tests/core_tests/integer_overflow.cpp
+++ b/tests/core_tests/integer_overflow.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "chaingen.h"
+#include "loki_tests.h"
 #include "integer_overflow.h"
 
 using namespace epee;
@@ -98,43 +99,48 @@ bool gen_uint_overflow_base::mark_last_valid_block(cryptonote::core& c, size_t e
 
 bool gen_uint_overflow_1::generate(std::vector<test_event_entry>& events) const
 {
-  uint64_t ts_start = 1338224400;
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table();
+  loki_chain_generator gen(events, hard_forks);
 
-  GENERATE_ACCOUNT(miner_account);
-  MAKE_GENESIS_BLOCK(events, blk_0, miner_account, ts_start);
-  DO_CALLBACK(events, "mark_last_valid_block");
-  MAKE_ACCOUNT(events, bob_account);
-  MAKE_ACCOUNT(events, alice_account);
+  gen.add_blocks_until_version(hard_forks.back().first);
+  gen.add_n_blocks(40);
+  gen.add_mined_money_unlock_blocks();
 
-  // Problem 1. Miner tx output overflow
-  MAKE_MINER_TX_MANUALLY(miner_tx_0, blk_0);
-  split_miner_tx_outs(miner_tx_0, MONEY_SUPPLY);
-  block blk_1;
-  if (!generator.construct_block_manually(blk_1, blk_0, miner_account, test_generator::bf_miner_tx, 0, 0, 0, crypto::hash(), 0, miner_tx_0))
-    return false;
-  events.push_back(blk_1);
+  cryptonote::account_base bob   = gen.add_account();
+  cryptonote::account_base alice = gen.add_account();
 
   // Problem 1. Miner tx outputs overflow
-  MAKE_MINER_TX_MANUALLY(miner_tx_1, blk_1);
-  split_miner_tx_outs(miner_tx_1, MONEY_SUPPLY);
-  block blk_2;
-  if (!generator.construct_block_manually(blk_2, blk_1, miner_account, test_generator::bf_miner_tx, 0, 0, 0, crypto::hash(), 0, miner_tx_1))
-    return false;
-  events.push_back(blk_2);
+  {
+    loki_blockchain_entry entry       = gen.create_next_block();
+    cryptonote::transaction &miner_tx = entry.block.miner_tx;
+    split_miner_tx_outs(miner_tx, MONEY_SUPPLY);
+    gen.add_block(entry, false /*can_be_added_to_blockchain*/, "We purposely overflow miner tx by MONEY_SUPPLY in the miner tx");
+  }
 
-  REWIND_BLOCKS(events, blk_2r, blk_2, miner_account);
-  MAKE_TX_LIST_START(events, txs_0, miner_account, bob_account, MONEY_SUPPLY, blk_2);
-  MAKE_TX_LIST(events, txs_0, miner_account, bob_account, MONEY_SUPPLY, blk_2);
-  MAKE_NEXT_BLOCK_TX_LIST(events, blk_3, blk_2r, miner_account, txs_0);
-  REWIND_BLOCKS(events, blk_3r, blk_3, miner_account);
+  // Problem 2. block_reward overflow
+  {
+    {
+      // Create txs with fee greater than the block reward
+      std::vector<cryptonote::transaction> txs;
+      txs.push_back(gen.create_and_add_tx(gen.first_miner_, alice, MK_COINS(1), MK_COINS(100) /*fee*/, false /*kept_by_block*/));
 
-  // Problem 2. total_fee overflow, block_reward overflow
-  std::list<cryptonote::transaction> txs_1;
-  // Create txs with huge fee
-  txs_1.push_back(construct_tx_with_fee(events, blk_3, bob_account, alice_account, MK_COINS(1), MONEY_SUPPLY - MK_COINS(1)));
-  txs_1.push_back(construct_tx_with_fee(events, blk_3, bob_account, alice_account, MK_COINS(1), MONEY_SUPPLY - MK_COINS(1)));
-  MAKE_NEXT_BLOCK_TX_LIST(events, blk_4, blk_3r, miner_account, txs_1);
+      loki_blockchain_entry entry       = gen.create_next_block(txs);
+      cryptonote::transaction &miner_tx = entry.block.miner_tx;
+      miner_tx.vout[0].amount           = 0; // Take partial block reward, fee > block_reward so ordinarly it would overflow. This should be disallowed
+      gen.add_block(entry, false /*can_be_added_to_blockchain*/, "We should not be able to add TX because the fee is greater than the base miner reward");
+    }
 
+    {
+      // Set kept_by_block = true
+      std::vector<cryptonote::transaction> txs;
+      txs.push_back(gen.create_and_add_tx(gen.first_miner_, alice, MK_COINS(1), MK_COINS(100) /*fee*/, true /*kept_by_block*/));
+
+      loki_blockchain_entry entry       = gen.create_next_block(txs);
+      cryptonote::transaction &miner_tx = entry.block.miner_tx;
+      miner_tx.vout[0].amount           = 0; // Take partial block reward, fee > block_reward so ordinarly it would overflow. This should be disallowed
+      gen.add_block(entry, false /*can_be_added_to_blockchain*/, "We should not be able to add TX because the fee is greater than the base miner reward even if kept_by_block is true");
+    }
+  }
   return true;
 }
 

--- a/tests/core_tests/integer_overflow.h
+++ b/tests/core_tests/integer_overflow.h
@@ -44,10 +44,7 @@ private:
   size_t m_last_valid_block_event_idx;
 };
 
-struct gen_uint_overflow_1 : public gen_uint_overflow_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
+struct gen_uint_overflow_1 : public gen_uint_overflow_base { bool generate(std::vector<test_event_entry>& events) const; };
 
 struct gen_uint_overflow_2 : public gen_uint_overflow_base
 {

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -35,6 +35,9 @@
 /*                                                                      */
 /************************************************************************/
 
+void                                      loki_register_callback                  (std::vector<test_event_entry> &events, std::string const &callback_name, loki_callback callback);
+std::vector<std::pair<uint8_t, uint64_t>> loki_generate_sequential_hard_fork_table(uint8_t max_hf_version = cryptonote::network_version_count - 1);
+
 struct loki_checkpointing_alt_chain_more_service_node_checkpoints_less_pow_overtakes : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_alt_chain_receive_checkpoint_votes_should_reorg_back       : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_alt_chain_with_increasing_service_node_checkpoints         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };

--- a/tests/core_tests/ring_signature_1.cpp
+++ b/tests/core_tests/ring_signature_1.cpp
@@ -83,14 +83,14 @@ bool gen_ring_signature_1::generate(std::vector<test_event_entry>& events) const
   txs.push_back( gen.create_and_add_tx(miner, some_account_1, MK_COINS(20) + rnd_20) );
   txs.push_back( gen.create_and_add_tx(miner, some_account_2, MK_COINS(20) + rnd_20) );
 
-  gen.add_block(txs);
+  gen.create_and_add_next_block(txs);
 
   gen.add_mined_money_unlock_blocks();
 
   DO_CALLBACK(events, "check_balances_1");
 
   auto tx = gen.create_and_add_tx(bob, alice, MK_COINS(129) + 2 * rnd_11 + rnd_20 + 3 * rnd_29 - TESTS_DEFAULT_FEE);
-  gen.add_block({tx});
+  gen.create_and_add_next_block({tx});
 
   DO_CALLBACK(events, "check_balances_2");
 


### PR DESCRIPTION
Fixes `gen_uint_overflow_1` test, has been tested with the reward fudge PR.

Had to change the loki_chain_generator API to work the way this test wanted to use blockchain data, so the bulk of changes is renaming.

@jagerman