### PR TITLE
Store proof info (keys, uptime, version) directly in LMDB

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -96,6 +96,10 @@
  *   KEY_IMAGE_EXISTS
  */
 
+namespace service_nodes {
+struct proof_info;
+}
+
 namespace cryptonote
 {
 struct checkpoint_t;
@@ -1823,8 +1827,22 @@ public:
   virtual bool get_output_blacklist(std::vector<uint64_t> &blacklist) const   = 0;
   virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist)   = 0;
   virtual void set_service_node_data(const std::string& data, bool long_term) = 0;
-  virtual bool get_service_node_data(std::string &data, bool long_term)       = 0;
+  virtual bool get_service_node_data(std::string &data, bool long_term) const = 0;
   virtual void clear_service_node_data()                                      = 0;
+
+  /// Updates the given proof data with the latest stored info for the given service node.  Returns
+  /// true if found (and fields updated), false otherwise.
+  virtual bool get_service_node_proof(const crypto::public_key &pubkey, service_nodes::proof_info &proof) const = 0;
+
+  /// Returns pubkeys and proof data for all currently stored service nodes.
+  virtual std::unordered_map<crypto::public_key, service_nodes::proof_info> get_all_service_node_proofs() const = 0;
+
+  /// Creates or updates the proof data for a service node from a proof.
+  virtual void set_service_node_proof(const crypto::public_key &pubkey, const service_nodes::proof_info &proof) = 0;
+
+  /// Removes stored serialized proof sn data associated with the given pubkey.  Returns true if
+  /// found, false if not found.
+  virtual bool remove_service_node_proof(const crypto::public_key &pubkey) = 0;
 
   /**
    * @brief set whether or not to automatically remove logs

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -40,66 +40,44 @@
 namespace cryptonote
 {
 
-typedef struct txindex {
+struct txindex {
     crypto::hash key;
     tx_data_t data;
-} txindex;
+};
 
-typedef struct mdb_txn_cursors
+struct mdb_txn_cursors
 {
-  MDB_cursor *m_txc_blocks;
-  MDB_cursor *m_txc_block_heights;
-  MDB_cursor *m_txc_block_info;
-  MDB_cursor *m_txc_block_checkpoints;
+  MDB_cursor *blocks;
+  MDB_cursor *block_heights;
+  MDB_cursor *block_info;
+  MDB_cursor *block_checkpoints;
 
-  MDB_cursor *m_txc_output_txs;
-  MDB_cursor *m_txc_output_amounts;
+  MDB_cursor *output_txs;
+  MDB_cursor *output_amounts;
 
-  MDB_cursor *m_txc_txs;
-  MDB_cursor *m_txc_txs_pruned;
-  MDB_cursor *m_txc_txs_prunable;
-  MDB_cursor *m_txc_txs_prunable_hash;
-  MDB_cursor *m_txc_txs_prunable_tip;
-  MDB_cursor *m_txc_tx_indices;
-  MDB_cursor *m_txc_tx_outputs;
+  MDB_cursor *txs;
+  MDB_cursor *txs_pruned;
+  MDB_cursor *txs_prunable;
+  MDB_cursor *txs_prunable_hash;
+  MDB_cursor *txs_prunable_tip;
+  MDB_cursor *tx_indices;
+  MDB_cursor *tx_outputs;
 
-  MDB_cursor *m_txc_spent_keys;
+  MDB_cursor *spent_keys;
 
-  MDB_cursor *m_txc_txpool_meta;
-  MDB_cursor *m_txc_txpool_blob;
+  MDB_cursor *txpool_meta;
+  MDB_cursor *txpool_blob;
 
-  MDB_cursor *m_txc_alt_blocks;
+  MDB_cursor *alt_blocks;
 
-  MDB_cursor *m_txc_hf_versions;
+  MDB_cursor *hf_versions;
 
-  MDB_cursor *m_txc_service_node_data;
-  MDB_cursor *m_txc_output_blacklist;
-  MDB_cursor *m_txc_properties;
-} mdb_txn_cursors;
+  MDB_cursor *service_node_data;
+  MDB_cursor *output_blacklist;
+  MDB_cursor *properties;
+};
 
-#define m_cur_blocks	m_cursors->m_txc_blocks
-#define m_cur_block_heights	m_cursors->m_txc_block_heights
-#define m_cur_block_info	m_cursors->m_txc_block_info
-#define m_cur_block_checkpoints m_cursors->m_txc_block_checkpoints
-#define m_cur_output_txs	m_cursors->m_txc_output_txs
-#define m_cur_output_amounts	m_cursors->m_txc_output_amounts
-#define m_cur_output_blacklist	m_cursors->m_txc_output_blacklist
-#define m_cur_txs	m_cursors->m_txc_txs
-#define m_cur_txs_pruned	m_cursors->m_txc_txs_pruned
-#define m_cur_txs_prunable	m_cursors->m_txc_txs_prunable
-#define m_cur_txs_prunable_hash	m_cursors->m_txc_txs_prunable_hash
-#define m_cur_txs_prunable_tip	m_cursors->m_txc_txs_prunable_tip
-#define m_cur_tx_indices	m_cursors->m_txc_tx_indices
-#define m_cur_tx_outputs	m_cursors->m_txc_tx_outputs
-#define m_cur_spent_keys	m_cursors->m_txc_spent_keys
-#define m_cur_txpool_meta	m_cursors->m_txc_txpool_meta
-#define m_cur_txpool_blob	m_cursors->m_txc_txpool_blob
-#define m_cur_alt_blocks	m_cursors->m_txc_alt_blocks
-#define m_cur_hf_versions	m_cursors->m_txc_hf_versions
-#define m_cur_service_node_data	m_cursors->m_txc_service_node_data
-#define m_cur_properties	m_cursors->m_txc_properties
-
-typedef struct mdb_rflags
+struct mdb_rflags
 {
   bool m_rf_txn;
   bool m_rf_blocks;
@@ -123,16 +101,16 @@ typedef struct mdb_rflags
   bool m_rf_hf_versions;
   bool m_rf_service_node_data;
   bool m_rf_properties;
-} mdb_rflags;
+};
 
-typedef struct mdb_threadinfo
+struct mdb_threadinfo
 {
   MDB_txn *m_ti_rtxn;	// per-thread read txn
   mdb_txn_cursors m_ti_rcursors;	// per-thread read cursors
   mdb_rflags m_ti_rflags;	// per-thread read state
 
   ~mdb_threadinfo();
-} mdb_threadinfo;
+};
 
 struct mdb_txn_safe
 {
@@ -428,9 +406,9 @@ private:
 
   uint64_t get_database_size() const override;
 
-  std::vector<uint64_t> get_block_info_64bit_fields(uint64_t start_height, size_t count, off_t offset) const;
+  std::vector<uint64_t> get_block_info_64bit_fields(uint64_t start_height, size_t count, uint64_t (*extract)(const void* mdb_block_info)) const;
 
-  uint64_t get_max_block_size();
+  uint64_t get_max_block_size() override;
   void add_max_block_size(uint64_t sz) override;
 
   // fix up anything that may be wrong due to past bugs

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -40,6 +40,8 @@
 namespace cryptonote
 {
 
+struct mdb_block_info;
+
 struct txindex {
     crypto::hash key;
     tx_data_t data;
@@ -408,7 +410,7 @@ private:
 
   uint64_t get_database_size() const override;
 
-  std::vector<uint64_t> get_block_info_64bit_fields(uint64_t start_height, size_t count, uint64_t (*extract)(const void* mdb_block_info)) const;
+  std::vector<uint64_t> get_block_info_64bit_fields(uint64_t start_height, size_t count, uint64_t (*extract)(const mdb_block_info*)) const;
 
   uint64_t get_max_block_size() override;
   void add_max_block_size(uint64_t sz) override;

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -73,6 +73,7 @@ struct mdb_txn_cursors
   MDB_cursor *hf_versions;
 
   MDB_cursor *service_node_data;
+  MDB_cursor *service_node_proofs;
   MDB_cursor *output_blacklist;
   MDB_cursor *properties;
 };
@@ -100,6 +101,7 @@ struct mdb_rflags
   bool m_rf_alt_blocks;
   bool m_rf_hf_versions;
   bool m_rf_service_node_data;
+  bool m_rf_service_node_proofs;
   bool m_rf_properties;
 };
 
@@ -427,8 +429,13 @@ private:
 
   bool get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const;
   void set_service_node_data(const std::string& data, bool long_term) override;
-  bool get_service_node_data(std::string& data, bool long_term) override;
+  bool get_service_node_data(std::string& data, bool long_term) const override;
   void clear_service_node_data() override;
+
+  bool get_service_node_proof(const crypto::public_key& pubkey, service_nodes::proof_info& proof) const override;
+  void set_service_node_proof(const crypto::public_key& pubkey, const service_nodes::proof_info& proof) override;
+  std::unordered_map<crypto::public_key, service_nodes::proof_info> get_all_service_node_proofs() const override;
+  bool remove_service_node_proof(const crypto::public_key& pubkey) override;
 
 private:
   MDB_env* m_env;
@@ -461,6 +468,7 @@ private:
   MDB_dbi m_hf_versions;
 
   MDB_dbi m_service_node_data;
+  MDB_dbi m_service_node_proofs;
 
   MDB_dbi m_properties;
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <map>
 #include "blockchain_db.h"
+#include "cryptonote_core/service_node_list.h"
 
 namespace cryptonote
 {
@@ -165,8 +166,13 @@ public:
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }
   virtual void set_service_node_data  (const std::string& data, bool long_term)      override { }
-  virtual bool get_service_node_data  (std::string& data, bool long_term)            override { return false; }
+  virtual bool get_service_node_data  (std::string& data, bool long_term)      const override { return false; }
   virtual void clear_service_node_data()                                             override { }
+
+  bool get_service_node_proof(const crypto::public_key &pubkey, service_nodes::proof_info &proof) const override { return false; }
+  std::unordered_map<crypto::public_key, service_nodes::proof_info> get_all_service_node_proofs() const override { return {}; }
+  void set_service_node_proof(const crypto::public_key &pubkey, const service_nodes::proof_info &proof) override { }
+  bool remove_service_node_proof(const crypto::public_key &pubkey) override { return false; }
 
   virtual void add_alt_block(const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata &blob, const cryptonote::blobdata *checkpoint) override {}
   virtual bool get_alt_block(const crypto::hash &blkid, alt_block_data_t *data, cryptonote::blobdata *blob, cryptonote::blobdata *checkpoint) override { return false; }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -928,6 +928,9 @@ namespace cryptonote
      */
     bool for_all_outputs(uint64_t amount, std::function<bool(uint64_t height)>) const;
 
