### PR TITLE
Build/core test fixes, incorporate LNS construct_tx revamp

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -313,4 +313,7 @@ namespace tools
   template <typename Enum>
   constexpr auto enum_count = static_cast<std::underlying_type_t<Enum>>(Enum::_count);
 
+  template <typename Enum>
+  constexpr Enum enum_top = static_cast<Enum>(enum_count<Enum> - 1);
+
 }

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -996,14 +996,14 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool check_outs_valid(const transaction& tx)
   {
-    if (tx.type != txtype::standard)
+    if (!tx.is_transfer())
     {
       CHECK_AND_NO_ASSERT_MES(tx.vout.size() == 0, false, "tx type: " << tx.type << " must have 0 outputs, received: " << tx.vout.size() << ", id=" << get_transaction_hash(tx));
     }
 
     if (tx.version >= txversion::v3_per_output_unlock_times)
     {
-      CHECK_AND_NO_ASSERT_MES(tx.vout.size() == tx.output_unlock_times.size(), false, "tx version 3 must have equal number of output unlock times and outputs");
+      CHECK_AND_NO_ASSERT_MES(tx.vout.size() == tx.output_unlock_times.size(), false, "tx version: " << tx.version << "must have equal number of output unlock times and outputs");
     }
 
     for(const tx_out& out: tx.vout)
@@ -1383,13 +1383,13 @@ namespace cryptonote
     // TODO(loki): Not sure if this is the right fix, we may just want to set
     // unprunable size to the size of the prefix because technically that is
     // what it is and then keep this code path.
-    if (t.type == txtype::standard)
+    if (t.is_transfer())
     {
       const unsigned int unprunable_size = t.unprunable_size;
       const unsigned int prefix_size = t.prefix_size;
 
       // base rct
-      CHECK_AND_ASSERT_MES(prefix_size <= unprunable_size && unprunable_size <= blob.size(), false, "Inconsistent transaction prefix, unprunable and blob sizes");
+      CHECK_AND_ASSERT_MES(prefix_size <= unprunable_size && unprunable_size <= blob.size(), false, "Inconsistent transaction prefix, unprunable and blob sizes in: " << __func__);
       cryptonote::get_blob_hash(epee::span<const char>(blob.data() + prefix_size, unprunable_size - prefix_size), hashes[1]);
     }
     else

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -82,7 +82,7 @@ static constexpr HardFork::Params testnet_hard_forks[] =
   { network_version_11_infinite_staking,    5,      0, 1551223964 },
   { network_version_12_checkpointing,       75471,  0, 1561608000 }, // 2019-06-28 14:00AEDT
   { network_version_13_enforce_checkpoints, 127028, 0, 1568440800 }, // 2019-09-13 16:00AEDT
-  { network_version_14,                     174630, 0, 1575075600 }, // 2019-11-30 07:00UTC
+  { network_version_14_blink_lns,           174630, 0, 1575075600 }, // 2019-11-30 07:00UTC
 };
 
 static constexpr HardFork::Params stagenet_hard_forks[] =

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -180,8 +180,8 @@ static_assert(BLINK_BURN_TX_FEE_PERCENT >= 0, "blink burn tx percent cannot be n
 #define HF_VERSION_INCREASE_FEE                 cryptonote::network_version_12_checkpointing
 #define HF_VERSION_PER_OUTPUT_FEE               cryptonote::network_version_13_enforce_checkpoints
 #define HF_VERSION_ED25519_KEY                  cryptonote::network_version_13_enforce_checkpoints
-#define HF_VERSION_FEE_BURNING                  cryptonote::network_version_14
-#define HF_VERSION_BLINK                        cryptonote::network_version_14
+#define HF_VERSION_FEE_BURNING                  cryptonote::network_version_14_blink_lns
+#define HF_VERSION_BLINK                        cryptonote::network_version_14_blink_lns
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 
@@ -284,7 +284,7 @@ namespace cryptonote
     network_version_11_infinite_staking, // Infinite Staking, CN-Turtle
     network_version_12_checkpointing, // Checkpointing, Relaxed Deregistration, RandomXL, Loki Storage Server
     network_version_13_enforce_checkpoints,
-    network_version_14,
+    network_version_14_blink_lns,
 
     network_version_count,
   };

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1072,7 +1072,7 @@ namespace cryptonote
         continue;
       }
 
