### PR TITLE
Remove broken timing "optimization"

### DIFF
--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -43,51 +43,6 @@
 
 namespace tools
 {
-  uint64_t get_tick_count()
-  {
-#if defined(__x86_64__)
-    uint32_t hi, lo;
-    __asm__ volatile("rdtsc" : "=a"(lo), "=d"(hi));
-    return (((uint64_t)hi) << 32) | (uint64_t)lo;
-#else
-    return epee::misc_utils::get_ns_count();
-#endif
-  }
-
-#ifdef __x86_64__
-  uint64_t get_ticks_per_ns()
-  {
-    uint64_t t0 = epee::misc_utils::get_ns_count(), t1;
-    uint64_t r0 = get_tick_count();
-
-    while (1)
-    {
-      t1 = epee::misc_utils::get_ns_count();
-      if (t1 - t0 > 1*1000000000) break; // work one second
-    }
-
-    uint64_t r1 = get_tick_count();
-    uint64_t tpns256 = 256 * (r1 - r0) / (t1 - t0);
-    return tpns256 ? tpns256 : 1;
-  }
-#endif
-
-#ifdef __x86_64__
-  uint64_t ticks_per_ns = get_ticks_per_ns();
-#endif
-
-  uint64_t ticks_to_ns(uint64_t ticks)
-  {
-#if defined(__x86_64__)
-    return 256 * ticks / ticks_per_ns;
-#else
-    return ticks;
-#endif
-  }
-}
-
-namespace tools
-{
 
 el::Level performance_timer_log_level = el::Level::Info;
 
@@ -109,7 +64,7 @@ PerformanceTimer::PerformanceTimer(bool paused): started(true), paused(paused)
   if (paused)
     ticks = 0;
   else
-    ticks = get_tick_count();
+    ticks = epee::misc_utils::get_ns_count();
 }
 
 LoggingPerformanceTimer::LoggingPerformanceTimer(const std::string &s, const std::string &cat, uint64_t unit, el::Level l): PerformanceTimer(), name(s), cat(cat), unit(unit), level(l)
@@ -138,12 +93,6 @@ LoggingPerformanceTimer::LoggingPerformanceTimer(const std::string &s, const std
   performance_timers->push_back(this);
 }
 
-PerformanceTimer::~PerformanceTimer()
-{
-  if (!paused)
-    ticks = get_tick_count() - ticks;
-}
-
 LoggingPerformanceTimer::~LoggingPerformanceTimer()
 {
   pause();
@@ -152,7 +101,7 @@ LoggingPerformanceTimer::~LoggingPerformanceTimer()
   if (log)
   {
     char s[12];
-    snprintf(s, sizeof(s), "%8llu  ", (unsigned long long)(ticks_to_ns(ticks) / (1000000000 / unit)));
+    snprintf(s, sizeof(s), "%8llu  ", (unsigned long long)(ticks / (1000000000 / unit)));
     size_t size = 0; for (const auto *tmp: *performance_timers) if (!tmp->paused || tmp==this) ++size;
     PERF_LOG_ALWAYS(level, cat.c_str(), "PERF " << s << std::string(size * 2, ' ') << "  " << name);
   }
@@ -167,7 +116,7 @@ void PerformanceTimer::pause()
 {
   if (paused)
     return;
-  ticks = get_tick_count() - ticks;
+  ticks = epee::misc_utils::get_ns_count() - ticks;
   paused = true;
 }
 
@@ -175,7 +124,7 @@ void PerformanceTimer::resume()
 {
   if (!paused)
     return;
-  ticks = get_tick_count() - ticks;
+  ticks = epee::misc_utils::get_ns_count() - ticks;
   paused = false;
 }
 
@@ -184,15 +133,15 @@ void PerformanceTimer::reset()
   if (paused)
     ticks = 0;
   else
-    ticks = get_tick_count();
+    ticks = epee::misc_utils::get_ns_count();
 }
 
 uint64_t PerformanceTimer::value() const
 {
   uint64_t v = ticks;
   if (!paused)
-    v = get_tick_count() - v;
-  return ticks_to_ns(v);
+    v = epee::misc_utils::get_ns_count() - v;
+  return v;
 }
 
 }

--- a/src/common/perf_timer.h
+++ b/src/common/perf_timer.h
@@ -41,15 +41,10 @@ class PerformanceTimer;
 
 extern el::Level performance_timer_log_level;
 
-uint64_t get_tick_count();
-uint64_t get_ticks_per_ns();
-uint64_t ticks_to_ns(uint64_t ticks);
-
 class PerformanceTimer
 {
 public:
   PerformanceTimer(bool paused = false);
-  ~PerformanceTimer();
   void pause();
   void resume();
   void reset();

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1282,7 +1282,7 @@ namespace cryptonote
         {
           m_add_timer.pause();
           m_core.resume_mine();
-          if (!starting) m_last_add_end_time = tools::get_tick_count();
+          if (!starting) m_last_add_end_time = epee::misc_utils::get_ns_count();
         };
 
         while (1)
@@ -1380,8 +1380,7 @@ namespace cryptonote
             starting = false;
             if (m_last_add_end_time)
             {
-              const uint64_t tnow = tools::get_tick_count();
-              const uint64_t ns = tools::ticks_to_ns(tnow - m_last_add_end_time);
+              const uint64_t ns = epee::misc_utils::get_ns_count() - m_last_add_end_time;
               MINFO("Restarting adding block after idle for " << ns/1e9 << " seconds");
             }
           }
@@ -1972,9 +1971,8 @@ skip:
             // if this has gone on for too long, drop incoming connection to guard against some wedge state
             if (!context.m_is_income)
             {
-              const uint64_t now = tools::get_tick_count();
-              const uint64_t dt = now - m_last_add_end_time;
-              if (tools::ticks_to_ns(dt) >= DROP_ON_SYNC_WEDGE_THRESHOLD)
+              const uint64_t ns = epee::misc_utils::get_ns_count() - m_last_add_end_time;
+              if (ns >= DROP_ON_SYNC_WEDGE_THRESHOLD)
               {
                 MDEBUG(context << "Block addition seems to have wedged, dropping connection");
                 return false;


### PR DESCRIPTION
This reverts the parts of upstream commit 6cf56682bc156f66cdbb290c9494c52501e2f5df related to doing rdtsc timing on x86-64 because it is incredibly broken:

- rdtsc is not a reliable duration timer on x86-64 on all: among other problems, CPU frequencies are not even close to constant, nor are returned values reliable across threads.

- As if the unreliability wasn't bad enough, this code also spends a **full second** in a busy loop to try to measure the number of rdtsc ticks per wallclock nanosecond, and does this during static initialization.  Thus every invocation of every binary wastes a full second a CPU to calibrate some timer ratio value that isn't even remotely reliable in the first place.

The second one is particularly annoying: trying to run `--help` or invoke an rpc command adds a full second of 100% CPU usage delay.  Before this commit:

    $ time ./bin/lokid --help >/dev/null

    real    0m1.018s
    user    0m1.014s
    sys     0m0.004s

and after:

    $ time ./bin/lokid --help >/dev/null

    real    0m0.013s
    user    0m0.008s
    sys     0m0.004s