### PR TITLE
Remove boost::value_initialized (including AUTO_VAL_INIT) and BOOST_FOREACH

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -30,7 +30,6 @@
 
 #include <limits>
 #include <boost/thread.hpp>
-#include <boost/utility/value_init.hpp>
 namespace epee
 {
 #define STD_TRY_BEGIN() try {
@@ -49,8 +48,6 @@ namespace epee
 	}
 
 
-
-#define AUTO_VAL_INIT(v)   boost::value_initialized<decltype(v)>()
 
 namespace misc_utils
 {
@@ -110,7 +107,7 @@ namespace misc_utils
   type_vec_type median(std::vector<type_vec_type> &v)
   {
     if(v.empty())
-      return boost::value_initialized<type_vec_type>();
+      return type_vec_type{};
     if(v.size() == 1)
       return v[0];
 

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -33,10 +33,8 @@
 
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/chrono.hpp>
-#include <boost/utility/value_init.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp> // TODO
 #include <boost/thread/condition_variable.hpp> // TODO
@@ -1186,7 +1184,7 @@ POP_WARNINGS
   {
     TRY_ENTRY();
     CRITICAL_REGION_LOCAL(m_threads_lock);
-    BOOST_FOREACH(boost::shared_ptr<boost::thread>& thp,  m_threads)
+    for (auto &thp : m_threads)
     {
       if(thp->get_id() == boost::this_thread::get_id())
         return true;
@@ -1657,7 +1655,7 @@ POP_WARNINGS
     //start async connect
     sock_.async_connect(remote_endpoint, [=](const boost::system::error_code& ec_)
       {
-        t_connection_context conn_context = AUTO_VAL_INIT(conn_context);
+        t_connection_context conn_context{};
         boost::system::error_code ignored_ec;
         boost::asio::ip::tcp::socket::endpoint_type lep = new_connection_l->socket().local_endpoint(ignored_ec);
         if(!ec_)

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -63,13 +63,13 @@
     { \
       handled = true; \
       uint64_t ticks = misc_utils::get_tick_count(); \
-      boost::value_initialized<command_type::request> req; \
-      bool parse_res = epee::serialization::load_t_from_json(static_cast<command_type::request&>(req), query_info.m_body); \
+      command_type::request req{}; \
+      bool parse_res = epee::serialization::load_t_from_json(req, query_info.m_body); \
       CHECK_AND_ASSERT_MES(parse_res, false, "Failed to parse json: \r\n" << query_info.m_body); \
       uint64_t ticks1 = epee::misc_utils::get_tick_count(); \
-      boost::value_initialized<command_type::response> resp;\
+      command_type::response resp{};\
       MINFO(m_conn_context << "calling " << s_pattern); \
-      if(!callback_f(static_cast<command_type::request&>(req), static_cast<command_type::response&>(resp), &m_conn_context)) \
+      if(!callback_f(req, resp, &m_conn_context)) \
       { \
         LOG_ERROR("Failed to " << #callback_f << "()"); \
         response_info.m_response_code = 500; \
@@ -77,7 +77,7 @@
         return true; \
       } \
       uint64_t ticks2 = epee::misc_utils::get_tick_count(); \
-      epee::serialization::store_t_to_json(static_cast<command_type::response&>(resp), response_info.m_body); \
+      epee::serialization::store_t_to_json(resp, response_info.m_body); \
       uint64_t ticks3 = epee::misc_utils::get_tick_count(); \
       response_info.m_mime_tipe = "application/json"; \
       response_info.m_header_info.m_content_type = " application/json"; \
@@ -91,13 +91,13 @@
     { \
       handled = true; \
       uint64_t ticks = misc_utils::get_tick_count(); \
-      boost::value_initialized<command_type::request> req; \
-      bool parse_res = epee::serialization::load_t_from_binary(static_cast<command_type::request&>(req), epee::strspan<uint8_t>(query_info.m_body)); \
+      command_type::request req{}; \
+      bool parse_res = epee::serialization::load_t_from_binary(req, epee::strspan<uint8_t>(query_info.m_body)); \
       CHECK_AND_ASSERT_MES(parse_res, false, "Failed to parse bin body data, body size=" << query_info.m_body.size()); \
       uint64_t ticks1 = misc_utils::get_tick_count(); \
-      boost::value_initialized<command_type::response> resp;\
+      command_type::response resp{};\
       MINFO(m_conn_context << "calling " << s_pattern); \
-      if(!callback_f(static_cast<command_type::request&>(req), static_cast<command_type::response&>(resp), &m_conn_context)) \
+      if(!callback_f(req, resp, &m_conn_context)) \
       { \
         LOG_ERROR("Failed to " << #callback_f << "()"); \
         response_info.m_response_code = 500; \
@@ -105,7 +105,7 @@
         return true; \
       } \
       uint64_t ticks2 = misc_utils::get_tick_count(); \
-      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), response_info.m_body); \
+      epee::serialization::store_t_to_binary(resp, response_info.m_body); \
       uint64_t ticks3 = epee::misc_utils::get_tick_count(); \
       response_info.m_mime_tipe = " application/octet-stream"; \
       response_info.m_header_info.m_content_type = " application/octet-stream"; \
@@ -123,11 +123,11 @@
     epee::serialization::portable_storage ps; \
     if(!ps.load_from_json(query_info.m_body)) \
     { \
-       boost::value_initialized<epee::json_rpc::error_response> rsp; \
-       static_cast<epee::json_rpc::error_response&>(rsp).jsonrpc = "2.0"; \
-       static_cast<epee::json_rpc::error_response&>(rsp).error.code = -32700; \
-       static_cast<epee::json_rpc::error_response&>(rsp).error.message = "Parse error"; \
-       epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \
+       epee::json_rpc::error_response rsp{}; \
+       rsp.jsonrpc = "2.0"; \
+       rsp.error.code = -32700; \
+       rsp.error.message = "Parse error"; \
+       epee::serialization::store_t_to_json(rsp, response_info.m_body); \
        return true; \
     } \
     epee::serialization::storage_entry id_; \
@@ -140,7 +140,7 @@
       rsp.jsonrpc = "2.0"; \
       rsp.error.code = -32600; \
       rsp.error.message = "Invalid Request"; \
-      epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \
+      epee::serialization::store_t_to_json(rsp, response_info.m_body); \
       return true; \
     } \
     if(false) return true; //just a stub to have "else if"
@@ -148,21 +148,19 @@
 
 #define PREPARE_OBJECTS_FROM_JSON(command_type) \
   handled = true; \
-  boost::value_initialized<epee::json_rpc::request<command_type::request> > req_; \
-  epee::json_rpc::request<command_type::request>& req = static_cast<epee::json_rpc::request<command_type::request>&>(req_);\
+  epee::json_rpc::request<command_type::request> req{}; \
   if(!req.load(ps)) \
   { \
-    epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
+    epee::json_rpc::error_response fail_resp{}; \
     fail_resp.jsonrpc = "2.0"; \
     fail_resp.id = req.id; \
     fail_resp.error.code = -32602; \
     fail_resp.error.message = "Invalid params"; \
-    epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(fail_resp), response_info.m_body); \
+    epee::serialization::store_t_to_json(fail_resp, response_info.m_body); \
     return true; \
   } \
   uint64_t ticks1 = epee::misc_utils::get_tick_count(); \
-  boost::value_initialized<epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> > resp_; \
-  epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error>& resp =  static_cast<epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> &>(resp_); \
+  epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> resp{}; \
   resp.jsonrpc = "2.0"; \
   resp.id = req.id;
 
@@ -178,13 +176,13 @@
     else if((callback_name == method_name) && (cond)) \
 { \
   PREPARE_OBJECTS_FROM_JSON(command_type) \
-  epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
+  epee::json_rpc::error_response fail_resp{}; \
   fail_resp.jsonrpc = "2.0"; \
   fail_resp.id = req.id; \
   MINFO(m_conn_context << "Calling RPC method " << method_name); \
   if(!callback_f(req.params, resp.result, fail_resp.error, &m_conn_context)) \
   { \
-    epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(fail_resp), response_info.m_body); \
+    epee::serialization::store_t_to_json(fail_resp, response_info.m_body); \
     return true; \
   } \
   FINALIZE_OBJECTS_TO_JSON(method_name) \
@@ -197,13 +195,13 @@
     else if(callback_name == method_name) \
 { \
   PREPARE_OBJECTS_FROM_JSON(command_type) \
-  epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
+  epee::json_rpc::error_response fail_resp{}; \
   fail_resp.jsonrpc = "2.0"; \
   fail_resp.id = req.id; \
   MINFO(m_conn_context << "calling RPC method " << method_name); \
   if(!callback_f(req.params, resp.result, fail_resp.error, response_info, &m_conn_context)) \
   { \
-    epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(fail_resp), response_info.m_body); \
+    epee::serialization::store_t_to_json(fail_resp, response_info.m_body); \
     return true; \
   } \
   FINALIZE_OBJECTS_TO_JSON(method_name) \
@@ -217,12 +215,12 @@
   MINFO(m_conn_context << "calling RPC method " << method_name); \
   if(!callback_f(req.params, resp.result, &m_conn_context)) \
   { \
-    epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
+    epee::json_rpc::error_response fail_resp{}; \
     fail_resp.jsonrpc = "2.0"; \
     fail_resp.id = req.id; \
     fail_resp.error.code = -32603; \
     fail_resp.error.message = "Internal error"; \
-    epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(fail_resp), response_info.m_body); \
+    epee::serialization::store_t_to_json(fail_resp, response_info.m_body); \
     return true; \
   } \
   FINALIZE_OBJECTS_TO_JSON(method_name) \
@@ -230,12 +228,12 @@
 }
 
 #define END_JSON_RPC_MAP() \
-  epee::json_rpc::error_response rsp; \
+  epee::json_rpc::error_response rsp{}; \
   rsp.id = id_; \
   rsp.jsonrpc = "2.0"; \
   rsp.error.code = -32601; \
   rsp.error.message = "Method not found"; \
-  epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \
+  epee::serialization::store_t_to_json(rsp, response_info.m_body); \
   return true; \
 }
 

--- a/contrib/epee/include/net/jsonrpc_server_handlers_map.h
+++ b/contrib/epee/include/net/jsonrpc_server_handlers_map.h
@@ -40,16 +40,14 @@ bool handle_rpc_request(const std::string& req_data, \
 
 #define PREPARE_JSONRPC2_OBJECTS_FROM_JSON(command_type) \
   handled = true; \
-  boost::value_initialized<epee::json_rpc::request<command_type::request> > req_; \
-  epee::json_rpc::request<command_type::request>& req = static_cast<epee::json_rpc::request<command_type::request>&>(req_);\
+  epee::json_rpc::request<command_type::request> req{}; \
   if(!req.load(ps)) \
   { \
     epee::net_utils::jsonrpc2::make_error_resp_json(-32602, "Invalid params", resp_data, req.id); \
     return true; \
   } \
   uint64_t ticks1 = epee::misc_utils::get_tick_count(); \
-  boost::value_initialized<epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> > resp_; \
-  epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error>& resp =  static_cast<epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> &>(resp_); \
+  epee::json_rpc::response<command_type::response, epee::json_rpc::dummy_error> resp{}; \
   resp.jsonrpc = "2.0"; \
   resp.id = req.id;
 
@@ -65,12 +63,12 @@ bool handle_rpc_request(const std::string& req_data, \
   else if (callback_name == method_name) \
   { \
     PREPARE_JSONRPC2_OBJECTS_FROM_JSON(command_type) \
-    epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
+    epee::json_rpc::error_response fail_resp{}; \
     fail_resp.jsonrpc = "2.0"; \
     fail_resp.id = req.id; \
     if(!callback_f(req.params, resp.result, fail_resp.error, m_conn_context)) \
     { \
-      epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(fail_resp), resp_data, 0, false); \
+      epee::serialization::store_t_to_json(fail_resp, resp_data, 0, false); \
       resp_data += "\n"; \
       return true; \
     } \

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -60,7 +60,6 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/chrono.hpp>
-#include <boost/utility/value_init.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/thread.hpp> 

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <boost/utility/value_init.hpp>
-#include <boost/foreach.hpp>
 #include "misc_log_ex.h"
 #include "enableable.h"
 #include "keyvalue_serialization_overloads.h"

--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -144,7 +144,7 @@ namespace epee
       std::string mb;
       mb.resize(sizeof(typename stl_container::value_type)*container.size());
       typename stl_container::value_type* p_elem = (typename stl_container::value_type*)mb.data();
-      BOOST_FOREACH(const typename stl_container::value_type& v, container)
+      for (const auto &v : container)
       {
         *p_elem = v;
         p_elem++;

--- a/contrib/epee/include/storages/http_abstract_invoke.h
+++ b/contrib/epee/include/storages/http_abstract_invoke.h
@@ -103,12 +103,12 @@ namespace epee
     template<class t_request, class t_response, class t_transport>
     bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
     {
-      epee::json_rpc::request<t_request> req_t = AUTO_VAL_INIT(req_t);
+      epee::json_rpc::request<t_request> req_t{};
       req_t.jsonrpc = "2.0";
       req_t.id = req_id;
       req_t.method = std::move(method_name);
       req_t.params = out_struct;
-      epee::json_rpc::response<t_response, epee::json_rpc::error> resp_t = AUTO_VAL_INIT(resp_t);
+      epee::json_rpc::response<t_response, epee::json_rpc::error> resp_t{};
       if(!epee::net_utils::invoke_http_json(uri, req_t, resp_t, transport, timeout, http_method))
       {
         return false;

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "portable_storage_template_helper.h"
-#include <boost/utility/value_init.hpp>
 #include "span.h"
 #include "net/levin_base.h"
 
@@ -117,7 +116,7 @@ namespace epee
       stg.store_to_binary(buff_to_send);
       int res = transport.invoke_async(command, epee::strspan<uint8_t>(buff_to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool 
       {
-        t_result result_struct = AUTO_VAL_INIT(result_struct);
+        t_result result_struct{};
         if( code <=0 )
         {
           LOG_PRINT_L1("Failed to invoke command " << command << " return code " << code);
@@ -176,17 +175,17 @@ namespace epee
         LOG_ERROR("Failed to load_from_binary in command " << command);
         return -1;
       }
-      boost::value_initialized<t_in_type> in_struct;
-      boost::value_initialized<t_out_type> out_struct;
+      t_in_type in_struct{};
+      t_out_type out_struct{};
 
-      if (!static_cast<t_in_type&>(in_struct).load(strg))
+      if (!in_struct.load(strg))
       {
         LOG_ERROR("Failed to load in_struct in command " << command);
         return -1;
       }
-      int res = cb(command, static_cast<t_in_type&>(in_struct), static_cast<t_out_type&>(out_struct), context);
+      int res = cb(command, in_struct, out_struct, context);
       serialization::portable_storage strg_out;
-      static_cast<t_out_type&>(out_struct).store(strg_out);
+      out_struct.store(strg_out);
 
       if(!strg_out.store_to_binary(buff_out))
       {
@@ -206,8 +205,8 @@ namespace epee
         LOG_ERROR("Failed to load_from_binary in notify " << command);
         return -1;
       }
-      boost::value_initialized<t_in_type> in_struct;
-      if (!static_cast<t_in_type&>(in_struct).load(strg))
+      t_in_type in_struct{};
+      if (!in_struct.load(strg))
       {
         LOG_ERROR("Failed to load in_struct in notify " << command);
         return -1;

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -137,7 +137,7 @@ namespace epee
     {
       TRY_ENTRY();
       std::stringstream ss;
-      storage_block_header sbh = AUTO_VAL_INIT(sbh);
+      storage_block_header sbh{};
       sbh.m_signature_a = SWAP32LE(PORTABLE_STORAGE_SIGNATUREA);
       sbh.m_signature_b = SWAP32LE(PORTABLE_STORAGE_SIGNATUREB);
       sbh.m_ver = PORTABLE_STORAGE_FORMAT_VER;

--- a/contrib/epee/tests/src/net/test_net.h
+++ b/contrib/epee/tests/src/net/test_net.h
@@ -212,9 +212,9 @@ namespace tests
     int handle_1(int command, COMMAND_EXAMPLE_1::request& arg, COMMAND_EXAMPLE_1::response& rsp, const net_utils::connection_context_base& context)
     {
       LOG_PRINT_L0("on_command_1: id " << arg.example_id_data << "---->>");      
-      COMMAND_EXAMPLE_2::request arg_ = AUTO_VAL_INIT(arg_);
+      COMMAND_EXAMPLE_2::request arg_{};
       arg_.example_id_data = arg.example_id_data;
-      COMMAND_EXAMPLE_2::response rsp_ = AUTO_VAL_INIT(rsp_);
+      COMMAND_EXAMPLE_2::response rsp_{};
       invoke_async<COMMAND_EXAMPLE_2::response>(context.m_connection_id, COMMAND_EXAMPLE_2::ID, arg_, [](int code, const COMMAND_EXAMPLE_2::response& rsp, const net_utils::connection_context_base& context)
         {
           if(code < 0)
@@ -320,13 +320,13 @@ namespace tests
     wait_event.lock();
     while(true)
     {
-      net_utils::connection_context_base cntxt_local = AUTO_VAL_INIT(cntxt_local);
+      net_utils::connection_context_base cntxt_local{};
       bool r = srv.connect_async("127.0.0.1", string_tools::num_to_string_fast(port), 5000, [&srv, &port, &wait_event, &i, &cntxt_local](const net_utils::connection_context_base& cntxt, const boost::system::error_code& ec)
       {
         CHECK_AND_ASSERT_MES(!ec, void(), "Some problems at connect, message: " << ec.message() );
         cntxt_local = cntxt;
         LOG_PRINT_L0("Invoking command 1 to " << port);
-        COMMAND_EXAMPLE_1::request arg = AUTO_VAL_INIT(arg);
+        COMMAND_EXAMPLE_1::request arg{};
         arg.example_id_data = i;
         /*vc2010 workaround*/
         int port_ = port;

--- a/contrib/epee/tests/src/storages/storage_tests.h
+++ b/contrib/epee/tests/src/storages/storage_tests.h
@@ -75,7 +75,7 @@ namespace epee
 
     inline test_struct get_test_struct()
     {
-      test_struct t = boost::value_initialized<test_struct>();
+      test_struct t{};
       t.m_bool = true;
       t.m_str = "ackamdc'kmecemcececmacmecmcm[aicm[oeicm[oeicm[qaicm[qoe";
       t.m_uint = 233242;

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -203,7 +203,7 @@ int check_flush(cryptonote::core &core, std::vector<block_complete_entry> &block
     // process transactions
     for(auto& tx_blob: block_entry.txs)
     {
-      tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      tx_verification_context tvc{};
       core.handle_incoming_tx(tx_blob, tvc, true, true, false);
       if(tvc.m_verifivation_failed)
       {
@@ -216,7 +216,7 @@ int check_flush(cryptonote::core &core, std::vector<block_complete_entry> &block
 
     // process block
 
-    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    block_verification_context bvc{};
 
     core.handle_incoming_block(block_entry.block, pblocks.empty() ? NULL : &pblocks[blockidx++], bvc, nullptr /*checkpoint*/, false); // <--- process block
 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -254,7 +254,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool generate_key_image_helper(const account_keys& ack, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, const crypto::public_key& out_key, const crypto::public_key& tx_public_key, const std::vector<crypto::public_key>& additional_tx_public_keys, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki, hw::device &hwdev)
   {
-    crypto::key_derivation recv_derivation = AUTO_VAL_INIT(recv_derivation);
+    crypto::key_derivation recv_derivation{};
     bool r = hwdev.generate_key_derivation(tx_public_key, ack.m_view_secret_key, recv_derivation);
     if (!r)
     {
@@ -265,7 +265,7 @@ namespace cryptonote
     std::vector<crypto::key_derivation> additional_recv_derivations;
     for (size_t i = 0; i < additional_tx_public_keys.size(); ++i)
     {
-      crypto::key_derivation additional_recv_derivation = AUTO_VAL_INIT(additional_recv_derivation);
+      crypto::key_derivation additional_recv_derivation{};
       r = hwdev.generate_key_derivation(additional_tx_public_keys[i], ack.m_view_secret_key, additional_recv_derivation);
       if (!r)
       {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -361,7 +361,7 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   {
     MINFO("Blockchain not loaded, generating genesis block.");
     block bl;
-    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    block_verification_context bvc{};
     generate_genesis_block(bl, get_config(m_nettype).GENESIS_TX, get_config(m_nettype).GENESIS_NONCE);
     db_wtxn_guard wtxn_guard(m_db);
     add_new_block(bl, bvc, nullptr /*checkpoint*/);
@@ -642,7 +642,7 @@ block Blockchain::pop_block_from_blockchain()
     }
     if (!is_coinbase(tx))
     {
-      cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      cryptonote::tx_verification_context tvc{};
 
       // FIXME: HardFork
       // Besides the below, popping a block should also remove the last entry
@@ -689,7 +689,7 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
     hook->init();
 
   db_wtxn_guard wtxn_guard(m_db);
-  block_verification_context bvc = boost::value_initialized<block_verification_context>();
+  block_verification_context bvc{};
   add_new_block(b, bvc, nullptr /*checkpoint*/);
   if (!update_next_cumulative_weight_limit())
     return false;
@@ -978,7 +978,7 @@ bool Blockchain::rollback_blockchain_switching(const std::list<block_and_checkpo
   //return back original chain
   for (auto& entry : original_chain)
   {
-    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    block_verification_context bvc{};
     bool r = handle_block_to_main_chain(entry.block, cryptonote::get_block_hash(entry.block), bvc, entry.checkpointed ? &entry.checkpoint : nullptr);
     CHECK_AND_ASSERT_MES(r && bvc.m_added_to_main_chain, false, "PANIC! failed to add (again) block while chain switching during the rollback!");
   }
@@ -1030,7 +1030,7 @@ bool Blockchain::switch_to_alternative_blockchain(const std::list<block_extended
   for(auto alt_ch_iter = alt_chain.begin(); alt_ch_iter != alt_chain.end(); alt_ch_iter++)
   {
     const auto &bei = *alt_ch_iter;
-    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    block_verification_context bvc{};
 
     // add block to main chain
     bool r = handle_block_to_main_chain(bei.bl, cryptonote::get_block_hash(bei.bl), bvc, bei.checkpointed ? &bei.checkpoint : nullptr);
@@ -1065,7 +1065,7 @@ bool Blockchain::switch_to_alternative_blockchain(const std::list<block_extended
   {
     for (auto &old_ch_ent : disconnected_chain)
     {
-      block_verification_context bvc = boost::value_initialized<block_verification_context>();
+      block_verification_context bvc{};
       bool r = handle_alternative_block(old_ch_ent.block, cryptonote::get_block_hash(old_ch_ent.block), bvc, old_ch_ent.checkpointed ? &old_ch_ent.checkpoint : nullptr);
       if (!r)
       {
@@ -1429,7 +1429,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
     //we have new block in alternative chain
     std::list<block_extended_info> alt_chain;
-    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    block_verification_context bvc{};
     std::vector<uint64_t> timestamps;
     if (!build_alt_chain(*from_block, alt_chain, timestamps, bvc, nullptr))
       return false;
@@ -1463,7 +1463,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     }
 
     // FIXME: consider moving away from block_extended_info at some point
-    block_extended_info bei = boost::value_initialized<block_extended_info>();
+    block_extended_info bei{};
     bei.bl = b;
     bei.height = alt_chain.size() ? prev_data.height + 1 : m_db->get_block_height(*from_block) + 1;
 
@@ -3640,7 +3640,7 @@ void Blockchain::return_tx_to_pool(std::vector<std::pair<transaction, blobdata>>
   uint8_t version = get_current_hard_fork_version();
   for (auto& tx : txs)
   {
-    cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote::tx_verification_context tvc{};
     // We assume that if they were in a block, the transactions are already
     // known to the network as a whole. However, if we had mined that block,
     // that might not be always true. Unlikely though, and always relaying
@@ -3916,7 +3916,7 @@ leave:
 #endif
     {
       // validate that transaction inputs and the keys spending them are correct.
-      tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      tx_verification_context tvc{};
       if(!check_tx_inputs(tx, tvc))
       {
         MERROR_VER("Block with id: " << id  << " has at least one transaction (id: " << tx_id << ") with wrong inputs.");

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -249,7 +249,7 @@ namespace cryptonote
               m_blockchain_storage(m_mempool, m_service_node_list),
               m_quorum_cop(*this),
               m_miner(this, &m_blockchain_storage),
-              m_miner_address(boost::value_initialized<account_public_address>()),
+              m_miner_address{},
               m_starter_message_showed(false),
               m_target_blockchain_height(0),
               m_checkpoints_path(""),
@@ -949,7 +949,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_tx_pre(const blobdata& tx_blob, tx_verification_context& tvc, cryptonote::transaction &tx, crypto::hash &tx_hash, bool keeped_by_block, bool relayed, bool do_not_relay)
   {
-    tvc = boost::value_initialized<tx_verification_context>();
+    tvc = {};
 
     if(tx_blob.size() > get_max_tx_size())
     {
@@ -1454,8 +1454,8 @@ namespace cryptonote
     std::vector<std::pair<crypto::hash, cryptonote::blobdata>> txs;
     if (m_mempool.get_relayable_transactions(txs) && !txs.empty())
     {
-      cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
-      tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      cryptonote_connection_context fake_context{};
+      tx_verification_context tvc{};
       NOTIFY_NEW_TRANSACTIONS::request r;
       for (auto it = txs.begin(); it != txs.end(); ++it)
       {
@@ -1474,7 +1474,7 @@ namespace cryptonote
 
     NOTIFY_UPTIME_PROOF::request req = m_service_node_list.generate_uptime_proof(*m_service_node_keys, m_sn_public_ip, m_storage_port);
 
-    cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+    cryptonote_connection_context fake_context{};
     bool relayed = get_protocol()->relay_uptime_proof(req, fake_context);
     if (relayed)
       MGINFO("Submitted uptime-proof for Service Node (yours): " << m_service_node_keys->pub);
@@ -1507,7 +1507,7 @@ namespace cryptonote
     req.votes                                 = m_quorum_cop.get_relayable_votes(get_current_blockchain_height());
     if (req.votes.size())
     {
-      cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+      cryptonote_connection_context fake_context{};
       if (get_protocol()->relay_service_node_votes(req, fake_context))
       {
         m_quorum_cop.set_votes_relayed(req.votes);
@@ -1587,7 +1587,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::handle_block_found(block& b, block_verification_context &bvc)
   {
-    bvc = boost::value_initialized<block_verification_context>();
+    bvc = {};
     std::vector<block_complete_entry> blocks;
     m_miner.pause();
     {
@@ -1625,8 +1625,8 @@ namespace cryptonote
       CHECK_AND_ASSERT_MES(txs.size() == b.tx_hashes.size() && !missed_txs.size(), false, "can't find some transactions in found block:" << get_block_hash(b) << " txs.size()=" << txs.size()
         << ", b.tx_hashes.size()=" << b.tx_hashes.size() << ", missed_txs.size()" << missed_txs.size());
 
-      cryptonote_connection_context exclude_context = boost::value_initialized<cryptonote_connection_context>();
-      NOTIFY_NEW_FLUFFY_BLOCK::request arg          = AUTO_VAL_INIT(arg);
+      cryptonote_connection_context exclude_context{};
+      NOTIFY_NEW_FLUFFY_BLOCK::request arg{};
       arg.current_blockchain_height                 = m_blockchain_storage.get_current_blockchain_height();
       arg.b                                         = blocks[0];
 
@@ -1684,7 +1684,7 @@ namespace cryptonote
   bool core::handle_incoming_block(const blobdata& block_blob, const block *b, block_verification_context& bvc, checkpoint_t *checkpoint, bool update_miner_blocktemplate)
   {
     TRY_ENTRY();
-    bvc = boost::value_initialized<block_verification_context>();
+    bvc = {};
 
     if (!check_incoming_block_size(block_blob))
     {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -106,7 +106,7 @@ namespace cryptonote
   bool get_deterministic_output_key(const account_public_address& address, const keypair& tx_key, size_t output_index, crypto::public_key& output_key)
   {
 
-    crypto::key_derivation derivation = AUTO_VAL_INIT(derivation);
+    crypto::key_derivation derivation{};
     bool r = crypto::generate_key_derivation(address.m_view_public_key, tx_key.sec, derivation);
     CHECK_AND_ASSERT_MES(r, false, "failed to generate_key_derivation(" << address.m_view_public_key << ", " << tx_key.sec << ")");
 
@@ -287,8 +287,8 @@ namespace cryptonote
     uint64_t summary_amounts = 0;
     // Miner Reward
     {
-      crypto::key_derivation derivation = AUTO_VAL_INIT(derivation);
-      crypto::public_key out_eph_public_key = AUTO_VAL_INIT(out_eph_public_key);
+      crypto::key_derivation derivation{};
+      crypto::public_key out_eph_public_key{};
       bool r = crypto::generate_key_derivation(miner_address.m_view_public_key, txkey.sec, derivation);
       CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to generate_key_derivation(" << miner_address.m_view_public_key << ", " << txkey.sec << ")");
 
@@ -310,8 +310,8 @@ namespace cryptonote
       for (size_t i = 0; i < service_node_info.size(); i++)
       {
         service_nodes::payout_entry const &payout = service_node_info[i];
-        crypto::key_derivation derivation         = AUTO_VAL_INIT(derivation);
-        crypto::public_key out_eph_public_key     = AUTO_VAL_INIT(out_eph_public_key);
+        crypto::key_derivation derivation{};
+        crypto::public_key out_eph_public_key{};
         bool r = crypto::generate_key_derivation(payout.address.m_view_public_key, gov_key.sec, derivation);
         CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to generate_key_derivation(" << payout.address.m_view_public_key << ", " << gov_key.sec << ")");
         r = crypto::derive_public_key(derivation, 1+i, payout.address.m_spend_public_key, out_eph_public_key);
@@ -339,7 +339,7 @@ namespace cryptonote
       {
         cryptonote::address_parse_info governance_wallet_address;
         cryptonote::get_account_address_from_str(governance_wallet_address, nettype, *cryptonote::get_config(nettype, hard_fork_version).GOVERNANCE_WALLET_ADDRESS);
-        crypto::public_key out_eph_public_key = AUTO_VAL_INIT(out_eph_public_key);
+        crypto::public_key out_eph_public_key{};
 
         if (!get_deterministic_output_key(governance_wallet_address.address, gov_key, tx.vout.size(), out_eph_public_key))
         {
@@ -961,7 +961,7 @@ namespace cryptonote
     )
   {
     //genesis block
-    bl = boost::value_initialized<block>();
+    bl = {};
 
     blobdata tx_bl;
     bool r = string_tools::parse_hexstr_to_binbuff(genesis_tx, tx_bl);

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -145,7 +145,7 @@ namespace cryptonote
     bool is_subaddress;
     bool is_integrated;
 
-    tx_destination_entry() : amount(0), addr(AUTO_VAL_INIT(addr)), is_subaddress(false), is_integrated(false) { }
+    tx_destination_entry() : amount(0), addr{}, is_subaddress(false), is_integrated(false) { }
     tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress) : amount(a), addr(ad), is_subaddress(is_subaddress), is_integrated(false) { }
     tx_destination_entry(const std::string &o, uint64_t a, const account_public_address &ad, bool is_subaddress) : original(o), amount(a), addr(ad), is_subaddress(is_subaddress), is_integrated(false) { }
 

--- a/src/cryptonote_core/miner.cpp
+++ b/src/cryptonote_core/miner.cpp
@@ -31,7 +31,6 @@
 
 #include <sstream>
 #include <numeric>
-#include <boost/utility/value_init.hpp>
 #include <boost/interprocess/detail/atomic.hpp>
 #include <boost/algorithm/string.hpp>
 #include "misc_language.h"
@@ -103,7 +102,7 @@ namespace cryptonote
 
 
   miner::miner(i_miner_handler* phandler, Blockchain* pbc):m_stop(1),
-    m_template(boost::value_initialized<block>()),
+    m_template{},
     m_template_no(0),
     m_diffic(0),
     m_thread_index(0),
@@ -159,8 +158,8 @@ namespace cryptonote
   bool miner::request_block_template()
   {
     block bl;
-    difficulty_type di = AUTO_VAL_INIT(di);
-    uint64_t height = AUTO_VAL_INIT(height);
+    difficulty_type di{};
+    uint64_t height{};
     uint64_t expected_reward; //only used for RPC calls - could possibly be useful here too?
 
     cryptonote::blobdata extra_nonce;
@@ -311,7 +310,7 @@ namespace cryptonote
           m_extra_messages[i] = buff;
       }
       m_config_folder_path = boost::filesystem::path(command_line::get_arg(vm, arg_extra_messages)).parent_path().string();
-      m_config = AUTO_VAL_INIT(m_config);
+      m_config = {};
       const std::string filename = m_config_folder_path + "/" + MINER_CONFIG_FILE_NAME;
       CHECK_AND_ASSERT_MES(epee::serialization::load_t_from_json_file(m_config, filename), false, "Failed to load data from " << filename);
       MINFO("Loaded " << m_extra_messages.size() << " extra messages, current index " << m_config.current_extra_message_index);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1678,9 +1678,9 @@ namespace service_nodes
         return false;
       }
 
-      crypto::key_derivation derivation     = AUTO_VAL_INIT(derivation);
-      crypto::public_key out_eph_public_key = AUTO_VAL_INIT(out_eph_public_key);
-      cryptonote::keypair gov_key           = cryptonote::get_deterministic_keypair_from_height(height);
+      crypto::key_derivation derivation{};
+      crypto::public_key out_eph_public_key{};
+      cryptonote::keypair gov_key = cryptonote::get_deterministic_keypair_from_height(height);
 
       bool r = crypto::generate_key_derivation(payout.address.m_view_public_key, gov_key.sec, derivation);
       CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to generate_key_derivation(" << payout.address.m_view_public_key << ", " << gov_key.sec << ")");

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -36,7 +36,6 @@
 #include <unordered_set>
 #include <queue>
 #include <boost/serialization/version.hpp>
-#include <boost/utility.hpp>
 
 #include "string_tools.h"
 #include "syncobj.h"

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -135,7 +135,7 @@ namespace cryptonote
 
     if(context.m_state == cryptonote_connection_context::state_synchronizing)
     {
-      NOTIFY_REQUEST_CHAIN::request r = boost::value_initialized<NOTIFY_REQUEST_CHAIN::request>();
+      NOTIFY_REQUEST_CHAIN::request r{};
       context.m_needed_objects.clear();
       m_core.get_short_chain_history(r.block_ids);
       handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
@@ -417,7 +417,7 @@ namespace cryptonote
     template<class t_core>
     bool t_cryptonote_protocol_handler<t_core>::get_payload_sync_data(blobdata& data)
   {
-    CORE_SYNC_DATA hsd = boost::value_initialized<CORE_SYNC_DATA>();
+    CORE_SYNC_DATA hsd{};
     get_payload_sync_data(hsd);
     epee::serialization::store_t_to_binary(hsd, data);
     return true;
@@ -540,7 +540,7 @@ namespace cryptonote
           if(!m_core.pool_has_tx(tx_hash))
           {
             MDEBUG("Incoming tx " << tx_hash << " not in pool, adding");
-            cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);                        
+            cryptonote::tx_verification_context tvc{};
             if(!m_core.handle_incoming_tx(tx_blob, tvc, true, true, false) || tvc.m_verifivation_failed)
             {
               LOG_PRINT_CCONTEXT_L1("Block verification failed: transaction verification failed, dropping connection");
@@ -663,7 +663,7 @@ namespace cryptonote
           return 1;
         }
           
-        block_verification_context bvc = boost::value_initialized<block_verification_context>();
+        block_verification_context bvc{};
         m_core.handle_incoming_block(arg.b.block, pblocks.empty() ? NULL : &pblocks[0], bvc, nullptr /*checkpoint*/); // got block from handle_notify_new_block
         if (!m_core.cleanup_handle_incoming_blocks(true))
         {
@@ -682,7 +682,7 @@ namespace cryptonote
         if( bvc.m_added_to_main_chain )
         {
           //TODO: Add here announce protocol usage
-          NOTIFY_NEW_FLUFFY_BLOCK::request reg_arg = AUTO_VAL_INIT(reg_arg);
+          NOTIFY_NEW_FLUFFY_BLOCK::request reg_arg{};
           reg_arg.current_blockchain_height = arg.current_blockchain_height;
           reg_arg.b = b;
           relay_block(reg_arg, context);
@@ -691,7 +691,7 @@ namespace cryptonote
         {
           context.m_needed_objects.clear();
           context.m_state = cryptonote_connection_context::state_synchronizing;
-          NOTIFY_REQUEST_CHAIN::request r = boost::value_initialized<NOTIFY_REQUEST_CHAIN::request>();
+          NOTIFY_REQUEST_CHAIN::request r{};
           m_core.get_short_chain_history(r.block_ids);
           handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
           MLOG_P2P_MESSAGE("-->>NOTIFY_REQUEST_CHAIN: m_block_ids.size()=" << r.block_ids.size() );
@@ -916,7 +916,7 @@ namespace cryptonote
     newtxs.reserve(arg.txs.size());
     for (size_t i = 0; i < arg.txs.size(); ++i)
     {
-      cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+      cryptonote::tx_verification_context tvc{};
       m_core.handle_incoming_tx(arg.txs[i], tvc, false, true, false);
       if(tvc.m_verifivation_failed)
       {
@@ -1339,7 +1339,7 @@ namespace cryptonote
               // process block
 
               TIME_MEASURE_START(block_process_time);
-              block_verification_context bvc = boost::value_initialized<block_verification_context>();
+              block_verification_context bvc{};
 
               m_core.handle_incoming_block(block_entry.block, pblocks.empty() ? NULL : &pblocks[blockidx], bvc, checkpoint, false); // <--- process block
 
@@ -2016,7 +2016,7 @@ skip:
     if(context.m_last_response_height < context.m_remote_blockchain_height-1)
     {//we have to fetch more objects ids, request blockchain entry
 
-      NOTIFY_REQUEST_CHAIN::request r = boost::value_initialized<NOTIFY_REQUEST_CHAIN::request>();
+      NOTIFY_REQUEST_CHAIN::request r{};
       m_core.get_short_chain_history(r.block_ids);
       CHECK_AND_ASSERT_MES(!r.block_ids.empty(), false, "Short chain history is empty");
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -390,7 +390,7 @@ namespace nodetool
       std::vector<std::string> perrs = command_line::get_arg(vm, arg_p2p_add_peer);
       for(const std::string& pr_str: perrs)
       {
-        nodetool::peerlist_entry pe = AUTO_VAL_INIT(pe);
+        nodetool::peerlist_entry pe{};
         pe.id = crypto::rand<uint64_t>();
         const uint16_t default_port = cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT;
         expect<epee::net_utils::network_address> adr = net::get_network_address(pr_str, default_port);
@@ -1063,7 +1063,7 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::do_peer_timed_sync(const epee::net_utils::connection_context_base& context_, peerid_type peer_id)
   {
-    typename COMMAND_TIMED_SYNC::request arg = AUTO_VAL_INIT(arg);
+    typename COMMAND_TIMED_SYNC::request arg{};
     m_payload_handler.get_payload_sync_data(arg.payload_data);
 
     network_zone& zone = m_network_zones.at(context_.m_remote_address.get_zone());
@@ -1225,7 +1225,7 @@ namespace nodetool
     }
 
     con->m_anchor = peer_type == anchor;
-    peerid_type pi = AUTO_VAL_INIT(pi);
+    peerid_type pi{};
     bool res = do_handshake_with_peer(pi, *con, just_take_peerlist);
 
     if(!res)
@@ -1245,7 +1245,7 @@ namespace nodetool
       return true;
     }
 
-    peerlist_entry pe_local = AUTO_VAL_INIT(pe_local);
+    peerlist_entry pe_local{};
     pe_local.adr = na;
     pe_local.id = pi;
     time_t last_seen;
@@ -1256,7 +1256,7 @@ namespace nodetool
     zone.m_peerlist.append_with_peer_white(pe_local);
     //update last seen and push it to peerlist manager
 
-    anchor_peerlist_entry ape = AUTO_VAL_INIT(ape);
+    anchor_peerlist_entry ape{};
     ape.adr = na;
     ape.id = pi;
     ape.first_seen = first_seen_stamp ? first_seen_stamp : time(nullptr);
@@ -1288,7 +1288,7 @@ namespace nodetool
     }
 
     con->m_anchor = false;
-    peerid_type pi = AUTO_VAL_INIT(pi);
+    peerid_type pi{};
     const bool res = do_handshake_with_peer(pi, *con, true);
     if (!res) {
       bool is_priority = is_priority_node(na);
@@ -1456,7 +1456,7 @@ namespace nodetool
         continue;
 
       tried_peers.insert(random_index);
-      peerlist_entry pe = AUTO_VAL_INIT(pe);
+      peerlist_entry pe{};
       bool r = use_white_list ? zone.m_peerlist.get_white_peer_by_index(pe, random_index):zone.m_peerlist.get_gray_peer_by_index(pe, random_index);
       CHECK_AND_ASSERT_MES(r, false, "Failed to get random peer from peerlist(white:" << use_white_list << ")");
 
@@ -1885,7 +1885,7 @@ namespace nodetool
       MWARNING("check_trust failed: peer_id mismatch (passed " << tr.peer_id << ", expected " << zone.m_config.m_peer_id<< ")");
       return false;
     }
-    crypto::public_key pk = AUTO_VAL_INIT(pk);
+    crypto::public_key pk{};
     epee::string_tools::hex_to_pod(::config::P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY, pk);
     crypto::hash h = get_proof_of_trust_hash(tr);
     if(!crypto::check_signature(h, pk, tr.sign))
@@ -2342,7 +2342,7 @@ namespace nodetool
   {
     network_zone& zone = m_network_zones.at(context.m_remote_address.get_zone());
     if (!zone.m_net_server.is_stop_signal_sent() && !context.m_is_income) {
-      epee::net_utils::network_address na = AUTO_VAL_INIT(na);
+      epee::net_utils::network_address na{};
       na = context.m_remote_address;
 
       zone.m_peerlist.remove_from_peer_anchor(na);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -829,8 +829,8 @@ namespace cryptonote
     }
     res.sanity_check_failed = false;
 
-    cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
-    tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote_connection_context fake_context{};
+    tx_verification_context tvc{};
     if(!m_core.handle_incoming_tx(tx_blob, tvc, false, false, req.do_not_relay) || tvc.m_verifivation_failed)
     {
       const vote_verification_context &vvc = tvc.m_vote_ctx;
@@ -1408,7 +1408,7 @@ namespace cryptonote
     template_req.reserve_size = 1;
     template_req.wallet_address = req.wallet_address;
     template_req.prev_block = req.prev_block;
-    submit_req.push_back(boost::value_initialized<std::string>());
+    submit_req.emplace_back();
     res.height = m_core.get_blockchain_storage().get_current_blockchain_height();
 
     for(size_t i = 0; i < req.amount_of_blocks; i++)
@@ -1532,8 +1532,8 @@ namespace cryptonote
     }
     else if (mode == invoke_http_mode::JON_RPC)
     {
-      epee::json_rpc::request<typename COMMAND_TYPE::request> json_req = AUTO_VAL_INIT(json_req);
-      epee::json_rpc::response<typename COMMAND_TYPE::response, std::string> json_resp = AUTO_VAL_INIT(json_resp);
+      epee::json_rpc::request<typename COMMAND_TYPE::request> json_req{};
+      epee::json_rpc::response<typename COMMAND_TYPE::response, std::string> json_resp{};
       json_req.jsonrpc = "2.0";
       json_req.id = epee::serialization::storage_entry(0);
       json_req.method = command_name;
@@ -2284,7 +2284,7 @@ namespace cryptonote
       bool r = m_core.get_pool_transaction(txid, txblob);
       if (r)
       {
-        cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+        cryptonote_connection_context fake_context{};
         NOTIFY_NEW_TRANSACTIONS::request r;
         r.txs.push_back(txblob);
         m_core.get_protocol()->relay_transactions(r, fake_context);

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -288,8 +288,8 @@ namespace rpc
       return;
     }
 
-    cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
-    tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote_connection_context fake_context{};
+    tx_verification_context tvc{};
 
     if(!m_core.handle_incoming_tx(tx_blob, tvc, false, false, !relay) || tvc.m_verifivation_failed)
     {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4756,7 +4756,7 @@ bool simple_wallet::start_mining(const std::vector<std::string>& args)
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
-  COMMAND_RPC_START_MINING::request req = AUTO_VAL_INIT(req); 
+  COMMAND_RPC_START_MINING::request req{};
   req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
 
   bool ok = true;
@@ -5528,14 +5528,14 @@ bool simple_wallet::print_ring_members(const std::vector<tools::wallet2::pending
       // convert relative offsets of ring member keys into absolute offsets (indices) associated with the amount
       std::vector<uint64_t> absolute_offsets = cryptonote::relative_output_offsets_to_absolute(in_key.key_offsets);
       // get block heights from which those ring member keys originated
-      COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
+      COMMAND_RPC_GET_OUTPUTS_BIN::request req{};
       req.outputs.resize(absolute_offsets.size());
       for (size_t j = 0; j < absolute_offsets.size(); ++j)
       {
         req.outputs[j].amount = in_key.amount;
         req.outputs[j].index = absolute_offsets[j];
       }
-      COMMAND_RPC_GET_OUTPUTS_BIN::response res = AUTO_VAL_INIT(res);
+      COMMAND_RPC_GET_OUTPUTS_BIN::response res{};
       bool r = m_wallet->invoke_http_bin("/get_outs.bin", req, res);
       err = interpret_rpc_response(r, res.status);
       if (!err.empty())

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -236,8 +236,8 @@ void WalletManagerImpl::setDaemonAddress(const std::string &address)
 
 bool WalletManagerImpl::connected(uint32_t *version)
 {
-    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req_t = AUTO_VAL_INIT(req_t);
-    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
+    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req_t{};
+    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> resp_t{};
     req_t.jsonrpc = "2.0";
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "get_version";

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -707,7 +707,7 @@ void message_store::write_to_file(const multisig_wallet_state &state, const std:
   crypto::chacha_key key;
   crypto::generate_chacha_key(&state.view_secret_key, sizeof(crypto::secret_key), key, 1);
 
-  file_data write_file_data = boost::value_initialized<file_data>();
+  file_data write_file_data{};
   write_file_data.magic_string = "MMS";
   write_file_data.file_version = 0;
   write_file_data.iv = crypto::rand<crypto::chacha_iv>();

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -77,8 +77,8 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
     return boost::optional<std::string>("offline");
   if (m_rpc_version == 0)
   {
-    cryptonote::COMMAND_RPC_GET_VERSION::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_GET_VERSION::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_GET_VERSION::request req_t{};
+    cryptonote::COMMAND_RPC_GET_VERSION::response resp_t{};
     m_daemon_rpc_mutex.lock();
     bool r = net_utils::invoke_http_json_rpc("/json_rpc", "get_version", req_t, resp_t, m_http_client, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
@@ -105,8 +105,8 @@ boost::optional<std::string> NodeRPCProxy::get_info() const
   const time_t now = time(NULL);
   if (now >= m_get_info_time + 30) // re-cache every 30 seconds
   {
-    cryptonote::COMMAND_RPC_GET_INFO::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_GET_INFO::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_GET_INFO::request req_t{};
+    cryptonote::COMMAND_RPC_GET_INFO::response resp_t{};
 
     m_daemon_rpc_mutex.lock();
     bool r = net_utils::invoke_http_json_rpc("/json_rpc", "get_info", req_t, resp_t, m_http_client, rpc_timeout);
@@ -166,8 +166,8 @@ boost::optional<std::string> NodeRPCProxy::get_earliest_height(uint8_t version, 
     return boost::optional<std::string>("offline");
   if (m_earliest_height[version] == 0)
   {
-    cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_HARD_FORK_INFO::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req_t{};
+    cryptonote::COMMAND_RPC_HARD_FORK_INFO::response resp_t{};
 
     m_daemon_rpc_mutex.lock();
     req_t.version = version;
@@ -188,8 +188,8 @@ boost::optional<uint8_t> NodeRPCProxy::get_hardfork_version() const
   if (m_offline)
     return boost::none;
 
-  cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_HARD_FORK_INFO::response resp = AUTO_VAL_INIT(resp);
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req{};
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::response resp{};
 
   m_daemon_rpc_mutex.lock();
   bool r = net_utils::invoke_http_json_rpc("/json_rpc", "hard_fork_info", req, resp, m_http_client, rpc_timeout);
@@ -213,8 +213,8 @@ boost::optional<std::string> NodeRPCProxy::refresh_dynamic_base_fee_cache(uint64
 
   if (m_dynamic_base_fee_estimate_cached_height != height || m_dynamic_base_fee_estimate_grace_blocks != grace_blocks)
   {
-    cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request req_t{};
+    cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::response resp_t{};
 
     m_daemon_rpc_mutex.lock();
     req_t.grace_blocks = grace_blocks;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -33,7 +33,6 @@
 #include <tuple>
 #include <boost/format.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/utility/value_init.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -1927,7 +1926,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
           {
             pk_to_unlock_times[tx_scan_info[o].in_ephemeral.pub] = tx_scan_info[o].unlock_time;
 
-            m_transfers.push_back(boost::value_initialized<transfer_details>());
+            m_transfers.emplace_back();
             transfer_details& td = m_transfers.back();
             td.m_block_height = height;
             td.m_internal_output_index = o;
@@ -2478,8 +2477,8 @@ void wallet2::parse_block_round(const cryptonote::blobdata &blob, cryptonote::bl
 //----------------------------------------------------------------------------------------------------
 void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices)
 {
-  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req{};
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res{};
   req.block_ids = short_chain_history;
 
   req.prune = true;
@@ -2502,8 +2501,8 @@ void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, 
 //----------------------------------------------------------------------------------------------------
 void wallet2::pull_hashes(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<crypto::hash> &hashes)
 {
-  cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_HASHES_FAST::response res = AUTO_VAL_INIT(res);
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req{};
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::response res{};
   req.block_ids = short_chain_history;
 
   req.start_height = start_height;
@@ -3357,8 +3356,8 @@ bool wallet2::get_rct_distribution(uint64_t &start_height, std::vector<uint64_t>
     }
   }
 
-  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response res = AUTO_VAL_INIT(res);
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req{};
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response res{};
   req.amounts.push_back(0);
   req.from_height = 0;
   req.cumulative = false;
@@ -3597,7 +3596,7 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
 
   bool r = epee::serialization::store_t_to_binary(account, account_data);
   CHECK_AND_ASSERT_MES(r, false, "failed to serialize wallet keys");
-  wallet2::keys_file_data keys_file_data = boost::value_initialized<wallet2::keys_file_data>();
+  wallet2::keys_file_data keys_file_data{};
 
   // Create a JSON object with "key_data" and "seed_language" as keys.
   rapidjson::Document json;
@@ -5278,8 +5277,8 @@ bool wallet2::check_connection(uint32_t *version, bool *ssl, uint32_t timeout)
 
   if (version)
   {
-    cryptonote::COMMAND_RPC_GET_VERSION::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_GET_VERSION::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_GET_VERSION::request req_t{};
+    cryptonote::COMMAND_RPC_GET_VERSION::response resp_t{};
     bool r = invoke_http_json_rpc("/json_rpc", "get_version", req_t, resp_t);
     if(!r) {
       *version = 0;
@@ -5481,8 +5480,8 @@ void wallet2::trim_hashchain()
   if (!m_blockchain.empty() && m_blockchain.size() == m_blockchain.offset())
   {
     MINFO("Fixing empty hashchain");
-    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request req = AUTO_VAL_INIT(req);
-    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response res = AUTO_VAL_INIT(res);
+    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request req{};
+    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response res{};
     m_daemon_rpc_mutex.lock();
     req.height = m_blockchain.size() - 1;
     bool r = invoke_http_json_rpc("/json_rpc", "getblockheaderbyheight", req, res, rpc_timeout);
@@ -5562,7 +5561,7 @@ void wallet2::store_to(const std::string &path, const epee::wipeable_string &pas
   boost::archive::portable_binary_oarchive ar(oss);
   ar << *this;
 
-  wallet2::cache_file_data cache_file_data = boost::value_initialized<wallet2::cache_file_data>();
+  wallet2::cache_file_data cache_file_data{};
   cache_file_data.cache_data = oss.str();
   std::string cipher;
   cipher.resize(cache_file_data.cache_data.size());
@@ -6148,8 +6147,8 @@ void wallet2::rescan_spent()
   {
     const size_t n_outputs = std::min<size_t>(chunk_size, m_transfers.size() - start_offset);
     MDEBUG("Calling is_key_image_spent on " << start_offset << " - " << (start_offset + n_outputs - 1) << ", out of " << m_transfers.size());
-    COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req = AUTO_VAL_INIT(req);
-    COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+    COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req{};
+    COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp{};
     for (size_t n = start_offset; n < start_offset + n_outputs; ++n)
       req.key_images.push_back(string_tools::pod_to_hex(m_transfers[n].m_key_image));
     m_daemon_rpc_mutex.lock();
@@ -7461,8 +7460,8 @@ uint32_t wallet2::adjust_priority(uint32_t priority)
         MERROR("The blockchain is too short");
         return priority;
       }
-      cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request getbh_req = AUTO_VAL_INIT(getbh_req);
-      cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response getbh_res = AUTO_VAL_INIT(getbh_res);
+      cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request getbh_req{};
+      cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response getbh_res{};
       m_daemon_rpc_mutex.lock();
       getbh_req.start_height = m_blockchain.size() - N;
       getbh_req.end_height = m_blockchain.size() - 1;
@@ -7661,8 +7660,8 @@ bool wallet2::find_and_save_rings(bool force)
   if (!m_ringdb)
     return false;
 
-  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
-  COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
+  COMMAND_RPC_GET_TRANSACTIONS::request req{};
+  COMMAND_RPC_GET_TRANSACTIONS::response res{};
 
   MDEBUG("Finding and saving rings...");
 
@@ -8483,8 +8482,8 @@ void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_
       
       // Convert light wallet string data to proper data structures
       crypto::public_key tx_public_key;
-      rct::key mask = AUTO_VAL_INIT(mask); // decrypted mask - not used here
-      rct::key rct_commit = AUTO_VAL_INIT(rct_commit);
+      rct::key mask{}; // decrypted mask - not used here
+      rct::key rct_commit{};
       THROW_WALLET_EXCEPTION_IF(string_tools::validate_hex(64, ores.amount_outs[amount_key].outputs[i].public_key), error::wallet_internal_error, "Invalid public_key");
       string_tools::hex_to_pod(ores.amount_outs[amount_key].outputs[i].public_key, tx_public_key);
       const uint64_t global_index = ores.amount_outs[amount_key].outputs[i].global_index;
@@ -8536,8 +8535,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     const bool has_rct_distribution = has_rct && get_rct_distribution(rct_start_height, rct_offsets);
 
     // get histogram for the amounts we need
-    cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t = AUTO_VAL_INIT(req_t);
-    cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t = AUTO_VAL_INIT(resp_t);
+    cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t{};
+    cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t{};
     {
       uint64_t max_rct_index = 0;
       for (size_t idx: selected_transfers)
@@ -8595,8 +8594,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> segregation_limit;
     if (is_after_segregation_fork && (m_segregate_pre_fork_outputs || m_key_reuse_mitigation2))
     {
-      cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req_t = AUTO_VAL_INIT(req_t);
-      cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response resp_t = AUTO_VAL_INIT(resp_t);
+      cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req_t{};
+      cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response resp_t{};
       for(size_t idx: selected_transfers)
         req_t.amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
       std::sort(req_t.amounts.begin(), req_t.amounts.end());
@@ -8643,8 +8642,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     LOG_PRINT_L2("base_requested_outputs_count: " << base_requested_outputs_count);
 
     // generate output indices to request
-    COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
-    COMMAND_RPC_GET_OUTPUTS_BIN::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+    COMMAND_RPC_GET_OUTPUTS_BIN::request req{};
+    COMMAND_RPC_GET_OUTPUTS_BIN::response daemon_resp{};
 
     std::unique_ptr<gamma_picker> gamma;
     if (has_rct_distribution)
@@ -9266,7 +9265,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
 
   // we still keep a copy, since we want to keep dsts free of change for user feedback purposes
   std::vector<cryptonote::tx_destination_entry> splitted_dsts = dsts;
-  cryptonote::tx_destination_entry change_dts = AUTO_VAL_INIT(change_dts);
+  cryptonote::tx_destination_entry change_dts{};
   change_dts.amount = found_money - needed_money;
   if (change_dts.amount == 0)
   {
@@ -9603,7 +9602,7 @@ void wallet2::light_wallet_get_unspent_outs()
     bool spent = false;
     bool add_transfer = true;
     crypto::key_image unspent_key_image;
-    crypto::public_key tx_public_key = AUTO_VAL_INIT(tx_public_key);
+    crypto::public_key tx_public_key{};
     THROW_WALLET_EXCEPTION_IF(string_tools::validate_hex(64, o.tx_pub_key), error::wallet_internal_error, "Invalid tx_pub_key field");
     string_tools::hex_to_pod(o.tx_pub_key, tx_public_key);
     
@@ -9644,7 +9643,7 @@ void wallet2::light_wallet_get_unspent_outs()
     if(!add_transfer)
       continue;
     
-    m_transfers.push_back(boost::value_initialized<transfer_details>());
+    m_transfers.emplace_back();
     transfer_details& td = m_transfers.back();
     
     td.m_block_height = o.height;
@@ -10997,8 +10996,8 @@ std::vector<uint64_t> wallet2::get_unspent_amounts_vector() const
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet2::select_available_outputs_from_histogram(uint64_t count, bool atleast, bool unlocked, bool allow_rct)
 {
-  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t = AUTO_VAL_INIT(req_t);
-  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t = AUTO_VAL_INIT(resp_t);
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t{};
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t{};
   m_daemon_rpc_mutex.lock();
   if (is_trusted_daemon())
     req_t.amounts = get_unspent_amounts_vector();
@@ -11036,8 +11035,8 @@ std::vector<size_t> wallet2::select_available_outputs_from_histogram(uint64_t co
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_num_rct_outputs()
 {
-  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t = AUTO_VAL_INIT(req_t);
-  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t = AUTO_VAL_INIT(resp_t);
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t{};
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t{};
   m_daemon_rpc_mutex.lock();
   req_t.amounts.push_back(0);
   req_t.min_count = 0;
@@ -11203,11 +11202,11 @@ bool wallet2::get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, s
 void wallet2::set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys)
 {
   // fetch tx from daemon and check if secret keys agree with corresponding public keys
-  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTIONS::request req{};
   req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
   req.decode_as_json = false;
   req.prune = true;
-  COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
+  COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
     const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
@@ -11253,11 +11252,11 @@ std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string
     "get_spend_proof requires spend secret key and is not available for a watch-only wallet");
 
   // fetch tx from daemon
-  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTIONS::request req{};
   req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
   req.decode_as_json = false;
   req.prune = true;
-  COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
+  COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
     const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
@@ -11312,14 +11311,14 @@ std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string
     const std::vector<uint64_t> absolute_offsets = cryptonote::relative_output_offsets_to_absolute(in_key->key_offsets);
     const size_t ring_size = in_key->key_offsets.size();
     THROW_WALLET_EXCEPTION_IF(absolute_offsets.size() != ring_size, error::wallet_internal_error, "absolute offsets size is wrong");
-    COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
+    COMMAND_RPC_GET_OUTPUTS_BIN::request req{};
     req.outputs.resize(ring_size);
     for (size_t j = 0; j < ring_size; ++j)
     {
       req.outputs[j].amount = in_key->amount;
       req.outputs[j].index = absolute_offsets[j];
     }
-    COMMAND_RPC_GET_OUTPUTS_BIN::response res = AUTO_VAL_INIT(res);
+    COMMAND_RPC_GET_OUTPUTS_BIN::response res{};
     bool r;
     {
       const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
@@ -11371,11 +11370,11 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
     "Signature header check error");
 
   // fetch tx from daemon
-  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTIONS::request req{};
   req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
   req.decode_as_json = false;
   req.prune = true;
-  COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
+  COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
     const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
@@ -11440,7 +11439,7 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
       continue;
 
     // get output pubkeys in the ring
-    COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
+    COMMAND_RPC_GET_OUTPUTS_BIN::request req{};
     const std::vector<uint64_t> absolute_offsets = cryptonote::relative_output_offsets_to_absolute(in_key->key_offsets);
     req.outputs.resize(absolute_offsets.size());
     for (size_t j = 0; j < absolute_offsets.size(); ++j)
@@ -11448,7 +11447,7 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
       req.outputs[j].amount = in_key->amount;
       req.outputs[j].index = absolute_offsets[j];
     }
-    COMMAND_RPC_GET_OUTPUTS_BIN::response res = AUTO_VAL_INIT(res);
+    COMMAND_RPC_GET_OUTPUTS_BIN::response res{};
     bool r;
     {
       const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
@@ -12598,8 +12597,8 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
 uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, size_t offset, uint64_t &spent, uint64_t &unspent, bool check_spent)
 {
   PERF_TIMER(import_key_images_lots);
-  COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req = AUTO_VAL_INIT(req);
-  COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+  COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req{};
+  COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp{};
 
   THROW_WALLET_EXCEPTION_IF(offset > m_transfers.size(), error::wallet_internal_error, "Offset larger than known outputs");
   THROW_WALLET_EXCEPTION_IF(signed_key_images.size() > m_transfers.size() - offset, error::wallet_internal_error,
@@ -13766,8 +13765,8 @@ std::vector<std::pair<uint64_t, uint64_t>> wallet2::estimate_backlog(const std::
   }
 
   // get txpool backlog
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response res = AUTO_VAL_INIT(res);
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request req{};
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response res{};
   m_daemon_rpc_mutex.lock();
   bool r = invoke_http_json_rpc("/json_rpc", "get_txpool_backlog", req, res, rpc_timeout);
   m_daemon_rpc_mutex.unlock();

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2806,7 +2806,7 @@ namespace tools
       return false;
     }
 
-    cryptonote::COMMAND_RPC_START_MINING::request daemon_req = AUTO_VAL_INIT(daemon_req); 
+    cryptonote::COMMAND_RPC_START_MINING::request daemon_req{}; 
     daemon_req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
     daemon_req.threads_count        = req.threads_count;
     daemon_req.do_background_mining = req.do_background_mining;

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -198,7 +198,7 @@ bool tests::proxy_core::handle_incoming_txs(const std::vector<blobdata>& tx_blob
 }
 
 bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block_, cryptonote::block_verification_context& bvc, cryptonote::checkpoint_t *checkpoint, bool update_miner_blocktemplate) {
-    block b = AUTO_VAL_INIT(b);
+    block b{};
 
     if(!parse_and_validate_block_from_blob(block_blob, b)) {
         cerr << "Failed to parse and validate new block" << endl;

--- a/tests/core_tests/block_reward.cpp
+++ b/tests/core_tests/block_reward.cpp
@@ -113,7 +113,7 @@ namespace
   uint64_t get_tx_out_amount(const transaction& tx)
   {
     uint64_t amount = 0;
-    BOOST_FOREACH(auto& o, tx.vout)
+    for (auto& o : tx.vout)
       amount += o.amount;
     return amount;
   }

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -469,7 +469,7 @@ static bool construct_miner_tx_with_extra_output(cryptonote::transaction& tx,
         cryptonote::address_parse_info governance_wallet_address;
         cryptonote::get_account_address_from_str(governance_wallet_address, nettype, *cryptonote::get_config(nettype, hard_fork_version).GOVERNANCE_WALLET_ADDRESS);
 
-        crypto::public_key out_eph_public_key = AUTO_VAL_INIT(out_eph_public_key);
+        crypto::public_key out_eph_public_key{};
 
         if (!get_deterministic_output_key(
               governance_wallet_address.address, gov_key, tx.vout.size(), out_eph_public_key)) {

--- a/tests/core_tests/chain_switch_1.cpp
+++ b/tests/core_tests/chain_switch_1.cpp
@@ -196,7 +196,7 @@ bool gen_chain_switch_1::check_split_switched(cryptonote::core& c, size_t ev_ind
   CHECK_EQ(2, c.get_alternative_blocks_count());
 
   // Some blocks that were in main chain are in alt chain now
-  BOOST_FOREACH(block b, alt_blocks)
+  for (block &b : alt_blocks)
   {
     CHECK_TEST_CONDITION(m_chain_1.end() != std::find(m_chain_1.begin(), m_chain_1.end(), b));
   }

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -675,7 +675,7 @@ void test_generator::get_last_n_block_weights(std::vector<uint64_t>& block_weigh
 {
   std::vector<block_info> blockchain;
   get_block_chain(blockchain, head, n);
-  BOOST_FOREACH(auto& bi, blockchain)
+  for (auto& bi : blockchain)
   {
     block_weights.push_back(bi.block_weight);
   }
@@ -768,7 +768,7 @@ bool test_generator::construct_block(cryptonote::block &blk,
 
   uint64_t total_fee = 0;
   size_t txs_weight = 0;
-  BOOST_FOREACH(auto& tx, tx_list)
+  for (auto& tx : tx_list)
   {
     uint64_t fee = 0;
     bool r = get_tx_fee(tx, fee);
@@ -777,7 +777,7 @@ bool test_generator::construct_block(cryptonote::block &blk,
     txs_weight += get_transaction_weight(tx);
   }
 
-  blk.miner_tx = AUTO_VAL_INIT(blk.miner_tx);
+  blk.miner_tx = {};
   size_t target_block_weight = txs_weight + get_transaction_weight(blk.miner_tx);
   cryptonote::loki_miner_tx_context miner_tx_context(cryptonote::FAKECHAIN, winner);
   manual_calc_batched_governance(*this, prev_id, miner_tx_context, m_hf_version, height);
@@ -1769,15 +1769,15 @@ bool extract_hard_forks(const std::vector<test_event_entry>& events, v_hardforks
 void get_confirmed_txs(const std::vector<cryptonote::block>& blockchain, const map_hash2tx_t& mtx, map_hash2tx_t& confirmed_txs)
 {
   std::unordered_set<crypto::hash> confirmed_hashes;
-  BOOST_FOREACH(const cryptonote::block& blk, blockchain)
+  for (const auto& blk : blockchain)
   {
-    BOOST_FOREACH(const crypto::hash& tx_hash, blk.tx_hashes)
+    for (const auto& tx_hash : blk.tx_hashes)
     {
       confirmed_hashes.insert(tx_hash);
     }
   }
 
-  BOOST_FOREACH(const auto& tx_pair, mtx)
+  for (const auto& tx_pair : mtx)
   {
     if (0 != confirmed_hashes.count(tx_pair.first))
     {
@@ -1829,7 +1829,7 @@ bool trim_block_chain(std::vector<const cryptonote::block*>& blockchain, const c
 uint64_t num_blocks(const std::vector<test_event_entry>& events)
 {
   uint64_t res = 0;
-  BOOST_FOREACH(const test_event_entry& ev, events)
+  for (const test_event_entry& ev : events)
   {
     if (typeid(cryptonote::block) == ev.type())
     {

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -636,7 +636,7 @@ public:
   bool operator()(const cryptonote::transaction& tx) const
   {
     log_event("cryptonote::transaction");
-    cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_txs_keeped_by_block, false, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
@@ -650,7 +650,7 @@ public:
     log_event("cryptonote::transaction");
     std::vector<cryptonote::blobdata> tx_blobs;
     std::vector<cryptonote::tx_verification_context> tvcs;
-     cryptonote::tx_verification_context tvc0 = AUTO_VAL_INIT(tvc0);
+     cryptonote::tx_verification_context tvc0{};
     for (const auto &tx: txs)
     {
       tx_blobs.push_back(t_serializable_object_to_blob(tx));
@@ -667,7 +667,7 @@ public:
   bool operator()(const cryptonote::block& b) const
   {
     log_event("cryptonote::block");
-    cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
+    cryptonote::block_verification_context bvc{};
     cryptonote::blobdata bd = t_serializable_object_to_blob(b);
     std::vector<cryptonote::block> pblocks;
     if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {bd, {}, {}}), pblocks))
@@ -702,7 +702,7 @@ public:
   {
     log_event("serialized_block");
 
-    cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
+    cryptonote::block_verification_context bvc{};
     std::vector<cryptonote::block> pblocks;
     if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {sr_block.data, {}, {}}), pblocks))
     {
@@ -730,7 +730,7 @@ public:
   {
     log_event("serialized_transaction");
 
-    cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(sr_tx.data, tvc, m_txs_keeped_by_block, false, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -300,7 +300,7 @@ int main(int argc, char* argv[])
     if (!failed_tests.empty())
     {
       MLOG(level, "FAILED TESTS:");
-      BOOST_FOREACH(auto test_name, failed_tests)
+      for (auto &test_name : failed_tests)
       {
         MLOG(level, "  " << test_name);
       }

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -55,7 +55,7 @@ namespace
 
     void step2_fill_inputs(const account_keys& sender_account_keys, const std::vector<tx_source_entry>& sources)
     {
-      BOOST_FOREACH(const tx_source_entry& src_entr, sources)
+      for (const auto &src_entr : sources)
       {
         m_in_contexts.push_back(keypair());
         keypair& in_ephemeral = m_in_contexts.back();
@@ -71,7 +71,7 @@ namespace
         input_to_key.k_image = img;
 
         // fill outputs array and use relative offsets
-        BOOST_FOREACH(const tx_source_entry::output_entry& out_entry, src_entr.outputs)
+        for (const auto &out_entry : src_entr.outputs)
           input_to_key.key_offsets.push_back(out_entry.first);
 
         input_to_key.key_offsets = absolute_output_offsets_to_relative(input_to_key.key_offsets);
@@ -82,7 +82,7 @@ namespace
     void step3_fill_outputs(const std::vector<tx_destination_entry>& destinations)
     {
       size_t output_index = 0;
-      BOOST_FOREACH(const tx_destination_entry& dst_entr, destinations)
+      for (const auto &dst_entr : destinations)
       {
         crypto::key_derivation derivation;
         crypto::public_key out_eph_public_key;
@@ -109,12 +109,12 @@ namespace
       m_tx.signatures.clear();
 
       size_t i = 0;
-      BOOST_FOREACH(const tx_source_entry& src_entr, sources)
+      for (const auto &src_entr : sources)
       {
         std::vector<const crypto::public_key*> keys_ptrs;
         std::vector<crypto::public_key> keys(src_entr.outputs.size());
         size_t j = 0;
-        BOOST_FOREACH(const tx_source_entry::output_entry& o, src_entr.outputs)
+        for (const auto &o : src_entr.outputs)
         {
           keys[j] = rct::rct2pk(o.second.dest);
           keys_ptrs.push_back(&keys[j]);
@@ -537,7 +537,7 @@ bool gen_tx_key_image_not_derive_from_tx_key::generate(std::vector<test_event_en
   // Tx with invalid key image can't be subscribed, so create empty signature
   tx.signatures.resize(1);
   tx.signatures[0].resize(1);
-  tx.signatures[0][0] = boost::value_initialized<crypto::signature>();
+  tx.signatures[0][0] = {};
 
   DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(tx);
@@ -560,7 +560,7 @@ bool gen_tx_key_image_is_invalid::generate(std::vector<test_event_entry>& events
   // Tx with invalid key image can't be subscribed, so create empty signature
   tx.signatures.resize(1);
   tx.signatures[0].resize(1);
-  tx.signatures[0][0] = boost::value_initialized<crypto::signature>();
+  tx.signatures[0][0] = {};
 
   DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(tx);

--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -209,11 +209,11 @@ void wallet_tools::gen_block_data(block_tracker &bt, const cryptonote::block *bl
   vtx.push_back(&(bl->miner_tx));
   height = boost::get<txin_gen>(*bl->miner_tx.vin.begin()).height;
 
-  BOOST_FOREACH(const crypto::hash &h, bl->tx_hashes) {
-          const map_hash2tx_t::const_iterator cit = mtx.find(h);
-          CHECK_AND_ASSERT_THROW_MES(mtx.end() != cit, "block contains an unknown tx hash @ " << height << ", " << h);
-          vtx.push_back(cit->second);
-        }
+  for (const auto &h : bl->tx_hashes) {
+    const map_hash2tx_t::const_iterator cit = mtx.find(h);
+    CHECK_AND_ASSERT_THROW_MES(mtx.end() != cit, "block contains an unknown tx hash @ " << height << ", " << h);
+    vtx.push_back(cit->second);
+  }
 
   bche.block = "NA";
   bche.txs.resize(bl->tx_hashes.size());
@@ -227,15 +227,15 @@ void wallet_tools::gen_block_data(block_tracker &bt, const cryptonote::block *bl
   o_indices.reserve(bl->tx_hashes.size() + 1);
 
   size_t cur = 0;
-  BOOST_FOREACH(const transaction *tx, vtx){
-          cur += 1;
-          o_indices.emplace_back();
-          bt.process(bl, tx, cur - 1);
-          bt.global_indices(tx, o_indices.back().indices);
+  for (const transaction *tx : vtx){
+    cur += 1;
+    o_indices.emplace_back();
+    bt.process(bl, tx, cur - 1);
+    bt.global_indices(tx, o_indices.back().indices);
 
-          if (cur > 1)  // miner not included
-            parsed_block.txes.push_back(*tx);
-        }
+    if (cur > 1)  // miner not included
+      parsed_block.txes.push_back(*tx);
+  }
 }
 
 void wallet_tools::compute_subaddresses(std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses, cryptonote::account_base & creds, size_t account, size_t minors)

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -101,7 +101,7 @@ uint64_t get_money_in_first_transfers(const tools::wallet2::transfer_container& 
 {
   uint64_t summ = 0;
   size_t count = 0;
-  BOOST_FOREACH(const tools::wallet2::transfer_details& td, incoming_transfers)
+  for (const auto& td : incoming_transfers)
   {
     summ += td.m_tx.vout[td.m_internal_output_index].amount;
     if(++count >= n_transfers)
@@ -158,13 +158,13 @@ bool transactions_flow_test(std::string& working_folder,
 
   //lets do some money
   epee::net_utils::http::http_simple_client http_client;
-  COMMAND_RPC_STOP_MINING::request daemon1_req = AUTO_VAL_INIT(daemon1_req);
-  COMMAND_RPC_STOP_MINING::response daemon1_rsp = AUTO_VAL_INIT(daemon1_rsp);
+  COMMAND_RPC_STOP_MINING::request daemon1_req{};
+  COMMAND_RPC_STOP_MINING::response daemon1_rsp{};
   bool r = http_client.set_server(daemon_addr_a, boost::none) && net_utils::invoke_http_json("/stop_mine", daemon1_req, daemon1_rsp, http_client, std::chrono::seconds(10));
   CHECK_AND_ASSERT_MES(r, false, "failed to stop mining");
 
-  COMMAND_RPC_START_MINING::request daemon_req = AUTO_VAL_INIT(daemon_req);
-  COMMAND_RPC_START_MINING::response daemon_rsp = AUTO_VAL_INIT(daemon_rsp);
+  COMMAND_RPC_START_MINING::request daemon_req{};
+  COMMAND_RPC_START_MINING::response daemon_rsp{};
   daemon_req.miner_address = w1.get_account().get_public_address_str(MAINNET);
   daemon_req.threads_count = 9;
   r = net_utils::invoke_http_json("/start_mining", daemon_req, daemon_rsp, http_client, std::chrono::seconds(10));
@@ -190,7 +190,7 @@ bool transactions_flow_test(std::string& working_folder,
     {
       //lets go!
       size_t count = 0;
-      BOOST_FOREACH(tools::wallet2::transfer_details& td, incoming_transfers)
+      for (auto& td : incoming_transfers)
       {
         cryptonote::transaction tx_s;
         bool r = do_send_money(w1, w1, 0, td.m_tx.vout[td.m_internal_output_index].amount - TEST_FEE, tx_s, 50);
@@ -216,7 +216,7 @@ bool transactions_flow_test(std::string& working_folder,
     size_t m_received_count;
     uint64_t amount_transfered;
   };
-  crypto::key_image lst_sent_ki = AUTO_VAL_INIT(lst_sent_ki);
+  crypto::key_image lst_sent_ki{};
   std::unordered_map<crypto::hash, tx_test_entry> txs;
   for(i = 0; i != transactions_count; i++)
   {
@@ -253,7 +253,7 @@ bool transactions_flow_test(std::string& working_folder,
     transfered_money += amount_to_tx;
 
     LOG_PRINT_L0("transferred " << amount_to_tx << ", i=" << i );
-    tx_test_entry& ent = txs[get_transaction_hash(tx)] = boost::value_initialized<tx_test_entry>();
+    tx_test_entry& ent = txs[get_transaction_hash(tx)] = {};
     ent.amount_transfered = amount_to_tx;
     ent.tx = tx;
     //if(i % transactions_per_second)
@@ -280,14 +280,14 @@ bool transactions_flow_test(std::string& working_folder,
   {
     tools::wallet2::transfer_container tc;
     w2.get_transfers(tc);
-    BOOST_FOREACH(tools::wallet2::transfer_details& td, tc)
+    for (auto& td : tc)
     {
       auto it = txs.find(td.m_txid);
       CHECK_AND_ASSERT_MES(it != txs.end(), false, "transaction not found in local cache");
       it->second.m_received_count += 1;
     }
 
-    BOOST_FOREACH(auto& tx_pair, txs)
+    for (auto& tx_pair : txs)
     {
       if(tx_pair.second.m_received_count != 1)
       {

--- a/tests/functional_tests/transactions_generation_from_blockchain.cpp
+++ b/tests/functional_tests/transactions_generation_from_blockchain.cpp
@@ -77,7 +77,7 @@ bool make_tx(blockchain_storage& bch)
   sources[0].outputs.push_back(make_outptu_entr_for_gindex(34, txs, v));
   sources[0].real_out_tx_key =
 
-  BOOST_FOREACH(transfer_container::iterator it, selected_transfers)
+  for (auto& it : selected_transfers)
   {
     sources.resize(sources.size()+1);
     cryptonote::tx_source_entry& src = sources.back();
@@ -87,7 +87,7 @@ bool make_tx(blockchain_storage& bch)
     if(daemon_resp.outs.size())
     {
       daemon_resp.outs[i].outs.sort([](const out_entry& a, const out_entry& b){return a.global_amount_index < b.global_amount_index;});
-      BOOST_FOREACH(out_entry& daemon_oe, daemon_resp.outs[i].outs)
+      for (out_entry& daemon_oe : daemon_resp.outs[i].outs)
       {
         if(td.m_global_output_index == daemon_oe.global_amount_index)
           continue;
@@ -147,7 +147,7 @@ bool make_tx(blockchain_storage& bch)
   }
 
   std::cout << "transaction generated ok and sent to daemon" << std::endl;
-  BOOST_FOREACH(transfer_container::iterator it, selected_transfers)
+  for (auto &it : selected_transfers)
     it->m_spent = true;
 
   return true;

--- a/tests/fuzz/block.cpp
+++ b/tests/fuzz/block.cpp
@@ -50,7 +50,7 @@ int BlockFuzzer::run(const std::string &filename)
     std::cout << "Error: failed to load file " << filename << std::endl;
     return 1;
   }
-  cryptonote::block b = AUTO_VAL_INIT(b);
+  cryptonote::block b{};
   if(!parse_and_validate_block_from_blob(s, b))
   {
     std::cout << "Error: failed to parse block from file  " << filename << std::endl;

--- a/tests/fuzz/bulletproof.cpp
+++ b/tests/fuzz/bulletproof.cpp
@@ -53,7 +53,7 @@ int BulletproofFuzzer::run(const std::string &filename)
   std::stringstream ss;
   ss << s;
   binary_archive<false> ba(ss);
-  rct::Bulletproof proof = AUTO_VAL_INIT(proof);
+  rct::Bulletproof proof{};
   bool r = ::serialization::serialize(ba, proof);
   if(!r)
   {

--- a/tests/fuzz/transaction.cpp
+++ b/tests/fuzz/transaction.cpp
@@ -50,7 +50,7 @@ int TransactionFuzzer::run(const std::string &filename)
     std::cout << "Error: failed to load file " << filename << std::endl;
     return 1;
   }
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx{};
   if(!parse_and_validate_tx_from_blob(s, tx))
   {
     std::cout << "Error: failed to parse transaction from file  " << filename << std::endl;

--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
     if (!failed_tests.empty())
     {
       MLOG(level, "FAILED TESTS:");
-      BOOST_FOREACH(auto test_name, failed_tests)
+      for (auto& test_name : failed_tests)
       {
         MLOG(level, "  " << test_name);
       }

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -38,7 +38,7 @@ static tools::wallet2::transfer_container make_transfers_container(size_t N)
   tools::wallet2::transfer_container transfers;
   for (size_t n = 0; n < N; ++n)
   {
-    transfers.push_back(AUTO_VAL_INIT(tools::wallet2::transfer_details()));
+    transfers.emplace_back();
     tools::wallet2::transfer_details &td = transfers.back();
     td.m_block_height = 1000;
     td.m_spent = false;

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <iostream>
 #include <vector>
-#include <boost/foreach.hpp>
 #include <boost/archive/portable_binary_iarchive.hpp>
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
@@ -296,7 +295,7 @@ namespace
   std::vector<T> linearize_vector2(const std::vector< std::vector<T> >& vec_vec)
   {
     std::vector<T> res;
-    BOOST_FOREACH(const auto& vec, vec_vec)
+    for (const auto& vec : vec_vec)
     {
       res.insert(res.end(), vec.begin(), vec.end());
     }

--- a/tests/unit_tests/test_protocol_pack.cpp
+++ b/tests/unit_tests/test_protocol_pack.cpp
@@ -42,7 +42,7 @@ TEST(protocol_pack, protocol_pack_command)
   r.total_height = 3;
   for(int i = 1; i < 10000; i += i*10)
   {
-    r.m_block_ids.resize(i, boost::value_initialized<crypto::hash>());
+    r.m_block_ids.resize(i, crypto::hash{});
     bool res = epee::serialization::store_t_to_binary(r, buff);
     ASSERT_TRUE(res);
 

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -137,7 +137,7 @@ TEST(parse_tx_extra, handles_pub_key_and_padding)
 
 TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx{};
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b = "dsdsdfsdfsf";
@@ -147,7 +147,7 @@ TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
 }
 TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx{};
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b(TX_EXTRA_NONCE_MAX_COUNT + 1, 0);
@@ -155,7 +155,7 @@ TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
 }
 TEST(parse_and_validate_tx_extra, fails_on_wrong_size_in_extra_nonce)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx{};
   tx.extra.resize(20, 0);
   tx.extra[0] = TX_EXTRA_NONCE;
   tx.extra[1] = 255;

--- a/tests/unit_tests/varint.cpp
+++ b/tests/unit_tests/varint.cpp
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <iostream>
 #include <vector>
-#include <boost/foreach.hpp>
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "serialization/binary_archive.h"


### PR DESCRIPTION
Neither of these have a place in modern C++11; boost::value_initialized
is entirely superseded by `Type var{};` which does value initialization
(or default construction if a default constructor is defined).  More
problematically, each `boost::value_initialized<T>` requires
instantiation of another wrapping templated type which is a pointless
price to pay the compiler in C++11 or newer.

Also removed is the AUTO_VAL_INIT macro (which is just a simple macro
around constructing a boost::value_initialized<T>).

BOOST_FOREACH is a similarly massive pile of code to implement
C++11-style for-each loops in pre-C++11 compilers. (And bizarrely it
*doesn't* appear to fall back to C++ for-each loops even when under
a C++11 compiler!)

This removes both entirely from the codebase.