-      if (tx_info[n].tx.type != txtype::standard)
+      if (!tx_info[n].tx.is_transfer())
         continue;
       const rct::rctSig &rv = tx_info[n].tx.rct_signatures;
       switch (rv.type) {
@@ -1418,18 +1418,21 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::check_tx_semantic(const transaction& tx, bool keeped_by_block) const
   {
-    if (tx.type != txtype::standard)
+    if (tx.is_transfer())
+    {
+      if (tx.vin.empty())
+      {
+        MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
+        return false;
+      }
+    }
+    else
     {
       if (tx.vin.size() != 0)
       {
         MERROR_VER("tx type: " << tx.type << " must have 0 inputs, received: " << tx.vin.size() << ", rejected for tx id = " << get_transaction_hash(tx));
         return false;
       }
-    }
-    else if (!tx.vin.size())
-    {
-      MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
-      return false;
     }
 
     if(!check_inputs_types_supported(tx))
@@ -1658,7 +1661,7 @@ namespace cryptonote
   bool core::relay_service_node_votes()
   {
     auto height = get_current_blockchain_height();
-    auto qnet_begins = get_earliest_ideal_height_for_version(network_version_14);
+    auto qnet_begins = get_earliest_ideal_height_for_version(network_version_14_blink_lns);
 
     auto votes = m_quorum_cop.get_relayable_votes(height);
     if (votes.empty())
@@ -1964,7 +1967,7 @@ namespace cryptonote
           uint8_t hf_version = get_blockchain_storage().get_current_hard_fork_version();
           if (!check_external_ping(m_last_lokinet_ping, LOKINET_PING_LIFETIME, "Lokinet"))
           {
-            if (hf_version >= cryptonote::network_version_14)
+            if (hf_version >= cryptonote::network_version_14_blink_lns)
             {
               MGINFO_RED(
                   "Failed to submit uptime proof: have not heard from lokinet recently. Make sure that it "

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -470,7 +470,7 @@ namespace cryptonote
       return false;
     }
 
-    if (tx_params.burn_fixed && tx_params.hf_version <= cryptonote::network_version_13_enforce_checkpoints)
+    if (tx_params.burn_fixed && tx_params.hf_version < cryptonote::network_version_14_blink_lns)
     {
       LOG_ERROR("cannot construct tx: burn can not be specified before hard fork 14");
       return false;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -165,14 +165,8 @@ namespace cryptonote
 
   struct loki_construct_tx_params
   {
-    // These are updated automatically (as appropriate) when set_hf_version() is called (from inside wallet2) with the hf version:
-    bool                burning_permitted = false;
-    bool                v4_allow_tx_types = false;
-    bool                v3_per_output_unlock = false;
-    bool                v2_rct = false;
-
-    // NOTE: Set to true manually if you need a staking transaction
-    bool                v3_is_staking_tx = false;
+    uint8_t hf_version = cryptonote::network_version_7;
+    txtype tx_type     = txtype::standard;
 
     // Can be set to non-zero values to have the tx be constructed specifying required burn amounts
     // Note that the percentage is relative to the minimal base tx fee, *not* the actual tx fee.
@@ -182,22 +176,13 @@ namespace cryptonote
     // and the burn amount will be 0.1+3(0.5)=1.6 (and thus the miner tx coinbase amount will be
     // 1.0).  (See also wallet2's get_fee_percent which needs to return a value large enough to
     // allow these amounts to be burned).
-    uint64_t            burn_fixed = 0; // atomic units
-    uint64_t            burn_percent = 0; // 123 = 1.23x base fee.
-
-    // Sets v4_allow_tx_types, v3_per_output_unlock, and v2_rct according to the given hf_version
-    void set_hf_version(uint8_t hf_version)
-    {
-      burning_permitted    = (hf_version >= HF_VERSION_FEE_BURNING);
-      v4_allow_tx_types    = (hf_version >= cryptonote::network_version_11_infinite_staking);
-      v3_per_output_unlock = (hf_version >= cryptonote::network_version_9_service_nodes);
-      v2_rct               = (hf_version >= cryptonote::network_version_7);
-    }
+    uint64_t burn_fixed   = 0; // atomic units
+    uint64_t burn_percent = 0; // 123 = 1.23x base fee.
   };
 
   //---------------------------------------------------------------
   crypto::public_key get_destination_view_key_pub(const std::vector<tx_destination_entry> &destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr);
-  bool construct_tx(const account_keys& sender_account_keys, std::vector<tx_source_entry> &sources, const std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, uint8_t hf_version = cryptonote::network_version_7, const loki_construct_tx_params &tx_params = {});
+  bool construct_tx(const account_keys& sender_account_keys, std::vector<tx_source_entry> &sources, const std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, const loki_construct_tx_params &tx_params = {});
   bool construct_tx_with_tx_key   (const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, std::vector<tx_source_entry>& sources, std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0}, rct::multisig_out *msout = NULL, bool shuffle_outs = true, loki_construct_tx_params const &tx_params = {});
   bool construct_tx_and_get_tx_key(const account_keys& sender_account_keys, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, std::vector<tx_source_entry>& sources, std::vector<tx_destination_entry>& destinations, const boost::optional<cryptonote::tx_destination_entry>& change_addr, const std::vector<uint8_t> &extra, transaction& tx, uint64_t unlock_time,       crypto::secret_key &tx_key,       std::vector<crypto::secret_key> &additional_tx_keys, const rct::RCTConfig &rct_config = { rct::RangeProofBorromean, 0}, rct::multisig_out *msout = NULL, loki_construct_tx_params const &tx_params = {});
   bool generate_output_ephemeral_keys(const size_t tx_version, bool &found_change,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -85,7 +85,7 @@ namespace service_nodes
 
   static constexpr service_node_info::version_t get_min_service_node_info_version_for_hf(uint8_t hf_version)
   {
-    return hf_version < cryptonote::network_version_14
+    return hf_version < cryptonote::network_version_14_blink_lns
       ? service_node_info::version_t::v2_ed25519
       : service_node_info::version_t::v3_quorumnet;
   }
@@ -439,7 +439,7 @@ namespace service_nodes
         money_transferred = rct::decodeRct(tx.rct_signatures, rct::sk2rct(scalar1), i, mask, hwdev);
         break;
       default:
-        LOG_PRINT_L0("Unsupported rct type: " << tx.rct_signatures.type);
+        LOG_PRINT_L0(__func__ << ": Unsupported rct type: " << (int)tx.rct_signatures.type);
         return 0;
       }
     }
@@ -714,6 +714,20 @@ namespace service_nodes
       return false;
     }
 
+    // A cryptonote transaction is constructed as follows
+    // P = Hs(aR)G + B
+
+    // P := Stealth Address
+    // a := Receiver's secret view key
+    // B := Receiver's public spend key
+    // R := TX Public Key
+    // G := Elliptic Curve
+
+    // In Loki we pack into the tx extra information to reveal information about the TX
+    // A := Public View Key (we pack contributor into tx extra, 'parsed_contribution.address')
+    // r := TX Secret Key   (we pack secret key into tx extra,  'parsed_contribution.tx_key`)
+
+    // Calulate 'Derivation := Hs(Ar)G'
     crypto::key_derivation derivation;
     if (!crypto::generate_key_derivation(parsed_contribution.address.m_view_public_key, parsed_contribution.tx_key, derivation))
     {
@@ -726,6 +740,17 @@ namespace service_nodes
 
     if (hf_version >= cryptonote::network_version_11_infinite_staking)
     {
+      // In Infinite Staking, we lock the key image that would be generated if
+      // you tried to send your stake and prevent it from being transacted on
+      // the network whilst you are a Service Node. To do this, we calculate
+      // the future key image that would be generated when they user tries to
+      // spend the staked funds. A key image is derived from the ephemeral, one
+      // time transaction private key, 'x' in the Cryptonote Whitepaper.
+
+      // This is only possible to generate if they are the staking to themselves
+      // as you need the recipients private keys to generate the key image that
+      // would be generated, when they want to spend it in the future.
+
       cryptonote::tx_extra_tx_key_image_proofs key_image_proofs;
       if (!get_tx_key_image_proofs_from_tx_extra(tx.extra, key_image_proofs))
       {
@@ -739,14 +764,30 @@ namespace service_nodes
         if (transferred == 0)
           continue;
 
+        // So prove that the destination stealth address can be decoded using the
+        // staker's packed address, which means that the recipient of the
+        // contribution is themselves (and hence they have the necessary secrets
+        // to generate the future key image).
+
+        // i.e Verify the packed information is valid by computing the stealth
+        // address P' (which should equal P if matching) using
+
+        // 'Derivation := Hs(Ar)G' (we calculated earlier) instead of 'Hs(aR)G'
+        // P' = Hs(Ar)G + B
+        //    = Hs(aR)G + B
+        //    = Derivation + B
+        //    = P
+
         crypto::public_key ephemeral_pub_key;
         {
+          // P' := Derivation + B
           if (!hwdev.derive_public_key(derivation, output_index, parsed_contribution.address.m_spend_public_key, ephemeral_pub_key))
           {
             LOG_PRINT_L1("Contribution TX: Could not derive TX ephemeral key on height: " << block_height << " for tx: " << get_transaction_hash(tx) << " for output: " << output_index);
             continue;
           }
 
+          // Stealth address public key should match the public key referenced in the TX only if valid information is given.
           const auto& out_to_key = boost::get<cryptonote::txout_to_key>(tx.vout[output_index].target);
           if (out_to_key.key != ephemeral_pub_key)
           {
@@ -755,6 +796,16 @@ namespace service_nodes
           }
         }
 
+        // To prevent the staker locking any arbitrary key image, the provided
+        // key image is included and verified in a ring signature which
+        // guarantees that 'the staker proves that he knows such 'x' (one time
+        // ephemeral secret key) and that (the future key image) P = xG'.
+        // Consequently the key image is not falsified and actually the future
+        // key image.
+
+        // The signer can try falsify the key image, but the equation used to
+        // construct the key image is re-derived by the verifier, false key
+        // images will not match the re-derived key image.
         crypto::public_key const *ephemeral_pub_key_ptr = &ephemeral_pub_key;
         for (auto proof = key_image_proofs.proofs.begin(); proof != key_image_proofs.proofs.end(); proof++)
         {
@@ -776,6 +827,9 @@ namespace service_nodes
     }
     else
     {
+      // Pre Infinite Staking, we only need to prove the amount sent is
+      // sufficient to become a contributor to the Service Node and that there
+      // is sufficient lock time on the staking output.
       for (size_t i = 0; i < tx.vout.size(); i++)
       {
         bool has_correct_unlock_time = false;
@@ -1372,7 +1426,8 @@ namespace service_nodes
     for (uint32_t index = 0; index < txs.size(); ++index)
     {
       const cryptonote::transaction& tx = txs[index];
-      if (tx.type == cryptonote::txtype::standard)
+      if ((hf_version >= cryptonote::network_version_14_blink_lns && tx.type == cryptonote::txtype::stake) ||
+          (hf_version <= cryptonote::network_version_13_enforce_checkpoints && tx.type == cryptonote::txtype::standard))
       {
         process_registration_tx(nettype, block, tx, index, my_keys);
         need_swarm_update += process_contribution_tx(nettype, block, tx, index);
@@ -2143,7 +2198,7 @@ namespace service_nodes
         info.version = version_t::v3_quorumnet;
       }
       // Make sure we handled any future state version upgrades:
-      assert(info.version == static_cast<version_t>(tools::enum_count<version_t> - 1));
+      assert(info.version == static_cast<version_t>(static_cast<uint8_t>(version_t::_count) - 1));
 
       service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));
     }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2198,8 +2198,7 @@ namespace service_nodes
         info.version = version_t::v3_quorumnet;
       }
       // Make sure we handled any future state version upgrades:
-      assert(info.version == static_cast<version_t>(static_cast<uint8_t>(version_t::_count) - 1));
-
+      assert(info.version == tools::enum_top<decltype(info.version)>);
       service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));
     }
     quorums = quorum_for_serialization_to_quorum_manager(state.quorums);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -534,7 +534,7 @@ namespace service_nodes
           cryptonote::transaction state_change_tx = {};
           if (cryptonote::add_service_node_state_change_to_tx_extra(state_change_tx.extra, state_change, hf_version))
           {
-            state_change_tx.version = cryptonote::transaction::get_min_version_for_hf(hf_version, m_core.get_nettype());
+            state_change_tx.version = cryptonote::transaction::get_max_version_for_hf(hf_version);
             state_change_tx.type    = cryptonote::txtype::state_change;
 
             cryptonote::tx_verification_context tvc = {};

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -128,7 +128,7 @@ namespace service_nodes {
   {
     return
         hf_version <= cryptonote::network_version_12_checkpointing ? quorum_type::obligations :
-        hf_version <  cryptonote::network_version_14               ? quorum_type::checkpointing :
+        hf_version <  cryptonote::network_version_14_blink_lns     ? quorum_type::checkpointing :
         quorum_type::blink;
   }
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -125,7 +125,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_duplicated_non_standard_tx(transaction const &tx, uint8_t hard_fork_version) const
   {
-    if (tx.type == txtype::standard)
+    if (tx.is_transfer())
       return false;
 
     auto &service_node_list = m_blockchain.get_service_node_list();
@@ -277,8 +277,7 @@ namespace cryptonote
       return false;
     }
 
-    if (!opts.kept_by_block && tx.type == txtype::standard &&
-        !m_blockchain.check_fee(tx_weight, tx.vout.size(), fee, burned, opts))
+    if (!opts.kept_by_block && tx.is_transfer() && !m_blockchain.check_fee(tx_weight, tx.vout.size(), fee, burned, opts))
     {
       tvc.m_verifivation_failed = true;
       tvc.m_fee_too_low = true;
@@ -360,7 +359,7 @@ namespace cryptonote
     uint64_t max_used_block_height = 0;
     cryptonote::txpool_tx_meta_t meta;
     bool ch_inp_res = check_tx_inputs([&tx]()->cryptonote::transaction&{ return tx; }, id, max_used_block_height, max_used_block_id, tvc, opts.kept_by_block);
-    const bool non_standard_tx = (tx.type != txtype::standard);
+    const bool non_standard_tx = !tx.is_transfer();
     if(!ch_inp_res)
     {
       // if the transaction was valid before (kept_by_block), then it
@@ -1915,7 +1914,7 @@ namespace cryptonote
           return false;
         }
 
-        const bool non_standard_tx = (tx.type != txtype::standard);
+        const bool non_standard_tx = !tx.is_transfer();
         m_txs_by_fee_and_receive_time.emplace(std::tuple<bool, double, time_t>(non_standard_tx, meta.fee / (double)meta.weight, meta.receive_time), txid);
         m_txpool_weight += meta.weight;
         return true;

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -998,8 +998,8 @@ void handle_blink(SNNetwork::message &m, void *self) {
 
     // Check tx for validity
     bool approved;
-    auto min = tx.get_min_version_for_hf(hf_version, snw.core.get_nettype()),
-         max = tx.get_max_version_for_hf(hf_version, snw.core.get_nettype());
+    auto min = tx.get_min_version_for_hf(hf_version),
+         max = tx.get_max_version_for_hf(hf_version);
     if (tx.version < min || tx.version > max) {
         approved = false;
         MINFO("Blink TX " << tx_hash << " rejected because TX version " << tx.version << " invalid: TX version not between " << min << " and " << max);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5850,10 +5850,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
       }
       unlock_block = bc_height + locked_blocks;
     }
-
-    loki_construct_tx_params tx_params = tools::wallet2::construct_params(priority);
-
-    ptx_vector = m_wallet->create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block, priority, extra, m_current_subaddress_account, subaddr_indices, tx_params);
+    ptx_vector = m_wallet->create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block, priority, extra, m_current_subaddress_account, subaddr_indices);
 
     if (ptx_vector.empty())
     {
@@ -6895,9 +6892,7 @@ bool simple_wallet::sweep_main(uint64_t below, Transfer transfer_type, const std
   SCOPED_WALLET_UNLOCK();
   try
   {
-    loki_construct_tx_params tx_params = tools::wallet2::construct_params(priority);
-
-    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices, tx_params);
+    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices);
     sweep_main_internal(sweep_type_t::all_or_below, ptx_vector, info, priority == tools::wallet2::BLINK_PRIORITY);
   }
   catch (const std::exception &e)
@@ -7031,10 +7026,8 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
 
   try
   {
-    loki_construct_tx_params tx_params = tools::wallet2::construct_params(priority);
-
     // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, 0 /* unlock_time */, priority, extra, tx_params);
+    auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, 0 /* unlock_time */, priority, extra);
     sweep_main_internal(sweep_type_t::single, ptx_vector, info, priority == tools::wallet2::BLINK_PRIORITY);
   }
   catch (const std::exception& e)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -521,14 +521,13 @@ private:
       std::vector<size_t> selected_transfers;
       std::vector<uint8_t> extra;
       uint64_t unlock_time;
-      bool v2_use_rct;
-      bool v3_per_output_unlock;
-      bool v4_allow_tx_types;
       rct::RCTConfig rct_config;
       std::vector<cryptonote::tx_destination_entry> dests; // original setup, does not include change
       uint32_t subaddr_account;   // subaddress account of your wallet to be used in this transfer
       std::set<uint32_t> subaddr_indices;  // set of address indices used as inputs in this transfer
 
+      uint8_t            hf_version;
+      cryptonote::txtype tx_type;
       BEGIN_SERIALIZE_OBJECT()
         FIELD(sources)
         FIELD(change_dts)
@@ -536,13 +535,13 @@ private:
         FIELD(selected_transfers)
         FIELD(extra)
         FIELD(unlock_time)
-        FIELD(v2_use_rct)
-        FIELD(v3_per_output_unlock)
-        FIELD(v4_allow_tx_types)
         FIELD(rct_config)
         FIELD(dests)
         FIELD(subaddr_account)
         FIELD(subaddr_indices)
+
+        FIELD(hf_version)
+        ENUM_FIELD(tx_type, tx_type < cryptonote::txtype::_count)
       END_SERIALIZE()
     };
 
@@ -950,11 +949,11 @@ private:
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
     bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, cryptonote::loki_construct_tx_params loki_tx_params);     // pass subaddr_indices by value on purpose
