### PR TITLE
Blink lock fixes

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1687,20 +1687,10 @@ namespace cryptonote
 
     if (!p2p_votes.empty())
     {
-      if (hf_version >= cryptonote::network_version_14_blink_lns)
-      {
-        NOTIFY_NEW_SERVICE_NODE_VOTE::request req{};
-        req.votes = std::move(p2p_votes);
-        cryptonote_connection_context fake_context{};
-        get_protocol()->relay_service_node_votes(req, fake_context);
-      }
-      else
-      {
-        NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request req{};
-        req.votes = std::move(p2p_votes);
-        cryptonote_connection_context fake_context{};
-        get_protocol()->relay_service_node_votes(req, fake_context);
-      }
+      NOTIFY_NEW_SERVICE_NODE_VOTE::request req{};
+      req.votes = std::move(p2p_votes);
+      cryptonote_connection_context fake_context{};
+      get_protocol()->relay_service_node_votes(req, fake_context);
     }
 
     return true;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1305,7 +1305,7 @@ namespace cryptonote
       auto mempool_lock = m_mempool.blink_shared_lock();
       for (size_t i = 0; i < blinks.size(); i++)
       {
-        if (want[i] && m_mempool.has_blink(blinks[i].tx_hash, true /*have lock*/))
+        if (want[i] && m_mempool.has_blink(blinks[i].tx_hash))
         {
           MDEBUG("Ignoring blink data for " << blinks[i].tx_hash << ": already have blink signatures");
           want[i] = false; // Already have it, move along
@@ -1402,7 +1402,7 @@ namespace cryptonote
 
     for (auto &b : blinks)
       if (b->approved())
-        if (m_mempool.add_existing_blink(b, true /*have lock*/))
+        if (m_mempool.add_existing_blink(b))
           added++;
 
     MINFO("Added blink signatures for " << added << " blinks");

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -157,6 +157,8 @@ namespace cryptonote
     /**
      * @brief attempts to add a blink transaction to the transaction pool.
      *
+     * This method must be called without a held blink lock.
+     *
      * This is only for use for new transactions that should not exist yet on the chain or mempool
      * (and will fail if already does).  See `add_existing_blink` instead to add blink data about a
      * transaction that already exists.  This is only meant to be called during the SN blink signing
@@ -184,6 +186,8 @@ namespace cryptonote
     /**
      * @brief attempts to add blink transaction information about an existing blink transaction
      *
+     * You *must* already hold a blink_unique_lock().
+     *
      * This method takes an approved blink_tx and records it in the known blinks data.  No check is
      * done that the transaction actually exists on the blockchain or mempool.  It is assumed that
      * the given shared_ptr is a new blink that is not yet shared between threads (and thus doesn't
@@ -193,32 +197,33 @@ namespace cryptonote
      * *not* check it (except as an assert when compiling in debug mode).
      *
      * @param blink the blink_tx shared_ptr
-     * @param have_lock can be specified as true to avoid taking out a unique lock on the blinks
-     * data structure; it should only be specified if a unique lock on the blink data is already
-     * held externally, i.e. by obtaining a lock with `blink_unique_lock`.
      *
      * @return true if the blink data was recorded, false if the given blink was already known.
      */
-    bool add_existing_blink(std::shared_ptr<blink_tx> blink, bool have_lock = false);
+    bool add_existing_blink(std::shared_ptr<blink_tx> blink);
 
     /**
      * @brief accesses blink tx details if the given tx hash is a known, approved blink tx, nullptr
      * otherwise.
      *
+     * You *must* already hold a blink_shared_lock() or blink_unique_lock().
+     *
      * @param tx_hash the hash of the tx to access
-     * @param have_lock can be specified as true to avoid taking out a shared lock; it should only
-     * be specified if a shared lock on the blink data is already held externally.
      */
-    std::shared_ptr<blink_tx> get_blink(const crypto::hash &tx_hash, bool have_lock = false) const;
+    std::shared_ptr<blink_tx> get_blink(const crypto::hash &tx_hash) const;
 
     /**
      * Equivalent to `(bool) get_blink(...)`, but slightly more efficient when the blink information
      * isn't actually needed beyond an existance test (as it avoids copying the shared_ptr).
+     *
+     * You *must* already hold a blink_shared_lock() or blink_unique_lock().
      */
-    bool has_blink(const crypto::hash &tx_hash, bool have_lock = false) const;
+    bool has_blink(const crypto::hash &tx_hash) const;
 
     /**
      * @brief modifies a vector of tx hashes to remove any that have known valid blink signatures
+     *
+     * Must not currently hold a blink lock.
      *
      * @param txs the tx hashes to check
      */
@@ -226,6 +231,8 @@ namespace cryptonote
 
     /**
      * @brief returns checksums of blink txes included in recently mined blocks and in the mempool
+     *
+     * Must not currently hold a blink lock.
      *
      * The returned map consists of height => hashsum pairs where the height is the height in which
      * the blink transactions were mined and the hashsum is a checksum of all the blink txes mined
@@ -238,6 +245,8 @@ namespace cryptonote
     /**
      * @brief returns the hashes of any non-immutable blink transactions mined in the given heights.
      * A height of 0 is allowed: it indicates blinks in the mempool.
+     *
+     * Must not currently hold a blink lock.
      *
      * Note that this returned hashes by MINED HEIGHTS, not BLINK HEIGHTS where are a different
      * concept.
@@ -694,6 +703,8 @@ namespace cryptonote
      * rollback is needed for the blink tx.  (That is, all blocks with height >=
      * blink_rollback_height need to be popped).
      *
+     * This method is *not* called with a blink lock held.
+     *
      * @return true if the conflicting transactions have been removed (and/or the rollback height
      * set), false if tx removal and/or rollback are insufficient to eliminate conflicting txes.
      */
@@ -759,7 +770,7 @@ namespace cryptonote
 
     // Helper method: retrieves hashes and mined heights of blink txes since the immutable block;
     // mempool blinks are included with a height of 0.  Also takes care of cleaning up any blinks
-    // that have become immutable.
+    // that have become immutable.  Blink lock must not be already held.
     std::pair<std::vector<crypto::hash>, std::vector<uint64_t>> get_blink_hashes_and_mined_heights() const;
   };
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -350,46 +350,6 @@ namespace cryptonote
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
-  // TODO(loki) - remove this after HF14
-  struct NOTIFY_NEW_SERVICE_NODE_VOTE_OLD
-  {
-  private:
-    struct alignas(8) blob { unsigned char data[120]; };
-  public:
-    const static int ID = BC_COMMANDS_POOL_BASE + 12;
-    struct request
-    {
-      std::vector<service_nodes::quorum_vote_t> votes;
-
-      BEGIN_KV_SERIALIZE_MAP()
-        auto &votes = this_ref.votes;
-
-        std::vector<blob> vote_blobs;
-        if (is_store) // means: "serializing".  Hate epee 2x: this is both badly named, and gross template parameter misuse.
-        {
-          vote_blobs.resize(votes.size());
-          for (size_t i = 0; i < votes.size(); i++)
-            vote_to_blob(votes[i], vote_blobs[i].data);
-        }
-        // Hate epee some more: this time for deficient serialization macros:
-        //KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(vote_blobs, "votes");
-        epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(vote_blobs, stg, hparent_section, "votes");
-        if (!is_store)
-        {
-          // Hate epee even more:
-          auto &v = const_cast<std::vector<service_nodes::quorum_vote_t>&>(votes);
-          v.resize(vote_blobs.size());
-          for (size_t i = 0; i < v.size(); i++)
-            blob_to_vote(vote_blobs[i].data, v[i]);
-        }
-      END_KV_SERIALIZE_MAP()
-    };
-  };
-
-
-  /************************************************************************/
-  /*                                                                      */
-  /************************************************************************/
   struct NOTIFY_REQUEST_BLOCK_BLINKS
   {
     constexpr static int ID = BC_COMMANDS_POOL_BASE + 13;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -81,7 +81,6 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)
       HANDLE_NOTIFY_T2(NOTIFY_UPTIME_PROOF, &cryptonote_protocol_handler::handle_uptime_proof)
       HANDLE_NOTIFY_T2(NOTIFY_NEW_SERVICE_NODE_VOTE, &cryptonote_protocol_handler::handle_notify_new_service_node_vote)
-      HANDLE_NOTIFY_T2(NOTIFY_NEW_SERVICE_NODE_VOTE_OLD, &cryptonote_protocol_handler::handle_notify_new_service_node_vote_old)
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_BLOCK_BLINKS, &cryptonote_protocol_handler::handle_request_block_blinks)
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_BLOCK_BLINKS, &cryptonote_protocol_handler::handle_response_block_blinks)
     END_INVOKE_MAP2()
