### PR TITLE
Don't define empty CPUID(..) if not x86-64, avoids unused func error

### DIFF
--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -99,9 +99,9 @@ static inline int force_software_aes(void)
   return use;
 }
 
+#if defined(__x86_64__)
 static void cpuid(int CPUInfo[4], int InfoType)
 {
-#if defined(__x86_64__)
     __asm __volatile__
     (
     "cpuid":
@@ -111,8 +111,9 @@ static void cpuid(int CPUInfo[4], int InfoType)
         "=d" (CPUInfo[3]) :
             "a" (InfoType), "c" (0)
         );
-#endif
 }
+#endif
+
 static inline int check_aes_hw(void)
 {
 #if defined(__x86_64__)


### PR DESCRIPTION
`cpuid(...)` is only used in `check_aes_hw` which only uses `cpuid(...)` if you're compiling for x86-64. This fixes the unused function werror when compiling release on other architectures.