+    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, cryptonote::txtype tx_type = cryptonote::txtype::standard);     // pass subaddr_indices by value on purpose
 
-    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const cryptonote::loki_construct_tx_params &loki_tx_params);
-    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, const cryptonote::loki_construct_tx_params &loki_tx_params);
-    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::loki_construct_tx_params loki_tx_params);
+    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, cryptonote::txtype tx_type = cryptonote::txtype::standard);
+    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type = cryptonote::txtype::standard);
+    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, cryptonote::txtype tx_type = cryptonote::txtype::standard);
 
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, std::vector<cryptonote::tx_destination_entry> dsts) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
@@ -1474,7 +1473,6 @@ private:
     stake_result check_stake_allowed(const crypto::public_key& sn_key, const cryptonote::address_parse_info& addr_info, uint64_t& amount, double fraction = 0);
     stake_result create_stake_tx    (const crypto::public_key& service_node_key, const cryptonote::address_parse_info& addr_info, uint64_t amount,
                                      double amount_fraction = 0, uint32_t priority = 0, uint32_t subaddr_account = 0, std::set<uint32_t> subaddr_indices = {});
-
     enum struct register_service_node_result_status
     {
       invalid,
@@ -1795,7 +1793,7 @@ BOOST_CLASS_VERSION(tools::wallet2::address_book_row, 17)
 BOOST_CLASS_VERSION(tools::wallet2::reserve_proof_entry, 0)
 BOOST_CLASS_VERSION(tools::wallet2::unsigned_tx_set, 0)
 BOOST_CLASS_VERSION(tools::wallet2::signed_tx_set, 1)
-BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 5)
+BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 6)
 BOOST_CLASS_VERSION(tools::wallet2::pending_tx, 3)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_sig, 0)
 
@@ -2181,7 +2179,6 @@ namespace boost
       }
       a & x.extra;
       a & x.unlock_time;
-      a & x.v2_use_rct;
       a & x.dests;
       if (ver < 1)
       {
@@ -2194,10 +2191,8 @@ namespace boost
         x.rct_config = { rct::RangeProofBorromean, 0 };
       if (ver < 2)
         return;
-      a & x.selected_transfers;
       if (ver < 3)
         return;
-      a & x.v3_per_output_unlock;
       if (ver < 5)
       {
         bool use_bulletproofs = x.rct_config.range_proof_type != rct::RangeProofBorromean;
@@ -2206,8 +2201,11 @@ namespace boost
           x.rct_config = { use_bulletproofs ? rct::RangeProofBulletproof : rct::RangeProofBorromean, 0 };
         return;
       }
-      a & x.v4_allow_tx_types;
       a & x.rct_config;
+
+      if (ver < 6) return;
+      a & x.tx_type;
+      a & x.hf_version;
     }
 
     template <class Archive>

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -2188,9 +2188,18 @@ namespace boost
       a & x.subaddr_account;
       a & x.subaddr_indices;
       if (!typename Archive::is_saving())
+      {
         x.rct_config = { rct::RangeProofBorromean, 0 };
+        if (ver < 6)
+        {
+          x.tx_type    = cryptonote::txtype::standard;
+          x.hf_version = cryptonote::network_version_13_enforce_checkpoints;
+        }
+      }
+
       if (ver < 2)
         return;
+      a & x.selected_transfers;
       if (ver < 3)
         return;
       if (ver < 5)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -828,10 +828,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       uint32_t priority = m_wallet->adjust_priority(req.priority);
-
-      auto tx_params = tools::wallet2::construct_params(priority);
-
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices, tx_params);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
 
       if (ptx_vector.empty())
       {
@@ -883,11 +880,8 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       uint32_t priority = m_wallet->adjust_priority(req.priority);
-
-      auto tx_params = tools::wallet2::construct_params(priority);
-
       LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices, tx_params);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
       LOG_PRINT_L2("on_transfer_split called create_transactions_2");
 
       return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
@@ -1296,10 +1290,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       uint32_t priority = m_wallet->adjust_priority(req.priority);
-
-      auto tx_params = tools::wallet2::construct_params(priority);
-
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices, tx_params);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
 
       return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
           res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, er);
