### PR TITLE
transaction generated for stake unlock

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -184,7 +184,7 @@ namespace cryptonote
     txversion version;
     txtype type;
 
-    bool is_transfer() const { return type == txtype::standard || type == txtype::stake || type == txtype::oxen_name_system; }
+    bool is_transfer() const { return type == txtype::standard || type == txtype::stake || type == txtype::key_image_unlock || type == txtype::oxen_name_system; }
 
     // not used after version 2, but remains for compatibility
     uint64_t unlock_time;  //number of block (or time), used as a limitation like: spend this tx not early then block/time

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3001,7 +3001,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
   if (!res)
     return false;
 
-  CHECK_AND_ASSERT_MES(max_used_block_height < m_db->height(), false, 
+  CHECK_AND_ASSERT_MES(max_used_block_height < m_db->height(), false,
       "internal error: max used block index=" << max_used_block_height << " is not less then blockchain size = " << m_db->height());
   max_used_block_id = m_db->get_block_hash_from_height(max_used_block_height);
   return true;
@@ -3501,6 +3501,17 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       if (!m_ons_db.validate_ons_tx(hf_version, get_current_blockchain_height(), tx, data, &fail_reason))
       {
         MERROR_VER("Failed to validate ONS TX reason: " << fail_reason);
+        tvc.m_verbose_error = std::move(fail_reason);
+        return false;
+      }
+    }
+    if (tx.type == txtype::key_image_unlock)
+    {
+      cryptonote::tx_extra_field data;
+      std::string fail_reason;
+      if (!service_nodes::validate_unstake_tx(hf_version, get_current_blockchain_height(), tx, data, &fail_reason))
+      {
+        MERROR_VER("Failed to validate Unstake TX reason: " << fail_reason);
         tvc.m_verbose_error = std::move(fail_reason);
         return false;
       }

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -2,6 +2,7 @@
 #include "cryptonote_basic/hardfork.h"
 #include "common/oxen.h"
 #include "epee/int-util.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
 #include <boost/endian/conversion.hpp>
 #include <limits>
 #include <vector>
@@ -203,6 +204,59 @@ bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions) {
   }
 
   return get_portions_from_percent(cut_percent, portions);
