### PR TITLE
Add hardfork at height 442333

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -71,8 +71,7 @@ static constexpr HardFork::Params mainnet_hard_forks[] =
   { network_version_11_infinite_staking,    234767, 0, 1554170400 }, // 2019-03-26 13:00AEDT
   { network_version_12_checkpointing,       321467, 0, 1563940800 }, // 2019-07-24 14:00AEDT
   { network_version_13_enforce_checkpoints, 385824, 0, 1571850000 }, // 2019-10-23 19:00AEDT
-  // TODO: add v14 fork height; also remember to update hf_min_loki_versions in service_node_list
-  // with the final 6.1.0 release version.
+  { network_version_14_blink_lns,           442333, 0, 1578528000 }, // 2020-01-09 00:00UTC
 };
 
 static constexpr HardFork::Params testnet_hard_forks[] =

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2029,7 +2029,7 @@ namespace service_nodes
   };
 
   static constexpr proof_version hf_min_loki_versions[] = {
-    {cryptonote::network_version_14_blink_lns,            {6,0,0}},
+    {cryptonote::network_version_14_blink_lns,            {6,1,0}},
     {cryptonote::network_version_13_enforce_checkpoints,  {5,1,0}},
     {cryptonote::network_version_12_checkpointing,        {4,0,3}},
   };

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -110,8 +110,8 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION{{1, 0, 7}};
-  constexpr std::array<int, 3> MIN_LOKINET_VERSION{{0, 6, 0}};
+  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION{{1, 0, 9}};
+  constexpr std::array<int, 3> MIN_LOKINET_VERSION{{0, 6, 1}};
 
   using swarm_id_t                         = uint64_t;
   constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;


### PR DESCRIPTION
Estimated time: Thu Jan  9 00:00:00 2020 UTC

Also updates the minimum required peer, storage server, and lokinet version numbers to release versions.