@@ -1354,10 +1345,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       uint32_t priority = m_wallet->adjust_priority(req.priority);
-
-      auto tx_params = tools::wallet2::construct_params(priority);
-
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra, tx_params);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra);
 
       if (ptx_vector.empty())
       {

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -54,7 +54,6 @@ set(core_tests_headers
   chaingen.h
   chaingen_tests_list.h
   double_spend.h
-  double_spend.inl
   integer_overflow.h
   multisig.h
   ring_signature_1.h

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -610,7 +610,7 @@ bool gen_block_invalid_binary_format::generate(std::vector<test_event_entry>& ev
   loki_register_callback(events, "check_blocks_arent_accepted", [&events, last_valid_height](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_blocks_arent_accepted");
-    CHECK_EQ(c.get_pool_transactions_count(), 1);
+    CHECK_EQ(c.get_pool().get_transactions_count(), 1);
     CHECK_EQ(c.get_current_blockchain_height(), last_valid_height + 1);
     return true;
   });

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -567,15 +567,56 @@ bool gen_block_is_too_big::generate(std::vector<test_event_entry>& events) const
   return true;
 }
 
-gen_block_invalid_binary_format::gen_block_invalid_binary_format()
-  : m_corrupt_blocks_begin_idx(0)
-{
-  REGISTER_CALLBACK("check_all_blocks_purged", gen_block_invalid_binary_format::check_all_blocks_purged);
-  REGISTER_CALLBACK("corrupt_blocks_boundary", gen_block_invalid_binary_format::corrupt_blocks_boundary);
-}
-
 bool gen_block_invalid_binary_format::generate(std::vector<test_event_entry>& events) const
 {
+#if 1
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table();
+  loki_chain_generator gen(events, hard_forks);
+
+  gen.add_blocks_until_version(hard_forks.back().first);
+  gen.add_n_blocks(10);
+  gen.add_mined_money_unlock_blocks();
+
+  uint64_t last_valid_height = gen.height();
+  cryptonote::transaction tx  = gen.create_and_add_tx(gen.first_miner_, gen.first_miner_, MK_COINS(30));
+  loki_blockchain_entry entry = gen.create_next_block({tx});
+
+  serialized_block block(t_serializable_object_to_blob(entry.block));
+  // Generate some corrupt blocks
+  {
+    loki_blockchain_addable<serialized_block> entry(block, false /*can_be_added_to_blockchain*/, "Corrupt block can't be added to blockchaain");
+    serialized_block &corrupt_block = entry.data;
+    for (size_t i = 0; i < corrupt_block.data.size() - 1; ++i)
+      corrupt_block.data[i] ^= corrupt_block.data[i + 1];
+    events.push_back(entry);
+  }
+
+  {
+    loki_blockchain_addable<serialized_block> entry(block, false /*can_be_added_to_blockchain*/, "Corrupt block can't be added to blockchaain");
+    serialized_block &corrupt_block = entry.data;
+    for (size_t i = 0; i < corrupt_block.data.size() - 2; ++i)
+      corrupt_block.data[i] ^= corrupt_block.data[i + 2];
+    events.push_back(entry);
+  }
+
+  {
+    loki_blockchain_addable<serialized_block> entry(block, false /*can_be_added_to_blockchain*/, "Corrupt block can't be added to blockchaain");
+    serialized_block &corrupt_block = entry.data;
+    for (size_t i = 0; i < corrupt_block.data.size() - 3; ++i)
+      corrupt_block.data[i] ^= corrupt_block.data[i + 3];
+    events.push_back(entry);
+  }
+
+  loki_register_callback(events, "check_blocks_arent_accepted", [&events, last_valid_height](cryptonote::core &c, size_t ev_index)
+  {
+    DEFINE_TESTS_ERROR_CONTEXT("check_blocks_arent_accepted");
+    CHECK_EQ(c.get_pool_transactions_count(), 1);
+    CHECK_EQ(c.get_current_blockchain_height(), last_valid_height + 1);
+    return true;
+  });
+
+  // TODO(loki): I don't know why difficulty has to be high for this test? Just generate some blocks and randomize the bytes???
+#else
   BLOCK_VALIDATION_INIT_GENERATE();
 
   std::vector<uint64_t> timestamps;
@@ -633,36 +674,7 @@ bool gen_block_invalid_binary_format::generate(std::vector<test_event_entry>& ev
   }
 
   DO_CALLBACK(events, "check_all_blocks_purged");
-
-  return true;
-}
-
-bool gen_block_invalid_binary_format::check_block_verification_context(const cryptonote::block_verification_context& bvc,
-                                                                       size_t event_idx, const cryptonote::block& blk)
-{
-  if (0 == m_corrupt_blocks_begin_idx || event_idx < m_corrupt_blocks_begin_idx)
-  {
-    return bvc.m_added_to_main_chain;
-  }
-  else
-  {
-    return (!bvc.m_added_to_main_chain && (bvc.m_already_exists || bvc.m_marked_as_orphaned || bvc.m_verifivation_failed))
-      || bvc.m_added_to_main_chain;
-  }
-}
-
-bool gen_block_invalid_binary_format::corrupt_blocks_boundary(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events)
-{
-  m_corrupt_blocks_begin_idx = ev_index + 1;
-  return true;
-}
-
-bool gen_block_invalid_binary_format::check_all_blocks_purged(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events)
-{
-  DEFINE_TESTS_ERROR_CONTEXT("gen_block_invalid_binary_format::check_all_blocks_purged");
-
-  CHECK_EQ(1, c.get_pool().get_transactions_count());
-  CHECK_EQ(m_corrupt_blocks_begin_idx - 2, c.get_current_blockchain_height());
+#endif
 
   return true;
 }

--- a/tests/core_tests/block_validation.h
+++ b/tests/core_tests/block_validation.h
@@ -192,12 +192,5 @@ struct gen_block_is_too_big : public gen_block_verification_base<1>
 
 struct gen_block_invalid_binary_format : public test_chain_unit_base
 {
-  gen_block_invalid_binary_format();
   bool generate(std::vector<test_event_entry>& events) const;
-  bool check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_idx, const cryptonote::block& /*blk*/);
-  bool check_all_blocks_purged(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-  bool corrupt_blocks_boundary(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-
-private:
-  size_t m_corrupt_blocks_begin_idx;
 };

--- a/tests/core_tests/bulletproofs.cpp
+++ b/tests/core_tests/bulletproofs.cpp
@@ -162,7 +162,7 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
     }
 
     loki_construct_tx_params tx_params;
-    tx_params.set_hf_version(generator.m_hf_version);
+    tx_params.hf_version = generator.m_hf_version;
     if (!cryptonote::construct_tx_and_get_tx_key(
         from.get_keys(),
         subaddresses,

--- a/tests/core_tests/bulletproofs.cpp
+++ b/tests/core_tests/bulletproofs.cpp
@@ -51,6 +51,15 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
   GENERATE_ACCOUNT(miner_account);
   MAKE_GENESIS_BLOCK(events, blk_0, miner_account, ts_start);
 
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = {
+      std::make_pair(7, 0),
+      std::make_pair(8, 1),
+      std::make_pair(cryptonote::network_version_count - 1, NUM_UNLOCKED_BLOCKS + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW + 1),
+  };
+  event_replay_settings settings = {};
+  settings.hard_forks            = hard_forks;
+  events.push_back(settings);
+
   // create 12 miner accounts, and have them mine the next 48 blocks
   int const NUM_MINERS = 12;
 
@@ -61,13 +70,25 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
   for (size_t i = 0; i < NUM_MINERS; ++i)
     miner_accounts[i].generate();
 
-  generator.m_hf_version = 8;
+  uint8_t const first_hf = hard_forks[1].first;
+  uint8_t const last_hf  = hard_forks.back().first;
+  generator.m_hf_version = first_hf;
   for (size_t n = 0; n < NUM_UNLOCKED_BLOCKS; ++n) {
-    CHECK_AND_ASSERT_MES(generator.construct_block_manually(blocks[n], *prev_block, miner_accounts[n % NUM_MINERS],
-        test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
-        8, 8, prev_block->timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
-          crypto::hash(), 0, transaction(), std::vector<crypto::hash>(), 0),
-        false, "Failed to generate block");
+    CHECK_AND_ASSERT_MES(
+        generator.construct_block_manually(blocks[n],
+                                           *prev_block,
+                                           miner_accounts[n % NUM_MINERS],
+                                           test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
+                                           first_hf,
+                                           first_hf,
+                                           prev_block->timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
+                                           crypto::hash(),
+                                           0,
+                                           transaction(),
+                                           std::vector<crypto::hash>(),
+                                           0),
+        false,
+        "Failed to generate block");
     events.push_back(blocks[n]);
     prev_block = blocks + n;
     LOG_PRINT_L0("Initial miner tx " << n << ": " << obj_to_json_str(blocks[n].miner_tx));
@@ -79,11 +100,21 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
     blk_last = blocks[NUM_UNLOCKED_BLOCKS - 1];
     for (size_t i = 0; i < CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW; ++i)
     {
-      CHECK_AND_ASSERT_MES(generator.construct_block_manually(blocks[NUM_UNLOCKED_BLOCKS + i], blk_last, miner_account,
-          test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
-          8, 8, blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
-          crypto::hash(), 0, transaction(), std::vector<crypto::hash>(), 0),
-          false, "Failed to generate block");
+      CHECK_AND_ASSERT_MES(
+          generator.construct_block_manually(blocks[NUM_UNLOCKED_BLOCKS + i],
+                                             blk_last,
+                                             miner_account,
+                                             test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
+                                             first_hf,
+                                             first_hf,
+                                             blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
+                                             crypto::hash(),
+                                             0,
+                                             transaction(),
+                                             std::vector<crypto::hash>(),
+                                             0),
+          false,
+          "Failed to generate block");
       events.push_back(blocks[NUM_UNLOCKED_BLOCKS+i]);
       blk_last = blocks[NUM_UNLOCKED_BLOCKS+i];
     }
@@ -95,14 +126,24 @@ bool gen_bp_tx_validation_base::generate_with(std::vector<test_event_entry>& eve
   // old style TX's on the fork height. So make sure we create one block so that
   // the block containing bulletproofs txes, which is 1 block after the fork
   // height, is tested with BP logic
-  generator.m_hf_version = cryptonote::network_version_11_infinite_staking;
+  generator.m_hf_version = last_hf;
   {
     block blk;
-    CHECK_AND_ASSERT_MES(generator.construct_block_manually(blk, blk_last, miner_account,
-        test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
-        generator.m_hf_version, generator.m_hf_version, blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
-        crypto::hash(), 0, transaction(), std::vector<crypto::hash>(), 0),
-        false, "Failed to generate block");
+    CHECK_AND_ASSERT_MES(
+        generator.construct_block_manually(blk,
+                                           blk_last,
+                                           miner_account,
+                                           test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_hf_version,
+                                           generator.m_hf_version,
+                                           generator.m_hf_version,
+                                           blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
+                                           crypto::hash(),
+                                           0,
+                                           transaction(),
+                                           std::vector<crypto::hash>(),
+                                           0),
+        false,
+        "Failed to generate block");
     events.push_back(blk);
     blk_last = blk;
   }

--- a/tests/core_tests/bulletproofs.h
+++ b/tests/core_tests/bulletproofs.h
@@ -94,20 +94,6 @@ private:
   size_t m_invalid_block_index;
 };
 
-template<>
-struct get_test_options<gen_bp_tx_validation_base> {
-  const std::vector<std::pair<uint8_t, uint64_t>> hard_forks = {
-    std::make_pair(7, 0),
-    std::make_pair(8, 1),
-    std::make_pair(11, gen_bp_tx_validation_base::NUM_UNLOCKED_BLOCKS + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW + 1),
-  };
-
-  const cryptonote::test_options test_options = {
-    hard_forks, 0
-  };
-};
-
-// valid
 struct gen_bp_tx_valid_1 : public gen_bp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -249,6 +249,13 @@ cryptonote::transaction loki_chain_generator::create_and_add_registration_tx(con
   return result;
 }
 
+cryptonote::transaction loki_chain_generator::create_and_add_staking_tx(const crypto::public_key &pub_key, const cryptonote::account_base &src, uint64_t amount, bool kept_by_block)
+{
+  cryptonote::transaction result = create_staking_tx(pub_key, src, amount);
+  add_tx(result, true /*can_be_added_to_blockchain*/, "" /*fail_msg*/, kept_by_block);
+  return result;
+}
+
 loki_blockchain_entry &loki_chain_generator::create_and_add_next_block(const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint, bool can_be_added_to_blockchain, std::string const &fail_msg)
 {
   loki_blockchain_entry entry   = create_next_block(txs, checkpoint);
@@ -269,29 +276,46 @@ cryptonote::transaction loki_chain_generator::create_tx(const cryptonote::accoun
   return t;
 }
 
-cryptonote::transaction loki_chain_generator::create_registration_tx(const cryptonote::account_base &src, const cryptonote::keypair &service_node_keys) const
+cryptonote::transaction
+loki_chain_generator::create_registration_tx(const cryptonote::account_base &src,
+                                             const cryptonote::keypair &service_node_keys,
+                                             uint64_t src_portions,
+                                             uint64_t src_operator_cut,
+                                             std::array<loki_service_node_contribution, 3> const &contributions,
+                                             int num_contributors) const
 {
-  uint64_t new_height                                          = get_block_height(top().block) + 1;
-  uint8_t new_hf_version                                       = get_hf_version_at(new_height);
-  uint64_t operator_cut                                        = 0;
-  std::vector<cryptonote::account_public_address> contributors = {src.get_keys().m_account_address};
-  std::vector<uint64_t> portions                               = {STAKING_PORTIONS};
-  cryptonote::block const &head                                = top().block;
-  cryptonote::transaction result                               = {};
+  cryptonote::transaction result = {};
   {
-    const auto staking_requirement = service_nodes::get_staking_requirement(cryptonote::FAKECHAIN, new_height, get_hf_version_at(new_height));
+    std::vector<cryptonote::account_public_address> contributors;
+    std::vector<uint64_t> portions;
+
+    contributors.reserve(1 + num_contributors);
+    portions.reserve    (1 + num_contributors);
+
+    contributors.push_back(src.get_keys().m_account_address);
+    portions.push_back(src_portions);
+    for (int i = 0; i < num_contributors; i++)
+    {
+      loki_service_node_contribution const &entry = contributions[i];
+      contributors.push_back(entry.contributor);
+      portions.push_back    (entry.portions);
+    }
+
+    uint64_t new_height    = get_block_height(top().block) + 1;
+    uint8_t new_hf_version = get_hf_version_at(new_height);
+    const auto staking_requirement = service_nodes::get_staking_requirement(cryptonote::FAKECHAIN, new_height, new_hf_version);
     uint64_t amount                = service_nodes::portions_to_amount(portions[0], staking_requirement);
 
     uint64_t unlock_time = 0;
     if (new_hf_version < cryptonote::network_version_11_infinite_staking)
       unlock_time = new_height + service_nodes::staking_num_lock_blocks(cryptonote::FAKECHAIN);
-    
+
     std::vector<uint8_t> extra;
     cryptonote::add_service_node_pubkey_to_tx_extra(extra, service_node_keys.pub);
     const uint64_t exp_timestamp = time(nullptr) + STAKING_AUTHORIZATION_EXPIRATION_WINDOW;
 
     crypto::hash hash;
-    if (!cryptonote::get_registration_hash(contributors, operator_cut, portions, exp_timestamp, hash))
+    if (!cryptonote::get_registration_hash(contributors, src_operator_cut, portions, exp_timestamp, hash))
     {
       MERROR("Could not make registration hash from addresses and portions");
       return {};
@@ -299,9 +323,9 @@ cryptonote::transaction loki_chain_generator::create_registration_tx(const crypt
 
     crypto::signature signature;
     crypto::generate_signature(hash, service_node_keys.pub, service_node_keys.sec, signature);
-    add_service_node_register_to_tx_extra(extra, contributors, operator_cut, portions, exp_timestamp, signature);
+    add_service_node_register_to_tx_extra(extra, contributors, src_operator_cut, portions, exp_timestamp, signature);
     add_service_node_contributor_to_tx_extra(extra, contributors.at(0));
-    loki_tx_builder(events_, result, head, src /*from*/, src /*to*/, amount, new_hf_version)
+    loki_tx_builder(events_, result, top().block, src /*from*/, src /*to*/, amount, new_hf_version)
         .with_tx_type(cryptonote::txtype::stake)
         .with_unlock_time(unlock_time)
         .with_extra(extra)
@@ -309,6 +333,29 @@ cryptonote::transaction loki_chain_generator::create_registration_tx(const crypt
   }
 
   service_node_keys_[service_node_keys.pub] = service_node_keys.sec; // NOTE: Save generated key for reuse later if we need to interact with the node again
+  return result;
+}
+
+cryptonote::transaction loki_chain_generator::create_staking_tx(const crypto::public_key &pub_key, const cryptonote::account_base &src, uint64_t amount) const
+{
+  cryptonote::transaction result = {};
+  std::vector<uint8_t> extra;
+  cryptonote::add_service_node_pubkey_to_tx_extra(extra, pub_key);
+  cryptonote::add_service_node_contributor_to_tx_extra(extra, src.get_keys().m_account_address);
+
+  uint64_t new_height    = get_block_height(top().block) + 1;
+  uint8_t new_hf_version = get_hf_version_at(new_height);
+
+  uint64_t unlock_time = 0;
+  if (new_hf_version < cryptonote::network_version_11_infinite_staking)
+    unlock_time = new_height + service_nodes::staking_num_lock_blocks(cryptonote::FAKECHAIN);
+
+  loki_tx_builder(events_, result, top().block, src /*from*/, src /*to*/, amount, new_hf_version)
+      .is_staking(true)
+      .with_unlock_time(unlock_time)
+      .with_extra(extra)
+      .with_per_output_unlock(true)
+      .build();
   return result;
 }
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -391,10 +391,9 @@ cryptonote::transaction loki_chain_generator::create_staking_tx(const crypto::pu
     unlock_time = new_height + service_nodes::staking_num_lock_blocks(cryptonote::FAKECHAIN);
 
   loki_tx_builder(events_, result, top().block, src /*from*/, src /*to*/, amount, new_hf_version)
-      .is_staking(true)
+      .with_tx_type(cryptonote::txtype::stake)
       .with_unlock_time(unlock_time)
       .with_extra(extra)
-      .with_per_output_unlock(true)
       .build();
   return result;
 }

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -49,6 +49,49 @@
 #include "chaingen.h"
 #include "device/device.hpp"
 
+// TODO(loki): Improved register callback that all tests should start using.
+// Classes are not regenerated when replaying the test through the blockchain.
+// Before, state saved in this class like saving indexes where events ocurred
+// would not persist because when replaying tests we create a new instance of
+// the test class.
+
+  // i.e.
+#if 0
+    std::vector<events> events;
+    {
+        gen_service_nodes generator;
+        generator.generate(events);
+    }
+
+    gen_service_nodes generator;
+    replay_events_through_core(generator, ...)
+#endif
+
+// Which is stupid. Instead we preserve the original generator. This means
+// all the tests that use callbacks to preserve state can be removed.
+
+// TODO(loki): A lot of code using the new lambda callbacks now have access to
+// the shared stack frame where before it didn't can be optimised to utilise the
+// frame instead of re-deriving where data should be in the
+// test_events_entry array
+void loki_register_callback(std::vector<test_event_entry> &events,
+                            std::string const &callback_name,
+                            loki_callback callback)
+{
+  events.push_back(loki_callback_entry{callback_name, callback});
+}
+
+std::vector<std::pair<uint8_t, uint64_t>>
+loki_generate_sequential_hard_fork_table(uint8_t max_hf_version)
+{
+  assert(max_hf_version < cryptonote::network_version_count);
+  std::vector<std::pair<uint8_t, uint64_t>> result = {};
+  uint64_t version_height = 0;
+  for (uint8_t version = cryptonote::network_version_7; version <= max_hf_version; version++)
+    result.emplace_back(std::make_pair(version, version_height++));
+  return result;
+}
+
 cryptonote::block loki_chain_generator_db::get_block_from_height(const uint64_t &height) const
 {
   assert(height < blockchain.size());

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -272,7 +272,7 @@ cryptonote::transaction loki_chain_generator::create_and_add_tx(const cryptonote
                                                                 uint64_t fee,
                                                                 bool kept_by_block)
 {
-  cryptonote::transaction t = create_tx(src, dest, amount, fee, kept_by_block);
+  cryptonote::transaction t = create_tx(src, dest, amount, fee);
   loki_tx_builder(events_, t, blocks_.back().block, src, dest, amount, hf_version_).with_fee(fee).build();
   add_tx(t, true /*can_be_added_to_blockchain*/, ""/*fail_msg*/, kept_by_block);
   return t;
@@ -309,10 +309,7 @@ loki_blockchain_entry &loki_chain_generator::create_and_add_next_block(const std
 cryptonote::transaction loki_chain_generator::create_tx(const cryptonote::account_base &src,
                                                         const cryptonote::account_base &dest,
                                                         uint64_t amount,
-                                                        uint64_t fee,
-                                                        bool kept_by_block,
-                                                        bool can_be_added_by_block,
-                                                        std::string const &fail_msg) const
+                                                        uint64_t fee) const
 {
   cryptonote::transaction t;
   loki_tx_builder(events_, t, blocks_.back().block, src, dest, amount, hf_version_).with_fee(fee).build();

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1347,6 +1347,12 @@ struct loki_chain_generator_db : public cryptonote::BaseTestDB
   bool              get_tx(const crypto::hash& h, cryptonote::transaction &tx) const override;
 };
 
+struct loki_service_node_contribution
+{
+    cryptonote::account_public_address contributor;
+    uint64_t                           portions;
+};
+
 struct loki_chain_generator
 {
   mutable std::unordered_map<crypto::public_key, crypto::secret_key>  service_node_keys_;
@@ -1391,11 +1397,18 @@ struct loki_chain_generator
   cryptonote::transaction                              create_and_add_tx             (const cryptonote::account_base& src, const cryptonote::account_base& dest, uint64_t amount, uint64_t fee = TESTS_DEFAULT_FEE, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default")), bool kept_by_block = false);
-  loki_blockchain_entry                               &create_and_add_next_block(const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
+  cryptonote::transaction                              create_and_add_staking_tx     (const crypto::public_key &pub_key, const cryptonote::account_base &src, uint64_t amount, bool kept_by_block = false);
+  loki_blockchain_entry                               &create_and_add_next_block     (const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
 
   // NOTE: Create transactions but don't add to events_
   cryptonote::transaction                              create_tx             (const cryptonote::account_base &src, const cryptonote::account_base &dest, uint64_t amount, uint64_t fee, bool kept_by_block, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {}) const;
-  cryptonote::transaction                              create_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default"))) const;
+  cryptonote::transaction                              create_registration_tx(const cryptonote::account_base &src,
+                                                                              const cryptonote::keypair &service_node_keys = cryptonote::keypair::generate(hw::get_device("default")),
+                                                                              uint64_t src_portions = STAKING_PORTIONS,
+                                                                              uint64_t src_operator_cut = 0,
+                                                                              std::array<loki_service_node_contribution, 3> const &contributors = {},
+                                                                              int num_contributors = 0) const;
+  cryptonote::transaction                              create_staking_tx     (const crypto::public_key& pub_key, const cryptonote::account_base &src, uint64_t amount) const;
   cryptonote::transaction                              create_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0) const;
   cryptonote::checkpoint_t                             create_service_node_checkpoint(uint64_t block_height, size_t num_votes) const;
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -235,6 +235,7 @@ typedef boost::variant<cryptonote::block,
                        event_visitor_settings,
                        event_replay_settings,
 
+                       std::string,
                        loki_callback_entry,
                        loki_blockchain_addable<loki_block_with_checkpoint>,
                        loki_blockchain_addable<cryptonote::block>,
@@ -863,6 +864,13 @@ public:
     return result;
   }
 
+  bool operator()(const std::string &msg) const
+  {
+    log_event("event_msgevent_marker");
+    MGINFO_MAGENTA(msg);
+    return true;
+  }
+
 private:
   void log_event(const std::string& event_type) const
   {
@@ -1413,6 +1421,8 @@ struct loki_chain_generator
   void                                                 add_service_node_checkpoint(uint64_t block_height, size_t num_votes);
   void                                                 add_mined_money_unlock_blocks(); // NOTE: Unlock all Loki generated from mining prior to this call i.e. CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW
 
+  // NOTE: Add an event that is just a user specified message to signify progress in the test
+  void                                                 add_event_msg(std::string const &msg) { events_.push_back(msg); }
   void                                                 add_tx(cryptonote::transaction const &tx, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {}, bool kept_by_block = false);
 
   // NOTE: Add constructed TX to events_ and assume that it is valid to add to the blockchain. If the TX is meant to be unaddable to the blockchain use the individual create + add functions to

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1424,7 +1424,7 @@ struct loki_chain_generator
   loki_blockchain_entry                               &create_and_add_next_block     (const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {});
 
   // NOTE: Create transactions but don't add to events_
-  cryptonote::transaction                              create_tx             (const cryptonote::account_base &src, const cryptonote::account_base &dest, uint64_t amount, uint64_t fee, bool kept_by_block, bool can_be_added_to_blockchain = true, std::string const &fail_msg = {}) const;
+  cryptonote::transaction                              create_tx             (const cryptonote::account_base &src, const cryptonote::account_base &dest, uint64_t amount, uint64_t fee) const;
   cryptonote::transaction                              create_registration_tx(const cryptonote::account_base &src,
                                                                               const cryptonote::keypair &service_node_keys = cryptonote::keypair::generate(hw::get_device("default")),
                                                                               uint64_t src_portions = STAKING_PORTIONS,

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1236,7 +1236,6 @@ class loki_tx_builder {
 
   /// required fields
   const std::vector<test_event_entry>& m_events;
-  const size_t m_hf_version;
   cryptonote::transaction& m_tx;
   const cryptonote::block& m_head;
   const cryptonote::account_base& m_from;
@@ -1247,9 +1246,6 @@ class loki_tx_builder {
   uint64_t m_unlock_time;
   std::vector<uint8_t> m_extra;
   cryptonote::loki_construct_tx_params m_tx_params;
-
-  /// optional fields
-  bool m_per_output_unlock = false;
 
   /// this makes sure we didn't forget to build it
   bool m_finished = false;
@@ -1268,10 +1264,11 @@ public:
     , m_from(from)
     , m_to(to)
     , m_amount(amount)
-    , m_hf_version(hf_version)
     , m_fee(TESTS_DEFAULT_FEE)
     , m_unlock_time(0)
-  {}
+  {
+    m_tx_params.hf_version = hf_version;
+  }
 
   loki_tx_builder&& with_fee(uint64_t fee) {
     m_fee = fee;
@@ -1283,18 +1280,13 @@ public:
     return std::move(*this);
   }
 
-  loki_tx_builder&& is_staking(bool val) {
-    m_tx_params.v3_is_staking_tx = val;
-    return std::move(*this);
-  }
-
   loki_tx_builder&& with_unlock_time(uint64_t val) {
     m_unlock_time = val;
     return std::move(*this);
   }
 
-  loki_tx_builder&& with_per_output_unlock(bool val = true) {
-    m_per_output_unlock = val;
+  loki_tx_builder&& with_tx_type(cryptonote::txtype val) {
+    m_tx_params.tx_type = val;
     return std::move(*this);
   }
 
@@ -1320,7 +1312,7 @@ public:
 
     cryptonote::tx_destination_entry change_addr{ change_amount, m_from.get_keys().m_account_address, false /*is_subaddr*/ };
     bool result = cryptonote::construct_tx(
-      m_from.get_keys(), sources, destinations, change_addr, m_extra, m_tx, m_unlock_time, m_hf_version, m_tx_params);
+      m_from.get_keys(), sources, destinations, change_addr, m_extra, m_tx, m_unlock_time, m_tx_params);
     return result;
   }
 };

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -185,6 +185,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_tx_signatures_are_invalid);
 
     GENERATE_AND_PLAY(gen_double_spend_in_tx);
+    GENERATE_AND_PLAY(gen_double_spend_in_the_same_block);
 
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_23_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_45_5_23_no_threshold);
@@ -223,10 +224,6 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(gen_tx_output_with_zero_amount); // TODO(loki): See comment in the function
 
       // Double spend
-      GENERATE_AND_PLAY(gen_double_spend_in_tx<false>);
-      GENERATE_AND_PLAY(gen_double_spend_in_tx<true>);
-      GENERATE_AND_PLAY(gen_double_spend_in_the_same_block<false>);
-      GENERATE_AND_PLAY(gen_double_spend_in_the_same_block<true>);
       GENERATE_AND_PLAY(gen_double_spend_in_different_blocks<false>);
       GENERATE_AND_PLAY(gen_double_spend_in_different_blocks<true>);
       GENERATE_AND_PLAY(gen_double_spend_in_different_chains);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -188,6 +188,8 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_double_spend_in_the_same_block);
     GENERATE_AND_PLAY(gen_double_spend_in_different_blocks);
     GENERATE_AND_PLAY(gen_double_spend_in_different_chains);
+    GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block);
+    GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks);
 
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_23_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_45_5_23_no_threshold);
@@ -226,10 +228,6 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(gen_tx_output_with_zero_amount); // TODO(loki): See comment in the function
 
       // Double spend
-      GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<false>);
-      GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<true>);
-      GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks<false>);
-      GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks<true>);
 
       GENERATE_AND_PLAY(gen_block_reward);
       GENERATE_AND_PLAY(gen_uint_overflow_2);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(loki_service_nodes_alt_quorums);
     GENERATE_AND_PLAY(loki_service_nodes_checkpoint_quorum_size);
     GENERATE_AND_PLAY(loki_service_nodes_gen_nodes);
+    GENERATE_AND_PLAY(loki_service_nodes_insufficient_contribution);
     GENERATE_AND_PLAY(loki_service_nodes_test_rollback);
     GENERATE_AND_PLAY(loki_service_nodes_test_swarms_basic);
 

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -184,6 +184,8 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_tx_output_is_not_txout_to_key);
     GENERATE_AND_PLAY(gen_tx_signatures_are_invalid);
 
+    GENERATE_AND_PLAY(gen_double_spend_in_tx);
+
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_23_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_45_5_23_no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_22_1__no_threshold);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -187,6 +187,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_double_spend_in_tx);
     GENERATE_AND_PLAY(gen_double_spend_in_the_same_block);
     GENERATE_AND_PLAY(gen_double_spend_in_different_blocks);
+    GENERATE_AND_PLAY(gen_double_spend_in_different_chains);
 
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_23_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_45_5_23_no_threshold);
@@ -225,7 +226,6 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(gen_tx_output_with_zero_amount); // TODO(loki): See comment in the function
 
       // Double spend
-      GENERATE_AND_PLAY(gen_double_spend_in_different_chains);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<false>);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<true>);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_different_blocks<false>);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -186,6 +186,7 @@ int main(int argc, char* argv[])
 
     GENERATE_AND_PLAY(gen_double_spend_in_tx);
     GENERATE_AND_PLAY(gen_double_spend_in_the_same_block);
