### PR TITLE
Do txn handling via TXN_BLOCK_PREFIX macro

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -6025,15 +6025,16 @@ void BlockchainLMDB::set_service_node_proof(const crypto::public_key &pubkey, co
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  mdb_txn_cursors *m_cursors = &m_wcursors;
-  CURSOR(service_node_proofs);
   service_node_proof_serialized data{proof};
 
+  TXN_BLOCK_PREFIX(0);
   MDB_val k{sizeof(pubkey), (void*) &pubkey},
           v{sizeof(data), &data};
-  int result = mdb_cursor_put(m_cursors->service_node_proofs, &k, &v, 0);
+  int result = mdb_put(*txn_ptr, m_service_node_proofs, &k, &v, 0);
   if (result)
     throw0(DB_ERROR(lmdb_error("Failed to add service node latest proof data to db transaction: ", result)));
+
+  TXN_BLOCK_POSTFIX_SUCCESS();
 }
 
 std::unordered_map<crypto::public_key, service_nodes::proof_info> BlockchainLMDB::get_all_service_node_proofs() const

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2047,7 +2047,6 @@ namespace service_nodes
   {
     std::unique_lock<cryptonote::Blockchain> lock{blockchain};
     auto &db = blockchain.get_db();
-    cryptonote::db_wtxn_guard guard{db};
     db.set_service_node_proof(pubkey, *this);
   }
 


### PR DESCRIPTION
Should get rid of the warning when updating proofs when syncing.

The macro comment claims to handle the case where we can be called from either inside or outside a block batch transaction.

(I'm resyncing this from scratch right now; will confirm that everything looks good when it finished and receives some proofs).