### PR TITLE
Some LNS prep changes: construct_tx update, infinite staking documentation

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -168,9 +168,9 @@ namespace cryptonote
     standard,
     state_change,
     key_image_unlock,
+    stake,
     _count
   };
-
 
   class transaction_prefix
   {
@@ -179,21 +179,21 @@ namespace cryptonote
     static char const *version_to_string(txversion v);
     static char const *type_to_string(txtype type);
 
-    static txversion get_min_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype = MAINNET);
-    static txversion get_max_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype = MAINNET);
+    static txversion get_min_version_for_hf(uint8_t hf_version);
+    static txversion get_max_version_for_hf(uint8_t hf_version);
+    static txtype    get_max_type_for_hf   (uint8_t hf_version);
 
     // tx information
     txversion version;
     txtype type;
 
+    bool is_transfer() const { return type == txtype::standard || type == txtype::stake; }
+
     // not used after version 2, but remains for compatibility
     uint64_t unlock_time;  //number of block (or time), used as a limitation like: spend this tx not early then block/time
-
     std::vector<txin_v> vin;
     std::vector<tx_out> vout;
-    //extra
     std::vector<uint8_t> extra;
-
     std::vector<uint64_t> output_unlock_times;
 
     BEGIN_SERIALIZE()
@@ -529,21 +529,15 @@ namespace cryptonote
   using byte_and_output_fees = std::pair<uint64_t, uint64_t>;
 
   //---------------------------------------------------------------
-  inline static cryptonote::network_type validate_nettype(cryptonote::network_type nettype)
+  inline txversion transaction_prefix::get_min_version_for_hf(uint8_t hf_version)
   {
-    cryptonote::network_type result = nettype;
-    assert(result != UNDEFINED);
-    if (result == UNDEFINED)
-    {
-      LOG_ERROR("Min/Max version query network type unexpectedly set to UNDEFINED, defaulting to MAINNET");
-      result = MAINNET;
-    }
-    return result;
+    if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_10_bulletproofs)
+      return txversion::v2_ringct;
+    return txversion::v4_tx_types;
   }
 
-  inline enum txversion transaction_prefix::get_max_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype)
+  inline txversion transaction_prefix::get_max_version_for_hf(uint8_t hf_version)
   {
-    nettype = validate_nettype(nettype);
     if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_8)
       return txversion::v2_ringct;
 
@@ -553,22 +547,13 @@ namespace cryptonote
     return txversion::v4_tx_types;
   }
 
-  inline enum txversion transaction_prefix::get_min_version_for_hf(uint8_t hf_version, cryptonote::network_type nettype)
+  inline txtype transaction_prefix::get_max_type_for_hf(uint8_t hf_version)
   {
-    nettype = validate_nettype(nettype);
-    if (nettype == MAINNET) // NOTE(loki): Add an exception for mainnet as there are v2's on mainnet.
-    {
-      if (hf_version == cryptonote::network_version_10_bulletproofs)
-        return txversion::v2_ringct;
-    }
-
-    if (hf_version >= cryptonote::network_version_7 && hf_version <= cryptonote::network_version_9_service_nodes)
-      return txversion::v2_ringct;
-
-    if (hf_version == cryptonote::network_version_10_bulletproofs)
-      return txversion::v3_per_output_unlock_times;
-
-    return txversion::v4_tx_types;
+    txtype result = txtype::standard;
+    if      (hf_version >= network_version_14_lns)              result = txtype::stake;
+    else if (hf_version >= network_version_11_infinite_staking) result = txtype::key_image_unlock;
+    else if (hf_version >= network_version_9_service_nodes)     result = txtype::state_change;
+    return result;
   }
 
   inline char const *transaction_prefix::version_to_string(txversion v)
@@ -590,6 +575,7 @@ namespace cryptonote
       case txtype::standard:         return "standard";
       case txtype::state_change:     return "state_change";
       case txtype::key_image_unlock: return "key_image_unlock";
