### PR TITLE
wallet: don't use pool tx list from long polling

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1346,9 +1346,9 @@ private:
 
     crypto::hash get_long_poll_tx_pool_checksum() const
     {
-      std::lock_guard<decltype(m_long_poll_tx_pool_cache_mutex)> lock(m_long_poll_tx_pool_cache_mutex);
+      std::lock_guard<decltype(m_long_poll_tx_pool_checksum_mutex)> lock(m_long_poll_tx_pool_checksum_mutex);
       return m_long_poll_tx_pool_checksum;
-    };
+    }
 
     // long_poll_pool_state is blocking and does NOT return to the caller until
     // the daemon detects a change in the contents of the txpool by comparing
@@ -1688,8 +1688,7 @@ private:
 
     std::recursive_mutex                      m_long_poll_mutex;
     epee::net_utils::http::http_simple_client m_long_poll_client;
-    mutable std::mutex                        m_long_poll_tx_pool_cache_mutex;
-    std::vector<crypto::hash>                 m_long_poll_tx_pool_cache;
+    mutable std::mutex                        m_long_poll_tx_pool_checksum_mutex;
     crypto::hash                              m_long_poll_tx_pool_checksum = {};
     epee::net_utils::ssl_options_t            m_long_poll_ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
 

--- a/tests/network_tests/daemons.py
+++ b/tests/network_tests/daemons.py
@@ -229,7 +229,8 @@ class Daemon(RPCDaemon):
 
 
 class Wallet(RPCDaemon):
-    base_args = ('--disable-rpc-login', '--non-interactive', '--password','', '--regtest', '--rpc-ssl=disabled', '--daemon-ssl=disabled')
+    base_args = ('--disable-rpc-login', '--non-interactive', '--password','', '--regtest', '--disable-rpc-long-poll',
+                 '--rpc-ssl=disabled', '--daemon-ssl=disabled')
 
     def __init__(
             self,


### PR DESCRIPTION
This fixes two issues: first when running with --disable-rpc-long-poll the long poll isn't present, so the list of pool txes will always be empty, which means unconfirmed_txs will get cleared on refresh because they don't appear to be in the node's pool.  This makes us likely to wind up with double spending failures on subsequent txes since we don't know about the outgoing unconfirmed_tx anymore.

Secondly, it seems like there's a potential race condition here even when long polling is enabled that can cause the same failure depending on the timing of polling in the long poll thread (for example, if it hits the 30s cooldown from a MAX_CONNECTIONS response), so just fixing this for the no-long-polling case doesn't seem sufficient.

The previous (< v6.1.1) code didn't have this issue because the tx construction and refreshing new pool data were synchronous.  (There is a potential race condition if refresh requests span the node finding a new block between the block refresh and the pool tx refresh, but that's already handled in the code by requiring two refreshes before setting it as unspent).

This reverts the old synchronous fetch-pool-txes behaviour on refresh so that there is no window of opportunity with long polling for us to prematurely treat unconfirmed_txs as failed/unspent.