@@ -120,7 +119,6 @@ namespace cryptonote
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
     int handle_uptime_proof(int command, NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_service_node_vote(int command, NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& context);
-    int handle_notify_new_service_node_vote_old(int command, NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& context);
     int handle_request_block_blinks(int command, NOTIFY_REQUEST_BLOCK_BLINKS::request& arg, cryptonote_connection_context& context);
     int handle_response_block_blinks(int command, NOTIFY_RESPONSE_BLOCK_BLINKS::request& arg, cryptonote_connection_context& context);
 
@@ -155,7 +153,6 @@ namespace cryptonote
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context);
-    virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool should_drop_connection(cryptonote_connection_context& context, uint32_t next_stripe);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -923,50 +923,6 @@ namespace cryptonote
   }
 
   //------------------------------------------------------------------------------------------------------------------------  
-  // TODO: delete this after HF14
-  template<class t_core>
-  int t_cryptonote_protocol_handler<t_core>::handle_notify_new_service_node_vote_old(int command, NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& context)
-  {
-    MLOG_P2P_MESSAGE("Received NOTIFY_NEW_SERVICE_NODE_VOTE_OLD (" << arg.votes.size() << " txes)");
-
-    if(context.m_state != cryptonote_connection_context::state_normal)
-      return 1;
-
-    if(!is_synchronized())
-    {
-      LOG_DEBUG_CC(context, "Received new service node vote while syncing, ignored");
-      return 1;
-    }
-
-    for(auto it = arg.votes.begin(); it != arg.votes.end();)
-    {
-      cryptonote::vote_verification_context vvc = {};
-      m_core.add_service_node_vote(*it, vvc);
-
-      if (vvc.m_verification_failed)
-      {
-        LOG_PRINT_CCONTEXT_L1("Vote type: " << it->type << ", verification failed, dropping connection");
-        drop_connection(context, false /*add_fail*/, false /*flush_all_spans i.e. delete cached block data from this peer*/);
-        return 1;
-      }
-
-      if (vvc.m_added_to_pool)
-      {
-        it++;
-      }
-      else
-      {
-        it = arg.votes.erase(it);
-      }
-    }
-
-    if (arg.votes.size())
-      relay_service_node_votes(arg, context);
-
-    return 1;
-  }
-
-  //------------------------------------------------------------------------------------------------------------------------  
   template<class t_core>
   int t_cryptonote_protocol_handler<t_core>::handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context)
   {
@@ -2504,14 +2460,6 @@ skip:
   bool t_cryptonote_protocol_handler<t_core>::relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context)
   {
     bool result = relay_to_synchronized_peers<NOTIFY_NEW_SERVICE_NODE_VOTE>(arg, exclude_context);
-    if (result)
-      m_core.set_service_node_votes_relayed(arg.votes);
-    return result;
-  }
-  template<class t_core>
-  bool t_cryptonote_protocol_handler<t_core>::relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& exclude_context)
-  {
-    bool result = relay_to_synchronized_peers<NOTIFY_NEW_SERVICE_NODE_VOTE_OLD>(arg, exclude_context);
     if (result)
       m_core.set_service_node_votes_relayed(arg.votes);
     return result;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -45,7 +45,6 @@ namespace cryptonote
     virtual bool relay_uptime_proof(NOTIFY_UPTIME_PROOF::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
-    virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
 
   /************************************************************************/
@@ -62,10 +61,6 @@ namespace cryptonote
       return false;
     }
     virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE::request& arg, cryptonote_connection_context& exclude_context)
