### PR TITLE
Wait for storage server

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1796,24 +1796,12 @@ namespace cryptonote
       m_check_uptime_proof_interval.do_call([&info, this]() {
         if (info.proof->timestamp <= static_cast<uint64_t>(time(nullptr) - UPTIME_PROOF_FREQUENCY_IN_SECONDS))
         {
-          uint8_t hf_version = get_blockchain_storage().get_current_hard_fork_version();
-
           if (!check_storage_server_ping(m_last_storage_server_ping))
           {
-            if (hf_version >= cryptonote::network_version_12_checkpointing)
-            {
-              MGINFO_RED(
-                  "Failed to submit uptime proof: have not heard from the storage server recently. Make sure that it "
-                  "is running! It is required to run alongside the Loki daemon after hard-fork 12");
-              return true;
-            }
-            else
-            {
-              MGINFO_RED(
-                  "We have not heard from the storage server recently. Make sure that it is running! After hard fork "
-                  "12, this Service Node will stop submitting uptime proofs if it does not hear from the Loki Storage "
-                  "Server.");
-            }
+            MGINFO_RED(
+                "Failed to submit uptime proof: have not heard from the storage server recently. Make sure that it "
+                "is running! It is required to run alongside the Loki daemon");
+            return true;
           }
 
           this->submit_uptime_proof();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1777,8 +1777,9 @@ namespace cryptonote
     const auto elapsed = std::time(nullptr) - last_time_storage_server_pinged;
     if (elapsed > STORAGE_SERVER_PING_LIFETIME)
     {
-      MWARNING("Have not heard from the storage server since at least: "
-               << tools::get_human_readable_timespan(std::chrono::seconds(last_time_storage_server_pinged)));
+      MWARNING("Have not heard from the storage server " <<
+              (!last_time_storage_server_pinged ? "since starting" :
+               "for more than " + tools::get_human_readable_timespan(std::chrono::seconds(elapsed))));
       return false;
     }
     return true;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -248,7 +248,7 @@ namespace cryptonote
               m_update_download(0),
               m_nettype(UNDEFINED),
               m_update_available(false),
-              m_last_storage_server_ping(time(nullptr)), // Reset the storage server last ping to make sure the very first uptime proof works
+              m_last_storage_server_ping(0),
               m_pad_transactions(false)
   {
     m_checkpoints_updating.clear();

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -724,11 +724,18 @@ bool t_rpc_command_executor::show_status() {
 
   if (!my_sn_key.empty()) {
     str.str("");
+    str << "SN: " << my_sn_key << ' ';
     if (!my_sn_registered)
-      str << "SN: " << my_sn_key << " -- not registered";
+      str << "not registered";
     else
-      str << "SN: " << my_sn_key << " -- " << (!my_sn_staked ? "awaiting" : my_sn_active ? "active" : "DECOMMISSIONED (" + std::to_string(my_decomm_remaining) + " blocks credit)")
-        << ", last uptime: " << (my_sn_last_uptime ? get_human_time_ago(my_sn_last_uptime, time(nullptr)) : "(never)");
+      str << (!my_sn_staked ? "awaiting" : my_sn_active ? "active" : "DECOMMISSIONED (" + std::to_string(my_decomm_remaining) + " blocks credit)")
+        << ", proof: " << (my_sn_last_uptime ? get_human_time_ago(my_sn_last_uptime, time(nullptr)) : "(never)");
+    str << ", s.server: ";
+    if (ires.last_storage_server_ping > 0)
+        str << "last ping " << get_human_time_ago(ires.last_storage_server_ping, time(nullptr));
+    else
+        str << "NO PING RECEIVED";
+
     tools::success_msg_writer() << str.str();
   }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -229,6 +229,7 @@ namespace cryptonote
     res.block_size_limit = res.block_weight_limit = m_core.get_blockchain_storage().get_current_cumulative_block_weight_limit();
     res.block_size_median = res.block_weight_median = m_core.get_blockchain_storage().get_current_cumulative_block_weight_median();
     res.start_time = restricted ? 0 : (uint64_t)m_core.get_start_time();
+    res.last_storage_server_ping = restricted ? 0 : (uint64_t)m_core.m_last_storage_server_ping;
     res.free_space = restricted ? std::numeric_limits<uint64_t>::max() : m_core.get_free_space();
     res.offline = m_core.offline();
     res.bootstrap_daemon_address = restricted ? "" : m_bootstrap_daemon_address;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -797,6 +797,7 @@ namespace cryptonote
       uint64_t block_size_median;           // Median block size of latest 100 blocks.
       uint64_t block_weight_median;         // Median block weight of latest 100 blocks.
       uint64_t start_time;                  // Start time of the daemon, as UNIX time.
+      uint64_t last_storage_server_ping;    // Last ping time of the storage server (0 if never or not running as a service node)
       uint64_t free_space;                  // Available disk space on the node.
       bool offline;                         // States if the node is offline (`true`) or online (`false`).
       bool untrusted;                       // States if the result is obtained using the bootstrap mode, and is therefore not trusted (`true`), or when the daemon is fully synced (`false`).
@@ -833,6 +834,7 @@ namespace cryptonote
         KV_SERIALIZE(block_size_median)
         KV_SERIALIZE_OPT(block_weight_median, (uint64_t)0)
         KV_SERIALIZE(start_time)
+        KV_SERIALIZE(last_storage_server_ping)
         KV_SERIALIZE(free_space)
         KV_SERIALIZE(offline)
         KV_SERIALIZE(untrusted)


### PR DESCRIPTION
Fixes #871 

I didn't do anything to reset the uptime proof timer because it isn't at all clear that it can be done in a thread-safe manner from the thread that handles the storage server rpc ping.