+      case txtype::stake:            return "stake";
       default: assert(false);        return "xx_unhandled_type";
     }
   }

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -971,14 +971,14 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool check_outs_valid(const transaction& tx)
   {
-    if (tx.type != txtype::standard)
+    if (!tx.is_transfer())
     {
       CHECK_AND_NO_ASSERT_MES(tx.vout.size() == 0, false, "tx type: " << tx.type << " must have 0 outputs, received: " << tx.vout.size() << ", id=" << get_transaction_hash(tx));
     }
 
     if (tx.version >= txversion::v3_per_output_unlock_times)
     {
-      CHECK_AND_NO_ASSERT_MES(tx.vout.size() == tx.output_unlock_times.size(), false, "tx version 3 must have equal number of output unlock times and outputs");
+      CHECK_AND_NO_ASSERT_MES(tx.vout.size() == tx.output_unlock_times.size(), false, "tx version: " << tx.version << "must have equal number of output unlock times and outputs");
     }
 
     for(const tx_out& out: tx.vout)
@@ -1371,13 +1371,13 @@ namespace cryptonote
     // TODO(loki): Not sure if this is the right fix, we may just want to set
     // unprunable size to the size of the prefix because technically that is
     // what it is and then keep this code path.
-    if (t.type == txtype::standard)
+    if (t.is_transfer())
     {
       const unsigned int unprunable_size = t.unprunable_size;
       const unsigned int prefix_size = t.prefix_size;
 
       // base rct
-      CHECK_AND_ASSERT_MES(prefix_size <= unprunable_size && unprunable_size <= blob.size(), false, "Inconsistent transaction prefix, unprunable and blob sizes");
+      CHECK_AND_ASSERT_MES(prefix_size <= unprunable_size && unprunable_size <= blob.size(), false, "Inconsistent transaction prefix, unprunable and blob sizes in: " << __func__);
       cryptonote::get_blob_hash(epee::span<const char>(blob.data() + prefix_size, unprunable_size - prefix_size), hashes[1]);
     }
     else

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -261,6 +261,7 @@ namespace cryptonote
     network_version_11_infinite_staking, // Infinite Staking, CN-Turtle
     network_version_12_checkpointing, // Checkpointing, Relaxed Deregistration, RandomXL, Loki Storage Server
     network_version_13_enforce_checkpoints,
+    network_version_14_lns,
 
     network_version_count,
   };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1271,8 +1271,8 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
       return false;
     }
 
