### PR TITLE
Set blink priority to 5

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -958,7 +958,7 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
   auto hf_version = m_wallet->get_hard_fork_version();
   if (hf_version && *hf_version >= HF_VERSION_BLINK)
   {
-    uint64_t pct = m_wallet->get_fee_percent(tools::wallet2::BLINK_PRIORITY);
+    uint64_t pct = m_wallet->get_fee_percent(tools::tx_priority_blink);
     uint64_t fixed = BLINK_BURN_FIXED;
 
     uint64_t typical_blink_fee = (base_fee.first * typical_size + base_fee.second * typical_outs) * pct / 100 + fixed;
@@ -5712,7 +5712,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
   uint64_t locked_blocks = 0;
   if (transfer_type == Transfer::Locked)
   {
-    if (priority == tools::wallet2::BLINK_PRIORITY)
+    if (priority == tools::tx_priority_blink)
     {
       fail_msg_writer() << tr("blink priority cannot be used for locked transfers");
       return false;
@@ -5866,7 +5866,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     }
 
     // if we need to check for backlog, check the worst case tx
-    if (m_wallet->confirm_backlog() && priority != tools::wallet2::BLINK_PRIORITY)
+    if (m_wallet->confirm_backlog() && priority != tools::tx_priority_blink)
     {
       std::stringstream prompt;
       double worst_fee_per_byte = std::numeric_limits<double>::max();
@@ -6034,7 +6034,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
           return false;
         }
 
-        commit_or_save(signed_tx.ptx, m_do_not_relay, priority == tools::wallet2::BLINK_PRIORITY);
+        commit_or_save(signed_tx.ptx, m_do_not_relay, priority == tools::tx_priority_blink);
       }
       catch (const std::exception& e)
       {
@@ -6063,7 +6063,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     }
     else
     {
-      commit_or_save(ptx_vector, m_do_not_relay, priority == tools::wallet2::BLINK_PRIORITY);
+      commit_or_save(ptx_vector, m_do_not_relay, priority == tools::tx_priority_blink);
     }
   }
   catch (const std::exception &e)
