### PR TITLE
Regenerate the checkpoint table in lmdb

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -427,6 +427,7 @@ private:
   void migrate_3_4();
   void migrate_4_5(cryptonote::network_type nettype);
   void migrate_5_6();
+  void migrate_6_7();
 
   void cleanup_batch();
 


### PR DESCRIPTION
Updating the checkpoint table in place, something must have been done
incorrectly or some bug, such that querying MDB_LAST on the checkpoint
table returns not the latest expected checkpoint.

Pulling out all the old checkpoints, generating a new table and
reinserting them resolves this.

Also removes txn argument from write_db_version, txn.commit() actually nullptrs the txn ptr, and in the function itself you regenerate the TXN using mdb_txn_begin so the argument is useless.