### PR TITLE
Wallet long polls for transactions in the pool

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -141,6 +141,18 @@ namespace crypto {
     generate_random_bytes_thread_safe(N, bytes);
   }
 
+  constexpr size_t SIZE_TS_IN_HASH = sizeof(crypto::hash) / sizeof(size_t);
+  static_assert(SIZE_TS_IN_HASH * sizeof(size_t) == sizeof(crypto::hash) && alignof(crypto::hash) >= alignof(size_t),
+      "Expected crypto::hash size/alignment not satisfied");
+
+  // Combine hashes together via XORs.
+  inline void hash_xor(crypto::hash &dest, const crypto::hash &src) {
+    size_t (&dest_)[SIZE_TS_IN_HASH] = reinterpret_cast<size_t (&)[SIZE_TS_IN_HASH]>(dest);
+    const size_t (&src_)[SIZE_TS_IN_HASH] = reinterpret_cast<const size_t (&)[SIZE_TS_IN_HASH]>(src);
+    for (size_t i = 0; i < SIZE_TS_IN_HASH; ++i)
+      dest_[i] ^= src_[i];
+  }
+
   /* Generate a value filled with random bytes.
    */
   template<typename T>

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1196,8 +1196,9 @@ namespace cryptonote
   {
     // Caller needs to do this around both this *and* parse_incoming_txs
     //auto lock = incoming_tx_lock();
-    uint8_t version = m_blockchain_storage.get_current_hard_fork_version();
-    bool ok = true;
+    uint8_t version      = m_blockchain_storage.get_current_hard_fork_version();
+    bool ok              = true;
+    bool tx_pool_changed = false;
     if (blink_rollback_height)
       *blink_rollback_height = 0;
     tx_pool_options tx_opts;
@@ -1223,7 +1224,10 @@ namespace cryptonote
         local_opts = &tx_opts;
       }
       if (m_mempool.add_tx(info.tx, info.tx_hash, *info.blob, weight, info.tvc, *local_opts, version, blink_rollback_height))
+      {
+        tx_pool_changed |= info.tvc.m_added_to_pool;
         MDEBUG("tx added: " << info.tx_hash);
+      }
       else
       {
         ok = false;
@@ -1234,6 +1238,7 @@ namespace cryptonote
       }
     }
 
+    if (tx_pool_changed) long_poll_wake_up_clients.notify_all();
     return ok;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1238,7 +1238,7 @@ namespace cryptonote
       }
     }
 
-    if (tx_pool_changed) long_poll_wake_up_clients.notify_all();
+    if (tx_pool_changed) m_long_poll_wake_up_clients.notify_all();
     return ok;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -963,7 +963,6 @@ namespace cryptonote
       */
      bool relay_txpool_transactions();
 
-     std::atomic<size_t>     m_long_poll_connections;
      std::mutex              m_long_poll_mutex;
      std::condition_variable m_long_poll_wake_up_clients;
  private:

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -963,8 +963,9 @@ namespace cryptonote
       */
      bool relay_txpool_transactions();
 
-     std::mutex              long_poll_mutex;
-     std::condition_variable long_poll_wake_up_clients;
+     std::atomic<size_t>     m_long_poll_connections;
+     std::mutex              m_long_poll_mutex;
+     std::condition_variable m_long_poll_wake_up_clients;
  private:
 
      /**

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -963,7 +963,9 @@ namespace cryptonote
       */
      bool relay_txpool_transactions();
 
