### PR TITLE
Fix testing in quorum check, find_index_in_quorum_group(..) >= 0

### DIFF
--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -381,7 +381,7 @@ namespace service_nodes
               if (good > 0)
                 LOG_PRINT_L2(good << " of " << total << " service nodes are active and passing checks; no state change votes required");
             }
-            else if (!tested_myself_once_per_block && find_index_in_quorum_group(quorum->workers, my_keys->pub))
+            else if (!tested_myself_once_per_block && (find_index_in_quorum_group(quorum->workers, my_keys->pub) >= 0))
             {
               // NOTE: Not in validating quorum , check if we're the ones
               // being tested. If so, check if we would be decommissioned


### PR DESCRIPTION
`find_index_in_quorum_group` returns -1 if not in the quorum, so check the result accordingly.

Old behaviour is this always returns true, every height unless you're the 0th service node in the quorum of nodes to be tested.

Fixes https://github.com/loki-project/loki/issues/1028