+    GENERATE_AND_PLAY(gen_double_spend_in_different_blocks);
 
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_23_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_45_5_23_no_threshold);
@@ -224,8 +225,6 @@ int main(int argc, char* argv[])
       GENERATE_AND_PLAY(gen_tx_output_with_zero_amount); // TODO(loki): See comment in the function
 
       // Double spend
-      GENERATE_AND_PLAY(gen_double_spend_in_different_blocks<false>);
-      GENERATE_AND_PLAY(gen_double_spend_in_different_blocks<true>);
       GENERATE_AND_PLAY(gen_double_spend_in_different_chains);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<false>);
       GENERATE_AND_PLAY(gen_double_spend_in_alt_chain_in_the_same_block<true>);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -145,6 +145,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_block_ts_in_future);
     GENERATE_AND_PLAY(gen_block_invalid_prev_id);
     GENERATE_AND_PLAY(gen_block_invalid_nonce);
+    GENERATE_AND_PLAY(gen_block_invalid_binary_format);
     GENERATE_AND_PLAY(gen_block_no_miner_tx);
     GENERATE_AND_PLAY(gen_block_unlock_time_is_low);
     GENERATE_AND_PLAY(gen_block_unlock_time_is_high);
@@ -214,7 +215,6 @@ int main(int argc, char* argv[])
     // TODO(loki): Tests we need to fix
 #if 0
       //GENERATE_AND_PLAY(gen_ring_signature_big); // Takes up to XXX hours (if CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW == 10)