-    const auto min_version = transaction::get_min_version_for_hf(version, nettype());
-    const auto max_version = transaction::get_max_version_for_hf(version, nettype());
+    txversion min_version = transaction::get_max_version_for_hf(version);
+    txversion max_version = transaction::get_min_version_for_hf(version);
     if (b.miner_tx.version < min_version || b.miner_tx.version > max_version)
     {
       MERROR_VER("Coinbase invalid version: " << b.miner_tx.version << " for hardfork: " << version << " min/max version:  " << min_version << "/" << max_version);
@@ -2864,7 +2864,8 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
   }
 
   if (hf_version > HF_VERSION_SMALLER_BP) {
-    if (tx.version >= txversion::v4_tx_types && tx.type == txtype::standard) {
+    if (tx.version >= txversion::v4_tx_types && tx.is_transfer())
+    {
       if (tx.rct_signatures.type == rct::RCTTypeBulletproof)
       {
         MERROR_VER("Ringct type " << (unsigned)rct::RCTTypeBulletproof << " is not allowed from v" << (HF_VERSION_SMALLER_BP + 1));
@@ -2975,22 +2976,20 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
 
   // Min/Max Type/Version Check
   {
-    const auto min_version = transaction::get_min_version_for_hf(hf_version, nettype());
-    const auto max_version = transaction::get_max_version_for_hf(hf_version, nettype());
-
-    if (hf_version >= network_version_11_infinite_staking)
-      tvc.m_invalid_type |= (tx.type > txtype::key_image_unlock);
-
+    txtype max_type       = transaction::get_max_type_for_hf(hf_version);
+    txversion min_version = transaction::get_min_version_for_hf(hf_version);
+    txversion max_version = transaction::get_max_version_for_hf(hf_version);
+    tvc.m_invalid_type    = (tx.type > max_type);
     tvc.m_invalid_version = tx.version < min_version || tx.version > max_version;
     if (tvc.m_invalid_version || tvc.m_invalid_type)
     {
-      if (tvc.m_invalid_version) MERROR_VER("TX Invalid version: " << tx.version << " for hardfork: " << hf_version << " min/max version:  " << min_version << "/" << max_version);
-      if (tvc.m_invalid_type)    MERROR_VER("TX Invalid type for hardfork: " << hf_version);
+      if (tvc.m_invalid_version) MERROR_VER("TX Invalid version: " << tx.version << " for hardfork: " << (int)hf_version << " min/max version:  " << min_version << "/" << max_version);
+      if (tvc.m_invalid_type)    MERROR_VER("TX Invalid type: " << tx.type << " for hardfork: " << (int)hf_version << " max type: " << max_type);
       return false;
     }
   }
 
-  if (tx.type == txtype::standard)
+  if (tx.is_transfer())
   {
     crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1039,7 +1039,7 @@ namespace cryptonote
         continue;
       }
 
-      if (tx_info[n].tx->type != txtype::standard)
+      if (!tx_info[n].tx->is_transfer())
         continue;
       const rct::rctSig &rv = tx_info[n].tx->rct_signatures;
       switch (rv.type) {
@@ -1238,18 +1238,21 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::check_tx_semantic(const transaction& tx, bool keeped_by_block) const
   {
-    if (tx.type != txtype::standard)
+    if (tx.is_transfer())
+    {
+      if (tx.vin.empty())
+      {
+        MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
+        return false;
+      }
+    }
+    else
     {
       if (tx.vin.size() != 0)
       {
         MERROR_VER("tx type: " << tx.type << " must have 0 inputs, received: " << tx.vin.size() << ", rejected for tx id = " << get_transaction_hash(tx));
         return false;
       }
-    }
-    else if (!tx.vin.size())
-    {
-      MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
-      return false;
     }
 
     if(!check_inputs_types_supported(tx))

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -165,27 +165,50 @@ namespace cryptonote
 
   //---------------------------------------------------------------
   crypto::public_key get_destination_view_key_pub(const std::vector<tx_destination_entry> &destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr);
-  bool construct_tx(const account_keys& sender_account_keys, std::vector<tx_source_entry> &sources, const std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, uint8_t hf_version = cryptonote::network_version_7, bool is_staking = false);
+  bool construct_tx(const account_keys &sender_account_keys,
+                    std::vector<tx_source_entry> &sources,
+                    const std::vector<tx_destination_entry> &destinations,
+                    const boost::optional<cryptonote::tx_destination_entry> &change_addr,
+                    const std::vector<uint8_t> &extra,
+                    transaction &tx,
+                    uint64_t unlock_time,
+                    uint8_t hf_version = cryptonote::network_version_7,
+                    txtype tx_type     = txtype::standard
+                   );
 
-  struct loki_construct_tx_params
-  {
-    bool                v4_allow_tx_types;
-    bool                v3_per_output_unlock;
-    bool                v3_is_staking_tx;     // NOTE: Set to true manually if you need a staking transaction
-    bool                v2_rct;
+  bool construct_tx_with_tx_key(const account_keys &sender_account_keys,
+                                const std::unordered_map<crypto::public_key, subaddress_index> &subaddresses,
+                                std::vector<tx_source_entry> &sources,
+                                std::vector<tx_destination_entry> &destinations,
+                                const boost::optional<cryptonote::tx_destination_entry> &change_addr,
+                                const std::vector<uint8_t> &extra,
+                                transaction &tx,
+                                uint64_t unlock_time,
+                                const crypto::secret_key &tx_key,
+                                const std::vector<crypto::secret_key> &additional_tx_keys,
+                                const rct::RCTConfig &rct_config = {rct::RangeProofBorromean, 0},
+                                rct::multisig_out *msout         = NULL,
+                                bool shuffle_outs                = true,
+                                uint8_t hf_version               = cryptonote::network_version_7,
+                                txtype tx_type                   = txtype::standard
+                                );
 
-    loki_construct_tx_params() = default;
-    loki_construct_tx_params(uint8_t hf_version)
-    {
-      *this = {};
-      v4_allow_tx_types    = (hf_version >= cryptonote::network_version_11_infinite_staking);
-      v3_per_output_unlock = (hf_version >= cryptonote::network_version_9_service_nodes);
-      v2_rct               = (hf_version >= cryptonote::network_version_7);
-    }
-  };
+  bool construct_tx_and_get_tx_key(const account_keys &sender_account_keys,
+                                   const std::unordered_map<crypto::public_key, subaddress_index> &subaddresses,
+                                   std::vector<tx_source_entry> &sources,
+                                   std::vector<tx_destination_entry> &destinations,
+                                   const boost::optional<cryptonote::tx_destination_entry> &change_addr,
+                                   const std::vector<uint8_t> &extra,
+                                   transaction &tx,
+                                   uint64_t unlock_time,
+                                   crypto::secret_key &tx_key,
+                                   std::vector<crypto::secret_key> &additional_tx_keys,
+                                   const rct::RCTConfig &rct_config = {rct::RangeProofBorromean, 0},
+                                   rct::multisig_out *msout         = NULL,
+                                   uint8_t hf_version               = cryptonote::network_version_7,
+                                   txtype tx_type                   = txtype::standard
+                                   );
 
-  bool construct_tx_with_tx_key   (const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, std::vector<tx_source_entry>& sources, std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0}, rct::multisig_out *msout = NULL, bool shuffle_outs = true, loki_construct_tx_params const tx_params = {});
-  bool construct_tx_and_get_tx_key(const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, std::vector<tx_source_entry>& sources, std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time,       crypto::secret_key &tx_key,       std::vector<crypto::secret_key> &additional_tx_keys, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0}, rct::multisig_out *msout = NULL, loki_construct_tx_params const tx_params = {});
   bool generate_output_ephemeral_keys(const size_t tx_version, bool &found_change,
                                       const cryptonote::account_keys &sender_account_keys, const crypto::public_key &txkey_pub,  const crypto::secret_key &tx_key,
                                       const cryptonote::tx_destination_entry &dst_entr, const boost::optional<cryptonote::tx_destination_entry> &change_addr, const size_t output_index,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1413,7 +1413,8 @@ namespace service_nodes
     for (uint32_t index = 0; index < txs.size(); ++index)
     {
       const cryptonote::transaction& tx = txs[index];
-      if (tx.type == cryptonote::txtype::standard)
+      if ((hf_version >= cryptonote::network_version_14_lns && tx.type == cryptonote::txtype::stake) ||
+          (hf_version <= cryptonote::network_version_13_enforce_checkpoints && tx.type == cryptonote::txtype::standard))
       {
         process_registration_tx(nettype, block, tx, index, my_keys);
         need_swarm_update += process_contribution_tx(nettype, block, tx, index);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -538,7 +538,7 @@ namespace service_nodes
           cryptonote::transaction state_change_tx = {};
           if (cryptonote::add_service_node_state_change_to_tx_extra(state_change_tx.extra, state_change, hf_version))
           {
-            state_change_tx.version = cryptonote::transaction::get_min_version_for_hf(hf_version, m_core.get_nettype());
+            state_change_tx.version = cryptonote::transaction::get_max_version_for_hf(hf_version);
             state_change_tx.type    = cryptonote::txtype::state_change;
 
             cryptonote::tx_verification_context tvc = {};

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -122,7 +122,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version, service_nodes::service_node_list const &service_node_list) const
   {
-    if (tx.type == txtype::standard)
+    if (tx.is_transfer())
       return false;
 
     if (tx.type == txtype::state_change)
@@ -289,7 +289,7 @@ namespace cryptonote
       fee = tx.rct_signatures.txnFee;
     }
 
-    if (!kept_by_block && tx.type == txtype::standard && !m_blockchain.check_fee(tx_weight, tx.vout.size(), fee))
+    if (!kept_by_block && tx.is_transfer() && !m_blockchain.check_fee(tx_weight, tx.vout.size(), fee))
     {
       tvc.m_verifivation_failed = true;
       tvc.m_fee_too_low = true;
@@ -345,7 +345,7 @@ namespace cryptonote
     uint64_t max_used_block_height = 0;
     cryptonote::txpool_tx_meta_t meta;
     bool ch_inp_res = check_tx_inputs([&tx]()->cryptonote::transaction&{ return tx; }, id, max_used_block_height, max_used_block_id, tvc, kept_by_block);
-    const bool non_standard_tx = (tx.type != txtype::standard);
+    const bool non_standard_tx = !tx.is_transfer();
     if(!ch_inp_res)
     {
       // if the transaction was valid before (kept_by_block), then it
@@ -1665,7 +1665,7 @@ namespace cryptonote
           return false;
         }
 
-        const bool non_standard_tx = (tx.type != txtype::standard);
+        const bool non_standard_tx = !tx.is_transfer();
         m_txs_by_fee_and_receive_time.emplace(std::tuple<bool, double, time_t>(non_standard_tx, meta.fee / (double)meta.weight, meta.receive_time), txid);
         m_txpool_weight += meta.weight;
         return true;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6860,7 +6860,7 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
   SCOPED_WALLET_UNLOCK();
   try
   {
-    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices, false, sweep_style);
+    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices, txtype::standard, sweep_style);
     sweep_main_internal(sweep_type_t::all_or_below, ptx_vector, info);
   }
   catch (const std::exception &e)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -514,14 +514,13 @@ private:
       std::vector<size_t> selected_transfers;
       std::vector<uint8_t> extra;
       uint64_t unlock_time;
-      bool v2_use_rct;
-      bool v3_per_output_unlock;
-      bool v4_allow_tx_types;
       rct::RCTConfig rct_config;
       std::vector<cryptonote::tx_destination_entry> dests; // original setup, does not include change
       uint32_t subaddr_account;   // subaddress account of your wallet to be used in this transfer
       std::set<uint32_t> subaddr_indices;  // set of address indices used as inputs in this transfer
 
+      uint8_t            hf_version;
+      cryptonote::txtype tx_type;
       BEGIN_SERIALIZE_OBJECT()
         FIELD(sources)
         FIELD(change_dts)
@@ -529,13 +528,13 @@ private:
         FIELD(selected_transfers)
         FIELD(extra)
         FIELD(unlock_time)
-        FIELD(v2_use_rct)
-        FIELD(v3_per_output_unlock)
-        FIELD(v4_allow_tx_types)
         FIELD(rct_config)
         FIELD(dests)
         FIELD(subaddr_account)
         FIELD(subaddr_indices)
+
+        FIELD(hf_version)
+        ENUM_FIELD(tx_type, tx_type < cryptonote::txtype::_count)
       END_SERIALIZE()
     };
 
@@ -919,9 +918,17 @@ private:
     // all locked & unlocked balances of all subaddress accounts
     uint64_t balance_all() const;
     uint64_t unlocked_balance_all(uint64_t *blocks_to_unlock = NULL) const;
-    void transfer_selected_rct(std::vector<cryptonote::tx_destination_entry> dsts, const std::vector<size_t>& selected_transfers, size_t fake_outputs_count,
-      std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs,
-      uint64_t unlock_time, uint64_t fee, const std::vector<uint8_t>& extra, cryptonote::transaction& tx, pending_tx &ptx, const rct::RCTConfig &rct_config, bool is_staking_tx = false);
+    void transfer_selected_rct(std::vector<cryptonote::tx_destination_entry> dsts,
+                               const std::vector<size_t> &selected_transfers,
+                               size_t fake_outputs_count,
+                               std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs,
+                               uint64_t unlock_time,
+                               uint64_t fee,
+                               const std::vector<uint8_t> &extra,
+                               cryptonote::transaction &tx,
+                               pending_tx &ptx,
+                               const rct::RCTConfig &rct_config,
+                               cryptonote::txtype tx_type = cryptonote::txtype::standard);
 
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
@@ -943,12 +950,47 @@ private:
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
     bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, bool is_staking_tx=false);     // pass subaddr_indices by value on purpose
+    std::vector<wallet2::pending_tx>
+    create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts,
+                          const size_t fake_outs_count,
+                          const uint64_t unlock_time,
+                          uint32_t priority,
+                          const std::vector<uint8_t> &extra,
+                          uint32_t subaddr_account,
+                          std::set<uint32_t> subaddr_indices, // pass subaddr_indices by value on purpose
+                          cryptonote::txtype tx_type = cryptonote::txtype::standard);
 
     enum struct sweep_style_t { normal, use_v1_tx };
-    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, bool is_staking_tx=false, sweep_style_t sweep_style = sweep_style_t::normal);
-    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra);
-    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, bool is_staking_tx=false);
+    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below,
+                                                             const cryptonote::account_public_address &address,
+                                                             bool is_subaddress,
+                                                             const size_t outputs,
+                                                             const size_t fake_outs_count,
+                                                             const uint64_t unlock_time,
+                                                             uint32_t priority,
+                                                             const std::vector<uint8_t> &extra,
+                                                             uint32_t subaddr_account,
+                                                             std::set<uint32_t> subaddr_indices,
+                                                             cryptonote::txtype tx_type = cryptonote::txtype::standard,
+                                                             sweep_style_t sweep_style  = sweep_style_t::normal);
+    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki,
+                                                                const cryptonote::account_public_address &address,
+                                                                bool is_subaddress,
+                                                                const size_t outputs,
+                                                                const size_t fake_outs_count,
+                                                                const uint64_t unlock_time,
+                                                                uint32_t priority,
+                                                                const std::vector<uint8_t> &extra);
+    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address,
+                                                              bool is_subaddress,
+                                                              const size_t outputs,
+                                                              std::vector<size_t> unused_transfers_indices,
+                                                              std::vector<size_t> unused_dust_indices,
+                                                              const size_t fake_outs_count,
+                                                              const uint64_t unlock_time,
+                                                              uint32_t priority,
+                                                              const std::vector<uint8_t> &extra,
+                                                              cryptonote::txtype tx_type = cryptonote::txtype::standard);
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, std::vector<cryptonote::tx_destination_entry> dsts) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
     void cold_sign_tx(const std::vector<pending_tx>& ptx_vector, signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::vector<std::string> & tx_device_aux);