-   private:
+     std::mutex              long_poll_mutex;
+     std::condition_variable long_poll_wake_up_clients;
+ private:
 
      /**
       * @copydoc Blockchain::add_new_block
@@ -1162,6 +1164,7 @@ namespace cryptonote
      bool m_pad_transactions;
 
      std::shared_ptr<tools::Notify> m_block_rate_notify;
+
    };
 }
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -545,17 +545,6 @@ namespace cryptonote
         tx_hashes.end());
   }
 
-  constexpr size_t SIZE_TS_IN_HASH = sizeof(crypto::hash) / sizeof(size_t);
-  static_assert(SIZE_TS_IN_HASH * sizeof(size_t) == sizeof(crypto::hash) && alignof(crypto::hash) >= alignof(size_t),
-      "Expected crypto::hash size/alignment not satisfied");
-
-  static void hash_xor(crypto::hash &checksum, const crypto::hash &x) {
-    size_t (&cs)[SIZE_TS_IN_HASH] = reinterpret_cast<size_t (&)[SIZE_TS_IN_HASH]>(checksum);
-    const size_t (&xs)[SIZE_TS_IN_HASH] = reinterpret_cast<const size_t (&)[SIZE_TS_IN_HASH]>(x);
-    for (size_t i = 0; i < SIZE_TS_IN_HASH; ++i)
-      cs[i] ^= xs[i];
-  }
-
   std::pair<std::vector<crypto::hash>, std::vector<uint64_t>> tx_memory_pool::get_blink_hashes_and_mined_heights() const
   {
     std::pair<std::vector<crypto::hash>, std::vector<uint64_t>> hnh;
@@ -619,7 +608,7 @@ namespace cryptonote
       if (it == result.end() || it->first != heights[i])
         result.emplace_hint(it, heights[i], hashes[i]);
       else
-        hash_xor(it->second, hashes[i]);
+        crypto::hash_xor(it->second, hashes[i]);
     }
     return result;
   }

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -72,7 +72,7 @@ public:
   void run()
   {
     MGINFO("Starting " << m_description << " RPC server...");
-    if (!m_server.run(32 /*threads*/, false /*wait - for all threads in the pool to exit when terminating*/))
+    if (!m_server.run(cryptonote::core_rpc_server::THREADS, false /*wait - for all threads in the pool to exit when terminating*/))
     {
       throw std::runtime_error("Failed to start " + m_description + " RPC server.");
     }

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -72,7 +72,7 @@ public:
   void run()
   {
     MGINFO("Starting " << m_description << " RPC server...");
-    if (!m_server.run(cryptonote::core_rpc_server::THREADS, false /*wait - for all threads in the pool to exit when terminating*/))
+    if (!m_server.run(m_server.m_max_long_poll_connections + cryptonote::core_rpc_server::DEFAULT_RPC_THREADS, false /*wait - for all threads in the pool to exit when terminating*/))
     {
       throw std::runtime_error("Failed to start " + m_description + " RPC server.");
     }

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -72,7 +72,7 @@ public:
   void run()
   {
     MGINFO("Starting " << m_description << " RPC server...");
-    if (!m_server.run(2, false))
+    if (!m_server.run(32 /*threads*/, false /*wait - for all threads in the pool to exit when terminating*/))
     {
       throw std::runtime_error("Failed to start " + m_description + " RPC server.");
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1143,9 +1143,7 @@ namespace cryptonote
         std::unique_lock<std::mutex> lock(m_core.long_poll_mutex);
         if (m_core.long_poll_wake_up_clients.wait_for(lock, tools::wallet2::rpc_long_poll_timeout) == std::cv_status::timeout)
         {
-          std::stringstream stream;
-          stream << "Long polling client timed out before " << __func__ << " txpool had an update";
-          res.status = stream.str();
+          res.status = CORE_RPC_STATUS_TX_LONG_POLL_TIMED_OUT;
           return true;
         }
       }

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -59,10 +59,7 @@ namespace cryptonote
   class core_rpc_server: public epee::http_server_impl_base<core_rpc_server>
   {
   public:
-    static constexpr size_t THREADS = 32;
-    static constexpr size_t MAX_LONG_POLL_CONNECTIONS = 30;
-    static_assert(THREADS > MAX_LONG_POLL_CONNECTIONS, "Can not have more long poll connections than threads assigned");
-
+    static constexpr int DEFAULT_RPC_THREADS = 2;
     static const command_line::arg_descriptor<bool> arg_public_node;
     static const command_line::arg_descriptor<std::string, false, true, 2> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
@@ -75,6 +72,7 @@ namespace cryptonote
     static const command_line::arg_descriptor<bool> arg_rpc_ssl_allow_any_cert;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_login;
+    static const command_line::arg_descriptor<int> arg_rpc_long_poll_connections;
 
     typedef epee::net_utils::connection_context_base connection_context;
 
@@ -326,7 +324,10 @@ namespace cryptonote
     }
 #endif
 
+    int              m_max_long_poll_connections;
 private:
+    std::atomic<int> m_long_poll_active_connections;
+
     bool check_core_busy();
     bool check_core_ready();
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -59,6 +59,9 @@ namespace cryptonote
   class core_rpc_server: public epee::http_server_impl_base<core_rpc_server>
   {
   public:
+    static constexpr size_t THREADS = 32;
+    static constexpr size_t MAX_LONG_POLL_CONNECTIONS = 30;
+    static_assert(THREADS > MAX_LONG_POLL_CONNECTIONS, "Can not have more long poll connections than threads assigned");
 
     static const command_line::arg_descriptor<bool> arg_public_node;
     static const command_line::arg_descriptor<std::string, false, true, 2> arg_rpc_bind_port;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -83,6 +83,7 @@ namespace cryptonote
 #define CORE_RPC_STATUS_OK   "OK"
 #define CORE_RPC_STATUS_BUSY   "BUSY"
 #define CORE_RPC_STATUS_NOT_MINING "NOT MINING"
+constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_TIMED_OUT[] = "Long polling client timed out before txpool had an update";
 
 // When making *any* change here, bump minor
 // If the change is incompatible, then bump major and set minor to 0

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1535,7 +1535,11 @@ namespace cryptonote
   {
     struct request_t
     {
+      bool         long_poll;        // Optional: If true, this call is blocking until timeout OR tx pool has changed since the last query. TX pool change is detected by comparing the hash of all the hashes in the tx pool.
+      crypto::hash tx_pool_checksum; // Optional: If `long_poll` is true the caller must pass the hashes of all their known tx pool hashes, XOR'ed together.
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(long_poll, false)
+        KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(tx_pool_checksum, crypto::hash{})
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8326,15 +8326,10 @@ bool simple_wallet::run()
     {
       try
       {
-        if (m_auto_refresh_enabled)
-        {
-          m_wallet->long_poll_pool_state();
+        if (m_auto_refresh_enabled && m_wallet->long_poll_pool_state())
           m_idle_cond.notify_one();
-        }
       }
-      catch (...)
-      {
-      }
+      catch (...) { }
     }
   });
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4999,7 +4999,7 @@ boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char
   // can't ask for password from a background thread
   if (!m_in_manual_refresh.load(std::memory_order_relaxed))
   {
-    message_writer(console_color_red, false) << boost::format(tr("Password needed (%s) - use the refresh command")) % reason;
+    message_writer(console_color_red, false) << boost::format(tr("Password needed %s")) % reason;
     m_cmd_binder.print_prompt();
     return boost::none;
   }
@@ -5009,7 +5009,7 @@ boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char
 #endif
   std::string msg = tr("Enter password");
   if (reason && *reason)
-    msg += std::string(" (") + reason + ")";
+    msg += reason;
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   if (!pwd_container)
   {
@@ -8320,7 +8320,23 @@ bool simple_wallet::run()
   refresh_main(0, ResetNone, true);
 
   m_auto_refresh_enabled = m_wallet->auto_refresh();
-  m_idle_thread = boost::thread([&]{wallet_idle_thread();});
+  m_idle_thread          = boost::thread([&] { wallet_idle_thread(); });
+  m_long_poll_thread     = boost::thread([&] {
+    for (;;)
+    {
+      try
+      {
+        if (m_auto_refresh_enabled)
+        {
+          m_wallet->long_poll_pool_state();
+          m_idle_cond.notify_one();
+        }
+      }
+      catch (...)
+      {
+      }
+    }
+  });
 
   message_writer(console_color_green, false) << "Background refresh thread started";
 
@@ -9349,7 +9365,6 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
 
   try
   {
-    m_wallet->update_pool_state();
     std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> pool_payments;
     m_wallet->get_unconfirmed_payments(pool_payments, m_current_subaddress_account);
     for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = pool_payments.begin(); i != pool_payments.end(); ++i) {

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -416,6 +416,7 @@ namespace cryptonote
 
     std::atomic<bool> m_idle_run;
     boost::thread m_idle_thread;
+    boost::thread m_long_poll_thread;
     boost::mutex m_idle_mutex;
     boost::condition_variable m_idle_cond;
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -426,6 +426,8 @@ namespace cryptonote
     uint32_t m_current_subaddress_account;
 
     bool m_long_payment_id_support;
+    std::atomic<uint64_t> m_password_asked_on_height;
+    crypto::hash          m_password_asked_on_checksum;
     
     // MMS
     mms::message_store& get_message_store() const { return m_wallet->get_message_store(); };

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -37,7 +37,7 @@ namespace tools
 
 static const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
 
-NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, boost::recursive_mutex &mutex)
+NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, std::recursive_mutex &mutex)
   : m_http_client(http_client)
   , m_daemon_rpc_mutex(mutex)
   , m_offline(false)
@@ -338,7 +338,7 @@ std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> NodeRPCP
     return result;
 
   {
-    boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
     if (m_all_service_nodes_cached_height != height && !update_all_service_nodes_cache(height, failed))
       return result;
 
@@ -360,7 +360,7 @@ std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry> NodeRPCP
     return result;
 
   {
-    boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
     if (m_contributed_service_nodes_cached_height != height || m_contributed_service_nodes_cached_address != contributor) {
 
       if (m_all_service_nodes_cached_height != height && !update_all_service_nodes_cache(height, failed))
@@ -399,7 +399,7 @@ std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::ent
     return result;
 
   {
-    boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
     if (m_service_node_blacklisted_key_images_cached_height != height)
     {
       cryptonote::COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::request req = {};

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <string>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 #include "include_base_utils.h"
 #include "net/http_client.h"
 #include "rpc/core_rpc_server_commands_defs.h"
@@ -40,7 +40,7 @@ namespace tools
 class NodeRPCProxy
 {
 public:
-  NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, boost::recursive_mutex &mutex);
+  NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, std::recursive_mutex &mutex);
 
   void invalidate();
   void set_offline(bool offline) { m_offline = offline; }
@@ -65,7 +65,7 @@ private:
   boost::optional<std::string> get_info() const;
 
   epee::net_utils::http::http_simple_client &m_http_client;
-  boost::recursive_mutex &m_daemon_rpc_mutex;
+  std::recursive_mutex &m_daemon_rpc_mutex;
   bool m_offline;
 
   mutable uint64_t m_service_node_blacklisted_key_images_cached_height;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2899,8 +2899,7 @@ void wallet2::update_pool_state(bool refreshed)
   std::vector<crypto::hash> tx_hashes;
   {
     std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
-    tx_hashes = std::move(m_long_poll_tx_pool_cache);
-    m_long_poll_tx_pool_cache.clear();
+    tx_hashes = m_long_poll_tx_pool_cache;
   }
 
   auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2880,16 +2880,18 @@ bool wallet2::long_poll_pool_state()
   THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_TX_LONG_POLL_TIMED_OUT &&
                             res.status != CORE_RPC_STATUS_OK, error::get_tx_pool_error, res.status);
 
-  m_long_poll_tx_pool_checksum = {};
-  for (crypto::hash const &hash : res.tx_hashes)
-    crypto::hash_xor(m_long_poll_tx_pool_checksum, hash);
-
-  {
-    std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
-    m_long_poll_tx_pool_cache = std::move(res.tx_hashes);
-  }
-
   bool result = res.status == CORE_RPC_STATUS_OK;
+  if (result)
+  {
+    m_long_poll_tx_pool_checksum = {};
+    for (crypto::hash const &hash : res.tx_hashes)
+      crypto::hash_xor(m_long_poll_tx_pool_checksum, hash);
+
+    {
+      std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
+      m_long_poll_tx_pool_cache = std::move(res.tx_hashes);
+    }
+  }
   return result;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1192,16 +1192,27 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 //----------------------------------------------------------------------------------------------------
 bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
-  boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
-
-  if(m_http_client.is_connected())
-    m_http_client.disconnect();
   m_daemon_address = std::move(daemon_address);
-  m_daemon_login = std::move(daemon_login);
+  m_daemon_login   = std::move(daemon_login);
   m_trusted_daemon = trusted_daemon;
-
   MINFO("setting daemon to " << get_daemon_address());
-  return m_http_client.set_server(get_daemon_address(), get_daemon_login(), std::move(ssl_options));
+
+  bool result = true;
+  {
+    std::lock_guard<std::recursive_mutex> daemon_mutex(m_daemon_rpc_mutex);
+    if(m_http_client.is_connected())
+      m_http_client.disconnect();
+    result &= m_http_client.set_server(get_daemon_address(), get_daemon_login(), ssl_options);
+  }
+
+  {
+    std::lock_guard<std::recursive_mutex> long_poll_mutex(m_long_poll_mutex);
+    if(m_long_poll_client.is_connected())
+      m_long_poll_client.disconnect();
+    result &= m_long_poll_client.set_server(get_daemon_address(), get_daemon_login(), std::move(ssl_options));
+  }
+
+  return result;
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, boost::asio::ip::tcp::endpoint proxy, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
@@ -1209,7 +1220,10 @@ bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::
   m_is_initialized = true;
   m_upper_transaction_weight_limit = upper_transaction_weight_limit;
   if (proxy != boost::asio::ip::tcp::endpoint{})
+  {
+    m_long_poll_client.set_connector(net::socks::connector{proxy});
     m_http_client.set_connector(net::socks::connector{std::move(proxy)});
+  }
   return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options));
 }
 //----------------------------------------------------------------------------------------------------
@@ -1622,7 +1636,14 @@ void wallet2::scan_output(const cryptonote::transaction &tx, bool miner_tx, cons
     CRITICAL_REGION_LOCAL(password_lock);
     if (!m_encrypt_keys_after_refresh)
     {
-      boost::optional<epee::wipeable_string> pwd = m_callback->on_get_password(pool ? blink ? "blink output receive in pool" : "output found in pool" : "output received");
+      char const blink_reason[] = "(blink output received in pool) - use the refresh command";
+      char const pool_reason[]  = "(output received in pool) - use the refresh, then show_transfers command";
+      char const block_reason[] = "(output received) - use the refresh command";
+
+      char const *reason = block_reason;
+      if (pool) reason = (blink) ? blink_reason : pool_reason;
+
+      boost::optional<epee::wipeable_string> pwd = m_callback->on_get_password(reason);
       THROW_WALLET_EXCEPTION_IF(!pwd, error::password_needed, tr("Password is needed to compute key image for incoming LOKI"));
       THROW_WALLET_EXCEPTION_IF(!verify_password(*pwd), error::password_needed, tr("Invalid password: password is needed to compute key image for incoming LOKI"));
       decrypt_keys(*pwd);
@@ -2842,11 +2863,40 @@ void wallet2::remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashe
     }
   }
 }
+//----------------------------------------------------------------------------------------------------
+void wallet2::long_poll_pool_state()
+{
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::request req  = {};
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::response res = {};
+  req.long_poll        = true;
+  req.tx_pool_checksum = m_long_poll_tx_pool_checksum;
+  bool r               = false;
+  {
+    std::lock_guard<decltype(m_long_poll_mutex)> lock(m_long_poll_mutex);
+    r = epee::net_utils::invoke_http_json("/get_transaction_pool_hashes.bin", req, res, m_long_poll_client, rpc_long_poll_timeout, "GET");
+  }
+  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_transaction_pool_hashes.bin");
+  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_transaction_pool_hashes.bin");
+  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_tx_pool_error);
 
+  m_long_poll_tx_pool_checksum = {};
+  for (crypto::hash const &hash : res.tx_hashes)
+    crypto::hash_xor(m_long_poll_tx_pool_checksum, hash);
+
+  {
+    std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
+    m_long_poll_tx_pool_cache = std::move(res.tx_hashes);
+  }
+}
 //----------------------------------------------------------------------------------------------------
 void wallet2::update_pool_state(bool refreshed)
 {
-  MTRACE("update_pool_state start");
+  MTRACE("update_pool_state: take hashes from cache");
+  std::vector<crypto::hash> tx_hashes;
+  {
+    std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
+    tx_hashes = std::move(m_long_poll_tx_pool_cache);
+  }
 
   auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
     if (m_encrypt_keys_after_refresh)
@@ -2856,24 +2906,13 @@ void wallet2::update_pool_state(bool refreshed)
     }
   });
 
