### PR TITLE
Change the default flag for emphasis to true in the Print function

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4455,7 +4455,7 @@ int main(int argc, char** argv) {
     tools::wallet_rpc_server::tr("This is the RPC loki wallet. It needs to connect to a loki\ndaemon to work correctly."),
     desc_params,
     po::positional_options_description(),
-    [](const std::string &s, bool emphasis){ epee::set_console_color(emphasis ? epee::console_color_white : epee::console_color_default, true); std::cout << s << std::endl; if (emphasis) epee::reset_console_color(); },
+    [](const std::string &s, bool emphasis){ epee::set_console_color(emphasis ? epee::console_color_white : epee::console_color_default, emphasis); std::cout << s << std::endl; if (emphasis) epee::reset_console_color(); },
     "loki-wallet-rpc.log",
     true
   );


### PR DESCRIPTION
Addressing #428

Currently bold text is being produced by the cli help for loki-wallet-rpc but is not being cleared leaving the users terminal in an altered state.    When the the emphasis flag in the Print function is set it triggers epee:reset_console_color().

The function in question called called by print:
```
\\ wallet_rpc_server.cpp line 4458
[](const std::string &s, bool emphasis){ epee::set_console_color(emphasis ? epee::console_color_white : epee::console_color_default, true); std::cout << s << std::endl; if (emphasis) epee::reset_console_color(); },
```

After change:
![bold_help](https://user-images.githubusercontent.com/2188604/73586917-5ff26f00-4508-11ea-86ec-212309a7fe4e.png)

