### PR TITLE
Don't print worker_index when not an obligations vote

### DIFF
--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -436,7 +436,9 @@ namespace service_nodes
 
     result = crypto::check_signature(hash, key, vote.signature);
     if (result)
-      MDEBUG("Signature accepted for " << vote.type << " voter " << vote.index_in_group << "/" << key << " voting for worker " << vote.state_change.worker_index << " at height " << vote.block_height);
+      MDEBUG("Signature accepted for " << vote.type << " voter " << vote.index_in_group << "/" << key
+              << (vote.type == quorum_type::obligations ? " voting for worker " + std::to_string(vote.state_change.worker_index) : "")
+              << " at height " << vote.block_height);
     else
       vvc.m_signature_not_valid = true;
 


### PR DESCRIPTION
Debug logging is printing:

    Signature accepted for checkpointing voter n/<pubkey> voting  for worker NNNNN at height H

where `NNNNN` looks like some random 16-bit number.