### PR TITLE
Turn staking requirement into integer math variant

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -92,6 +92,7 @@ namespace cryptonote {
 
   uint64_t block_reward_unpenalized_formula_v8(uint64_t height)
   {
+    std::fesetround(FE_TONEAREST);
     uint64_t result = 28000000000.0 + 100000000000.0 / loki::exp2(height / (720.0 * 90.0)); // halve every 90 days.
     return result;
   }

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -45,6 +45,7 @@ using namespace epee;
 #include "ringct/rctSigs.h"
 #include "multisig/multisig.h"
 #include "int-util.h"
+#include <cfenv>
 
 using namespace crypto;
 
@@ -981,6 +982,7 @@ namespace cryptonote
   {
     blobdata bd = get_block_hashing_blob(b);
     rx_slow_hash(main_height, seed_height, seed_hash.data, bd.data(), bd.size(), res.data, 0, 1);
+    std::fesetround(FE_TONEAREST);
   }
 
   bool get_block_longhash(const Blockchain *pbc, const block& b, crypto::hash& res, const uint64_t height, const int miners)
@@ -993,7 +995,8 @@ namespace cryptonote
     const_cast<int &>(miners) = 0;
 #endif
 
-    if (hf_version >= network_version_12_checkpointing) {
+    if (hf_version >= network_version_12_checkpointing)
+    {
       uint64_t seed_height, main_height;
       crypto::hash hash;
       if (pbc != NULL)
@@ -1008,6 +1011,7 @@ namespace cryptonote
         main_height = 0;
       }
       rx_slow_hash(main_height, seed_height, hash.data, bd.data(), bd.size(), res.data, miners, 0);
+      std::fesetround(FE_TONEAREST);
       return true;
     }
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -45,7 +45,6 @@ using namespace epee;
 #include "ringct/rctSigs.h"
 #include "multisig/multisig.h"
 #include "int-util.h"
-#include <cfenv>
 
 using namespace crypto;
 
@@ -982,7 +981,6 @@ namespace cryptonote
   {
     blobdata bd = get_block_hashing_blob(b);
     rx_slow_hash(main_height, seed_height, seed_hash.data, bd.data(), bd.size(), res.data, 0, 1);
-    std::fesetround(FE_TONEAREST);
   }
 
   bool get_block_longhash(const Blockchain *pbc, const block& b, crypto::hash& res, const uint64_t height, const int miners)
@@ -995,8 +993,7 @@ namespace cryptonote
     const_cast<int &>(miners) = 0;
 #endif
 
-    if (hf_version >= network_version_12_checkpointing)
-    {
+    if (hf_version >= network_version_12_checkpointing) {
       uint64_t seed_height, main_height;
       crypto::hash hash;
       if (pbc != NULL)
@@ -1011,7 +1008,6 @@ namespace cryptonote
         main_height = 0;
       }
       rx_slow_hash(main_height, seed_height, hash.data, bd.data(), bd.size(), res.data, miners, 0);
-      std::fesetround(FE_TONEAREST);
       return true;
     }
 

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -3,7 +3,7 @@
 #include "int-util.h"
 #include <vector>
 #include <boost/lexical_cast.hpp>
-#include <fenv.h>
+#include <cfenv>
 
 #include "service_node_rules.h"
 
@@ -17,7 +17,7 @@ uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t he
 
   if (hf_version >= cryptonote::network_version_13_enforce_checkpoints)
   {
-    constexpr uint64_t y[] = {
+    constexpr int64_t heights[] = {
         385824,
         429024,
         472224,
@@ -33,7 +33,7 @@ uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t he
         1000000,
     };
 
-    constexpr uint64_t x[] = {
+    constexpr int64_t lsr[] = {
         20458380815527,
         19332319724305,
         18438564443912,
@@ -49,25 +49,25 @@ uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t he
         15000000000000,
     };
 
-    assert(height >= y[0]);
-    constexpr uint64_t LAST_HEIGHT      = y[loki::array_count(y) - 1];
-    constexpr uint64_t LAST_REQUIREMENT = x[loki::array_count(x) - 1];
+    assert(height >= heights[0]);
+    constexpr uint64_t LAST_HEIGHT      = heights[loki::array_count(heights) - 1];
+    constexpr uint64_t LAST_REQUIREMENT = lsr    [loki::array_count(lsr) - 1];
     if (height >= LAST_HEIGHT)
         return LAST_REQUIREMENT;
 
     size_t i = 0;
-    for (size_t index = 0; index < loki::array_count(y); index++)
+    for (size_t index = 1; index < loki::array_count(heights); index++)
     {
-      if (y[index] > height)
+      if (heights[index] > static_cast<int64_t>(height))
       {
         i = (index - 1);
         break;
       }
     }
 
-    uint64_t H      = height;
-    uint64_t result = y[i] + (H - x[i]) * ((y[i + 1] - y[i]) / (x[i + 1] - x[i]));
-    return result;
+    int64_t H      = height;
+    int64_t result = lsr[i] + (H - heights[i]) * ((lsr[i + 1] - lsr[i]) / (heights[i + 1] - heights[i]));
+    return static_cast<uint64_t>(result);
   }
 
   uint64_t hardfork_height = m_nettype == cryptonote::MAINNET ? 101250 : 96210 /* stagenet */;

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -77,11 +77,8 @@ uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t he
   uint64_t base = 0, variable = 0;
   if (hf_version >= cryptonote::network_version_11_infinite_staking)
   {
-    auto round_method = std::fegetround();
-    std::fesetround(FE_TONEAREST);
     base     = 15000 * COIN;
     variable = (25007.0 * COIN) / loki::exp2(height_adjusted/129600.0);
-    std::fesetround(round_method);
   }
   else
   {

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -75,6 +75,7 @@ uint64_t get_staking_requirement(cryptonote::network_type m_nettype, uint64_t he
 
   uint64_t height_adjusted = height - hardfork_height;
   uint64_t base = 0, variable = 0;
+  std::fesetround(FE_TONEAREST);
   if (hf_version >= cryptonote::network_version_11_infinite_staking)
   {
     base     = 15000 * COIN;

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -88,6 +88,7 @@ TEST(service_nodes, staking_requirement)
     ASSERT_LT(mainnet_delta, atomic_epsilon);
   }
 
+  // NOTE: Staking Requirement Algorithm Switch 2
   // Sliftly after the boundary when the scheme switches over to a smooth emissions curve to 15k
   {
     uint64_t height = 235987;
@@ -98,24 +99,40 @@ TEST(service_nodes, staking_requirement)
     ASSERT_LT(mainnet_delta, atomic_epsilon);
   }
 
-  // Check requirements are decreasing after switching over to new requirements curve
+  // Check staking requirement on height whose value is different with different floating point rounding modes, we expect FE_TONEAREST.
   {
-    uint64_t height = 706050;
+    uint64_t height = 373200;
     int64_t  mainnet_requirement  = (int64_t)service_nodes::get_staking_requirement(cryptonote::MAINNET, height, cryptonote::network_version_11_infinite_staking);
 
-    int64_t  mainnet_expected = (int64_t)((15984 * COIN) + 588930000);
-    int64_t  mainnet_delta    = std::abs(mainnet_requirement - mainnet_expected);
-    ASSERT_LT(mainnet_delta, atomic_epsilon);
+    int64_t  mainnet_expected = (int64_t)((20839 * COIN) + 644149350);
+    ASSERT_EQ(mainnet_requirement, mainnet_expected);
   }
 
-  // Check approaching 15k requirement
+  // NOTE: Staking Requirement Algorithm Switch: Integer Math Variant ^____^
   {
-    uint64_t height = 3643650;
-    int64_t  mainnet_requirement  = (int64_t)service_nodes::get_staking_requirement(cryptonote::MAINNET, height, cryptonote::network_version_11_infinite_staking);
+    uint64_t height = 450000;
+    uint64_t mainnet_requirement  = service_nodes::get_staking_requirement(cryptonote::MAINNET, height, cryptonote::network_version_13_enforce_checkpoints);
 
-    int64_t  mainnet_expected = (int64_t)((15000 * COIN) + 150000);
-    int64_t  mainnet_delta    = std::abs(mainnet_requirement - mainnet_expected);
-    ASSERT_LT(mainnet_delta, atomic_epsilon);
+    uint64_t  mainnet_expected = (18898 * COIN) + 351896001;
+    ASSERT_EQ(mainnet_requirement, mainnet_expected);
+  }
+
+  // Just before 15k boundary
+  {
+    uint64_t height = 999999;
+    uint64_t mainnet_requirement  = service_nodes::get_staking_requirement(cryptonote::MAINNET, height, cryptonote::network_version_13_enforce_checkpoints);
+
+    uint64_t mainnet_expected = (15000 * COIN) + 3122689;
+    ASSERT_EQ(mainnet_requirement, mainnet_expected);
+  }
+
+  // 15k requirement boundary
+  {
+    uint64_t height = 1000000;
+    uint64_t mainnet_requirement  = service_nodes::get_staking_requirement(cryptonote::MAINNET, height, cryptonote::network_version_13_enforce_checkpoints);
+
+    uint64_t mainnet_expected = 15000 * COIN;
+    ASSERT_EQ(mainnet_requirement, mainnet_expected);
   }
 }
 


### PR DESCRIPTION
Original comment and data points for the algorithm from @Jagerman

```
x = 385824 429024 472224 515424 558624 601824 645024 688224 731424 774624 817824 861024 904224

y =  20458380815527 19332319724305 18438564443912 17729190407764 17166159862153 16719282221956 16364595203882 16083079931076 15859641110978 15682297601941 15541539965538 15429820555489 15341148800970

So, e.g., for H=450000 you'd get i=1, so:  intlsr = 19332319724305 + (450000 - 429024) * (18438564443912 - 19332319724305) / (472224 - 429024)
= 18898.351882603

versus 18872.560735094 from the LSR.
```

This is a linear step-down approximation of the staking requirement to remove the use of floating point math.

![unknown](https://user-images.githubusercontent.com/12163539/66376397-4a0deb00-e9fb-11e9-9180-f8fe558ebff2.png)

Will write some unit tests- to verify later.