+    /// Returns true if we have a BlockchainDB reference, i.e. if we have been initialized
+    bool has_db() const { return m_db; }
+
     /**
      * @brief get a reference to the BlockchainDB in use by Blockchain
      *

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -855,7 +855,7 @@ namespace cryptonote
       *
       * @return all the service nodes that can be matched from pubkeys in param
       */
-     std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
+     std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys = {}) const;
 
      /**
        * @brief get whether `pubkey` is known as a service node.
@@ -1101,6 +1101,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<90, false> m_block_rate_interval; //!< interval for checking block rate
      epee::math_helper::once_a_time_seconds<60*60*5, true> m_blockchain_pruning_interval; //!< interval for incremental blockchain pruning
      epee::math_helper::once_a_time_seconds<60*2, false> m_service_node_vote_relayer;
+     epee::math_helper::once_a_time_seconds<60*60, false> m_sn_proof_cleanup_interval;
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2465,6 +2465,15 @@ namespace service_nodes
 
     // NOTE: Load uptime proof data
     m_proofs = db.get_all_service_node_proofs();
+    if (m_service_node_keys)
+    {
+      // Reset our own proof timestamp to zero so that we aggressively try to resend proofs on
+      // startup (in case we are restarting because the last proof that we think went out didn't
+      // actually make it to the network).
+      auto &mine = m_proofs[m_service_node_keys->pub];
+      mine.timestamp = mine.effective_timestamp = 0;
+    }
+
     initialize_x25519_map();
 
     MGINFO("Service node data loaded successfully, height: " << m_state.height);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -85,8 +85,8 @@ namespace service_nodes
   service_node_list::service_node_list(cryptonote::Blockchain &blockchain)
   : m_blockchain(blockchain) // Warning: don't touch `blockchain`, it gets initialized *after* us
   , m_service_node_keys(nullptr)
-  , m_db(nullptr)
   , m_store_quorum_history(0)
+  , m_state{this}
   , m_state_added_to_archive(false)
   {
   }
@@ -291,6 +291,12 @@ namespace service_nodes
     return result;
   }
 
+  size_t service_node_list::get_service_node_count() const
+  {
+    std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
+    return m_state.service_nodes_infos.size();
+  }
+
   std::vector<service_node_pubkey_info> service_node_list::get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
@@ -315,12 +321,6 @@ namespace service_nodes
     }
 
     return result;
-  }
-
-  void service_node_list::set_db_pointer(cryptonote::BlockchainDB* db)
-  {
-    std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
-    m_db = db;
   }
 
   void service_node_list::set_my_service_node_keys(const service_node_keys *keys)
@@ -580,7 +580,12 @@ namespace service_nodes
           info.swarm_id = UNASSIGNED_SWARM_ID;
         }
 
-        info.proof->update_timestamp(0);
+        if (sn_list)
+        {
+          auto &proof = sn_list->m_proofs[key];
+          proof.timestamp = proof.effective_timestamp = 0;
+          proof.store(key, sn_list->m_blockchain.get_db());
+        }
         return true;
 
       case new_state::recommission:
@@ -612,8 +617,12 @@ namespace service_nodes
         // the failure conditions.  We set only the effective but not *actual*
         // timestamp so that we delay obligations checks but don't prevent the
         // next actual proof from being sent/relayed.
-        info.proof->effective_timestamp = block.timestamp;
-        info.proof->votes.fill({});
+        if (sn_list)
+        {
+          auto &proof = sn_list->m_proofs[key];
+          proof.effective_timestamp = block.timestamp;
+          proof.votes.fill({});
+        }
         return true;
 
       case new_state::ip_change_penalty:
@@ -949,8 +958,6 @@ namespace service_nodes
     info.last_reward_block_height      = block_height;
     info.last_reward_transaction_index = index;
     info.swarm_id                      = UNASSIGNED_SWARM_ID;
-    info.proof->pubkey_ed25519         = crypto::ed25519_public_key::null();
-    info.proof->pubkey_x25519          = crypto::x25519_public_key::null();
     info.last_ip_change_height         = block_height;
     info.version                       = get_min_service_node_info_version_for_hf(hf_version);
 
@@ -996,6 +1003,15 @@ namespace service_nodes
       const auto iter = service_nodes_infos.find(key);
       if (iter != service_nodes_infos.end())
         return false;
+
+      // Explicitly reset any stored proof to 0, and store it just in case this is a
+      // re-registration: we want to wipe out any data from the previous registration.
+      if (sn_list)
+      {
+        auto &proof = sn_list->m_proofs[key];
+        proof = {};
+        proof.store(key, sn_list->m_blockchain.get_db());
+      }
 
       if (my_keys && my_keys->pub == key) MGINFO_GREEN("Service node registered (yours): " << key << " on height: " << block_height);
       else                                LOG_PRINT_L1("New service node registered: "     << key << " on height: " << block_height);
@@ -1520,7 +1536,7 @@ namespace service_nodes
     if (hf_version >= cryptonote::network_version_12_checkpointing && m_alt_state.size())
     {
       cryptonote::checkpoint_t immutable_checkpoint;
-      if (m_db->get_immutable_checkpoint(&immutable_checkpoint, block_height))
+      if (m_blockchain.get_db().get_immutable_checkpoint(&immutable_checkpoint, block_height))
       {
         for (auto it = m_alt_state.begin(); it != m_alt_state.end(); )
         {
@@ -1533,7 +1549,7 @@ namespace service_nodes
 
     cryptonote::network_type nettype = m_blockchain.nettype();
     m_state_history.insert(m_state_history.end(), m_state);
-    m_state.update_from_block(*m_db, nettype, m_state_history, m_state_archive, {}, block, txs, m_service_node_keys);
+    m_state.update_from_block(m_blockchain.get_db(), nettype, m_state_history, m_state_archive, {}, block, txs, m_service_node_keys);
   }
 
   void service_node_list::blockchain_detached(uint64_t height, bool /*by_pop_blocks*/)