@@ -1462,7 +1504,6 @@ private:
     stake_result check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction = 0);
     stake_result create_stake_tx    (const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount,
                                      double amount_fraction = 0, uint32_t priority = 0, uint32_t subaddr_account = 0, std::set<uint32_t> subaddr_indices = {});
-
     enum struct register_service_node_result_status
     {
       invalid,
@@ -1782,7 +1823,7 @@ BOOST_CLASS_VERSION(tools::wallet2::address_book_row, 17)
 BOOST_CLASS_VERSION(tools::wallet2::reserve_proof_entry, 0)
 BOOST_CLASS_VERSION(tools::wallet2::unsigned_tx_set, 0)
 BOOST_CLASS_VERSION(tools::wallet2::signed_tx_set, 1)
-BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 5)
+BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 6)
 BOOST_CLASS_VERSION(tools::wallet2::pending_tx, 3)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_sig, 0)
 
@@ -2158,7 +2199,6 @@ namespace boost
       }
       a & x.extra;
       a & x.unlock_time;
-      a & x.v2_use_rct;
       a & x.dests;
       if (ver < 1)
       {
@@ -2171,10 +2211,8 @@ namespace boost
         x.rct_config = { rct::RangeProofBorromean, 0 };
       if (ver < 2)
         return;
-      a & x.selected_transfers;
       if (ver < 3)
         return;
-      a & x.v3_per_output_unlock;
       if (ver < 5)
       {
         bool use_bulletproofs = x.rct_config.range_proof_type != rct::RangeProofBorromean;
@@ -2183,8 +2221,11 @@ namespace boost
           x.rct_config = { use_bulletproofs ? rct::RangeProofBulletproof : rct::RangeProofBorromean, 0 };
         return;
       }
-      a & x.v4_allow_tx_types;
       a & x.rct_config;
+
+      if (ver < 6) return;
+      a & x.tx_type;
+      a & x.hf_version;
     }
 
     template <class Archive>

