### PR TITLE
Add Lokinet peer stats to deregistration voting process

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -69,6 +69,7 @@ static_assert(STAKING_PORTIONS % 12 == 0, "Use a multiple of twelve, so that it 
 
 #define STORAGE_SERVER_PING_LIFETIME                    UPTIME_PROOF_FREQUENCY_IN_SECONDS
 #define LOKINET_PING_LIFETIME                           UPTIME_PROOF_FREQUENCY_IN_SECONDS
+#define LOKINET_RC_RECEIVED_MAX_IN_SECONDS              (2*24*3600) // very relaxed restriction -- we must have seen an RC (RouterContact) within the last 2 days. TODO: tune
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    20000 // NOTE(loki): For testing suite, //size of block (bytes) after which reward for block calculated using block size - before first fork

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2081,13 +2081,14 @@ namespace cryptonote
     m_lmq->set_active_sns(std::move(active_sns));
   }
 
-  void core::request_peer_stats(std::function<void(bool success, std::vector<std::string> data)> results_handler)
+  void core::request_peer_stats(
+      std::vector<std::string> router_ids,
+      std::function<void(bool success, std::vector<std::string> data)> results_handler)
   {
     if (not m_lokinet_lmq_connection)
       throw std::runtime_error("cannot request peer stats without a lokinet connected");
 
-    // TODO: pass desired peer pubkeys to lokinet
-    m_lmq->request(*m_lokinet_lmq_connection, "lokid.get_peer_stats", std::move(results_handler));
+    m_lmq->request(*m_lokinet_lmq_connection, "lokid.get_peer_stats", std::move(results_handler), lokimq::bt_serialize(router_ids));
   }
 
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2080,6 +2080,16 @@ namespace cryptonote
     m_service_node_list.copy_active_x25519_pubkeys(std::inserter(active_sns, active_sns.end()));
     m_lmq->set_active_sns(std::move(active_sns));
   }
