### PR TITLE
Misc changes

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -71,6 +71,8 @@ static constexpr HardFork::Params mainnet_hard_forks[] =
   { network_version_11_infinite_staking,    234767, 0, 1554170400 }, // 2019-03-26 13:00AEDT
   { network_version_12_checkpointing,       321467, 0, 1563940800 }, // 2019-07-24 14:00AEDT
   { network_version_13_enforce_checkpoints, 385824, 0, 1571850000 }, // 2019-10-23 19:00AEDT
+  // TODO: add v14 fork height; also remember to update hf_min_loki_versions in service_node_list
+  // with the final 6.1.0 release version.
 };
 
 static constexpr HardFork::Params testnet_hard_forks[] =

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2028,6 +2028,7 @@ namespace service_nodes
   };
 
   static constexpr proof_version hf_min_loki_versions[] = {
+    {cryptonote::network_version_14_blink_lns,            {6,0,0}},
     {cryptonote::network_version_13_enforce_checkpoints,  {5,1,0}},
     {cryptonote::network_version_12_checkpointing,        {4,0,3}},
   };


### PR DESCRIPTION
Two small commits I had sitting around:
1 - enforce 6.0.0 version in uptime proofs
2 - show when the first lokinet & storage server pings come in after startup, or after a proof failure due to them not pinging.