### PR TITLE
Blink test fix

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1121,7 +1121,7 @@ namespace cryptonote
         if (parsed_txs[i].tvc.m_should_be_relayed)
           newtxs.push_back(std::move(arg.txs[i]));
 
-        if (parsed_txs[i].tvc.m_added_to_pool)
+        if (parsed_txs[i].tvc.m_added_to_pool || parsed_txs[i].already_have)
           unknown_txs.erase(parsed_txs[i].tx_hash);
       }
       arg.txs = std::move(newtxs);

--- a/tests/network_tests/daemons.py
+++ b/tests/network_tests/daemons.py
@@ -217,9 +217,9 @@ class Daemon(RPCDaemon):
     def ping(self, *, storage=True, lokinet=True):
         """Sends fake storage server and lokinet pings to the running lokid"""
         if storage:
-            self.json_rpc("storage_server_ping", { "version_major": 1, "version_minor": 0, "version_patch": 9 })
+            self.json_rpc("storage_server_ping", { "version_major": 9, "version_minor": 9, "version_patch": 9 })
         if lokinet:
-            self.json_rpc("lokinet_ping", { "version": [0,6,0] })
+            self.json_rpc("lokinet_ping", { "version": [9,9,9] })
 
 
     def p2p_resync(self):


### PR DESCRIPTION
Fix a bug caused by the lokinet required version bump, and fix a weird edge case that the test code sometimes triggers where a blink signature doesn't get added to a syncing node if the blink tx was somehow already known without the blink signature.