### PR TITLE
Another deadlock fix

### DIFF
--- a/src/common/lock.h
+++ b/src/common/lock.h
@@ -33,11 +33,6 @@
 
 namespace tools {
 
-template <typename... Lock, size_t... Index>
-void lock_tuple_impl(std::tuple<Lock...> &locks, std::index_sequence<Index...>) {
-    std::lock(std::get<Index>(locks)...);
-}
-
 /// Takes any number of lockable objects, locks them atomically, and returns a tuple of
 /// std::unique_lock holding the individual locks.
 template <typename... T>
@@ -45,8 +40,8 @@ template <typename... T>
 [[gnu::warn_unused_result]]
 #endif
 std::tuple<std::unique_lock<T>...> unique_locks(T& ...lockables) {
-    auto locks = std::make_tuple(std::unique_lock<T>(lockables, std::defer_lock)...);
-    lock_tuple_impl(locks, std::make_index_sequence<sizeof...(T)>{});
+    std::lock(lockables...);
+    auto locks = std::make_tuple(std::unique_lock<T>(lockables, std::adopt_lock)...);
     return locks;
 }
 

--- a/src/common/lock.h
+++ b/src/common/lock.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2019, The Loki Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <mutex>
+#include <tuple>
+
+namespace tools {
+
+template <typename... Lock, size_t... Index>
+void lock_tuple_impl(std::tuple<Lock...> &locks, std::index_sequence<Index...>) {
+    std::lock(std::get<Index>(locks)...);
+}
+
+/// Takes any number of lockable objects, locks them atomically, and returns a tuple of
+/// std::unique_lock holding the individual locks.
+template <typename... T>
+#ifdef __GNUG__
+[[gnu::warn_unused_result]]
+#endif
+std::tuple<std::unique_lock<T>...> unique_locks(T& ...lockables) {
+    auto locks = std::make_tuple(std::unique_lock<T>(lockables, std::defer_lock)...);
+    lock_tuple_impl(locks, std::make_index_sequence<sizeof...(T)>{});
+    return locks;
+}
+
+/// Shortcut around getting a std::unique_lock<T> without worrying about T.  The first argument is
+/// the mutex (or other Lockable object); it and any remaining args (such as `std::defer_lock`) are
+/// forwarded to the std::unique_lock<T> constructor.
+template <typename T, typename... Args>
+#ifdef __GNUG__
+[[gnu::warn_unused_result]]
+#endif
+std::unique_lock<T> unique_lock(T& lockable, Args&&... args) {
+    return std::unique_lock<T>(lockable, std::forward<Args>(args)...);
+}
+
+}

--- a/src/common/lock.h
+++ b/src/common/lock.h
@@ -30,6 +30,7 @@
 
 #include <mutex>
 #include <tuple>
+#include <boost/thread/lock_algorithms.hpp>
 
 namespace tools {
 
@@ -40,7 +41,7 @@ template <typename... T>
 [[gnu::warn_unused_result]]
 #endif
 std::tuple<std::unique_lock<T>...> unique_locks(T& ...lockables) {
-    std::lock(lockables...);
+    boost::lock(lockables...);
     auto locks = std::make_tuple(std::unique_lock<T>(lockables, std::adopt_lock)...);
     return locks;
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2138,7 +2138,7 @@ namespace service_nodes
         REJECT_PROOF("invalid quorumnet port in uptime proof");
     }
 
-    auto locks = tools::unique_locks(m_sn_mutex, m_x25519_map_mutex);
+    auto locks = tools::unique_locks(m_blockchain, m_sn_mutex, m_x25519_map_mutex);
     auto it = m_state.service_nodes_infos.find(proof.pubkey);
     if (it == m_state.service_nodes_infos.end())
       REJECT_PROOF("no such service node is currently registered");

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -42,6 +42,7 @@
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
 #include "common/boost_serialization_helper.h"
+#include "common/lock.h"
 #include "int-util.h"
 #include "misc_language.h"
 #include "warnings.h"
@@ -237,7 +238,7 @@ namespace cryptonote
       uint64_t *blink_rollback_height)
   {
     // this should already be called with that lock, but let's make it explicit for clarity
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
 
     PERF_TIMER(add_tx);
     if (tx.version == txversion::v0)
@@ -383,7 +384,7 @@ namespace cryptonote
         try
         {
           m_parsed_tx_cache.insert(std::make_pair(id, tx));
-          CRITICAL_REGION_LOCAL1(m_blockchain);
+          auto b_lock = tools::unique_lock(m_blockchain);
           LockedTXN lock(m_blockchain);
           m_blockchain.add_txpool_tx(id, blob, meta);
           if (!insert_key_images(tx, id, opts.kept_by_block))
@@ -427,7 +428,7 @@ namespace cryptonote
       {
         if (opts.kept_by_block)
           m_parsed_tx_cache.insert(std::make_pair(id, tx));
-        CRITICAL_REGION_LOCAL1(m_blockchain);
+        auto b_lock = tools::unique_lock(m_blockchain);
         LockedTXN lock(m_blockchain);
         m_blockchain.remove_txpool_tx(id);
         m_blockchain.add_txpool_tx(id, blob, meta);
@@ -473,7 +474,7 @@ namespace cryptonote
   bool tx_memory_pool::add_new_blink(const std::shared_ptr<blink_tx> &blink_ptr, tx_verification_context &tvc, bool &blink_exists)
   {
     assert((bool) blink_ptr);
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     auto &blink = *blink_ptr;
     auto &tx = boost::get<transaction>(blink.tx); // will throw if just a hash w/o a transaction
     auto txhash = get_transaction_hash(tx);
@@ -701,13 +702,13 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_txpool_weight() const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     return m_txpool_weight;
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::set_txpool_max_weight(size_t bytes)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     m_txpool_max_weight = bytes;
   }
   //---------------------------------------------------------------------------------
@@ -845,8 +846,8 @@ namespace cryptonote
   //       is treated properly.  Should probably not return early, however.
   bool tx_memory_pool::remove_transaction_keyimages(const transaction_prefix& tx, const crypto::hash &actual_hash)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     // ND: Speedup
     for(const txin_v& vi: tx.vin)
     {
@@ -875,8 +876,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::take_tx(const crypto::hash &id, transaction &tx, cryptonote::blobdata &txblob, size_t& tx_weight, uint64_t& fee, bool &relayed, bool &do_not_relay, bool &double_spend_seen)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     auto sorted_it = find_tx_in_sorted_container(id);
 
@@ -945,8 +945,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::remove_stuck_transactions()
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     std::list<std::pair<crypto::hash, uint64_t>> remove;
     m_blockchain.for_all_txpool_txes([this, &remove](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata*) {
       uint64_t tx_age = time(nullptr) - meta.receive_time;
@@ -1008,8 +1008,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::get_relayable_transactions(std::vector<std::pair<crypto::hash, cryptonote::blobdata>> &txs) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     const uint64_t now = time(NULL);
     txs.reserve(m_blockchain.get_txpool_tx_count());
     m_blockchain.for_all_txpool_txes([this, now, &txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *){
@@ -1062,8 +1062,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   int tx_memory_pool::set_relayable(const std::vector<crypto::hash> &tx_hashes) {
     int updated = 0;
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
     LockedTXN lock(m_blockchain);
     for (auto &tx : tx_hashes)
     {
@@ -1086,8 +1085,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::set_relayed(const std::vector<std::pair<crypto::hash, cryptonote::blobdata>> &txs)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     const time_t now = time(NULL);
     LockedTXN lock(m_blockchain);
     for (auto &tx : txs)
@@ -1113,15 +1112,14 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_transactions_count(bool include_unrelayed_txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
     return m_blockchain.get_txpool_tx_count(include_unrelayed_txes);
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::get_transactions(std::vector<transaction>& txs, bool include_unrelayed_txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     txs.reserve(m_blockchain.get_txpool_tx_count(include_unrelayed_txes));
     m_blockchain.for_all_txpool_txes([&txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *bd){
       transaction tx;
@@ -1139,8 +1137,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_hashes(std::vector<crypto::hash>& txs, bool include_unrelayed_txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     txs.reserve(m_blockchain.get_txpool_tx_count(include_unrelayed_txes));
     m_blockchain.for_all_txpool_txes([&txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *bd){
       txs.push_back(txid);
@@ -1150,8 +1148,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_backlog(std::vector<tx_backlog_entry>& backlog, bool include_unrelayed_txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     const uint64_t now = time(NULL);
     backlog.reserve(m_blockchain.get_txpool_tx_count(include_unrelayed_txes));
     m_blockchain.for_all_txpool_txes([&backlog, now](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *bd){
@@ -1162,8 +1160,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_stats(struct txpool_stats& stats, bool include_unrelayed_txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     const uint64_t now = time(NULL);
     std::map<uint64_t, txpool_histo> agebytes;
     stats.txs_total = m_blockchain.get_txpool_tx_count(include_unrelayed_txes);
@@ -1240,8 +1238,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::get_transactions_and_spent_keys_info(std::vector<tx_info>& tx_infos, std::vector<spent_key_image_info>& key_image_infos, bool include_sensitive_data) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     tx_infos.reserve(m_blockchain.get_txpool_tx_count());
     key_image_infos.reserve(m_blockchain.get_txpool_tx_count());
 
@@ -1321,8 +1319,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     tx_infos.reserve(m_blockchain.get_txpool_tx_count());
     key_image_infos.reserve(m_blockchain.get_txpool_tx_count());
     m_blockchain.for_all_txpool_txes([&tx_infos, key_image_infos](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *bd){
@@ -1368,8 +1366,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool> spent) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     spent.clear();
 
@@ -1386,8 +1383,8 @@ namespace cryptonote
     if (tx_hashes.empty())
       return 0;
     txblobs.reserve(txblobs.size() + tx_hashes.size());
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     int added = 0;
     for (auto &id : tx_hashes)
     {
@@ -1415,7 +1412,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::on_blockchain_inc(block const &blk)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     m_input_cache.clear();
     m_parsed_tx_cache.clear();
 
@@ -1494,7 +1491,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::on_blockchain_dec()
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     m_input_cache.clear();
     m_parsed_tx_cache.clear();
     return true;
@@ -1503,8 +1500,8 @@ namespace cryptonote
   std::vector<uint8_t> tx_memory_pool::have_txs(const std::vector<crypto::hash> &hashes) const
   {
     std::vector<uint8_t> result(hashes.size(), false);
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     auto &db = m_blockchain.get_db();
     for (size_t i = 0; i < hashes.size(); i++)
       result[i] = db.txpool_has_tx(hashes[i]);
@@ -1519,8 +1516,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_tx_keyimges_as_spent(const transaction& tx, std::vector<crypto::hash> *conflicting) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     bool ret = false;
     for(const auto& in: tx.vin)
     {
@@ -1539,7 +1536,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_tx_keyimg_as_spent(const crypto::key_image& key_im) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    auto lock = tools::unique_lock(m_transactions_lock);
     return m_spent_key_images.end() != m_spent_key_images.find(key_im);
   }
   //---------------------------------------------------------------------------------
@@ -1653,8 +1650,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::mark_double_spend(const transaction &tx)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     bool changed = false;
     LockedTXN lock(m_blockchain);
     for(size_t i = 0; i!= tx.vin.size(); i++)
@@ -1698,8 +1695,7 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::fill_block_template(block &bl, size_t median_weight, uint64_t already_generated_coins, size_t &total_weight, uint64_t &fee, uint64_t &expected_reward, uint8_t version, uint64_t height)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     uint64_t best_coinbase = 0, coinbase = 0;
     total_weight = 0;
@@ -1820,8 +1816,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::validate(uint8_t version)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
+
     size_t tx_weight_limit = get_transaction_weight_limit(version);
     std::unordered_set<crypto::hash> remove;
 
@@ -1884,8 +1880,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::init(size_t max_txpool_weight)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     m_txpool_max_weight = max_txpool_weight ? max_txpool_weight : DEFAULT_TXPOOL_MAX_WEIGHT;
     m_txs_by_fee_and_receive_time.clear();


### PR DESCRIPTION
#975 avoided the database deadlock but caused a mutex deadlock when receiving proofs because the added m_blockchain lock caused different paths with different lock orderings between `m_blockchain` and `m_sn_mutex`.  The second commit here (one line) fixes it; the first adds a helper to clean up code that needs to take multiple locks, and then applies it in a bunch of places where we currently take two locks sequentially.

(That bigger commit should have no significant changes.  Though it might in theory prevent a deadlock in some lock race condition because it is now taking locks with `std::lock` instead of sequentially)