+}
+
+template <typename... T>
+static bool check_condition(bool condition, std::string* reason, T&&... args) {
+  if (condition && reason)
+  {
+    std::ostringstream os;
+    (os << ... << std::forward<T>(args));
+    *reason = os.str();
+  }
+  return condition;
+}
+
+bool validate_unstake_tx(uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_field &extra, std::string *reason)
+{
+  // -----------------------------------------------------------------------------------------------
+  // Pull out Extra from TX
+  // -----------------------------------------------------------------------------------------------
+  {
+    if (check_condition(tx.type != cryptonote::txtype::key_image_unlock, reason, tx, ", uses wrong tx type, expected=", cryptonote::txtype::key_image_unlock))
+      return false;
+
+    //if (check_condition(!cryptonote::get_field_from_tx_extra(tx.extra, extra), reason, tx, ", didn't have unstake tx_extra"))
+      //return false;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Simple Unstake Extra Validation
+  // -----------------------------------------------------------------------------------------------
+  {
+    //if (check_condition(extra.version != 0, reason, tx, ", ", lns_extra_string(nettype, lns_extra), " unexpected version=", std::to_string(lns_extra.version), ", expected=0"))
+      //return false;
+
+    //if (check_condition(!lns::mapping_type_allowed(hf_version, lns_extra.type), reason, tx, ", ", lns_extra_string(nettype, lns_extra), " specifying type=", lns_extra.type, " that is disallowed in hardfork ", hf_version))
+      //return false;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Burn Validation
+  // -----------------------------------------------------------------------------------------------
+  {
+    uint64_t burn                = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
+    uint64_t const burn_required = UNSTAKE_BURN_FIXED;
+    if (burn != burn_required)
+    {
+      char const *over_or_under = burn > burn_required ? "too much " : "insufficient ";
+      //if (check_condition(true, reason, tx, ", ", lns_extra_string(nettype, lns_extra), " burned ", over_or_under, "oxen=", burn, ", require=", burn_required))
+      //if (check_condition(true, reason, tx, ", burned ", over_or_under, "oxen=", burn, ", require=", burn_required))
+        //return false;
+    }
+  }
+
+  return true;
 }
 
 } // namespace service_nodes

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -45,7 +45,7 @@ namespace service_nodes {
 
   static_assert(PULSE_QUORUM_NUM_VALIDATORS >= PULSE_BLOCK_REQUIRED_SIGNATURES);
   static_assert(PULSE_QUORUM_ENTROPY_LAG >= PULSE_QUORUM_SIZE, "We need to pull atleast PULSE_QUORUM_SIZE number of blocks from the Blockchain, we can't if the amount of blocks to go back from the tip of the Blockchain is less than the blocks we need.");
-  
+
   constexpr size_t pulse_min_service_nodes(cryptonote::network_type nettype)
   {
     return (nettype == cryptonote::MAINNET) ? 50 : PULSE_QUORUM_SIZE;
@@ -293,5 +293,7 @@ uint64_t     get_locked_key_image_unlock_height(cryptonote::network_type nettype
 uint64_t get_portions_to_make_amount(uint64_t staking_requirement, uint64_t amount, uint64_t max_portions = STAKING_PORTIONS);
 
 bool get_portions_from_percent_str(std::string cut_str, uint64_t& portions);
+
+bool validate_unstake_tx(uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_field &extra, std::string *reason);
 
 }

--- a/src/oxen_economy.h
+++ b/src/oxen_economy.h
@@ -31,6 +31,14 @@ constexpr uint64_t FOUNDATION_REWARD_HF17 =  1'833'333'333;
 static_assert(MINER_REWARD_HF15        + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF15);
 static_assert(CHAINFLIP_LIQUIDITY_HF16 + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF16);
 static_assert(                           SN_REWARD_HF15 + FOUNDATION_REWARD_HF17 == BLOCK_REWARD_HF17);
+// -------------------------------------------------------------------------------------------------
+//
+// Staking
+//
+// -------------------------------------------------------------------------------------------------
+
+// A fixed amount (in atomic currency units) that a service node unstaker must burn.
+inline constexpr uint64_t UNSTAKE_BURN_FIXED           = 0.5 * ::COIN;  
 
 // -------------------------------------------------------------------------------------------------
 //

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8693,13 +8693,13 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
     cryptonote::tx_destination_entry de = {};
     de.addr = this->get_address();
     de.is_subaddress = false;
-    de.amount = 0;
+    de.amount = UNSTAKE_BURN_FIXED;
     dsts.push_back(de);
 
     std::optional<uint8_t> hf_version = get_hard_fork_version();
     std::vector<uint8_t> extra;
     // Priority set to unimportant because it does not take effect until processed in a block
-    uint32_t priority = tx_priority::tx_priority_unimportant; 
+    uint32_t priority = tx_priority::tx_priority_unimportant;
     std::set<uint32_t> subaddr_indices  = {};
     oxen_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority);
     tx_params.burn_fixed = UNSTAKE_BURN_FIXED;
@@ -10867,6 +10867,7 @@ bool wallet2::light_wallet_key_image_is_ours(const crypto::key_image& key_image,
 // usable balance.
 std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra_base, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, oxen_construct_tx_params &tx_params)
 {
+
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
   std::unique_lock hwdev_lock{hwdev};

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8702,8 +8702,8 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
     std::set<uint32_t> subaddr_indices  = {};
     loki_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority);
 
-    add_service_node_pubkey_to_tx_extra(result.ptx.tx.extra, sn_key);
-    add_tx_key_image_unlock_to_tx_extra(result.ptx.tx.extra, unlock);
+    add_service_node_pubkey_to_tx_extra(extra, sn_key);
+    add_tx_key_image_unlock_to_tx_extra(extra, unlock);
     auto ptx_vector      = create_transactions_2(dsts,
                                       CRYPTONOTE_DEFAULT_TX_MIXIN,
                                       0,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8693,7 +8693,7 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
     cryptonote::tx_destination_entry de = {};
     de.addr = this->get_address();
     de.is_subaddress = false;
-    de.amount = UNSTAKE_BURN_FIXED;
+    de.amount = 0;
     dsts.push_back(de);
 
     std::optional<uint8_t> hf_version = get_hard_fork_version();
@@ -8701,8 +8701,7 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
     // Priority set to unimportant because it does not take effect until processed in a block
     uint32_t priority = tx_priority::tx_priority_unimportant;
     std::set<uint32_t> subaddr_indices  = {};
-    oxen_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority);
-    tx_params.burn_fixed = UNSTAKE_BURN_FIXED;
+    oxen_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority, UNSTAKE_BURN_FIXED);
 
     add_service_node_pubkey_to_tx_extra(extra, sn_key);
     add_tx_key_image_unlock_to_tx_extra(extra, unlock);
@@ -9927,7 +9926,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   // throw if total amount overflows uint64_t
   for(auto& dt: dsts)
   {
-    THROW_WALLET_EXCEPTION_IF(0 == dt.amount && (tx_params.tx_type != txtype::oxen_name_system), error::zero_destination);
+    THROW_WALLET_EXCEPTION_IF(0 == dt.amount && !(tx_params.tx_type == txtype::oxen_name_system || tx_params.tx_type == txtype::key_image_unlock), error::zero_destination);
     needed_money += dt.amount;
     LOG_PRINT_L2("transfer: adding " << print_money(dt.amount) << ", for a total of " << print_money (needed_money));
     THROW_WALLET_EXCEPTION_IF(needed_money < dt.amount, error::tx_sum_overflow, dsts, fee, m_nettype);
@@ -10874,6 +10873,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   hw::mode_resetter rst{hwdev};
 
   bool const is_ons_tx = (tx_params.tx_type == txtype::oxen_name_system);
+  bool const is_unstake_tx = (tx_params.tx_type == txtype::key_image_unlock);
   auto original_dsts = dsts;
   if (is_ons_tx)
   {
@@ -10965,7 +10965,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   needed_money = 0;
   for(auto& dt: dsts)
   {
-    THROW_WALLET_EXCEPTION_IF(0 == dt.amount && !is_ons_tx, error::zero_destination);
+    THROW_WALLET_EXCEPTION_IF(0 == dt.amount && !(is_ons_tx || is_unstake_tx), error::zero_destination);
+
     needed_money += dt.amount;
     LOG_PRINT_L2("transfer: adding " << print_money(dt.amount) << ", for a total of " << print_money (needed_money));
     THROW_WALLET_EXCEPTION_IF(needed_money < dt.amount, error::tx_sum_overflow, dsts, 0, m_nettype);
@@ -10973,7 +10974,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
 
 
   // throw if attempting a transaction with no money
-  THROW_WALLET_EXCEPTION_IF(needed_money == 0 && !is_ons_tx, error::zero_destination);
+  THROW_WALLET_EXCEPTION_IF(needed_money == 0 && !(is_ons_tx || is_unstake_tx), error::zero_destination);
 
   std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddr = unlocked_balance_per_subaddress(subaddr_account, false);
   std::map<uint32_t, uint64_t> balance_per_subaddr = balance_per_subaddress(subaddr_account, false);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8698,9 +8698,11 @@ wallet2::request_stake_unlock_result wallet2::can_request_stake_unlock(const cry
 
     std::optional<uint8_t> hf_version = get_hard_fork_version();
     std::vector<uint8_t> extra;
-    uint32_t priority = this->get_default_priority();
+    // Priority set to unimportant because it does not take effect until processed in a block
+    uint32_t priority = tx_priority::tx_priority_unimportant; 
     std::set<uint32_t> subaddr_indices  = {};
-    loki_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority);
+    oxen_construct_tx_params tx_params = wallet2::construct_params(*hf_version, cryptonote::txtype::key_image_unlock, priority);
+    tx_params.burn_fixed = UNSTAKE_BURN_FIXED;
 
     add_service_node_pubkey_to_tx_extra(extra, sn_key);
     add_tx_key_image_unlock_to_tx_extra(extra, unlock);


### PR DESCRIPTION
Addressing #1351 

So I've modified the unlock transaction to include a transaction sent to the users own address. 

Attempting to resolve the issue using the second option:

_Require that unlock txes have an output, and thus also a fee. Thus an unlock would now have 1-output back into the originating wallet, which would make the wallet see it._

However I am also of the opinion that the 3rd option of adding a burned amount to each stake unlock is a good idea.

Could I get some feedback on if this is the right path to be taking to generate an output for the unlock stake transaction?