### PR TITLE
Reward winner sorting and error msgs

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -474,14 +474,15 @@ namespace service_nodes
     cryptonote::tx_extra_service_node_state_change state_change;
     if (!cryptonote::get_service_node_state_change_from_tx_extra(tx.extra, state_change, hf_version))
     {
-      LOG_PRINT_L1("Transaction: " << cryptonote::get_transaction_hash(tx) << ", did not have valid state change data in tx extra rejecting malformed tx");
+      MERROR("Transaction: " << cryptonote::get_transaction_hash(tx) << ", did not have valid state change data in tx extra rejecting malformed tx");
       return false;
     }
 
     auto it = state_history.find(state_change.block_height);
     if (it == state_history.end())
     {
-      LOG_PRINT_L1("Transaction: " << cryptonote::get_transaction_hash(tx) << ", references quorum at height: " << cryptonote::get_block_hash(block) << ", that is not stored");
+      MERROR("Transaction: " << cryptonote::get_transaction_hash(tx) << " in block " << cryptonote::get_block_height(block) << " " << cryptonote::get_block_hash(block)
+          << " references quorum height " << state_change.block_height << " but that height is not stored!");
       return false;
     }
 
@@ -507,14 +508,14 @@ namespace service_nodes
 
     if (!quorums)
     {
-      LOG_PRINT_L1("Could not get a quorum that could completely validate the votes from state change in tx: " << get_transaction_hash(tx) << ", skipping transaction");
+      MERROR("Could not get a quorum that could completely validate the votes from state change in tx: " << get_transaction_hash(tx) << ", skipping transaction");
       return false;
     }
 
     crypto::public_key key;
     if (!get_pubkey_from_quorum(*quorums->obligations, quorum_group::worker, state_change.service_node_index, key))
     {
-      LOG_PRINT_L1("Retrieving the public key from state change in tx: " << cryptonote::get_transaction_hash(tx) << " failed");
+      MERROR("Retrieving the public key from state change in tx: " << cryptonote::get_transaction_hash(tx) << " failed");
       return false;
     }
 

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -223,7 +223,7 @@ namespace service_nodes
       crypto::public_key const &key = quorum.validators[vote.validator_index];
       if (!crypto::check_signature(hash, key, vote.signature))
       {
-        LOG_PRINT_L1("Invalid signatures for votes");
+        LOG_PRINT_L1("Invalid signature for voter " << vote.validator_index << "/" << key);
         vvc.m_signature_not_valid = true;
         return bad_tx(tvc);
       }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2655,12 +2655,10 @@ bool t_rpc_command_executor::print_sn(const std::vector<std::string> &args)
         return b_remaining < a_remaining;
     });
 
-    std::stable_sort(registered.begin(), registered.end(),
+    std::sort(registered.begin(), registered.end(),
         [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *b) {
-        if (a->last_reward_block_height == b->last_reward_block_height)
-          return a->last_reward_transaction_index < b->last_reward_transaction_index;
-
-        return a->last_reward_block_height < b->last_reward_block_height;
+        return std::make_tuple(a->last_reward_block_height, a->last_reward_transaction_index, a->service_node_pubkey)
+             < std::make_tuple(b->last_reward_block_height, b->last_reward_transaction_index, b->service_node_pubkey);
     });
 
     if (req.include_json)


### PR DESCRIPTION
- Fixes minor bug in print_sn ordering (it doesn't sort by pubkey when two nodes with identical last reward height and tx index, which can happen as a result of state changes).
- `process_state_change_tx` errors need to be printed by default as errors: if we run into one we probably just desynced the local SN state.