### PR TITLE
Fix burning tx construction

### DIFF
--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1327,7 +1327,6 @@ public:
 
   bool build()
   {
-    m_tx_params.set_hf_version(m_hf_version);
     m_finished = true;
 
     std::vector<cryptonote::tx_source_entry> sources;


### PR DESCRIPTION
The intermediate temporary txes built during burned tx construction don't need (and shouldn't have) burn info at all: these txes are only fake txes constructed to properly get all fees, and get rebuilt later, where we properly handle the blink amounts.  Including the percent, in particular, caused transfer_selected_rct to raise an exception (since it doesn't have enough info to calculate a percentage).

This also fixes a bug where burned amounts were being overcalculated on multi-tx transactions because the burn amount was accumulating through the loop that applied the base burn amount.