### PR TITLE
iOS build fix

### DIFF
--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -214,7 +214,7 @@ namespace
   >;
 
   template<typename T>
-  quoted_result<T> quoted(const T& arg)
+  quoted_result<T> add_quotes(const T& arg)
   {
     return boost::range::join(boost::range::join(ceref(u8"\""), arg), ceref(u8"\""));
   }
@@ -242,13 +242,13 @@ namespace
   {
     str.append(u8"Digest ");
     add_first_field(str, u8"algorithm", algorithm);
-    add_field(str, u8"nonce", quoted(user.server.nonce));
-    add_field(str, u8"realm", quoted(user.server.realm));
-    add_field(str, u8"response", quoted(response));
-    add_field(str, u8"uri", quoted(uri));
-    add_field(str, u8"username", quoted(user.credentials.username));
+    add_field(str, u8"nonce", add_quotes(user.server.nonce));
+    add_field(str, u8"realm", add_quotes(user.server.realm));
+    add_field(str, u8"response", add_quotes(response));
+    add_field(str, u8"uri", add_quotes(uri));
+    add_field(str, u8"username", add_quotes(user.credentials.username));
     if (!user.server.opaque.empty())
-      add_field(str, u8"opaque", quoted(user.server.opaque));
+      add_field(str, u8"opaque", add_quotes(user.server.opaque));
   }
 
   //! Implements superseded algorithm specified in RFC 2069
@@ -674,8 +674,8 @@ namespace
           Digest::name, (i == 0 ? boost::string_ref{} : sess_algo)
         );
         add_field(out, u8"algorithm", algorithm);
-        add_field(out, u8"realm", quoted(auth_realm));
-        add_field(out, u8"nonce", quoted(nonce));
+        add_field(out, u8"realm", add_quotes(auth_realm));
+        add_field(out, u8"nonce", add_quotes(nonce));
         add_field(out, u8"stale", is_stale ? ceref("true") : ceref("false"));
         
         fields.push_back(std::make_pair(std::string(server_auth_field), std::move(out)));


### PR DESCRIPTION
Apple clang is resolving the `quoted()` calls here as [`std::quoted(std::string)`](https://en.cppreference.com/w/cpp/io/manip/quoted) because of the ADL with the `std::string` argument, then boost fails because rather than passing boost ranges the code ends up passing libc++'s internal `__quoted_output_proxy` (the opaque return type of `std::quoted()`:

```
.../boost/concept/detail/general.hpp:52:10: note: in instantiation of template class 'boost::mpl::if_<boost::concepts::not_satisfied<boost::SinglePassRangeConcept<const std::__1::__quoted_output_proxy<char, std::__1::__wrap_iter<const char *>, std::__1::char_traits<char> > > >, boost::concepts::constraint<boost::SinglePassRangeConcept<const std::__1::__quoted_output_proxy<char, std::__1::__wrap_iter<const char *>, std::__1::char_traits<char> > > >, boost::concepts::requirement<boost::concepts::failed ************boost::SinglePassRangeConcept<const std::__1::__quoted_output_proxy<char, std::__1::__wrap_iter<const char *>, std::__1::char_traits<char> > >::************> >' requested here
  : mpl::if_<
         ^
```

(This only appeared now because std::quoted() doesn't exist before C++14).

This works around the issue by just renaming the internal `quoted()` function to `add_quotes()`.