@@ -1815,8 +1831,12 @@ namespace service_nodes
     }
 
     state_t alt_state = *starting_state;
-    alt_state.update_from_block(*m_db, m_blockchain.nettype(), m_state_history, m_state_archive, m_alt_state, block, txs, m_service_node_keys);
-    m_alt_state[block_hash] = std::move(alt_state);
+    alt_state.update_from_block(m_blockchain.get_db(), m_blockchain.nettype(), m_state_history, m_state_archive, m_alt_state, block, txs, m_service_node_keys);
+    auto alt_it = m_alt_state.find(block_hash);
+    if (alt_it != m_alt_state.end())
+      alt_it->second = std::move(alt_state);
+    else
+      m_alt_state.emplace(block_hash, std::move(alt_state));
 
     if (checkpoint)
     {
@@ -1878,7 +1898,7 @@ namespace service_nodes
 
   bool service_node_list::store()
   {
-    if (!m_db)
+    if (!m_blockchain.has_db())
         return false; // Haven't been initialized yet
 
     uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
@@ -1932,8 +1952,9 @@ namespace service_nodes
       CHECK_AND_ASSERT_MES(r, false, "Failed to store service node info: failed to serialize long term data");
       m_cache_data_blob.append(ss.str());
       {
-        cryptonote::db_wtxn_guard txn_guard(m_db);
-        m_db->set_service_node_data(m_cache_data_blob, true /*long_term*/);
+        auto &db = m_blockchain.get_db();
+        cryptonote::db_wtxn_guard txn_guard{db};
+        db.set_service_node_data(m_cache_data_blob, true /*long_term*/);
       }
     }
 
@@ -1945,8 +1966,9 @@ namespace service_nodes
       CHECK_AND_ASSERT_MES(r, false, "Failed to store service node info: failed to serialize short term data data");
       m_cache_data_blob.append(ss.str());
       {
-        cryptonote::db_wtxn_guard txn_guard(m_db);
-        m_db->set_service_node_data(m_cache_data_blob, false /*long_term*/);
+        auto &db = m_blockchain.get_db();
+        cryptonote::db_wtxn_guard txn_guard{db};
+        db.set_service_node_data(m_cache_data_blob, false /*long_term*/);
       }
     }
 
@@ -2007,12 +2029,60 @@ namespace service_nodes
     {cryptonote::network_version_12_checkpointing,        {4,0,3}},
   };
 
