### PR TITLE
Remove set_hf_verion() from earlier rebasing to dev

### DIFF
--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1327,9 +1327,7 @@ public:
 
   bool build()
   {
-    m_tx_params.set_hf_version(m_hf_version);
     m_finished = true;
-
     std::vector<cryptonote::tx_source_entry> sources;
     std::vector<cryptonote::tx_destination_entry> destinations;
     uint64_t change_amount;


### PR DESCRIPTION
This snuck in when rebasing https://github.com/loki-project/loki/pull/918 before https://github.com/loki-project/loki/pull/939 was merged in which had the `loki_construct_tx_params` revamp.