-  // get the pool state
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::request req;
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::response res;
-  m_daemon_rpc_mutex.lock();
-  bool r = invoke_http_json("/get_transaction_pool_hashes.bin", req, res, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_transaction_pool_hashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_transaction_pool_hashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_tx_pool_error);
-  MTRACE("update_pool_state got pool");
-
   // remove any pending tx that's not in the pool
   std::unordered_map<crypto::hash, wallet2::unconfirmed_transfer_details>::iterator it = m_unconfirmed_txs.begin();
   while (it != m_unconfirmed_txs.end())
   {
     const crypto::hash &txid = it->first;
     bool found = false;
-    for (const auto &it2: res.tx_hashes)
+    for (const auto &it2: tx_hashes)
     {
       if (it2 == txid)
       {
@@ -2929,13 +2968,13 @@ void wallet2::update_pool_state(bool refreshed)
   // the in transfers list instead (or nowhere if it just
   // disappeared without being mined)
   if (refreshed)
-    remove_obsolete_pool_txs(res.tx_hashes);
+    remove_obsolete_pool_txs(tx_hashes);
 
   MTRACE("update_pool_state done second loop");
 
   // gather txids of new pool txes to us
   std::vector<std::pair<crypto::hash, bool>> txids;
-  for (const auto &txid: res.tx_hashes)
+  for (const auto &txid: tx_hashes)
   {
     bool txid_found_in_up = false;
     for (const auto &up: m_unconfirmed_payments)
@@ -3006,9 +3045,7 @@ void wallet2::update_pool_state(bool refreshed)
     MDEBUG("asking for " << txids.size() << " transactions");
     req.decode_as_json = false;
     req.prune = true;
-    m_daemon_rpc_mutex.lock();
     bool r = invoke_http_json("/gettransactions", req, res, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
     MDEBUG("Got " << r << " and " << res.status);
     if (r && res.status == CORE_RPC_STATUS_OK)
     {
@@ -5340,7 +5377,7 @@ bool wallet2::check_connection(uint32_t *version, bool *ssl, uint32_t timeout)
   }
 
   {
-    boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+    std::lock_guard <decltype(m_daemon_rpc_mutex)> lock(m_daemon_rpc_mutex);
     if(!m_http_client.is_connected(ssl))
     {
       m_node_rpc_proxy.invalidate();
@@ -5375,9 +5412,17 @@ void wallet2::set_offline(bool offline)
   m_http_client.set_auto_connect(!offline);
   if (offline)
   {
-    boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
     if(m_http_client.is_connected())
       m_http_client.disconnect();
+  }
+
+  m_long_poll_client.set_auto_connect(!offline);
+  if (offline)
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_long_poll_mutex);
+    if(m_long_poll_client.is_connected())
+      m_long_poll_client.disconnect();
   }
 }
 //----------------------------------------------------------------------------------------------------
@@ -5997,11 +6042,6 @@ void wallet2::get_transfers(get_transfers_args_t args, std::vector<transfer_view
 
   MDEBUG("Getting transfers of type(s) " << (args.in ? "in " : "") << (args.out ? "out " : "") << (args.pending ? "pending " : "") << (args.failed ? "failed " : "")
       << (args.pool ? "pool " : "") << " for heights in [" << args.min_height << "," << args.max_height << "]");
-
-  if ((args.in || args.out || args.pool) && is_connected())
-  {
-    update_pool_state();
-  }
 
   size_t size = 0;
   if (args.in)
@@ -7797,7 +7837,7 @@ bool wallet2::find_and_save_rings(bool force)
       req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txs_hashes[s]));
     bool r;
     {
-      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
+      const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex};
       r = invoke_http_json("/gettransactions", req, res, rpc_timeout);
     }
     THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
@@ -11426,7 +11466,7 @@ void wallet2::set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_
   COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
-    const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
+    const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex}; 
     r = invoke_http_json("/gettransactions", req, res, rpc_timeout);
   }
   THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
