### PR TITLE
Fix for older libc++

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -152,7 +152,7 @@ namespace epee
     template<typename T, size_t Size, class t_storage>
     static bool unserialize_stl_container_t_val(std::array<T, Size>& array, t_storage& stg, typename t_storage::hsection hparent_section, const char* pname)
     {
-      static_assert(array.size() > 0, "cannot deserialize empty std::array");
+      static_assert(Size > 0, "cannot deserialize empty std::array");
       size_t next_i = 0;
       T exchange_val;
       typename t_storage::harray hval_array = stg.get_first_value(pname, exchange_val, hparent_section);
@@ -245,7 +245,7 @@ namespace epee
     template<typename T, size_t Size, class t_storage>
     static bool unserialize_stl_container_t_obj(std::array<T, Size>& array, t_storage& stg, typename t_storage::hsection hparent_section, const char* pname)
     {
-      static_assert(array.size() > 0, "cannot deserialize empty std::array");
+      static_assert(Size > 0, "cannot deserialize empty std::array");
       size_t next_i = 0;
       bool res = false;
       T val = T{};


### PR DESCRIPTION
Older libc++ (as on our travis-ci darwin build) apparently don't
properly treat std::array's size() method as constexpr.  Work around
this by using the deduced `Size` template parameter instead.