### PR TITLE
Ci caching

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -26,7 +26,7 @@ local gtest_filter = '-AddressFromURL.Failure:DNSResolver.DNSSEC*';
 
 local docker_base = 'registry.oxen.rocks/lokinet-ci-';
 
-local submodules_commands = ['git fetch --tags', 'git submodule update --init --recursive --depth=1'];
+local submodules_commands = ['git fetch --tags', 'git submodule update --init --recursive --depth=1 --jobs=4'];
 local submodules = {
   name: 'submodules',
   image: 'drone/git',


### PR DESCRIPTION
Updates CI to use the pre-built images (with all deps installed) on all architectures, now that the CI generating script (in lokinet -- see https://github.com/oxen-io/lokinet/pull/1774) has images for all architectures.

(My vim now reformats jsonnet on save, which is a good thing in general but also makes the diff huge; ignore whitespace changes recommended to view the diff).