-  void service_node_info::derive_x25519_pubkey_from_ed25519() {
-    if (0 != crypto_sign_ed25519_pk_to_curve25519(proof->pubkey_x25519.data, proof->pubkey_ed25519.data)) {
-      proof->pubkey_x25519 = crypto::x25519_public_key::null();
-      proof->pubkey_ed25519 = crypto::ed25519_public_key::null();
+  template <typename T>
+  static bool update_val(T &val, const T &to) {
+    if (val != to) {
+      val = to;
+      return true;
     }
+    return false;
+  }
 
+  void proof_info::store(const crypto::public_key &pubkey, cryptonote::BlockchainDB &db)
+  {
+    cryptonote::db_wtxn_guard guard{db};
+    db.set_service_node_proof(pubkey, *this);
+  }
+
+  bool proof_info::update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2)
+  {
+    bool update_db = false;
+    update_db |= update_val(timestamp, ts);
+    update_db |= update_val(public_ip, ip);
+    update_db |= update_val(storage_port, s_port);
+    update_db |= update_val(quorumnet_port, q_port);
+    update_db |= update_val(version, ver);
+    update_db |= update_val(pubkey_ed25519, pk_ed);
+    effective_timestamp = timestamp;
+    pubkey_x25519 = pk_x2;
+
+    // Track an IP change (so that the obligations quorum can penalize for IP changes)
+    // We only keep the two most recent because all we really care about is whether it had more than one
+    //
+    // If we already know about the IP, update its timestamp:
+    auto now = std::time(nullptr);
+    if (public_ips[0].first && public_ips[0].first == public_ip)
+      public_ips[0].second = now;
+    else if (public_ips[1].first && public_ips[1].first == public_ip)
+      public_ips[1].second = now;
+    // Otherwise replace whichever IP has the older timestamp
+    else if (public_ips[0].second > public_ips[1].second)
+      public_ips[1] = {public_ip, now};
+    else
+      public_ips[0] = {public_ip, now};
+
+    return update_db;
+  };
+
+  void proof_info::update_pubkey(const crypto::ed25519_public_key &pk) {
+    if (pk == pubkey_ed25519)
+      return;
+    if (pk && 0 == crypto_sign_ed25519_pk_to_curve25519(pubkey_x25519.data, pk.data)) {
+      pubkey_ed25519 = pk;
+    } else {
+      pubkey_x25519 = crypto::x25519_public_key::null();
+      pubkey_ed25519 = crypto::ed25519_public_key::null();
+    }
   }
 
 #define REJECT_PROOF(log) do { LOG_PRINT_L2("Rejecting uptime proof from " << proof.pubkey << ": " log); return false; } while (0)
@@ -2053,17 +2123,22 @@ namespace service_nodes
       if (0 != crypto_sign_ed25519_pk_to_curve25519(derived_x25519_pubkey.data, proof.pubkey_ed25519.data)
           || !derived_x25519_pubkey)
         REJECT_PROOF("invalid ed25519 pubkey included in proof (x25519 derivation failed)");
-
+    }
+    if (hf_version >= cryptonote::network_version_14_blink_lns)
+    {
       if (proof.qnet_port == 0)
         REJECT_PROOF("invalid quorumnet port in uptime proof");
     }
 
-    std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
+    std::unique_lock<boost::recursive_mutex> sn_lock{m_sn_mutex, std::defer_lock};
+    std::unique_lock<std::shared_timed_mutex> x_lock{m_x25519_map_mutex, std::defer_lock};
+    std::lock(sn_lock, x_lock);
+
     auto it = m_state.service_nodes_infos.find(proof.pubkey);
     if (it == m_state.service_nodes_infos.end())
       REJECT_PROOF("no such service node is currently registered");
 
-    auto &iproof = *it->second->proof;
+    auto &iproof = m_proofs[proof.pubkey];
 
     if (iproof.timestamp >= now - (UPTIME_PROOF_FREQUENCY_IN_SECONDS / 2))
       REJECT_PROOF("already received one uptime proof for this node recently");
@@ -2079,62 +2154,82 @@ namespace service_nodes
       LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
     }
 
-    iproof.update_timestamp(now);
-    iproof.version       = proof.snode_version;
-    iproof.public_ip     = proof.public_ip;
-    iproof.storage_port  = proof.storage_port;
+    auto old_x25519 = iproof.pubkey_x25519;
+    if (iproof.update(now, proof.public_ip, proof.storage_port, proof.qnet_port, proof.snode_version, proof.pubkey_ed25519, derived_x25519_pubkey))
+      iproof.store(proof.pubkey, m_blockchain.get_db());
 
-    if (hf_version >= HF_VERSION_ED25519_KEY)
+    if ((uint64_t) m_x25519_map_last_pruned + X25519_MAP_PRUNING_INTERVAL <= now)
     {
-      time_t now = std::time(nullptr);
-      if (m_x25519_map_last_pruned + X25519_MAP_PRUNING_INTERVAL <= now)
-      {
-        time_t cutoff = now - 24*60*60;
-        erase_if(m_x25519_to_pub, [&cutoff](const decltype(m_x25519_to_pub)::value_type &x) { return x.second.second < cutoff; });
-        m_x25519_map_last_pruned = now;
-      }
-
-      iproof.quorumnet_port = proof.qnet_port;
-      iproof.pubkey_ed25519 = proof.pubkey_ed25519;
-      if (iproof.pubkey_x25519 && iproof.pubkey_x25519 != derived_x25519_pubkey)
-        m_x25519_to_pub.erase(iproof.pubkey_x25519);
-      iproof.pubkey_x25519 = derived_x25519_pubkey;
-      m_x25519_to_pub[derived_x25519_pubkey] = {proof.pubkey, now};
+      time_t cutoff = now - X25519_MAP_PRUNING_LAG;
+      erase_if(m_x25519_to_pub, [&cutoff](const decltype(m_x25519_to_pub)::value_type &x) { return x.second.second < cutoff; });
+      m_x25519_map_last_pruned = now;
     }
 
-    // Track an IP change (so that the obligations quorum can penalize for IP changes)
-    // We only keep the two most recent because all we really care about is whether it had more than one
-    auto &ips = iproof.public_ips;
-
-    // If we already know about the IP, update its timestamp:
-    if (ips[0].first && ips[0].first == proof.public_ip)
-        ips[0].second = now;
-    else if (ips[1].first && ips[1].first == proof.public_ip)
-        ips[1].second = now;
-    // Otherwise replace whichever IP has the older timestamp
-    else if (ips[0].second > ips[1].second)
-        ips[1] = {proof.public_ip, now};
-    else
-        ips[0] = {proof.public_ip, now};
+    if (old_x25519 != derived_x25519_pubkey)
+    {
+      if (old_x25519)
+        m_x25519_to_pub.erase(old_x25519);
+      if (derived_x25519_pubkey)
+        m_x25519_to_pub[derived_x25519_pubkey] = {proof.pubkey, now};
+    }
 
     return true;
   }
 
+  void service_node_list::cleanup_proofs()
+  {
+    MDEBUG("Cleaning up expired SN proofs");
+    std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
+    uint64_t now = std::time(nullptr);
+    auto& db = m_blockchain.get_db();
+    cryptonote::db_wtxn_guard guard{db};
+    for (auto it = m_proofs.begin(); it != m_proofs.end(); )
+    {
+      auto& pubkey = it->first;
+      auto& proof = it->second;
+      // 6h here because there's no harm in leaving proofs around a bit longer (they aren't big, and
+      // we only store one per SN), and it's possible that we could reorg a few blocks and resurrect
+      // a service node but don't want to prematurely expire the proof.
+      if (!m_state.service_nodes_infos.count(pubkey) && proof.timestamp + 6*60*60 < now)
+      {
+        db.remove_service_node_proof(pubkey);
+        it = m_proofs.erase(it);
+      }
+      else
+        ++it;
+    }
+  }
+
   crypto::public_key service_node_list::get_pubkey_from_x25519(const crypto::x25519_public_key &x25519) const {
+    std::shared_lock<std::shared_timed_mutex> lock{m_x25519_map_mutex};
     auto it = m_x25519_to_pub.find(x25519);
     if (it != m_x25519_to_pub.end())
       return it->second.first;
     return crypto::null_pkey;
   }
 