-      //GENERATE_AND_PLAY(gen_block_invalid_binary_format); // Takes up to 3 hours, if CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW == 500, up to 30 minutes, if CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW == 10
 
       // Transaction verification tests
       GENERATE_AND_PLAY(gen_tx_mixed_key_offset_not_exist); // TODO(loki): See comment in the function

--- a/tests/core_tests/double_spend.cpp
+++ b/tests/core_tests/double_spend.cpp
@@ -177,7 +177,12 @@ bool gen_double_spend_in_the_same_block::generate(std::vector<test_event_entry>&
 
   for (int kept_by_block_int = 0; kept_by_block_int < 2; kept_by_block_int++)
   {
-    bool kept_by_block                    = static_cast<bool>(kept_by_block_int);
+    bool kept_by_block = static_cast<bool>(kept_by_block_int);
+    if (kept_by_block)
+      gen.add_event_msg("Double spending transaction kept by block should be allowed");
+    else
+      gen.add_event_msg("Double spending transaction kept by block false, disallowed");
+
     uint64_t amount                       = MK_COINS(10);
     cryptonote::account_base const &miner = gen.first_miner_;
     cryptonote::account_base bob          = gen.add_account();

--- a/tests/core_tests/double_spend.cpp
+++ b/tests/core_tests/double_spend.cpp
@@ -63,7 +63,9 @@ bool gen_double_spend_in_tx::generate(std::vector<test_event_entry>& events) con
 
   {
     cryptonote::transaction tx_1;
-    if (!construct_tx(gen.first_miner_.get_keys(), sources, destinations, boost::none, std::vector<uint8_t>(), tx_1, 0, gen.hf_version_))
+    loki_construct_tx_params tx_params;
+    tx_params.hf_version = gen.hf_version_;
+    if (!construct_tx(gen.first_miner_.get_keys(), sources, destinations, boost::none, std::vector<uint8_t>(), tx_1, 0, tx_params))
       return false;
 
     uint64_t expected_height = gen.height();
@@ -78,7 +80,7 @@ bool gen_double_spend_in_tx::generate(std::vector<test_event_entry>& events) con
       crypto::hash top_hash;
       c.get_blockchain_top(top_height, top_hash);
       CHECK_TEST_CONDITION(top_height == expected_height);
-      CHECK_TEST_CONDITION_MSG(c.get_pool_transactions_count() == 0, "The double spend TX should not be added to the pool");
+      CHECK_TEST_CONDITION_MSG(c.get_pool().get_transactions_count() == 0, "The double spend TX should not be added to the pool");
       return true;
     });
   }
@@ -86,7 +88,9 @@ bool gen_double_spend_in_tx::generate(std::vector<test_event_entry>& events) con
   // NOTE: Do the same with a new transaction but this time kept by block, can't reused old transaction because we cache the bad TX hash
   {
     cryptonote::transaction tx_1;
-    if (!construct_tx(gen.first_miner_.get_keys(), sources, destinations, boost::none, std::vector<uint8_t>(), tx_1, 0, gen.hf_version_))
+    loki_construct_tx_params tx_params;
+    tx_params.hf_version = gen.hf_version_;
+    if (!construct_tx(gen.first_miner_.get_keys(), sources, destinations, boost::none, std::vector<uint8_t>(), tx_1, 0, tx_params))
       return false;
 
     uint64_t expected_height    = gen.height();
@@ -101,7 +105,7 @@ bool gen_double_spend_in_tx::generate(std::vector<test_event_entry>& events) con
       crypto::hash top_hash;
       c.get_blockchain_top(top_height, top_hash);
       CHECK_TEST_CONDITION(top_height == expected_height);
-      CHECK_TEST_CONDITION_MSG(c.get_pool_transactions_count() == 0, "The double spend TX should not be added to the pool");
+      CHECK_TEST_CONDITION_MSG(c.get_pool().get_transactions_count() == 0, "The double spend TX should not be added to the pool");
       return true;
     });
   }
@@ -186,8 +190,8 @@ bool gen_double_spend_in_different_blocks::generate(std::vector<test_event_entry
     loki_register_callback(events, "check_txpool", [&events, kept_by_block](cryptonote::core &c, size_t ev_index)
     {
       DEFINE_TESTS_ERROR_CONTEXT("check_txpool");
-      if (kept_by_block) CHECK_EQ(c.get_pool_transactions_count(), 1);
-      else               CHECK_EQ(c.get_pool_transactions_count(), 0);
+      if (kept_by_block) CHECK_EQ(c.get_pool().get_transactions_count(), 1);
+      else               CHECK_EQ(c.get_pool().get_transactions_count(), 0);
       return true;
     });
   }
@@ -271,8 +275,8 @@ bool gen_double_spend_in_alt_chain_in_different_blocks::generate(std::vector<tes
     loki_register_callback(events, "check_txpool", [&events, kept_by_block](cryptonote::core &c, size_t ev_index)
     {
       DEFINE_TESTS_ERROR_CONTEXT("check_txpool");
-      if (kept_by_block) CHECK_EQ(c.get_pool_transactions_count(), 1);
-      else               CHECK_EQ(c.get_pool_transactions_count(), 0);
+      if (kept_by_block) CHECK_EQ(c.get_pool().get_transactions_count(), 1);
+      else               CHECK_EQ(c.get_pool().get_transactions_count(), 0);
       return true;
     });
   }