@@ -6771,7 +6771,7 @@ bool simple_wallet::sweep_main(uint64_t below, Transfer transfer_type, const std
   priority = m_wallet->adjust_priority(priority);
   uint64_t unlock_block = 0;
   if (transfer_type == Transfer::Locked) {
-    if (priority == tools::wallet2::BLINK_PRIORITY) {
+    if (priority == tools::tx_priority_blink) {
       fail_msg_writer() << tr("blink priority cannot be used for locked transfers");
       return false;
     }
@@ -6900,7 +6900,7 @@ bool simple_wallet::sweep_main(uint64_t below, Transfer transfer_type, const std
   try
   {
     auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices);
-    sweep_main_internal(sweep_type_t::all_or_below, ptx_vector, info, priority == tools::wallet2::BLINK_PRIORITY);
+    sweep_main_internal(sweep_type_t::all_or_below, ptx_vector, info, priority == tools::tx_priority_blink);
   }
   catch (const std::exception &e)
   {
@@ -7035,7 +7035,7 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   {
     // figure out what tx will be necessary
     auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, CRYPTONOTE_DEFAULT_TX_MIXIN, 0 /* unlock_time */, priority, extra);
-    sweep_main_internal(sweep_type_t::single, ptx_vector, info, priority == tools::wallet2::BLINK_PRIORITY);
+    sweep_main_internal(sweep_type_t::single, ptx_vector, info, priority == tools::tx_priority_blink);
   }
   catch (const std::exception& e)
   {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -43,8 +43,6 @@
 #include "common_defines.h"
 #include "common/util.h"
 
-#include "cryptonote_core/service_node_rules.h"
-
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
 #include <boost/format.hpp>
@@ -1423,7 +1421,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
 //    - confirmed_transfer_details)
 
 PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const string &payment_id, optional<uint64_t> amount, uint32_t mixin_count,
-                                                  PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+                                                  uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
     clearStatus();
@@ -1438,8 +1436,7 @@ PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const 
     if (fake_outs_count == 0)
         fake_outs_count = DEFAULT_MIXIN;
     fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
-
-    uint32_t adjusted_priority = m_wallet->adjust_priority(static_cast<uint32_t>(priority));
+    uint32_t adjusted_priority = m_wallet->adjust_priority(priority);
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -153,7 +153,7 @@ public:
 
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                         optional<uint64_t> amount, uint32_t mixin_count,
-                                        PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
+                                        uint32_t priority = 0,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;
     virtual PendingTransaction * createSweepUnmixableTransaction() override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -77,14 +77,6 @@ struct PendingTransaction
         Status_Critical
     };
 
-    enum Priority {
-        Priority_Default = 0,
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
-        Priority_Last
-    };
-
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
@@ -824,16 +816,18 @@ struct Wallet
      * \param mixin_count       mixin count. if 0 passed, wallet will use default value
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, blink.
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
 
-    virtual PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
-                                                   optional<uint64_t> amount, uint32_t mixin_count,
-                                                   PendingTransaction::Priority = PendingTransaction::Priority_Low,
-                                                   uint32_t subaddr_account = 0,
-                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
+    virtual PendingTransaction *createTransaction(const std::string &dst_addr,
+                                                  const std::string &payment_id,
+                                                  optional<uint64_t> amount,
+                                                  uint32_t mixin_count,
+                                                  uint32_t priority                  = 0,
+                                                  uint32_t subaddr_account           = 0,
+                                                  std::set<uint32_t> subaddr_indices = {}) = 0;
 
     /*!
      * \brief createSweepUnmixableTransaction creates transaction with unmixable outputs.
@@ -1256,7 +1250,6 @@ struct WalletManagerBase
     //! checks for an update and returns version, hash and url
     static std::tuple<bool, std::string, std::string, std::string, std::string> checkUpdates(const std::string &software, std::string subdir);
 };
-
 
 struct WalletManagerFactory
 {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -303,6 +303,16 @@ private:
     END_KV_SERIALIZE_MAP()
   };
 
+  enum tx_priority
+  {
+    tx_priority_default     = 0,
+    tx_priority_unimportant = 1,
+    tx_priority_normal      = 2,
+    tx_priority_elevated    = 3,
+    tx_priority_priority    = 4,
+    tx_priority_blink       = 5,
+    tx_priority_last
+  };
 
   class wallet_keys_unlocker;
   class wallet2
@@ -312,9 +322,7 @@ private:
     friend class wallet_keys_unlocker;
     friend class wallet_device_callback;
   public:
-    static constexpr uint32_t BLINK_PRIORITY = 0x626c6e6b; // "blnk"
     static constexpr const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
-
     enum RefreshType {
       RefreshFull,
       RefreshOptimizeCoinbase,
@@ -1377,7 +1385,7 @@ private:
     cryptonote::byte_and_output_fees get_base_fees() const;
     uint64_t get_fee_quantization_mask() const;
     uint64_t adjust_mixin(uint64_t mixin) const;
-    uint32_t adjust_priority(uint32_t priority, bool blink = false);
+    uint32_t adjust_priority(uint32_t priority);
 
     // Shortcut to set up construction parameters; the returned object is default constructed unless
     // priority is blink in which case the burn values are set appropriately.

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -860,7 +860,8 @@ namespace tools
     try
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      uint32_t priority = m_wallet->adjust_priority(req.priority, req.blink);
+      uint32_t priority = m_wallet->adjust_priority(req.priority);
+      if (req.blink) priority = tools::tx_priority_blink;
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
 
       if (ptx_vector.empty())
@@ -912,7 +913,8 @@ namespace tools
     try
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      uint32_t priority = m_wallet->adjust_priority(req.priority, req.blink);
+      uint32_t priority = m_wallet->adjust_priority(req.priority);
+      if (req.blink) priority = tools::tx_priority_blink;
       LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
       LOG_PRINT_L2("on_transfer_split called create_transactions_2");
@@ -1322,7 +1324,8 @@ namespace tools
     try
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      uint32_t priority = m_wallet->adjust_priority(req.priority, req.blink);
+      uint32_t priority = m_wallet->adjust_priority(req.priority);
+      if (req.blink) priority = tools::tx_priority_blink;
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
 
       return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, req.blink,
@@ -1377,7 +1380,8 @@ namespace tools
     try
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      uint32_t priority = m_wallet->adjust_priority(req.priority, req.blink);
+      uint32_t priority = m_wallet->adjust_priority(req.priority);
+      if (req.blink) priority = tools::tx_priority_blink;
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra);
 
       if (ptx_vector.empty())

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -480,8 +480,8 @@ namespace wallet_rpc
       std::list<transfer_destination> destinations; // Array of destinations to receive LOKI.
       uint32_t account_index;                       // (Optional) Transfer from this account index. (Defaults to 0)
       std::set<uint32_t> subaddr_indices;           // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
-      uint32_t priority;                            // Set a priority for the transaction. Accepted Values are: default (1), or 0-3 for: unimportant, normal, elevated, priority.
-      bool blink;                                   // Specifies that the tx should be blinked (`priority` will be ignored).
+      uint32_t priority;                            // Set a priority for the transaction. Accepted values are: or 0-5 for: default, unimportant, normal, elevated, priority, blink.
+      bool blink;                                   // (Deprecated) Set priority to 5 for blink, field is deprecated: specifies that the tx should be blinked (`priority` will be ignored).
       uint64_t ring_size;                           // (Deprecated) Set to 10. Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
       uint64_t unlock_time;                         // Number of blocks before the loki can be spent (0 to use the default lock time).
       std::string payment_id;                       // (Optional) Random 64-character hex string to identify a transaction.
@@ -541,9 +541,9 @@ namespace wallet_rpc
       std::list<transfer_destination> destinations; // Array of destinations to receive LOKI:
       uint32_t account_index;                       // (Optional) Transfer from this account index. (Defaults to 0)
       std::set<uint32_t> subaddr_indices;           // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
-      uint32_t priority;                            // Set a priority for the transactions. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
-      bool blink;                                   // Specifies that the tx should be blinked (`priority` will be ignored).
-      uint64_t ring_size;                           // (Ignored) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
+      uint32_t priority;                            // Set a priority for the transaction. Accepted values are: or 0-5 for: default, unimportant, normal, elevated, priority, blink.
+      bool blink;                                   // (Deprecated) Set priority to 5 for blink, field is deprecated: specifies that the tx should be blinked (`priority` will be ignored).
+      uint64_t ring_size;                           // (Deprecated) Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
       uint64_t unlock_time;                         // Number of blocks before the loki can be spent (0 to not add a lock).
       std::string payment_id;                       // (Optional) Random 32-byte/64-character hex string to identify a transaction.
       bool get_tx_keys;                             // (Optional) Return the transaction keys after sending.
@@ -791,8 +791,8 @@ namespace wallet_rpc
       std::string address;                // Destination public address.
       uint32_t account_index;             // Sweep transactions from this account.
       std::set<uint32_t> subaddr_indices; // (Optional) Sweep from this set of subaddresses in the account.
-      uint32_t priority;                  // (Optional) Priority for sending the sweep transfer, partially determines fee. 
-      bool blink;                         // Specifies that the tx should be blinked (`priority` will be ignored).
+      uint32_t priority;                  // Set a priority for the transaction. Accepted values are: or 0-5 for: default, unimportant, normal, elevated, priority, blink.
+      bool blink;                         // (Deprecated) Set priority to 5 for blink, field is deprecated: specifies that the tx should be blinked (`priority` will be ignored).
       uint64_t ring_size;                 // (Deprecated) Set to 10. Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
       uint64_t outputs;                   // 
       uint64_t unlock_time;               // Number of blocks before the loki can be spent (0 to not add a lock). 
@@ -863,8 +863,8 @@ namespace wallet_rpc
     struct request_t
     {
       std::string address;    // Destination public address.
-      uint32_t priority;      // (Optional) Priority for sending the sweep transfer, partially determines fee.
-      bool blink;             // Specifies that the tx should be blinked (`priority` will be ignored).
+      uint32_t priority;      // Set a priority for the transaction. Accepted values are: or 0-5 for: default, unimportant, normal, elevated, priority, blink.
+      bool blink;             // (Deprecated) Set priority to 5 for blink, field is deprecated: specifies that the tx should be blinked (`priority` will be ignored).
       uint64_t ring_size;     // (Deprecated) Set to 10. Sets ringsize to n (mixin + 1). Loki ring_size is statically set to 10.
       uint64_t outputs;       // 
       uint64_t unlock_time;   // Number of blocks before the loki can be spent (0 to not add a lock).
@@ -924,7 +924,7 @@ namespace wallet_rpc
     struct request_t
     {
       std::string hex; // Transaction metadata returned from a transfer method with get_tx_metadata set to true.
-      bool blink;      // True if this tx was constructed and should be submitted to the blink quorum
+      bool blink;      // (Optional): True if this tx was constructed with a blink priority and should be submitted to the blink quorum
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(hex)
@@ -2599,7 +2599,7 @@ namespace wallet_rpc
       uint64_t           amount;           // Amount of Loki to stake in atomic units.
       std::set<uint32_t> subaddr_indices;  // (Optional) Transfer from this set of subaddresses. (Defaults to 0)
       std::string        service_node_key; // Service Node Public Address.
-      uint32_t           priority;         // Set a priority for the transaction. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
+      uint32_t           priority;         // Set a priority for the transaction. Accepted values are: or 0-4 for: default, unimportant, normal, elevated, priority.
       bool               get_tx_key;       // (Optional) Return the transaction key after sending.
       bool               do_not_relay;     // (Optional) If true, the newly created transaction will not be relayed to the loki network. (Defaults to false)
       bool               get_tx_hex;       // Return the transaction as hex string after sending (Defaults to false)


### PR DESCRIPTION
Make blink priority uniform across wallet2, mobile wallet API and RPC.

Add a macro to deprecate some RPC fields once we hit v7.1.0