### PR TITLE
Fix "__memcpy_chk" undefined on Windows target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,12 +673,10 @@ else()
   add_cxx_flag_if_supported(-Wformat-security CXX_SECURITY_FLAGS)
 
   # -fstack-protector
-  if (NOT WIN32)
-    add_c_flag_if_supported(-fstack-protector C_SECURITY_FLAGS)
-    add_cxx_flag_if_supported(-fstack-protector CXX_SECURITY_FLAGS)
-    add_c_flag_if_supported(-fstack-protector-strong C_SECURITY_FLAGS)
-    add_cxx_flag_if_supported(-fstack-protector-strong CXX_SECURITY_FLAGS)
-  endif()
+  add_c_flag_if_supported(-fstack-protector C_SECURITY_FLAGS)
+  add_cxx_flag_if_supported(-fstack-protector CXX_SECURITY_FLAGS)
+  add_c_flag_if_supported(-fstack-protector-strong C_SECURITY_FLAGS)
+  add_cxx_flag_if_supported(-fstack-protector-strong CXX_SECURITY_FLAGS)
 
   # New in GCC 8.2
   if (NOT WIN32)


### PR DESCRIPTION
Enable -fstack-protector* on msys to get -lssp  implicitly.
mingw64 doesn't provide fortified functions which are required if you
define FORTIFY_SOURCES to be > 0. By enabling -fstack-protector* you
implicitly link against libssp which provides fortified variants of the
missing functions.

See: https://github.com/msys2/MINGW-packages/issues/5803

@jagerman

Fixes: https://github.com/loki-project/loki/issues/904