--- a/tests/core_tests/bulletproofs.cpp
+++ b/tests/core_tests/bulletproofs.cpp
@@ -161,7 +161,6 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
       return false;
     }
 
-    loki_construct_tx_params tx_params(generator.m_hf_version);
     if (!cryptonote::construct_tx_and_get_tx_key(
         from.get_keys(),
         subaddresses,
@@ -175,7 +174,7 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
         additional_tx_keys,
         rct_config[n],
         nullptr, /*multisig_out*/
-        tx_params))
+        generator.m_hf_version))
     {
       MDEBUG("construct_tx_and_get_tx_key failure");
       return false;

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -301,7 +301,11 @@ cryptonote::transaction loki_chain_generator::create_registration_tx(const crypt
     crypto::generate_signature(hash, service_node_keys.pub, service_node_keys.sec, signature);
     add_service_node_register_to_tx_extra(extra, contributors, operator_cut, portions, exp_timestamp, signature);
     add_service_node_contributor_to_tx_extra(extra, contributors.at(0));
-    loki_tx_builder(events_, result, head, src /*from*/, src /*to*/, amount, new_hf_version).is_staking(true).with_unlock_time(unlock_time).with_extra(extra).with_per_output_unlock(true).build();
+    loki_tx_builder(events_, result, head, src /*from*/, src /*to*/, amount, new_hf_version)
+        .with_tx_type(cryptonote::txtype::stake)
+        .with_unlock_time(unlock_time)
+        .with_extra(extra)
+        .build();
   }
 
   service_node_keys_[service_node_keys.pub] = service_node_keys.sec; // NOTE: Save generated key for reuse later if we need to interact with the node again
@@ -351,9 +355,12 @@ cryptonote::transaction loki_chain_generator::create_state_change_tx(service_nod
     std::vector<uint8_t> extra;
     const bool full_tx_made = cryptonote::add_service_node_state_change_to_tx_extra(result.extra, state_change_extra, get_hf_version_at(height + 1));
     assert(full_tx_made);
-    if (fee) loki_tx_builder(events_, result, top().block, first_miner_, first_miner_, 0 /*amount*/, get_hf_version_at(height + 1)).with_fee(fee).with_extra(extra).with_per_output_unlock(true).build();
-    result.version = cryptonote::transaction::get_max_version_for_hf(get_hf_version_at(height + 1), cryptonote::FAKECHAIN);
-    result.type    = cryptonote::txtype::state_change;
+    if (fee) loki_tx_builder(events_, result, top().block, first_miner_, first_miner_, 0 /*amount*/, get_hf_version_at(height + 1)).with_tx_type(cryptonote::txtype::state_change).with_fee(fee).with_extra(extra).build();
+    else
+    {
+      result.type    = cryptonote::txtype::state_change;
+      result.version = cryptonote::transaction::get_max_version_for_hf(get_hf_version_at(height + 1));
+    }
   }
 
   return result;
@@ -950,7 +957,10 @@ cryptonote::transaction make_registration_tx(std::vector<test_event_entry>& even
   crypto::generate_signature(hash, service_node_keys.pub, service_node_keys.sec, signature);
   add_service_node_register_to_tx_extra(extra, contributors, operator_cut, portions, exp_timestamp, signature);
   add_service_node_contributor_to_tx_extra(extra, contributors.at(0));
-  loki_tx_builder(events, tx, head, account, account, amount, hf_version).is_staking(true).with_extra(extra).with_unlock_time(unlock_time).with_per_output_unlock(true).build();
+
+  cryptonote::txtype tx_type = cryptonote::txtype::standard;
+  if (hf_version >= cryptonote::network_version_14_lns) tx_type = cryptonote::txtype::stake;
+  loki_tx_builder(events, tx, head, account, account, amount, hf_version).with_tx_type(tx_type).with_extra(extra).with_unlock_time(unlock_time).build();
   events.push_back(tx);
   return tx;
 }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1245,8 +1245,7 @@ class loki_tx_builder {
   std::vector<uint8_t> m_extra;
 
   /// optional fields
-  bool m_per_output_unlock = false;
-  bool m_is_staking        = false;
+  cryptonote::txtype m_tx_type = cryptonote::txtype::standard;
 
   /// this makes sure we didn't forget to build it
   bool m_finished = false;
@@ -1268,7 +1267,8 @@ public:
     , m_hf_version(hf_version)
     , m_fee(TESTS_DEFAULT_FEE)
     , m_unlock_time(0)
-  {}
+  {
+  }
 
   loki_tx_builder&& with_fee(uint64_t fee) {
     m_fee = fee;
@@ -1280,18 +1280,13 @@ public:
     return std::move(*this);
   }
 
-  loki_tx_builder&& is_staking(bool val) {
-    m_is_staking = val;
-    return std::move(*this);
-  }
-
   loki_tx_builder&& with_unlock_time(uint64_t val) {
     m_unlock_time = val;
     return std::move(*this);
   }
 
-  loki_tx_builder&& with_per_output_unlock(bool val = true) {
-    m_per_output_unlock = val;
+  loki_tx_builder&& with_tx_type(cryptonote::txtype val) {
+    m_tx_type = val;
     return std::move(*this);
   }
 
@@ -1316,8 +1311,7 @@ public:
       m_events, m_head, m_from, m_to.get_keys().m_account_address, m_amount, m_fee, nmix, sources, destinations, &change_amount);
 
     cryptonote::tx_destination_entry change_addr{ change_amount, m_from.get_keys().m_account_address, false /*is_subaddr*/ };
-    bool result = cryptonote::construct_tx(
-      m_from.get_keys(), sources, destinations, change_addr, m_extra, m_tx, m_unlock_time, m_hf_version, m_is_staking);
+    bool result = cryptonote::construct_tx(m_from.get_keys(), sources, destinations, change_addr, m_extra, m_tx, m_unlock_time, m_hf_version, m_tx_type);
     return result;
   }
 };

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -368,8 +368,7 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
 #endif
   std::vector<crypto::secret_key> additional_tx_secret_keys;
   auto sources_copy = sources;