@@ -311,7 +315,7 @@ bool gen_double_spend_in_different_chains::generate(std::vector<test_event_entry
     CHECK_EQ(top_hash, block_hash);
 
     // TODO(loki): This is questionable behaviour, currently we keep alt chains even after switching over
-    CHECK_EQ(c.get_pool_transactions_count(), 1);
+    CHECK_EQ(c.get_pool().get_transactions_count(), 1);
     CHECK_EQ(c.get_alternative_blocks_count(), 1);
     return true;
   });

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -98,18 +98,9 @@ struct gen_double_spend_in_alt_chain_in_different_blocks : public gen_double_spe
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
-
-class gen_double_spend_in_different_chains : public test_chain_unit_base
+struct gen_double_spend_in_different_chains : public test_chain_unit_base
 {
-public:
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const size_t expected_blockchain_height = 4 + 2 * CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
-
-  gen_double_spend_in_different_chains();
-
   bool generate(std::vector<test_event_entry>& events) const;
-
-  bool check_double_spend(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
 };
 
 

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -31,32 +31,6 @@
 #pragma once 
 #include "chaingen.h"
 
-const size_t invalid_index_value = std::numeric_limits<size_t>::max();
-const uint64_t FIRST_BLOCK_REWARD = 17592186044415;
-
-
-template<class concrete_test>
-class gen_double_spend_base : public test_chain_unit_base
-{
-public:
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-
-  gen_double_spend_base();
-
-  bool check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool tx_added, size_t event_idx, const cryptonote::transaction& tx);
-  bool check_block_verification_context(const cryptonote::block_verification_context& bvc, size_t event_idx, const cryptonote::block& block);
-
-  bool mark_last_valid_block(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-  bool mark_invalid_tx(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-  bool mark_invalid_block(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-  bool check_double_spend(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
-
-private:
-  cryptonote::block m_last_valid_block;
-  size_t m_invalid_tx_index;
-  size_t m_invalid_block_index;
-};
-
 struct gen_double_spend_in_tx : public test_chain_unit_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
@@ -72,29 +46,13 @@ struct gen_double_spend_in_different_blocks : public test_chain_unit_base
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
-
-template<bool txs_keeped_by_block>
-struct gen_double_spend_in_alt_chain_in_the_same_block : public gen_double_spend_base< gen_double_spend_in_alt_chain_in_the_same_block<txs_keeped_by_block> >
+struct gen_double_spend_in_alt_chain_in_the_same_block : public test_chain_unit_base
 {
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const bool has_invalid_tx = !txs_keeped_by_block;
-  static const size_t expected_pool_txs_count = has_invalid_tx ? 1 : 2;
-  static const uint64_t expected_bob_balance = send_amount;
-  static const uint64_t expected_alice_balance = 0;
-
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
-
-template<bool txs_keeped_by_block>
-struct gen_double_spend_in_alt_chain_in_different_blocks : public gen_double_spend_base< gen_double_spend_in_alt_chain_in_different_blocks<txs_keeped_by_block> >
+struct gen_double_spend_in_alt_chain_in_different_blocks : public test_chain_unit_base
 {
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const bool has_invalid_tx = !txs_keeped_by_block;
-  static const size_t expected_pool_txs_count = has_invalid_tx ? 1 : 2;
-  static const uint64_t expected_bob_balance = send_amount;
-  static const uint64_t expected_alice_balance = 0;
-
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
@@ -102,18 +60,3 @@ struct gen_double_spend_in_different_chains : public test_chain_unit_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
 };
-
-
-#define INIT_DOUBLE_SPEND_TEST()                                           \
-  uint64_t ts_start = 1338224400;                                          \
-  GENERATE_ACCOUNT(miner_account);                                         \
-  MAKE_GENESIS_BLOCK(events, blk_0, miner_account, ts_start);              \
-  MAKE_ACCOUNT(events, bob_account);                                       \
-  MAKE_ACCOUNT(events, alice_account);                                     \
-  REWIND_BLOCKS(events, blk_0r, blk_0, miner_account);                     \
-  MAKE_TX(events, tx_0, miner_account, bob_account, send_amount, blk_0);   \
-  MAKE_NEXT_BLOCK_TX1(events, blk_1, blk_0r, miner_account, tx_0);         \
-  REWIND_BLOCKS(events, blk_1r, blk_1, miner_account);
-
-
-#include "double_spend.inl"

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -67,15 +67,8 @@ struct gen_double_spend_in_the_same_block : public test_chain_unit_base
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
-template<bool txs_keeped_by_block>
-struct gen_double_spend_in_different_blocks : public gen_double_spend_base< gen_double_spend_in_different_blocks<txs_keeped_by_block> >
+struct gen_double_spend_in_different_blocks : public test_chain_unit_base
 {
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const bool has_invalid_tx = !txs_keeped_by_block;
-  static const size_t expected_pool_txs_count = has_invalid_tx ? 0 : 1;
-  static const uint64_t expected_bob_balance = 0;
-  static const uint64_t expected_alice_balance = send_amount - TESTS_DEFAULT_FEE;
-
   bool generate(std::vector<test_event_entry>& events) const;
 };
 

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -57,19 +57,10 @@ private:
   size_t m_invalid_block_index;
 };
 
-
-template<bool txs_keeped_by_block>
-struct gen_double_spend_in_tx : public gen_double_spend_base< gen_double_spend_in_tx<txs_keeped_by_block> >
+struct gen_double_spend_in_tx : public test_chain_unit_base
 {
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const bool has_invalid_tx = true;
-  static const size_t expected_pool_txs_count = 0;
-  static const uint64_t expected_bob_balance = send_amount;
-  static const uint64_t expected_alice_balance = 0;
-
   bool generate(std::vector<test_event_entry>& events) const;
 };
-
 
 template<bool txs_keeped_by_block>
 struct gen_double_spend_in_the_same_block : public gen_double_spend_base< gen_double_spend_in_the_same_block<txs_keeped_by_block> >

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -62,18 +62,10 @@ struct gen_double_spend_in_tx : public test_chain_unit_base
   bool generate(std::vector<test_event_entry>& events) const;
 };
 
-template<bool txs_keeped_by_block>
-struct gen_double_spend_in_the_same_block : public gen_double_spend_base< gen_double_spend_in_the_same_block<txs_keeped_by_block> >
+struct gen_double_spend_in_the_same_block : public test_chain_unit_base
 {
-  static const uint64_t send_amount = FIRST_BLOCK_REWARD - TESTS_DEFAULT_FEE;
-  static const bool has_invalid_tx = !txs_keeped_by_block;
-  static const size_t expected_pool_txs_count = has_invalid_tx ? 1 : 2;
-  static const uint64_t expected_bob_balance = send_amount;
-  static const uint64_t expected_alice_balance = 0;
-
   bool generate(std::vector<test_event_entry>& events) const;
 };
-
 
 template<bool txs_keeped_by_block>
 struct gen_double_spend_in_different_blocks : public gen_double_spend_base< gen_double_spend_in_different_blocks<txs_keeped_by_block> >

--- a/tests/core_tests/double_spend.inl
+++ b/tests/core_tests/double_spend.inl
@@ -119,44 +119,6 @@ bool gen_double_spend_base<concrete_test>::check_double_spend(cryptonote::core& 
 //======================================================================================================================
 
 template<bool txs_keeped_by_block>
-bool gen_double_spend_in_tx<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
-{
-  INIT_DOUBLE_SPEND_TEST();
-  DO_CALLBACK(events, "mark_last_valid_block");
-
-  std::vector<cryptonote::tx_source_entry> sources;
-  cryptonote::tx_source_entry se;
-  se.amount = tx_0.vout[0].amount;
-  se.push_output(0, boost::get<cryptonote::txout_to_key>(tx_0.vout[0].target).key, se.amount);
-  se.real_output = 0;
-  se.rct = false;
-  se.real_out_tx_key = get_tx_pub_key_from_extra(tx_0);
-  se.real_output_in_tx_index = 0;
-  sources.push_back(se);
-  // Double spend!
-  sources.push_back(se);
-
-  cryptonote::tx_destination_entry de;
-  de.addr = alice_account.get_keys().m_account_address;
-  de.amount = 2 * se.amount - TESTS_DEFAULT_FEE;
-  std::vector<cryptonote::tx_destination_entry> destinations;
-  destinations.push_back(de);
-
-  cryptonote::transaction tx_1;
-  if (!construct_tx(bob_account.get_keys(), sources, destinations, boost::none, std::vector<uint8_t>(), tx_1, 0))
-    return false;
-
-  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_keeped_by_block, txs_keeped_by_block);
-  DO_CALLBACK(events, "mark_invalid_tx");
-  events.push_back(tx_1);
-  DO_CALLBACK(events, "mark_invalid_block");
-  MAKE_NEXT_BLOCK_TX1(events, blk_2, blk_1r, miner_account, tx_1);
-  DO_CALLBACK(events, "check_double_spend");
-
-  return true;
-}
-
-template<bool txs_keeped_by_block>
 bool gen_double_spend_in_the_same_block<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
 {
   INIT_DOUBLE_SPEND_TEST();

--- a/tests/core_tests/double_spend.inl
+++ b/tests/core_tests/double_spend.inl
@@ -119,37 +119,6 @@ bool gen_double_spend_base<concrete_test>::check_double_spend(cryptonote::core& 
 //======================================================================================================================
 
 template<bool txs_keeped_by_block>
-bool gen_double_spend_in_different_blocks<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
-{
-  INIT_DOUBLE_SPEND_TEST();
-
-  DO_CALLBACK(events, "mark_last_valid_block");
-  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_keeped_by_block, txs_keeped_by_block);
-
-  // Create two identical transactions, but don't push it to events list
-  MAKE_TX(events, tx_blk_2, bob_account, alice_account, send_amount - TESTS_DEFAULT_FEE, blk_1);
-  events.pop_back();
-  MAKE_TX(events, tx_blk_3, bob_account, alice_account, send_amount - TESTS_DEFAULT_FEE, blk_1);
-  events.pop_back();
-
-  events.push_back(tx_blk_2);
-  MAKE_NEXT_BLOCK_TX1(events, blk_2, blk_1r, miner_account, tx_blk_2);
-  DO_CALLBACK(events, "mark_last_valid_block");
-
-  if (has_invalid_tx)
-  {
-    DO_CALLBACK(events, "mark_invalid_tx");
-  }
-  events.push_back(tx_blk_3);
-  DO_CALLBACK(events, "mark_invalid_block");
-  MAKE_NEXT_BLOCK_TX1(events, blk_3, blk_2, miner_account, tx_blk_3);
-
-  DO_CALLBACK(events, "check_double_spend");
-
-  return true;
-}
-
-template<bool txs_keeped_by_block>
 bool gen_double_spend_in_alt_chain_in_the_same_block<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
 {
   INIT_DOUBLE_SPEND_TEST();

--- a/tests/core_tests/double_spend.inl
+++ b/tests/core_tests/double_spend.inl
@@ -119,33 +119,6 @@ bool gen_double_spend_base<concrete_test>::check_double_spend(cryptonote::core& 
 //======================================================================================================================
 
 template<bool txs_keeped_by_block>
-bool gen_double_spend_in_the_same_block<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
-{
-  INIT_DOUBLE_SPEND_TEST();
-
-  DO_CALLBACK(events, "mark_last_valid_block");
-  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_keeped_by_block, txs_keeped_by_block);
-
-  MAKE_TX_LIST_START(events, txs_1, bob_account, alice_account, send_amount - TESTS_DEFAULT_FEE, blk_1);
-  cryptonote::transaction tx_1 = txs_1.front();
-  auto tx_1_idx = events.size() - 1;
-  // Remove tx_1, it is being inserted back a little later
-  events.pop_back();
-
-  if (has_invalid_tx)
-  {
-    DO_CALLBACK(events, "mark_invalid_tx");
-  }
-  MAKE_TX_LIST(events, txs_1, bob_account, alice_account, send_amount - TESTS_DEFAULT_FEE, blk_1);
-  events.insert(events.begin() + tx_1_idx, tx_1);
-  DO_CALLBACK(events, "mark_invalid_block");
-  MAKE_NEXT_BLOCK_TX_LIST(events, blk_2, blk_1r, miner_account, txs_1);
-  DO_CALLBACK(events, "check_double_spend");
-
-  return true;
-}
-
-template<bool txs_keeped_by_block>
 bool gen_double_spend_in_different_blocks<txs_keeped_by_block>::generate(std::vector<test_event_entry>& events) const
 {
   INIT_DOUBLE_SPEND_TEST();

--- a/tests/core_tests/integer_overflow.cpp
+++ b/tests/core_tests/integer_overflow.cpp
@@ -29,7 +29,6 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "chaingen.h"
-#include "loki_tests.h"
 #include "integer_overflow.h"
 
 using namespace epee;

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -34,49 +34,6 @@
 #undef LOKI_DEFAULT_LOG_CATEGORY
 #define LOKI_DEFAULT_LOG_CATEGORY "sn_core_tests"
 
-// TODO(loki): Improved register callback that all tests should start using.
-// Classes are not regenerated when replaying the test through the blockchain.
-// Before, state saved in this class like saving indexes where events ocurred
-// would not persist because when replaying tests we create a new instance of
-// the test class.
-
-  // i.e.
-#if 0
-    std::vector<events> events;
-    {
-        gen_service_nodes generator;
-        generator.generate(events);
-    }
-
-    gen_service_nodes generator;
-    replay_events_through_core(generator, ...)
-#endif
-
-// Which is stupid. Instead we preserve the original generator. This means
-// all the tests that use callbacks to preserve state can be removed.
-
-// TODO(loki): A lot of code using the new lambda callbacks now have access to
-// the shared stack frame where before it didn't can be optimised to utilise the
-// frame instead of re-deriving where data should be in the
-// test_events_entry array
-void loki_register_callback(std::vector<test_event_entry> &events,
-                            std::string const &callback_name,
-                            loki_callback callback)
-{
-  events.push_back(loki_callback_entry{callback_name, callback});
-}
-
-std::vector<std::pair<uint8_t, uint64_t>>
-loki_generate_sequential_hard_fork_table(uint8_t max_hf_version)
-{
-  assert(max_hf_version < cryptonote::network_version_count);
-  std::vector<std::pair<uint8_t, uint64_t>> result = {};
-  uint64_t version_height = 0;
-  for (uint8_t version = cryptonote::network_version_7; version <= max_hf_version; version++)
-    result.emplace_back(std::make_pair(version, version_height++));
-  return result;
-}
-
 // Suppose we have checkpoint and alt block at height 40 and the main chain is at height 40 with a differing block.
 // Main chain receives checkpoints for height 40 on the alt chain via votes and reorgs back to height 39.
 // Now main chain has an alt block sitting in its DB for height 40 which actually starts beyond the chain.
@@ -160,7 +117,6 @@ bool loki_checkpointing_alt_chain_handle_alt_blocks_at_tip::generate(std::vector
   });
   return true;
 }
-
 
 // NOTE: - Checks that a chain with a checkpoint but less PoW is preferred over a chain that is longer with more PoW but no checkpoints
 bool loki_checkpointing_alt_chain_more_service_node_checkpoints_less_pow_overtakes::generate(std::vector<test_event_entry>& events)

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -540,7 +540,7 @@ bool loki_core_fee_burning::generate(std::vector<test_event_entry>& events)
 
   auto add_burning_tx = [&events, &gen, &dummy, newest_hf](const std::array<uint64_t, 3> &send_fee_burn) {
     auto send = send_fee_burn[0], fee = send_fee_burn[1], burn = send_fee_burn[2];
-    transaction tx = gen.create_tx(gen.first_miner_, dummy, send, fee, false);
+    transaction tx = gen.create_tx(gen.first_miner_, dummy, send, fee);
     std::vector<uint8_t> burn_extra;
     add_burned_amount_to_tx_extra(burn_extra, burn);
     loki_tx_builder(events, tx, gen.blocks().back().block, gen.first_miner_, dummy, send, newest_hf).with_fee(fee).with_extra(burn_extra).build();

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -568,7 +568,7 @@ bool loki_core_fee_burning::generate(std::vector<test_event_entry>& events)
   gen.add_blocks_until_version(hard_forks.back().first);
 
   uint8_t newest_hf = hard_forks.back().first;
-  assert(newest_hf >= cryptonote::network_version_14);
+  assert(newest_hf >= cryptonote::network_version_14_blink_lns);
 
   gen.add_n_blocks(60);
   gen.add_mined_money_unlock_blocks();

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1064,7 +1064,7 @@ bool loki_service_nodes_checkpoint_quorum_size::generate(std::vector<test_event_
   loki_chain_generator gen(events, hard_forks);
 
   gen.add_blocks_until_version(hard_forks.back().first);
-  gen.add_n_blocks(40);
+  gen.add_n_blocks(35);
   gen.add_mined_money_unlock_blocks();
 
   std::vector<cryptonote::transaction> registration_txs(service_nodes::CHECKPOINT_QUORUM_SIZE - 1);
@@ -1196,7 +1196,6 @@ bool loki_service_nodes_test_rollback::generate(std::vector<test_event_entry>& e
   std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table(cryptonote::network_version_9_service_nodes);
   loki_chain_generator gen(events, hard_forks);
   gen.add_blocks_until_version(hard_forks.back().first);
-
   gen.add_n_blocks(20); /// generate some outputs and unlock them
   gen.add_mined_money_unlock_blocks();
 
@@ -1285,7 +1284,7 @@ bool loki_service_nodes_test_swarms_basic::generate(std::vector<test_event_entry
   /// Create some service nodes before hf version 10
   constexpr size_t INIT_SN_COUNT  = 13;
   constexpr size_t TOTAL_SN_COUNT = 25;
-  gen.add_n_blocks(100);
+  gen.add_n_blocks(90);
   gen.add_mined_money_unlock_blocks();
 
   /// register some service nodes

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -35,9 +35,6 @@
 /*                                                                      */
 /************************************************************************/
 
-void                                      loki_register_callback                  (std::vector<test_event_entry> &events, std::string const &callback_name, loki_callback callback);
-std::vector<std::pair<uint8_t, uint64_t>> loki_generate_sequential_hard_fork_table(uint8_t max_hf_version = cryptonote::network_version_count - 1);
-
 struct loki_checkpointing_alt_chain_handle_alt_blocks_at_tip                         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_alt_chain_more_service_node_checkpoints_less_pow_overtakes : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_alt_chain_receive_checkpoint_votes_should_reorg_back       : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -56,6 +56,7 @@ struct loki_core_test_state_change_ip_penalty_disallow_dupes                    
 struct loki_service_nodes_alt_quorums                                                : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_checkpoint_quorum_size                                     : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_gen_nodes                                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct loki_service_nodes_insufficient_contribution                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_test_rollback                                              : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_service_nodes_test_swarms_basic                                          : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -369,7 +369,7 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
   std::vector<crypto::secret_key> additional_tx_secret_keys;
   auto sources_copy = sources;
   loki_construct_tx_params tx_params;
-  tx_params.set_hf_version(cryptonote::network_version_8);
+  tx_params.hf_version = cryptonote::network_version_8;
   r = construct_tx_and_get_tx_key(miner_account[creator].get_keys(), subaddresses, sources, destinations, boost::none, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_secret_keys, { rct::RangeProofBorromean, 0 }, msoutp, tx_params);
   CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
 

--- a/tests/core_tests/rct.cpp
+++ b/tests/core_tests/rct.cpp
@@ -122,7 +122,7 @@ bool gen_rct_tx_validation_base::generate_with(std::vector<test_event_entry>& ev
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[miner_accounts[n].get_keys().m_account_address.m_spend_public_key] = {0,0};
     loki_construct_tx_params tx_params;
-    tx_params.set_hf_version(cryptonote::network_version_8);
+    tx_params.hf_version = cryptonote::network_version_8;
     bool r = construct_tx_and_get_tx_key(miner_accounts[n].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), rct_txes[n], 0, tx_key, additional_tx_keys, {}, nullptr, tx_params);
     CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
     events.push_back(rct_txes[n]);
@@ -226,7 +226,7 @@ bool gen_rct_tx_validation_base::generate_with(std::vector<test_event_entry>& ev
   std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
   subaddresses[miner_accounts[0].get_keys().m_account_address.m_spend_public_key] = {0,0};
   loki_construct_tx_params tx_params;
-  tx_params.set_hf_version(cryptonote::network_version_8);
+  tx_params.hf_version = cryptonote::network_version_8;
   bool r = construct_tx_and_get_tx_key(miner_accounts[0].get_keys(), subaddresses, sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), tx, 0, tx_key, additional_tx_keys, {}, nullptr, tx_params);
   CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
 

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -358,7 +358,7 @@ bool gen_tx_invalid_input_amount::generate(std::vector<test_event_entry>& events
 
   transaction tx = {};
   cryptonote::tx_destination_entry change_addr{ change_amount, miner_account.get_keys().m_account_address, false /*is_subaddress*/ };
-  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7, false /*is_staking*/));
+  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, {}));
 
   DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(tx);
@@ -669,7 +669,7 @@ bool gen_tx_output_with_zero_amount::generate(std::vector<test_event_entry>& eve
 
   transaction tx = {};
   cryptonote::tx_destination_entry change_addr{ change_amount, miner_account.get_keys().m_account_address, false /*is_subaddress*/ };
-  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, cryptonote::network_version_7, false /*is_staking*/));
+  assert(cryptonote::construct_tx(miner_account.get_keys(), sources, destinations, change_addr, {} /*tx_extra*/, tx, 0 /*unlock_time*/, {}));
 
 #else
   transaction tx           = {};

--- a/tests/performance_tests/check_tx_signature.h
+++ b/tests/performance_tests/check_tx_signature.h
@@ -72,7 +72,7 @@ public:
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
     loki_construct_tx_params tx_params;
-    tx_params.set_hf_version(cryptonote::network_version_9_service_nodes);
+    tx_params.hf_version = cryptonote::network_version_count - 1;
     rct::RCTConfig rct_config{range_proof_type, bp_version};
     if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, tx_params))
       return false;
@@ -136,7 +136,7 @@ public:
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
 
     loki_construct_tx_params tx_params;
-    tx_params.set_hf_version(cryptonote::network_version_10_bulletproofs);
+    tx_params.hf_version = cryptonote::network_version_count - 1;
     m_txes.resize(a_num_txes + (extra_outs > 0 ? 1 : 0));
     for (size_t n = 0; n < a_num_txes; ++n)
     {

--- a/tests/performance_tests/construct_tx.h
+++ b/tests/performance_tests/construct_tx.h
@@ -75,7 +75,7 @@ public:
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
     rct::RCTConfig rct_config{range_proof_type, bp_version};
     cryptonote::loki_construct_tx_params tx_params;
-    tx_params.set_hf_version(cryptonote::network_version_9_service_nodes);
+    tx_params.hf_version = cryptonote::network_version_count - 1;
     return cryptonote::construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, m_destinations, cryptonote::tx_destination_entry{}, std::vector<uint8_t>(), m_tx, 0, tx_key, additional_tx_keys, rct_config, nullptr, tx_params);
   }
 

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -89,9 +89,9 @@ namespace
         std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
         subaddresses[from.m_account_address.m_spend_public_key] = {0,0};
 
-        cryptonote::loki_construct_tx_params tx_params = {};
-        tx_params.v2_rct = rct;
-        tx_params.v3_per_output_unlock = per_output_unlock;
+        cryptonote::loki_construct_tx_params tx_params;
+        tx_params.hf_version = cryptonote::network_version_10_bulletproofs - 1;
+        if (bulletproof) tx_params.hf_version = cryptonote::network_version_count - 1;
         if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, 0, tx_key, extra_keys, { bulletproof ? rct::RangeProofBulletproof : rct::RangeProofBorromean, bulletproof ? 2 : 0 }, nullptr, tx_params))
             throw std::runtime_error{"transaction construction error"};
 