+  void service_node_list::initialize_x25519_map() {
+    auto sn_infos = get_service_node_list_state();
+    std::unique_lock<std::shared_timed_mutex> lock{m_x25519_map_mutex};
+
+    auto now = std::time(nullptr);
+    for (const auto &sn_info : sn_infos)
+    {
+      auto it = m_proofs.find(sn_info.pubkey);
+      if (it == m_proofs.end())
+       continue;
+      if (const auto &x2_pk = it->second.pubkey_x25519)
+        m_x25519_to_pub.emplace(x2_pk, std::make_pair(sn_info.pubkey, now));
+    }
+  }
+
   void service_node_list::record_checkpoint_vote(crypto::public_key const &pubkey, uint64_t height, bool voted)
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
-    auto it = m_state.service_nodes_infos.find(pubkey);
-    if (it == m_state.service_nodes_infos.end())
+    if (!m_state.service_nodes_infos.count(pubkey))
       return;
 
-    proof_info &info = *it->second->proof;
+    auto &info = m_proofs[pubkey];
     info.votes[info.vote_index].height = height;
     info.votes[info.vote_index].voted  = voted;
     info.vote_index                    = (info.vote_index + 1) % info.votes.size();
@@ -2144,22 +2239,20 @@ namespace service_nodes
   {
     std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
 
-    auto it = m_state.service_nodes_infos.find(pubkey);
-    if (it == m_state.service_nodes_infos.end()) {
+    if (!m_state.service_nodes_infos.count(pubkey)) {
       LOG_PRINT_L2("No Service Node is known by this pubkey: " << pubkey);
       return false;
-    } else {
-
-      proof_info &info = *it->second->proof;
-      if (info.storage_server_reachable != value)
-      {
-        info.storage_server_reachable           = value;
-        LOG_PRINT_L2("Setting reachability status for node " << pubkey << " as: " << (value ? "true" : "false"));
-      }
-
-      info.storage_server_reachable_timestamp = time(nullptr);
-      return true;
     }
+
+    proof_info &info = m_proofs[pubkey];
+    if (info.storage_server_reachable != value)
+    {
+      info.storage_server_reachable = value;
+      LOG_PRINT_L2("Setting reachability status for node " << pubkey << " as: " << (value ? "true" : "false"));
+    }
+
+    info.storage_server_reachable_timestamp = time(nullptr);
+    return true;
   }
 
   static quorum_manager quorum_for_serialization_to_quorum_manager(service_node_list::quorum_for_serialization const &source)
@@ -2174,14 +2267,17 @@ namespace service_nodes
     return result;
   }
 
-  service_node_list::state_t::state_t(cryptonote::Blockchain const &blockchain, state_serialized &&state)
+  service_node_list::state_t::state_t(service_node_list* snl, state_serialized &&state)
   : height{state.height}
   , key_image_blacklist{std::move(state.key_image_blacklist)}
   , only_loaded_quorums{state.only_stored_quorums}
   , block_hash{state.block_hash}