-  loki_construct_tx_params tx_params(cryptonote::network_version_8);
-  r = construct_tx_and_get_tx_key(miner_account[creator].get_keys(), subaddresses, sources, destinations, boost::none, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_secret_keys, { rct::RangeProofBorromean, 0 }, msoutp, tx_params);
+  r = construct_tx_and_get_tx_key(miner_account[creator].get_keys(), subaddresses, sources, destinations, boost::none, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_secret_keys, { rct::RangeProofBorromean, 0 }, msoutp, block_major);
   CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
 
 #ifndef NO_MULTISIG

--- a/tests/core_tests/rct.cpp
+++ b/tests/core_tests/rct.cpp
@@ -121,8 +121,7 @@ bool gen_rct_tx_validation_base::generate_with(std::vector<test_event_entry>& ev
     std::vector<crypto::secret_key> additional_tx_keys;
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[miner_accounts[n].get_keys().m_account_address.m_spend_public_key] = {0,0};
-    loki_construct_tx_params tx_params(cryptonote::network_version_8);
-    bool r = construct_tx_and_get_tx_key(miner_accounts[n].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), rct_txes[n], 0, tx_key, additional_tx_keys, {}, nullptr, tx_params);
+    bool r = construct_tx_and_get_tx_key(miner_accounts[n].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), rct_txes[n], 0, tx_key, additional_tx_keys, {}, nullptr);
     CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
     events.push_back(rct_txes[n]);
     starting_rct_tx_hashes.push_back(get_transaction_hash(rct_txes[n]));
