### PR TITLE
Increase maximum uptime credit to 48h

### DIFF
--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -22,7 +22,7 @@ namespace service_nodes {
   // deregistration transaction to the network, starting a 30-day deregistration count down.
   constexpr int64_t DECOMMISSION_CREDIT_PER_DAY = BLOCKS_EXPECTED_IN_HOURS(24) / 30;
   constexpr int64_t DECOMMISSION_INITIAL_CREDIT = BLOCKS_EXPECTED_IN_HOURS(2);
-  constexpr int64_t DECOMMISSION_MAX_CREDIT     = BLOCKS_EXPECTED_IN_HOURS(24);
+  constexpr int64_t DECOMMISSION_MAX_CREDIT     = BLOCKS_EXPECTED_IN_HOURS(48);
   constexpr int64_t DECOMMISSION_MINIMUM        = BLOCKS_EXPECTED_IN_HOURS(2);
 
   static_assert(DECOMMISSION_INITIAL_CREDIT <= DECOMMISSION_MAX_CREDIT, "Initial registration decommission credit cannot be larger than the maximum decommission credit");


### PR DESCRIPTION
You'll now hit this maxmimum if you've been up for ~60d.  Note that this
will not fully apply until the whole network has upgraded to v5; before
the fork height non-upgraded SNs voting for you will still only award
max 24h credit.