### PR TITLE
Cleanup on block adding failure

### DIFF
--- a/src/common/loki.h
+++ b/src/common/loki.h
@@ -42,20 +42,27 @@ double      exp2            (double);
 uint64_t    clamp_u64       (uint64_t val, uint64_t min, uint64_t max);
 
 template <typename lambda_t>
-struct defer
+struct deferred
 {
+private:
   lambda_t lambda;
-  defer(lambda_t lambda) : lambda(lambda) {}
-  ~defer() { lambda(); }
+  bool cancelled = false;
+public:
+  deferred(lambda_t lambda) : lambda(lambda) {}
+  void cancel() { cancelled = true; }
+  ~deferred() { if (!cancelled) lambda(); }
 };
+
+template <typename lambda_t>
+#ifdef __GNUG__
+[[gnu::warn_unused_result]]
+#endif
+deferred<lambda_t> defer(lambda_t lambda) { return lambda; }
 
 struct defer_helper
 {
   template <typename lambda_t>
-  defer<lambda_t> operator+(lambda_t lambda)
-  {
-    return defer<lambda_t>(lambda);
-  }
+  deferred<lambda_t> operator+(lambda_t lambda) { return lambda; }
 };
 
 #define LOKI_TOKEN_COMBINE2(x, y) x ## y


### PR DESCRIPTION
If a block adding fails (triggering the "Block added hook signalled
failure" error message) the service node list doesn't get reset, which
immediately leads to a bad service node winner (because the winner was
already incremented and not popped off).

This updates it to call the blockchain detached hooks to do the cleanup.

It also changes around loki::defer a little bit to rename the internal
class to `deferred` and make it cancellable (by calling `.cancel()`).
`loki::defer` is repurposed as a free function to get a named `deferred`
object given a lambda, which is needed to be able to call `cancel()` on
it.  (The LOKI_DEFER macro still works as is with a generated name).