### PR TITLE
Android patches, add blink param for sending blobs on mobile

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -180,9 +180,9 @@ namespace cryptonote
     return true;
   }
 
-  // NOTE: Compiling with a minimum Mac OSX API of 10.13 and generating
-  // a binary_archive with a one_shot_read_buffer, causes the following snippet
-  // to fail
+  // NOTE: Compiling with a libc++ (Mac OSX 10.13, our Android NDK version) and
+  // generating a binary_archive with a one_shot_read_buffer, causes the
+  // following snippet to fail
 
 #if 0
   explicit binary_archive(stream_type &s) : base_type(s) {
@@ -199,11 +199,9 @@ namespace cryptonote
 
   // A seekg followed by a tellg returns 0, no state flags are set on the io
   // stream. So use the old method that copies the blob into a stringstream
-  // instead for APPLE targets.
-  
-  // 2020-01-08, doyle
+  // 2020-01-15, doyle
 
-#if defined __APPLE__
+#if defined(_LIBCPP_VERSION)
   #define BINARY_ARCHIVE_STREAM(stream_name, blob) \
     std::stringstream stream_name; \
     stream_name.write(reinterpret_cast<const char *>(blob.data()), blob.size())

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -77,7 +77,7 @@ std::vector<std::string> PendingTransactionImpl::txid() const
     return txid;
 }
 
-bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
+bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite, bool blink)
 {
 
     LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
@@ -128,7 +128,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
 
         while (!m_pending_tx.empty()) {
             auto & ptx = m_pending_tx.back();
-            m_wallet.m_wallet->commit_tx(ptx);
+            m_wallet.m_wallet->commit_tx(ptx, blink);
             // if no exception, remove element from vector
             m_pending_tx.pop_back();
         } // TODO: extract method;

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -45,7 +45,7 @@ public:
     ~PendingTransactionImpl();
     int status() const override;
     std::string errorString() const override;
-    bool commit(const std::string &filename = "", bool overwrite = false) override;
+    bool commit(const std::string &filename = "", bool overwrite = false, bool blink = false) override;
     uint64_t amount() const override;
     uint64_t dust() const override;
     uint64_t fee() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -89,7 +89,7 @@ struct PendingTransaction
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
     // commit transaction or save to file if filename is provided.
-    virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
+    virtual bool commit(const std::string &filename = "", bool overwrite = false, bool blink = false) = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t dust() const = 0;
     virtual uint64_t fee() const = 0;


### PR DESCRIPTION
```
This is possibly due to Android using an old NDK which is buggy in
similar vein to Mac OSX 10.13 being buggy when trying to implement
tools::one_shot_read_buffer
```