### PR TITLE
__thread -> thread_local

### DIFF
--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -91,7 +91,7 @@ namespace tools
 
 el::Level performance_timer_log_level = el::Level::Info;
 
-static __thread std::vector<LoggingPerformanceTimer*> *performance_timers = NULL;
+static thread_local std::vector<LoggingPerformanceTimer*> *performance_timers = NULL;
 
 void set_performance_timer_log_level(el::Level level)
 {

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -31,8 +31,8 @@
 #include "cryptonote_config.h"
 #include "common/util.h"
 
-static __thread int depth = 0;
-static __thread bool is_leaf = false;
+static thread_local int depth = 0;
+static thread_local bool is_leaf = false;
 
 namespace tools
 {


### PR DESCRIPTION
It is sad that a prominent upstream monero contributor added `__thread`
to C++ code in 2017 when `thread_local` has been standardized since
C++11.

`__thread` isn't even supported by some compilers (like MSVC).