+  , sn_list{snl}
   {
+    if (!sn_list)
+      throw std::logic_error("Cannot deserialize a state_t without a service_node_list");
     if (state.version == state_serialized::version_t::version_0)
-      block_hash = blockchain.get_block_id_by_height(height);
+      block_hash = sn_list->m_blockchain.get_block_id_by_height(height);
 
     for (auto &pubkey_info : state.infos)
     {
@@ -2190,7 +2286,7 @@ namespace service_nodes
       if (info.version < version_t::v1_add_registration_hf_version)
       {
         info.version = version_t::v1_add_registration_hf_version;
-        info.registration_hf_version = blockchain.get_hard_fork_version(pubkey_info.info->registration_height);
+        info.registration_hf_version = sn_list->m_blockchain.get_hard_fork_version(pubkey_info.info->registration_height);
       }
       if (info.version < version_t::v3_quorumnet)
       {
@@ -2208,16 +2304,17 @@ namespace service_nodes
   {
     LOG_PRINT_L1("service_node_list::load()");
     reset(false);
-    if (!m_db)
+    if (!m_blockchain.has_db())
     {
       return false;
     }
 
     // NOTE: Deserialize long term state history
     uint64_t bytes_loaded = 0;
-    cryptonote::db_rtxn_guard txn_guard(m_db);
+    auto &db = m_blockchain.get_db();
+    cryptonote::db_rtxn_guard txn_guard{db};
     std::string blob;
-    if (m_db->get_service_node_data(blob, true /*long_term*/))
+    if (db.get_service_node_data(blob, true /*long_term*/))
     {
       bytes_loaded += blob.size();
       std::stringstream ss;
@@ -2260,16 +2357,16 @@ namespace service_nodes
               continue;
             }
 
-            state_t entry(m_blockchain, std::move(serialized_entry));
+            state_t entry{this, std::move(serialized_entry)};
             entry.height--;
             entry.quorums = quorum_for_serialization_to_quorum_manager(prev_serialized_entry.quorums);
 
             if ((serialized_entry.height % STORE_LONG_TERM_STATE_INTERVAL) == 0)
             {
               state_t long_term_state                  = entry;
-              cryptonote::block const &block           = m_db->get_block_from_height(long_term_state.height + 1);
-              std::vector<cryptonote::transaction> txs = m_db->get_tx_list(block.tx_hashes);
-              long_term_state.update_from_block(*m_db, m_blockchain.nettype(), {} /*state_history*/, {} /*state_archive*/, {} /*alt_states*/, block, txs, nullptr /*my_keys*/);
+              cryptonote::block const &block           = db.get_block_from_height(long_term_state.height + 1);
+              std::vector<cryptonote::transaction> txs = db.get_tx_list(block.tx_hashes);
+              long_term_state.update_from_block(db, m_blockchain.nettype(), {} /*state_history*/, {} /*state_archive*/, {} /*alt_states*/, block, txs, nullptr /*my_keys*/);
 
               entry.service_nodes_infos                = {};
               entry.key_image_blacklist                = {};
@@ -2281,21 +2378,14 @@ namespace service_nodes
         }
         else
         {
-          for (state_serialized &entry : data_in.states) {
-            for (auto &pki : entry.infos)
-            {
-              if (const auto &x25519_pub = pki.info->proof->pubkey_x25519)
-                m_x25519_to_pub[x25519_pub] = {pki.pubkey, time_t(nullptr)};
-            }
-
-            m_state_archive.emplace_hint(m_state_archive.end(), m_blockchain, std::move(entry));
-          }
+          for (state_serialized &entry : data_in.states)
+            m_state_archive.emplace_hint(m_state_archive.end(), this, std::move(entry));
         }
       }
     }
 
     // NOTE: Deserialize short term state history
-    if (!m_db->get_service_node_data(blob, false))
+    if (!db.get_service_node_data(blob, false))
       return false;
 
     bytes_loaded += blob.size();
@@ -2347,7 +2437,7 @@ namespace service_nodes
         {
           state_serialized &serialized_entry      = data_in.states[i];
           state_serialized &prev_serialized_entry = data_in.states[i - 1];
-          state_t entry(m_blockchain, std::move(serialized_entry));
+          state_t entry{this, std::move(serialized_entry)};
           entry.quorums = quorum_for_serialization_to_quorum_manager(prev_serialized_entry.quorums);
           entry.height--;
           if (i == last_index) m_state = std::move(entry);
@@ -2361,13 +2451,16 @@ namespace service_nodes
         {
           state_serialized &entry = data_in.states[i];
           if (entry.block_hash == crypto::null_hash) entry.block_hash = m_blockchain.get_block_id_by_height(entry.height);
-          m_state_history.emplace_hint(m_state_history.end(), m_blockchain, std::move(entry));
+          m_state_history.emplace_hint(m_state_history.end(), this, std::move(entry));
         }
 
-        state_serialized &last_entry = data_in.states[last_index];
-        m_state = state_t(m_blockchain, std::move(last_entry));
+        m_state = {this, std::move(data_in.states[last_index])};
       }
     }
+
+    // NOTE: Load uptime proof data
+    m_proofs = db.get_all_service_node_proofs();
+    initialize_x25519_map();
 
     MGINFO("Service node data loaded successfully, height: " << m_state.height);
     MGINFO(m_state.service_nodes_infos.size()
@@ -2382,12 +2475,12 @@ namespace service_nodes
   {
     m_state_history.clear();
     m_old_quorum_states.clear();
-    m_state = {};
+    m_state = state_t{this};
 
-    if (m_db && delete_db_entry)
+    if (m_blockchain.has_db() && delete_db_entry)
     {
-      cryptonote::db_wtxn_guard txn_guard(m_db);
-      m_db->clear_service_node_data();
+      cryptonote::db_wtxn_guard txn_guard{m_blockchain.get_db()};
+      m_blockchain.get_db().clear_service_node_data();
     }
 
     uint64_t hardfork_9_from_height = 0;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -96,6 +96,9 @@ namespace service_nodes
     if (m_blockchain.get_current_hard_fork_version() < cryptonote::network_version_9_service_nodes)
       return;
 
+    m_rescanning = true;
+    LOKI_DEFER { m_rescanning = false; };
+
     auto scan_start         = std::chrono::high_resolution_clock::now();
     uint64_t chain_height   = m_blockchain.get_current_blockchain_height();
     uint64_t current_height = chain_height - 1;
@@ -580,7 +583,7 @@ namespace service_nodes
           info.swarm_id = UNASSIGNED_SWARM_ID;
         }
 
-        if (sn_list)
+        if (sn_list && !sn_list->m_rescanning)
         {
           auto &proof = sn_list->m_proofs[key];
           proof.timestamp = proof.effective_timestamp = 0;
@@ -1006,7 +1009,7 @@ namespace service_nodes
 
       // Explicitly reset any stored proof to 0, and store it just in case this is a
       // re-registration: we want to wipe out any data from the previous registration.
-      if (sn_list)
+      if (sn_list && !sn_list->m_rescanning)
       {
         auto &proof = sn_list->m_proofs[key];
         proof = {};

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2083,6 +2083,7 @@ namespace service_nodes
     if (pk && 0 == crypto_sign_ed25519_pk_to_curve25519(pubkey_x25519.data, pk.data)) {
       pubkey_ed25519 = pk;
     } else {
+      MWARNING("Failed to derive x25519 pubkey from ed25519 pubkey " << pubkey_ed25519);
       pubkey_x25519 = crypto::x25519_public_key::null();
       pubkey_ed25519 = crypto::ed25519_public_key::null();
     }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -452,8 +452,8 @@ namespace service_nodes
     return *new_ptr;
   }
 
-  bool service_node_list::state_t::process_state_change_tx(std::set<state_t> const &state_history,
-                                                           std::set<state_t> const &state_archive,
+  bool service_node_list::state_t::process_state_change_tx(state_set const &state_history,
+                                                           state_set const &state_archive,
                                                            std::unordered_map<crypto::hash, state_t> const &alt_states,
                                                            cryptonote::network_type nettype,
                                                            const cryptonote::block &block,
@@ -1360,8 +1360,8 @@ namespace service_nodes
 
   void service_node_list::state_t::update_from_block(cryptonote::BlockchainDB const &db,
                                                      cryptonote::network_type nettype,
-                                                     std::set<state_t> const &state_history,
-                                                     std::set<state_t> const &state_archive,
+                                                     state_set const &state_history,
+                                                     state_set const &state_archive,
                                                      std::unordered_map<crypto::hash, state_t> const &alt_states,
                                                      const cryptonote::block &block,
                                                      const std::vector<cryptonote::transaction> &txs,
@@ -1572,7 +1572,7 @@ namespace service_nodes
       return;
     }
 
-    std::set<state_t> &history = (using_archive) ? m_state_archive : m_state_history;
+    auto &history = (using_archive) ? m_state_archive : m_state_history;
     auto it = std::prev(history.end());
     m_state = std::move(*it);
     history.erase(it);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -30,6 +30,7 @@
 
 #include <boost/variant.hpp>
 #include <mutex>
+#include <shared_mutex>
 #include "serialization/serialization.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_core/service_node_rules.h"
@@ -61,9 +62,8 @@ namespace service_nodes
 
   struct proof_info
   {
-    uint64_t timestamp           = 0; // The actual time we last received an uptime proof
+    uint64_t timestamp           = 0; // The actual time we last received an uptime proof (serialized)
     uint64_t effective_timestamp = 0; // Typically the same, but on recommissions it is set to the recommission block time to fend off instant obligation checks
-    std::array<uint16_t, 3> version{{0,0,0}};
     std::array<checkpoint_vote_record, CHECKPOINT_NUM_QUORUMS_TO_PARTICIPATE_IN> votes;
     uint8_t vote_index = 0;
     std::array<std::pair<uint32_t, uint64_t>, 2> public_ips = {}; // (not serialized)
@@ -72,17 +72,29 @@ namespace service_nodes
     uint64_t storage_server_reachable_timestamp = 0;
     proof_info() { votes.fill({}); }
 
-    // Called to update both actual and effective timestamp, i.e. when a proof is received
-    void update_timestamp(uint64_t ts) { timestamp = ts; effective_timestamp = ts; }
-
-    // Unlike the above, these four *do* get serialized, but directly from state_t rather than as a subobject:
+    // Unlike all of the above (except for timestamp), these values *do* get serialized
     uint32_t public_ip      = 0;
     uint16_t storage_port   = 0;
     uint16_t quorumnet_port = 0;
+    std::array<uint16_t, 3> version{{0,0,0}};
     crypto::ed25519_public_key pubkey_ed25519 = crypto::ed25519_public_key::null();
 
     // Derived from pubkey_ed25519, not serialized
     crypto::x25519_public_key pubkey_x25519 = crypto::x25519_public_key::null();
+
+    // Updates pubkey_ed25519 to the given key, re-deriving the x25519 key if it actually changes
+    // (does nothing if the key is the same as the current value).  If x25519 derivation fails then
+    // both pubkeys are set to null.
+    void update_pubkey(const crypto::ed25519_public_key &pk);
+
+    // Called to update data received from a proof is received, updating values in the local object.
+    // Returns true if serializable data is changed (in which case `store()` should be called).
+    // Note that this does not update the m_x25519_to_pub map if the x25519 key changes (that's the
+    // caller's responsibility).
+    bool update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2);
+
+    // Stores this record in the database.
+    void store(const crypto::public_key &pubkey, cryptonote::BlockchainDB &db);
   };
 
   struct service_node_info // registration information
@@ -93,6 +105,7 @@ namespace service_nodes
       v1_add_registration_hf_version,
       v2_ed25519,
       v3_quorumnet,
+      v4_noproofs,
 
       _count
     };
@@ -163,15 +176,8 @@ namespace service_nodes
     swarm_id_t                         swarm_id = 0;
     cryptonote::account_public_address operator_address{};
     uint64_t                           last_ip_change_height = 0; // The height of the last quorum penalty for changing IPs
-    version_t                          version = version_t::v3_quorumnet;
+    version_t                          version = tools::enum_top<version_t>;
     uint8_t                            registration_hf_version = 0;
-
-    // The data in `proof_info` are shared across states because we don't want to roll them back in
-    // the event of a reorg: we always want them to contain the latest received info.  They are also
-    // deliberately mutable (via the dereferenced non-const type) so that they can be updated
-    // without needing to duplicate state.  Only IP/ports/ed25519 pubkey are serialized; the rest
-    // of proof info is transient.
-    std::shared_ptr<proof_info> proof = std::make_shared<proof_info>();
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -181,8 +187,6 @@ namespace service_nodes
     bool can_transition_to_state(uint8_t hf_version, uint64_t block_height, new_state proposed_state) const;
     bool can_be_voted_on        (uint64_t block_height) const;
     size_t total_num_locked_contributions() const;
-
-    void derive_x25519_pubkey_from_ed25519(); // Attempts to set x25519 from ed25519 pubkey.  Sets both to null if conversion fails.
 
     BEGIN_SERIALIZE_OBJECT()
       ENUM_FIELD(version, version < version_t::_count)
@@ -200,18 +204,23 @@ namespace service_nodes
       VARINT_FIELD(portions_for_operator)
       FIELD(operator_address)
       VARINT_FIELD(swarm_id)
-      VARINT_FIELD_N("public_ip", proof->public_ip)
-      VARINT_FIELD_N("storage_port", proof->storage_port)
+      if (version < version_t::v4_noproofs) {
+        uint32_t fake_ip = 0;
+        uint16_t fake_port = 0;
+        VARINT_FIELD_N("public_ip", fake_ip)
+        VARINT_FIELD_N("storage_port", fake_port)
+      }
       VARINT_FIELD(last_ip_change_height)
       if (version >= version_t::v1_add_registration_hf_version)
         VARINT_FIELD(registration_hf_version);
-      if (version >= version_t::v2_ed25519) {
-        FIELD_N("pubkey_ed25519", proof->pubkey_ed25519)
-        if (!W)
-          derive_x25519_pubkey_from_ed25519();
+      if (version >= version_t::v2_ed25519 && version < version_t::v4_noproofs) {
+        crypto::ed25519_public_key fake_pk = crypto::ed25519_public_key::null();
+        FIELD_N("pubkey_ed25519", fake_pk)
+        if (version >= version_t::v3_quorumnet) {
+          uint16_t fake_port = 0;
+          VARINT_FIELD_N("quorumnet_port", fake_port)
+        }
       }
-      if (version >= version_t::v3_quorumnet)
-        VARINT_FIELD_N("quorumnet_port", proof->quorumnet_port)
     END_SERIALIZE()
   };
 
@@ -320,27 +329,46 @@ namespace service_nodes
     std::shared_ptr<const quorum> get_quorum(quorum_type type, uint64_t height, bool include_old = false, std::vector<std::shared_ptr<const quorum>> *alt_states = nullptr) const;
     bool                          get_quorum_pubkey(quorum_type type, quorum_group group, uint64_t height, size_t quorum_index, crypto::public_key &key) const;
 
-    std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys) const;
+    size_t get_service_node_count() const;
+    std::vector<service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key> &service_node_pubkeys = {}) const;
     const std::vector<key_image_blacklist_entry> &get_blacklisted_key_images() const { return m_state.key_image_blacklist; }
+
+    /// Accesses a proof with the required lock held; used to extract needed proof values.  Func
+    /// should be callable with a single `const proof_info &` argument.  If there is no proof info
+    /// at all for the given pubkey then Func will not be called.
+    template <typename Func>
+    void access_proof(const crypto::public_key &pubkey, Func f) const {
+      std::unique_lock<boost::recursive_mutex> lock;
+      auto it = m_proofs.find(pubkey);
+      if (it != m_proofs.end())
+        f(it->second);
+    }
 
     /// Returns the (monero curve) pubkey associated with a x25519 pubkey.  Returns a null public
     /// key if not found.  (Note: this is just looking up the association, not derivation).
     crypto::public_key get_pubkey_from_x25519(const crypto::x25519_public_key &x25519) const;
 
-    /// Does something read-only for each service node info in the range of pubkeys.  The SN lock is
-    /// held while iterating, so the "something" should be quick.  Func should take arguments:
-    /// (const std::string &pubkey, const service_node_info &info)
+    /// Initializes the x25519 map from current pubkey state; called during initialization
+    void initialize_x25519_map();
+
+    /// Does something read-only for each registered service node in the range of pubkeys.  The SN
+    /// lock is held while iterating, so the "something" should be quick.  Func should take
+    /// arguments:
+    ///     (const crypto::public_key&, const service_node_info&, const proof_info&)
+    /// Unknown public keys are skipped.
     template <typename It, typename Func>
-    void for_each_service_node_info(It begin, It end, Func f) const {
+    void for_each_service_node_info_and_proof(It begin, It end, Func f) const {
+      static const proof_info empty_proof{};
       std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
       for (auto sni_end = m_state.service_nodes_infos.end(); begin != end; ++begin) {
         auto it = m_state.service_nodes_infos.find(*begin);
-        if (it != sni_end)
-          f(it->first, *it->second);
+        if (it != sni_end) {
+          auto pit = m_proofs.find(it->first);
+          f(it->first, *it->second, (pit != m_proofs.end() ? pit->second : empty_proof));
+        }
       }
     }
 
-    void set_db_pointer(cryptonote::BlockchainDB* db);
     void set_my_service_node_keys(const service_node_keys *keys);
     void set_quorum_history_storage(uint64_t hist_size); // 0 = none (default), 1 = unlimited, N = # of blocks
     bool store();
@@ -349,6 +377,9 @@ namespace service_nodes
     cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(const service_node_keys &keys, uint32_t public_ip, uint16_t storage_port, uint16_t quorumnet_port) const;
     bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation);
     void record_checkpoint_vote     (crypto::public_key const &pubkey, uint64_t height, bool voted);
+
+    // Called every hour to remove proofs for expired SNs from memory and the database.
+    void cleanup_proofs();
 
     bool set_storage_server_peer_reachable(crypto::public_key const &pubkey, bool value);
 
@@ -414,15 +445,16 @@ namespace service_nodes
     using block_height = uint64_t;
     struct state_t
     {
-      crypto::hash                           block_hash;
-      bool                                   only_loaded_quorums;
+      crypto::hash                           block_hash{crypto::null_hash};
+      bool                                   only_loaded_quorums{false};
       service_nodes_infos_t                  service_nodes_infos;
       std::vector<key_image_blacklist_entry> key_image_blacklist;
       block_height                           height{0};
       mutable quorum_manager                 quorums;          // Mutable because we are allowed to (and need to) change it via std::set iterator
+      service_node_list*                     sn_list;
 
-      state_t() = default;
-      state_t(cryptonote::Blockchain const &blockchain, state_serialized &&state);
+      state_t(service_node_list* snl) : sn_list{snl} {}
+      state_t(service_node_list* snl, state_serialized &&state);
 
       friend bool operator<(const state_t &a, const state_t &b) { return a.height < b.height; }
       friend bool operator<(const state_t &s, block_height h)   { return s.height < h; }
@@ -472,12 +504,12 @@ namespace service_nodes
     mutable boost::recursive_mutex m_sn_mutex;
     cryptonote::Blockchain&        m_blockchain;
     const service_node_keys       *m_service_node_keys;
-    cryptonote::BlockchainDB      *m_db;
     uint64_t                       m_store_quorum_history;
 
     /// Maps x25519 pubkeys to registration pubkeys + last block seen value (used for expiry)
     std::unordered_map<crypto::x25519_public_key, std::pair<crypto::public_key, time_t>> m_x25519_to_pub;
     time_t m_x25519_map_last_pruned = 0;
+    mutable std::shared_timed_mutex m_x25519_map_mutex;
 
     struct quorums_by_height
     {
@@ -492,6 +524,7 @@ namespace service_nodes
     state_set                                 m_state_archive; // Store state_t's where ((height < m_state_history.first()) && (height % STORE_LONG_TERM_STATE_INTERVAL))
     state_t                                   m_state;
     std::unordered_map<crypto::hash, state_t> m_alt_state;
+    std::unordered_map<crypto::public_key, proof_info> m_proofs;
 
     bool                                   m_state_added_to_archive;
     data_for_serialization                 m_cache_long_term_data;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -495,6 +495,7 @@ namespace service_nodes
 
   private:
     // Note(maxim): private methods don't have to be protected the mutex
+    bool m_rescanning = false; /* set to true when doing a rescan so we know not to reset proofs */
     void rescan_starting_from_curr_state(bool store_to_disk);
     void process_block(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
 

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -362,7 +362,7 @@ namespace service_nodes
   bool verify_vote_signature(uint8_t hf_version, const quorum_vote_t &vote, cryptonote::vote_verification_context &vvc, const service_nodes::quorum &quorum)
   {
     bool result = true;
-    if (vote.type >= quorum_type::_count)
+    if (vote.type > tools::enum_top<quorum_type>)
     {
       vvc.m_invalid_vote_type = true;
       result = false;

--- a/src/quorumnet/sn_network.cpp
+++ b/src/quorumnet/sn_network.cpp
@@ -446,7 +446,7 @@ void SNNetwork::worker_thread(std::string worker_id) {
             const bool &public_cmd = cmdit->second.second;
             if (!public_cmd && !msg.sn) {
                 // If they aren't valid, tell them so that they can disconnect (and attempt to reconnect later with appropriate authentication)
-                SN_LOG(warn, worker_id << "/" << object_id << " received quorum-only command " << msg.command << " from an non-SN authenticated remote; replying with a BYE");
+                SN_LOG(warn, worker_id << "/" << object_id << " received quorum-only command " << msg.command << " from non-SN remote " << as_hex(msg.pubkey) << "; replying with a BYE");
                 send(msg.pubkey, "BYE", send_option::incoming{});
                 detail::send_control(get_control_socket(), "DISCONNECT", {{"pubkey",msg.pubkey}});
                 continue;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1354,7 +1354,7 @@ struct loki_blockchain_entry
   std::vector<cryptonote::transaction>       txs;
   uint64_t                                   block_weight;
   uint64_t                                   already_generated_coins;
-  service_nodes::service_node_list::state_t  service_node_state;
+  service_nodes::service_node_list::state_t  service_node_state{nullptr};
   bool                                       checkpointed;
   cryptonote::checkpoint_t                   checkpoint;
 };
@@ -1387,7 +1387,7 @@ struct loki_service_node_contribution
 struct loki_chain_generator
 {
   mutable std::unordered_map<crypto::public_key, crypto::secret_key>  service_node_keys_;
-  std::set<service_nodes::service_node_list::state_t>                 state_history_;
+  service_nodes::service_node_list::state_set                         state_history_;
 
   service_nodes::service_node_keys get_cached_keys(const crypto::public_key &pubkey) const;
 


### PR DESCRIPTION
Edit: see revamped version below.

~~The map was being initialized too early, from before recent state proof
data had been set, and so on startup quorumnet SN authentication was
failing to recognize incoming SN connections until a proof had been
received from the remote SN.~~

This also adds a shared mutex around the x25519 map access.