### PR TITLE
Allow converting to blink priority from mobile wallets

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -33,8 +33,6 @@
 #include <stdexcept>
 #include <string>
 #include <boost/uuid/uuid.hpp>
-#include <stdexcept>
-#include <chrono>
 
 #define CRYPTONOTE_DNS_TIMEOUT_MS                       20000
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -33,10 +33,8 @@
 
 #include <string>
 #include <vector>
-#include <list>
 #include <set>
 #include <ctime>
-#include <iostream>
 #include <stdexcept>
 
 //  Public interface for libwallet library
@@ -82,6 +80,7 @@ struct PendingTransaction
         Priority_Low = 1,
         Priority_Medium = 2,
         Priority_High = 3,
+        Priority_Blink = 0x626c6e6b,
         Priority_Last
     };
 


### PR DESCRIPTION
Mobile wallets pass the blink priority which gets static_cast<..>()-ed into the PendingTransactions Priority enum.