### PR TITLE
Don't use alt quorums when processing blocks to the main chain

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1478,7 +1478,7 @@ namespace service_nodes
 
     cryptonote::network_type nettype = m_blockchain.nettype();
     m_state_history.insert(m_state_history.end(), m_state);
-    m_state.update_from_block(*m_db, nettype, m_state_history, m_alt_state, block, txs, m_service_node_keys);
+    m_state.update_from_block(*m_db, nettype, m_state_history, {} /*m_alt_state*/, block, txs, m_service_node_keys);
   }
 
   void service_node_list::blockchain_detached(uint64_t height, bool /*by_pop_blocks*/)


### PR DESCRIPTION
If you accept a block on the main chain due to an alternative quorum,
eventually that alternative quorum will get pruned as it corresponds to an
alternative block and not the current block.

This should not be accepted via the main chain, but instead the block
should be passed through the alt chain block added hook (eventually if it's
valid)