@@ -224,8 +223,7 @@ bool gen_rct_tx_validation_base::generate_with(std::vector<test_event_entry>& ev
   std::vector<crypto::secret_key> additional_tx_keys;
   std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
   subaddresses[miner_accounts[0].get_keys().m_account_address.m_spend_public_key] = {0,0};
-  loki_construct_tx_params tx_params(cryptonote::network_version_8);
-  bool r = construct_tx_and_get_tx_key(miner_accounts[0].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_keys, {}, nullptr, tx_params);
+  bool r = construct_tx_and_get_tx_key(miner_accounts[0].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_keys, {}, nullptr);
   CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
 
   if (post_tx)

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -358,7 +358,7 @@ bool gen_tx_invalid_input_amount::generate(std::vector<test_event_entry>& events
 
   transaction tx = {};
   cryptonote::tx_destination_entry change_addr{ change_amount, miner_account.get_keys().m_account_address, false /*is_subaddress*/ };
-  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7, false /*is_staking*/));
+  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7));
 
   DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(tx);
@@ -508,7 +508,7 @@ bool gen_tx_mixed_key_offset_not_exist::generate(std::vector<test_event_entry>& 
 
   transaction tx = {};
   cryptonote::tx_destination_entry change_addr{ change_amount, miner_account.get_keys().m_account_address, false /*is_subaddress*/ };
-  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7, false /*is_staking*/));
+  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7));
 
   DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(tx);