@@ -11476,7 +11516,7 @@ std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string
   COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
-    const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
+    const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex};
     r = invoke_http_json("/gettransactions", req, res, rpc_timeout);
   }
   THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
@@ -11538,7 +11578,7 @@ std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string
     COMMAND_RPC_GET_OUTPUTS_BIN::response res{};
     bool r;
     {
-      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
+      const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex}; 
       r = invoke_http_bin("/get_outs.bin", req, res, rpc_timeout);
     }
     THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_outs.bin");
@@ -11594,7 +11634,7 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
   COMMAND_RPC_GET_TRANSACTIONS::response res{};
   bool r;
   {
-    const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
+    const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex}; 
     r = invoke_http_json("/gettransactions", req, res, rpc_timeout);
   }
   THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
@@ -11667,7 +11707,7 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
     COMMAND_RPC_GET_OUTPUTS_BIN::response res{};
     bool r;
     {
-      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex}; 
+      const std::lock_guard<std::recursive_mutex> lock{m_daemon_rpc_mutex}; 
       r = invoke_http_bin("/get_outs.bin", req, res, rpc_timeout);
     }
     THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_outs.bin");
@@ -14306,11 +14346,11 @@ void wallet2::finish_rescan_bc_keep_key_images(uint64_t transfer_height, const c
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_bytes_sent() const
 {
-  return m_http_client.get_bytes_sent();
+  return m_http_client.get_bytes_sent() + m_long_poll_client.get_bytes_sent();
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_bytes_received() const
 {
-  return m_http_client.get_bytes_received();
+  return m_http_client.get_bytes_received() + m_long_poll_client.get_bytes_received();
 }
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2900,6 +2900,7 @@ void wallet2::update_pool_state(bool refreshed)
   {
     std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
     tx_hashes = std::move(m_long_poll_tx_pool_cache);
+    m_long_poll_tx_pool_cache.clear();
   }
 
   auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1343,7 +1343,10 @@ private:
 
     // This call also takes the long poll mutex and uses it's own individual
     // http client that it exclusively owns.
-    void long_poll_pool_state();
+
+    // Returns true if call succeeded, false if the long poll timed out, throws
+    // if a network error.
+    bool long_poll_pool_state();
     void update_pool_state(bool refreshed = false);
     void remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashes);
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1337,6 +1337,12 @@ private:
     bool import_key_images(signed_tx_set & signed_tx, size_t offset=0, bool only_selected_transfers=false);
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
 
+    crypto::hash get_long_poll_tx_pool_checksum() const
+    {
+      std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
+      return m_long_poll_tx_pool_checksum;
+    };
+
     // long_poll_pool_state is blocking and does NOT return to the caller until
     // the daemon detects a change in the contents of the txpool by comparing
     // our last tx pool checksum with theirs.
@@ -1674,7 +1680,7 @@ private:
 
     std::recursive_mutex                      m_long_poll_mutex;
     epee::net_utils::http::http_simple_client m_long_poll_client;
-    std::mutex                                m_long_poll_tx_pool_cache_mutex;
+    mutable std::mutex                        m_long_poll_tx_pool_cache_mutex;
     std::vector<crypto::hash>                 m_long_poll_tx_pool_cache;
     crypto::hash                              m_long_poll_tx_pool_checksum = {};
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -314,6 +314,7 @@ private:
   public:
     static constexpr uint32_t BLINK_PRIORITY = 0x626c6e6b; // "blnk"
     static constexpr const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
+    static constexpr const auto rpc_long_poll_timeout       = std::chrono::seconds(15);
 
     enum RefreshType {
       RefreshFull,
@@ -1336,6 +1337,13 @@ private:
     bool import_key_images(signed_tx_set & signed_tx, size_t offset=0, bool only_selected_transfers=false);
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
 
+    // long_poll_pool_state is blocking and does NOT return to the caller until
+    // the daemon detects a change in the contents of the txpool by comparing
+    // our last tx pool checksum with theirs.
+
+    // This call also takes the long poll mutex and uses it's own individual
+    // http client that it exclusively owns.
+    void long_poll_pool_state();
     void update_pool_state(bool refreshed = false);
     void remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashes);
 
@@ -1415,21 +1423,21 @@ private:
     inline bool invoke_http_json(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET")
     {
       if (m_offline) return false;
-      boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+      std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
       return epee::net_utils::invoke_http_json(uri, req, res, m_http_client, timeout, http_method);
     }
     template<class t_request, class t_response>
     inline bool invoke_http_bin(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET")
     {
       if (m_offline) return false;
-      boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+      std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
       return epee::net_utils::invoke_http_bin(uri, req, res, m_http_client, timeout, http_method);
     }
     template<class t_request, class t_response>
     inline bool invoke_http_json_rpc(const boost::string_ref uri, const std::string& method_name, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
     {
       if (m_offline) return false;
-      boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+      std::lock_guard<std::recursive_mutex> lock(m_daemon_rpc_mutex);
       return epee::net_utils::invoke_http_json_rpc(uri, method_name, req, res, m_http_client, timeout, http_method, req_id);
     }
 
@@ -1548,6 +1556,7 @@ private:
     void finish_rescan_bc_keep_key_images(uint64_t transfer_height, const crypto::hash &hash);
     void set_offline(bool offline = true);
 
+
   private:
     /*!
      * \brief  Stores wallet information to wallet file.
@@ -1660,6 +1669,12 @@ private:
     std::unordered_map<crypto::hash, crypto::secret_key> m_tx_keys;
     std::unordered_map<crypto::hash, std::vector<crypto::secret_key>> m_additional_tx_keys;
 
+    std::recursive_mutex                      m_long_poll_mutex;
+    epee::net_utils::http::http_simple_client m_long_poll_client;
+    std::mutex                                m_long_poll_tx_pool_cache_mutex;
+    std::vector<crypto::hash>                 m_long_poll_tx_pool_cache;
+    crypto::hash                              m_long_poll_tx_pool_checksum = {};
+
     transfer_container m_transfers;
     payment_container m_payments;
     std::unordered_map<crypto::key_image, size_t> m_key_images;
@@ -1678,7 +1693,7 @@ private:
 
     std::atomic<bool> m_run;
 
-    boost::recursive_mutex m_daemon_rpc_mutex;
+    std::recursive_mutex m_daemon_rpc_mutex;
 
     bool m_trusted_daemon;
     i_wallet2_callback* m_callback;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -416,8 +416,8 @@ namespace tools
     //----------------------------------------------------------------------------------------------------
     struct get_tx_pool_error : public refresh_error
     {
-      explicit get_tx_pool_error(std::string&& loc)
-        : refresh_error(std::move(loc), "Error getting transaction pool")
+      explicit get_tx_pool_error(std::string&& loc, const std::string &message = "")
+        : refresh_error(std::move(loc), "Error getting transaction pool " + message)
       {
       }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2403,8 +2403,6 @@ namespace tools
       }
     }
 
-    m_wallet->update_pool_state();
-
     std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> pool_payments;
     m_wallet->get_unconfirmed_payments(pool_payments, req.account_index);
     for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = pool_payments.begin(); i != pool_payments.end(); ++i) {


### PR DESCRIPTION
This will improve the detection rate of incoming transactions and consequently Blink.

- The daemon starts up with multiple number of threads that are available to process RPC requests.
- Wallets now have a long polling thread that block on a query to the transaction pool.
- The daemon keeps the connection open until the tx pools contents have changed (tx gets added to pool) and writes the response to the user
- Wallet caches this and informs the user that a tx is available in the background thread by waking up the background refresh thread.

`simplewallet -> wallet2::long_poll_pool_state() -> daemon::on_get_transaction_hashes_bin() -> wallet caches response and wakes up simple_wallet::wallet_idle_thread` 