+
+  void core::request_peer_stats(std::function<void(bool success, std::vector<std::string> data)> results_handler)
+  {
+    if (not m_lokinet_lmq_connection)
+      throw std::runtime_error("cannot request peer stats without a lokinet connected");
+
+    // TODO: pass desired peer pubkeys to lokinet
+    m_lmq->request(*m_lokinet_lmq_connection, "lokid.get_peer_stats", std::move(results_handler));
+  }
+
   //-----------------------------------------------------------------------------------------------
   crypto::hash core::get_tail_id() const
   {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2083,7 +2083,7 @@ namespace cryptonote
 
   void core::request_peer_stats(
       std::vector<std::string> router_ids,
-      std::function<void(bool success, std::vector<std::string> data)> results_handler)
+      std::function<void(bool success, std::vector<std::string> data)> results_handler) const
   {
     if (not m_lokinet_lmq_connection)
       throw std::runtime_error("cannot request peer stats without a lokinet connected");

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -331,7 +331,7 @@ namespace cryptonote
      /// Called (from service_node_quorum_cop) to request peer stats from the connected lokinet daemon
      void request_peer_stats(
           std::vector<std::string> router_ids,
-          std::function<void(bool success, std::vector<std::string> data)> results_handler);
+          std::function<void(bool success, std::vector<std::string> data)> results_handler) const;
 
      /**
       * @brief get the cryptonote protocol instance

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -992,6 +992,11 @@ namespace cryptonote
      uint16_t storage_port() const { return m_storage_port; }
      uint16_t quorumnet_port() const { return m_quorumnet_port; }
 
+     // when lokinet connects via lokimq, we keep up with the connection so that we can make
+     // bi-directional requests. TODO: this is a messy place to put this, but currently the
+     // lmq server is not accessible to quorum_cop where this connection is needed
+     std::optional<lokimq::ConnectionID> m_lokinet_lmq_connection = std::nullopt;
+
      /**
       * @brief attempts to relay any transactions in the mempool which need it
       *

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -328,6 +328,9 @@ namespace cryptonote
      /// active SNs.
      void update_lmq_sns();
 
+     /// Called (from service_node_quorum_cop) to request peer stats from the connected lokinet daemon
+     void request_peer_stats(std::function<void(bool success, std::vector<std::string> data)> results_handler);
+
      /**
       * @brief get the cryptonote protocol instance
       *

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -329,7 +329,9 @@ namespace cryptonote
      void update_lmq_sns();
 
      /// Called (from service_node_quorum_cop) to request peer stats from the connected lokinet daemon
-     void request_peer_stats(std::function<void(bool success, std::vector<std::string> data)> results_handler);
+     void request_peer_stats(
+          std::vector<std::string> router_ids,
+          std::function<void(bool success, std::vector<std::string> data)> results_handler);
 
      /**
       * @brief get the cryptonote protocol instance

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2010,7 +2010,7 @@ namespace service_nodes
     last_rc_updated = std::chrono::milliseconds(lokimq::get_int<int64_t>(dict.at(LastRCUpdatedKey)));
   }
 
-  peer_stats_list bt_decode_peer_stats_list(std::string_view data)
+  peer_stats_map bt_decode_peer_stats_map(std::string_view data)
   {
     // this is expected to be encoded as:
     // dict [router_id -> [dict representing peer stats, e.g. lokinet_peer_stats::bt_decode()]]
@@ -2071,9 +2071,9 @@ namespace service_nodes
     return router_id;
   }
 
-  std::future<peer_stats_list> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids)
+  std::future<peer_stats_map> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids)
   {
-    std::promise<peer_stats_list> promise;
+    std::promise<peer_stats_map> promise;
     try
     {
       core.request_peer_stats(router_ids, [&](bool success, std::vector<std::string> data) {
@@ -2083,7 +2083,7 @@ namespace service_nodes
         if (data.empty())
           throw std::runtime_error("Empty response from lokinet");
 
-        promise.set_value(bt_decode_peer_stats_list(data[0]));
+        promise.set_value(bt_decode_peer_stats_map(data[0]));
       });
     }
     catch (const std::exception& e)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2010,7 +2010,7 @@ namespace service_nodes
     last_rc_updated = std::chrono::milliseconds(lokimq::get_int<int64_t>(dict.at(LastRCUpdatedKey)));
   }
 
-  peer_stats_list bt_doced_peer_stats_list(std::string_view data)
+  peer_stats_list bt_decode_peer_stats_list(std::string_view data)
   {
     // this is expected to be encoded as:
     // dict [router_id -> [dict representing peer stats, e.g. lokinet_peer_stats::bt_decode()]]
@@ -2083,7 +2083,7 @@ namespace service_nodes
         if (data.empty())
           throw std::runtime_error("Empty response from lokinet");
 
-        promise.set_value(bt_doced_peer_stats_list(data[0]));
+        promise.set_value(bt_decode_peer_stats_list(data[0]));
       });
     }
     catch (const std::exception& e)

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string_view>
+#include <lokimq/bt_serialize.h>
 #include "serialization/serialization.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_core/service_node_rules.h"
@@ -66,7 +67,7 @@ namespace service_nodes
   // tracks lokinet's PeerStats struct and is used to reflect the behavior of a service node's peers on the lokinet network
   struct lokinet_peer_stats
   {
-    crypto::ed25519_public_key router_id = crypto::ed25519_public_key::null();
+    std::string router_id;
 
     int32_t num_connection_attempts = 0;
     int32_t num_connection_successes = 0;
@@ -87,7 +88,12 @@ namespace service_nodes
     std::chrono::milliseconds least_rc_remaining_lifetime = 0ms;
     std::chrono::milliseconds last_rc_updated = 0ms;
 
+    // Decodes a peerstats into this existing struct
     void bt_decode(std::string_view data);
+    void bt_decode(const lokimq::bt_dict& dict);
+
+    // Decodes a list of peer stats
+    static std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats> bt_decode_list(std::string_view data);
   };
 
   struct proof_info

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -101,7 +101,7 @@ namespace service_nodes
   std::string ed25519_pubkey_to_router_id(const crypto::ed25519_public_key& pubkey);
 
   // Decodes a list of peer stats
-  peer_stats_list bt_doced_peer_stats_list(std::string_view data);
+  peer_stats_list bt_decode_peer_stats_list(std::string_view data);
 
   // makes a request to lokinet to retrieve peer stats for a given list of service nodes
   std::future<peer_stats_list> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -94,17 +94,17 @@ namespace service_nodes
     void bt_decode(std::string_view data);
     void bt_decode(const lokimq::bt_dict& dict);
   };
-  using peer_stats_list = std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats>;
+  using peer_stats_map = std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats>;
 
   // functions for converting lokinet's RouterID string representation to/from an ed25519 public key
   crypto::ed25519_public_key parse_router_id(std::string_view router_id);
   std::string ed25519_pubkey_to_router_id(const crypto::ed25519_public_key& pubkey);
 
   // Decodes a list of peer stats
-  peer_stats_list bt_decode_peer_stats_list(std::string_view data);
+  peer_stats_map bt_decode_peer_stats_map(std::string_view data);
 
   // makes a request to lokinet to retrieve peer stats for a given list of service nodes
-  std::future<peer_stats_list> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);
+  std::future<peer_stats_map> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);
 
 
   struct proof_info

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <future>
 #include <shared_mutex>
 #include <string_view>
 #include <lokimq/bt_serialize.h>
@@ -44,6 +45,7 @@ using namespace std::chrono_literals;
 
 namespace cryptonote
 {
+class core;
 class Blockchain;
 class BlockchainDB;
 struct checkpoint_t;
@@ -91,14 +93,19 @@ namespace service_nodes
     // Decodes a peerstats into this existing struct
     void bt_decode(std::string_view data);
     void bt_decode(const lokimq::bt_dict& dict);
-
-    // Decodes a list of peer stats
-    static std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats> bt_decode_list(std::string_view data);
   };
+  using peer_stats_list = std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats>;
 
   // functions for converting lokinet's RouterID string representation to/from an ed25519 public key
   crypto::ed25519_public_key parse_router_id(std::string_view router_id);
   std::string ed25519_pubkey_to_router_id(const crypto::ed25519_public_key& pubkey);
+
+  // Decodes a list of peer stats
+  peer_stats_list bt_doced_peer_stats_list(std::string_view data);
+
+  // makes a request to lokinet to retrieve peer stats for a given list of service nodes
+  std::future<peer_stats_list> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);
+
 
   struct proof_info
   {

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <mutex>
 #include <shared_mutex>
 #include <string_view>
@@ -37,6 +38,8 @@
 #include "cryptonote_core/service_node_voting.h"
 #include "cryptonote_core/service_node_quorum_cop.h"
 #include "common/util.h"
+
+using namespace std::chrono_literals;
 
 namespace cryptonote
 {
@@ -58,6 +61,33 @@ namespace service_nodes
       KV_SERIALIZE(height);
       KV_SERIALIZE(voted);
     END_KV_SERIALIZE_MAP()
+  };
+
+  // tracks lokinet's PeerStats struct and is used to reflect the behavior of a service node's peers on the lokinet network
+  struct lokinet_peer_stats
+  {
+    crypto::ed25519_public_key router_id = crypto::ed25519_public_key::null();
+
+    int32_t num_connection_attempts = 0;
+    int32_t num_connection_successes = 0;
+    int32_t num_connection_rejections = 0;
+    int32_t num_connection_timeouts = 0;
+
+    int32_t num_path_builds = 0;
+    int64_t num_packets_attempted = 0;
+    int64_t num_packets_sent = 0;
+    int64_t num_packets_dropped = 0;
+    int64_t num_packets_resent = 0;
+
+    int32_t num_distinct_rcs_received = 0;
+    int32_t num_late_rcs = 0;
+
+    int64_t peak_bandwidth_bytes_per_sec = 0;
+    std::chrono::milliseconds longest_rc_receive_interval = 0ms;
+    std::chrono::milliseconds least_rc_remaining_lifetime = 0ms;
+    std::chrono::milliseconds last_rc_updated = 0ms;
+
+    void bt_decode(std::string_view data);
   };
 
   struct proof_info

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -96,6 +96,10 @@ namespace service_nodes
     static std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats> bt_decode_list(std::string_view data);
   };
 
+  // functions for converting lokinet's RouterID string representation to/from an ed25519 public key
+  crypto::ed25519_public_key parse_router_id(std::string_view router_id);
+  std::string ed25519_pubkey_to_router_id(const crypto::ed25519_public_key& pubkey);
+
   struct proof_info
   {
     uint64_t timestamp           = 0; // The actual time we last received an uptime proof (serialized)

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -103,9 +103,6 @@ namespace service_nodes
   // Decodes a list of peer stats
   peer_stats_map bt_decode_peer_stats_map(std::string_view data);
 
-  // makes a request to lokinet to retrieve peer stats for a given list of service nodes
-  std::future<peer_stats_map> request_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);
-
 
   struct proof_info
   {
@@ -129,6 +126,8 @@ namespace service_nodes
 
     // Derived from pubkey_ed25519, not serialized
     crypto::x25519_public_key pubkey_x25519 = crypto::x25519_public_key::null();
+
+    std::chrono::milliseconds last_rc_updated_ms = 0ms;
 
     // Updates pubkey_ed25519 to the given key, re-deriving the x25519 key if it actually changes
     // (does nothing if the key is the same as the current value).  If x25519 derivation fails then
@@ -370,6 +369,9 @@ namespace service_nodes
     bool is_service_node(const crypto::public_key& pubkey, bool require_active = true) const;
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;
     uint64_t height() const { return m_state.height; }
+
+    // makes a request to lokinet to retrieve peer stats for a given list of service nodes
+    std::future<peer_stats_map> update_peer_stats(const cryptonote::core& core, std::vector<std::string> router_ids);
 
     /// Note(maxim): this should not affect thread-safety as the returned object is const
     ///

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -475,6 +475,22 @@ namespace service_nodes
 
   bool quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const * /*checkpoint*/)
   {
+
+    try
+    {
+      m_core.request_peer_stats([](bool success, std::vector<std::string> data){
+        // TODO: how should we handle this? 
+        if (not success)
+          MWARNING("Failed to request peer stats from lokinet");
+
+        // TODO: parse and inspect peer stats
+      });
+    }
+    catch (const std::exception& e)
+    {
+      MERROR("caught exception while trying to request peer stats: " << e.what());
+    }
+
     process_quorums(block);
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1
     m_vote_pool.remove_expired_votes(height);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -203,9 +203,13 @@ namespace service_nodes
 
   void quorum_cop::process_quorums(cryptonote::block const &block)
   {
+    MFATAL("process_quorums");
     uint8_t const hf_version = block.major_version;
     if (hf_version < cryptonote::network_version_9_service_nodes)
+    {
+      MFATAL("hf_version < version_9");
       return;
+    }
 
     uint64_t const REORG_SAFETY_BUFFER_BLOCKS = (hf_version >= cryptonote::network_version_12_checkpointing)
                                                     ? REORG_SAFETY_BUFFER_BLOCKS_POST_HF12
@@ -216,11 +220,17 @@ namespace service_nodes
     uint64_t const height        = cryptonote::get_block_height(block);
     uint64_t const latest_height = std::max(m_core.get_current_blockchain_height(), m_core.get_target_blockchain_height());
     if (latest_height < VOTE_LIFETIME)
+    {
+      MFATAL("< VOTE_LIFETIME");
       return;
+    }
 
     uint64_t const start_voting_from_height = latest_height - VOTE_LIFETIME;
     if (height < start_voting_from_height)
+    {
+      MFATAL("< start_voting_from_height");
       return;
+    }
 
     service_nodes::quorum_type const max_quorum_type = service_nodes::max_quorum_type_for_hf(hf_version);
     bool tested_myself_once_per_block                = false;
@@ -247,6 +257,7 @@ namespace service_nodes
 
         case quorum_type::obligations:
         {
+          MFATAL("obligations quorum");
 
           m_obligations_height = std::max(m_obligations_height, start_voting_from_height);
           for (; m_obligations_height < (height - REORG_SAFETY_BUFFER_BLOCKS); m_obligations_height++)
@@ -283,10 +294,16 @@ namespace service_nodes
             // NOTE: Wait at least 2 hours before we're allowed to vote so that we collect necessary voting information from people on the network
             bool alive_for_min_time = live_time >= MIN_TIME_IN_S_BEFORE_VOTING;
             if (!alive_for_min_time)
+            {
+              MFATAL("not up long enough");
               continue;
+            }
 
             if (!m_core.service_node())
+            {
+              MFATAL("not a service node");
               continue;
+            }
 
             auto quorum = m_core.get_quorum(quorum_type::obligations, m_obligations_height);
             if (!quorum)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -333,26 +333,8 @@ namespace service_nodes
               //       with a better asynchronous model.
               lock.unlock();
 
-              std::promise<std::unordered_map<crypto::ed25519_public_key, lokinet_peer_stats>> promise;
-
-              try
-              {
-                m_core.request_peer_stats(router_ids, [&](bool success, std::vector<std::string> data) {
-                  if (not success)
-                    throw std::runtime_error("Failed to request peer stats from lokinet");
-
-                  if (data.empty())
-                    throw std::runtime_error("Empty response from lokinet");
-
-                  promise.set_value(lokinet_peer_stats::bt_decode_list(data[0]));
-                });
-              }
-              catch (const std::exception& e)
-              {
-                promise.set_exception(std::current_exception());
-              }
-
-              auto peer_stats = promise.get_future().get();
+              auto future = service_nodes::request_peer_stats(m_core, router_ids);
+              auto peer_stats = future.get();
               // TODO: inspect peer stats and modify proofs
 
               lock.lock();

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -78,6 +78,7 @@ namespace service_nodes
 
   struct service_node_test_results {
     bool uptime_proved            = true;
+    bool rc_received_recently     = true;
     bool single_ip                = true;
     bool voted_in_checkpoints     = true;
     bool storage_server_reachable = true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3145,7 +3145,12 @@ namespace cryptonote { namespace rpc {
     return handle_ping<LOKINET_PING>(
         req.version, service_nodes::MIN_LOKINET_VERSION,
         "Lokinet", m_core.m_last_lokinet_ping, LOKINET_PING_LIFETIME,
-        [this](bool significant) { if (significant) m_core.reset_proof_interval(); });
+        [this, &context](bool significant) {
+          if (significant) 
+            m_core.reset_proof_interval();
+
+          m_core.m_lokinet_lmq_connection = context.lmq_connection_id;
+        });
   }
   //------------------------------------------------------------------------------------------------------------------------------
   GET_STAKING_REQUIREMENT::response core_rpc_server::invoke(GET_STAKING_REQUIREMENT::request&& req, rpc_context context)

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -110,6 +110,9 @@ namespace cryptonote { namespace rpc {
     // A free-form identifier identifiying the remote address of the request; this might be IP:PORT,
     // or could contain a pubkey, or ...
     std::string_view remote;
+
+    // If RPC source is rpc_source::lmq, this stores the ConnectionID associated with the request.
+    std::optional<lokimq::ConnectionID> lmq_connection_id = std::nullopt;
   };
 
   struct rpc_request {

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -150,6 +150,7 @@ lmq_rpc::lmq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
       request.context.admin = m.access.auth >= AuthLevel::admin;
       request.context.source = rpc_source::lmq;
       request.context.remote = m.remote;
+      request.context.lmq_connection_id = m.conn;
       request.body = m.data.empty() ? ""sv : m.data[0];
 
       try {

--- a/tests/network_tests/daemons.py
+++ b/tests/network_tests/daemons.py
@@ -153,8 +153,6 @@ class Daemon(RPCDaemon):
                 '--p2p-bind-port={}'.format(self.p2p_port),
                 '--rpc-bind-ip={}'.format(self.listen_ip),
                 '--rpc-bind-port={}'.format(self.rpc_port),
-                '--zmq-rpc-bind-ip={}'.format(self.listen_ip),
-                '--zmq-rpc-bind-port={}'.format(self.zmq_port),
                 '--quorumnet-port={}'.format(self.qnet_port),
                 )
 

--- a/tests/network_tests/service_node_network.py
+++ b/tests/network_tests/service_node_network.py
@@ -54,6 +54,9 @@ def vprint(*args, timestamp=True, **kwargs):
             print(datetime.now(), end=" ")
         print(*args, **kwargs)
 
+'''
+sleep a few seconds, then call code that calls snn.mine
+'''
 
 class SNNetwork:
     def __init__(self, datadir, *, binpath='../../build/bin', sns=20, nodes=3):

--- a/tests/unit_tests/service_nodes.cpp
+++ b/tests/unit_tests/service_nodes.cpp
@@ -557,3 +557,47 @@ TEST(service_nodes, service_node_get_locked_key_image_unlock_height)
     ASSERT_EQ(unlock_height, expected);
   }
 }
+
+TEST(service_nodes, lokinet_peer_stats_deserialization)
+{
+  constexpr std::string_view data =
+    "d"
+    "21:numConnectionAttempts" "i1e"
+    "22:numConnectionSuccesses" "i2e"
+    "23:numConnectionRejections" "i3e"
+    "21:numConnectionTimeouts" "i4e"
+    "13:numPathBuilds" "i5e"
+    "19:numPacketsAttempted" "i6e"
+    "14:numPacketsSent" "i7e"
+    "17:numPacketsDropped" "i8e"
+    "16:numPacketsResent" "i9e"
+    "22:numDistinctRCsReceived" "i10e"
+    "10:numLateRCs" "i11e"
+    "24:peakBandwidthBytesPerSec" "i12e"
+    "24:longestRCReceiveInterval" "i13e"
+    "24:leastRCRemainingLifetime" "i14e"
+    "13:lastRCUpdated" "i15e"
+    "e";
+
+  service_nodes::lokinet_peer_stats stats;
+
+  ASSERT_NO_THROW(stats.bt_decode(data));
+
+  // TODO: router_id
+
+  ASSERT_EQ(1, stats.num_connection_attempts);
+  ASSERT_EQ(2, stats.num_connection_successes);
+  ASSERT_EQ(3, stats.num_connection_rejections);
+  ASSERT_EQ(4, stats.num_connection_timeouts);
+  ASSERT_EQ(5, stats.num_path_builds);
+  ASSERT_EQ(6, stats.num_packets_attempted);
+  ASSERT_EQ(7, stats.num_packets_sent);
+  ASSERT_EQ(8, stats.num_packets_dropped);
+  ASSERT_EQ(9, stats.num_packets_resent);
+  ASSERT_EQ(10, stats.num_distinct_rcs_received);
+  ASSERT_EQ(11, stats.num_late_rcs);
+  ASSERT_EQ(12, stats.peak_bandwidth_bytes_per_sec);
+  ASSERT_EQ(13, stats.longest_rc_receive_interval.count());
+  ASSERT_EQ(14, stats.least_rc_remaining_lifetime.count());
+  ASSERT_EQ(15, stats.last_rc_updated.count());
+}


### PR DESCRIPTION
This PR adds the capability to request lokinet's peer stats and include this in its deregistration voting process.