@@ -669,7 +669,7 @@ bool gen_tx_output_with_zero_amount::generate(std::vector<test_event_entry>& eve
 
   transaction tx = {};
   cryptonote::tx_destination_entry change_addr{ change_amount, miner_account.get_keys().m_account_address, false /*is_subaddress*/ };
-  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7, false /*is_staking*/));
+  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7));
 
 #else
   transaction tx           = {};

--- a/tests/performance_tests/check_tx_signature.h
+++ b/tests/performance_tests/check_tx_signature.h
@@ -71,9 +71,8 @@ public:
     std::vector<crypto::secret_key> additional_tx_keys;
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
-    loki_construct_tx_params tx_params(cryptonote::network_version_9_service_nodes);
     rct::RCTConfig rct_config{range_proof_type, bp_version};
-    if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, tx_params))
+    if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, cryptonote::network_version_count - 1))
       return false;
 
     get_transaction_prefix_hash(m_tx, m_tx_prefix_hash);
@@ -134,11 +133,10 @@ public:
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
 
-    loki_construct_tx_params tx_params(cryptonote::network_version_10_bulletproofs);
     m_txes.resize(a_num_txes + (extra_outs > 0 ? 1 : 0));
     for (size_t n = 0; n < a_num_txes; ++n)
     {
-      if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_txes[n], 0, tx_key, additional_tx_keys, {rct::RangeProofPaddedBulletproof, 2}, nullptr, tx_params))
+      if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_txes[n], 0, tx_key, additional_tx_keys, {rct::RangeProofPaddedBulletproof, 2}, nullptr, cryptonote::network_version_count - 1))
         return false;
     }
 
@@ -149,7 +147,7 @@ public:
       for (size_t n = 1; n < extra_outs; ++n)
         destinations.push_back(tx_destination_entry(1, m_alice.get_keys().m_account_address, false));
 
-      if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_txes.back(), 0, tx_key, additional_tx_keys, {rct::RangeProofMultiOutputBulletproof, 2}, nullptr, tx_params))
+      if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_txes.back(), 0, tx_key, additional_tx_keys, {rct::RangeProofMultiOutputBulletproof, 2}, nullptr, cryptonote::network_version_count - 1))
         return false;
     }
 

--- a/tests/performance_tests/construct_tx.h
+++ b/tests/performance_tests/construct_tx.h
@@ -74,8 +74,7 @@ public:
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
     rct::RCTConfig rct_config{range_proof_type, bp_version};
-    cryptonote::loki_construct_tx_params tx_params(cryptonote::network_version_9_service_nodes);
-    return cryptonote::construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, m_destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, tx_params);
+    return cryptonote::construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, m_destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, cryptonote::network_version_count - 1);
   }
 
 private:

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -89,10 +89,9 @@ namespace
         std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
         subaddresses[from.m_account_address.m_spend_public_key] = {0,0};
 
-        cryptonote::loki_construct_tx_params tx_params = {};
-        tx_params.v2_rct = rct;
-        tx_params.v3_per_output_unlock = per_output_unlock;
-        if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, 0, tx_key, extra_keys, { bulletproof ? rct::RangeProofBulletproof : rct::RangeProofBorromean, bulletproof ? 2 : 0 }, nullptr, tx_params))
+        uint8_t hf_version = cryptonote::network_version_10_bulletproofs - 1;
+        if (bulletproof) hf_version = cryptonote::network_version_count - 1;
+        if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, 0, tx_key, extra_keys, { bulletproof ? rct::RangeProofBulletproof : rct::RangeProofBorromean, bulletproof ? 2 : 0 }, nullptr, hf_version))
             throw std::runtime_error{"transaction construction error"};
 
         return tx;


### PR DESCRIPTION
Separating out some stuff from my LNS changes early that can be reviewed independently.

- Setting up tx.is_transfer() to encapsulate, normal transfers, staking transfers and name service transfers- so that we can apply normal TX validation rules on all those types of transactions.
- Remove tx params as not necessary in construct_tx anymore 
- Describe how infinite staking works in code
- Remove nettype from min tx version function. Just always enforce the lower version, no harm in doing so across all the nettypes.

@jagerman
