### PR TITLE
Add systemd notify & watchdog support

### DIFF
--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -27,6 +27,12 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+pkg_check_modules(SYSTEMD libsystemd)
+
+if(SYSTEMD_FOUND)
+  add_definitions(-DENABLE_SYSTEMD)
+endif()
+
 set(cryptonote_core_sources
   blockchain.cpp
   cryptonote_core.cpp
@@ -79,4 +85,5 @@ target_link_libraries(cryptonote_core
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
   PRIVATE
+    ${SYSTEMD_LIBRARIES}
     ${EXTRA_LIBRARIES})

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1117,6 +1117,7 @@ namespace cryptonote
      epee::math_helper::periodic_task m_blockchain_pruning_interval{5h}; //!< interval for incremental blockchain pruning
      epee::math_helper::periodic_task m_service_node_vote_relayer{2min, false};
      epee::math_helper::periodic_task m_sn_proof_cleanup_interval{1h, false};
+     epee::math_helper::periodic_task m_systemd_notify_interval{10s};
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?
 


### PR DESCRIPTION
This enables optional support for systemd notification which allows lokid to be run via `Type=notify`, allowing it to better signal status to systemd and enables systemd watchdog handling to restart if something goes wrong.

Enabled here are:
- systemd watchdog ping every 10s (from the idle loop callback, so it something deadlocks it's likely to stop firing).
- systemd status update every 10s, so that `systemctl status loki-node` gives you a status line such as:

      Status: "Height: 450085, SN: active, proof: 15m12s, storage: 3m7s,  lokinet: 27s"
- initialization notification so that systemd can wait for and report on initialization status rather than just that the process has launched.
- shutdown notification

All of these require changing the service type to `Type=notify` in the `[Service]` section of the systemd service file; enabling the watchdog also requires adding a `WatchdogSec=5min` line in the `[Service]` section to have systemd restart it after 5 minutes with no watchdog ping.

The systemd support is optional and requires the libsystemd-dev package to be built (and is probably not feasible at all for a static build).