### PR TITLE
Fix contrib/depends library incompatibilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,9 +1015,14 @@ if (LOKI_DEBUG_SHORT_PROOFS)
   add_definitions(-DUPTIME_PROOF_BASE_MINUTE=3) # 20x faster uptime proofs
 endif()
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(ZMQ REQUIRED libzmq)
-pkg_check_modules(SODIUM REQUIRED libsodium)
+if(NOT ZMQ_LIBRARIES) # may be already set (such as by contrib/depends toolchain)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(ZMQ REQUIRED libzmq)
+endif()
+if(NOT SODIUM_LIBRARIES)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SODIUM REQUIRED libsodium)
+endif()
 include_directories(${ZMQ_INCLUDE_DIRS} ${SODIUM_INCLUDE_DIRS})
 link_directories(${ZMQ_LIBRARY_DIRS} ${SODIUM_LIBRARY_DIRS})
 

--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -7,7 +7,7 @@ $(package)_patches=b3123a2fd1e77cbdceb5ee7a70e796063b5ee5b9.patch 87b81926aaaea7
 $(package)_dependencies=sodium
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared
+  $(package)_config_opts=--without-documentation --disable-shared --with-libsodium
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -38,8 +38,13 @@ SET(Protobuf_INCLUDE_DIR @prefix@/include CACHE PATH "Protobuf include dir")
 SET(Protobuf_INCLUDE_DIRS @prefix@/include CACHE PATH "Protobuf include dir")
 SET(Protobuf_LIBRARY @prefix@/lib/libprotobuf.a CACHE FILEPATH "Protobuf library")
 
-SET(ZMQ_INCLUDE_PATH @prefix@/include)
-SET(ZMQ_LIB @prefix@/lib/libzmq.a)
+SET(ZMQ_INCLUDE_DIRS @prefix@/include)
+SET(ZMQ_LIBRARIES @prefix@/lib/libzmq.a)
+SET(ZMQ_LIBRARY_DIRS @prefix@/lib)
+
+SET(SODIUM_INCLUDE_DIRS @prefix@/include)
+SET(SODIUM_LIBRARIES @prefix@/lib/libsodium.a)
+SET(SODIUM_LIBRARY_DIRS @prefix@/lib)
 
 SET(Boost_IGNORE_SYSTEM_PATH ON)
 SET(BOOST_ROOT @prefix@)

--- a/src/quorumnet/CMakeLists.txt
+++ b/src/quorumnet/CMakeLists.txt
@@ -45,4 +45,4 @@ loki_add_library(quorumnet
   ${quorumnet_sources}
   ${quorumnet_headers}
   ${quorumnet_private_headers})
-target_link_libraries(quorumnet PRIVATE ${ZMQ_LIB})
+target_link_libraries(quorumnet PRIVATE ${ZMQ_LIBRARIES})

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -139,5 +139,5 @@ target_link_libraries(daemon_rpc_server
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
-    ${ZMQ_LIB}
+    ${ZMQ_LIBRARIES}
     ${EXTRA_LIBRARIES})


### PR DESCRIPTION
sodium and zmq libs weren't using the same variable name which would end
up linking to system libsodium even when we meant to link to the static
one from contrib/depends.