-    {
-      return false;
-    }
-    virtual bool relay_service_node_votes(NOTIFY_NEW_SERVICE_NODE_VOTE_OLD::request& arg, cryptonote_connection_context& exclude_context)
     {
       return false;
     }

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -741,7 +741,10 @@ void process_blink_signatures(SNNWrapper &snw, const std::shared_ptr<blink_tx> &
     if (became_approved) {
         MINFO("Accumulated enough signatures for blink tx: enabling tx relay");
         auto &pool = snw.core.get_pool();
-        pool.add_existing_blink(btxptr);
+        {
+            auto lock = pool.blink_unique_lock();
+            pool.add_existing_blink(btxptr);
+        }
         pool.set_relayable({{btx.get_txhash()}});
         snw.core.relay_txpool_transactions();
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -717,7 +717,7 @@ namespace cryptonote
       if (might_be_blink)
       {
         if (!blink_lock) blink_lock.lock();
-        e.blink = pool.has_blink(tx_hash, true /*have lock*/);
+        e.blink = pool.has_blink(tx_hash);
       }
 
       // fill up old style responses too, in case an old wallet asks

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -622,9 +622,8 @@ namespace cryptonote
       LOG_PRINT_L2("Found " << found_in_pool << "/" << vh.size() << " transactions in the pool");
     }
 
-    bool blink_enabled = m_core.get_blockchain_storage().get_current_hard_fork_version() >= HF_VERSION_BLINK;
     uint64_t immutable_height = m_core.get_blockchain_storage().get_immutable_height();
-    auto pool_lock = pool.blink_shared_lock(std::defer_lock); // Defer until/unless we actually need it
+    auto blink_lock = pool.blink_shared_lock(std::defer_lock); // Defer until/unless we actually need it
 
     std::vector<std::string>::const_iterator txhi = req.txs_hashes.begin();
     std::vector<crypto::hash>::const_iterator vhi = vh.begin();
@@ -698,7 +697,7 @@ namespace cryptonote
       }
       auto ptx_it = per_tx_pool_tx_info.find(tx_hash);
       e.in_pool = ptx_it != per_tx_pool_tx_info.end();
-      bool might_be_blink = blink_enabled;
+      bool might_be_blink = true;
       if (e.in_pool)
       {
         e.block_height = e.block_timestamp = std::numeric_limits<uint64_t>::max();
@@ -717,7 +716,7 @@ namespace cryptonote
 
       if (might_be_blink)
       {
-        if (!pool_lock) pool_lock.lock();
+        if (!blink_lock) blink_lock.lock();
         e.blink = pool.has_blink(tx_hash, true /*have lock*/);
       }
 


### PR DESCRIPTION
This fixes a potential deadlock in the tx_pool blink lock (more details in the commit message).  It seems to trigger very rarely (I've had it happen twice in the last week across 40 SN nodes, some others have reported it as well), but when it happens it freezes up the idle task jobs (one of which wants a blink pool lock) so that uptime proofs stop going out but RPC and P2P keep operating which makes it not look hung.

This also cuts away from pre-HF14 code which isn't terribly important but it was simpler to cut it out than to update it when running through all the blink locking code again.