### PR DESCRIPTION
This also merges in a manually merged https://github.com/loki-project/loki/pull/913 because the staking changes here fix up some of the redundant-ness in `loki_construct_tx_params` (you can derive most of the current params by just sending in the `hf_version` and desired `tx_type`) and I didn't want to continue fixing around the old style params in `core_tests` to have it re-replaced again in LNS.

Core tests are all passing as of this commit.

- Fix assert to use version_t::_count in service_node_list.cpp

- Incoporate staking changes from LNS which revamp construct tx to
  derive more of the parameters from hf_version and type. This removes
  extraneous parameters that can be derived elsewhere.

  Also delegate setting loki_construct_tx_params into wallet2 atleast,
  so that callers into the wallet logic, like rpc server, simplewallet
  don't need bend backwards to get the HF version whereas the wallet has
  dedicated functions for determining the HF.

- Revert double spend behaviour fixes core_test loki_core_test_deregister_on_split

- Setting up tx.is_transfer() to encapsulate, normal transfers, staking transfers and name service transfers- so that we can apply normal TX validation rules on all those types of transactions.

- Remove some params in tx_params as not necessary in construct_tx anymore

- Describe how infinite staking works in code

- Remove nettype from min tx version function. Just always enforce the lower version, no harm in doing so across all the nettypes.

Edit: Also merges in core tests from https://github.com/loki-project/loki/pull/909