### PR TITLE
add threading to add block

### DIFF
--- a/src/wallet3/transaction_scanner.cpp
+++ b/src/wallet3/transaction_scanner.cpp
@@ -34,6 +34,7 @@ namespace wallet
 
     // A derivation is simply the private view key multiplied by the tx public key
     // do this for every tx public key in the transaction
+    //TODO SEAN THIS IS A BOTTLENECK
     auto derivations = wallet_keys->generate_key_derivations(tx_public_keys);
     bool coinbase_transaction = cryptonote::is_coinbase(tx.tx);
     // Output belongs to public key derived as follows:
@@ -55,6 +56,7 @@ namespace wallet
         std::optional<cryptonote::subaddress_index> sub_index{std::nullopt};
         for (derivation_index = 0; derivation_index < derivations.size(); derivation_index++)
         {
+          //TODO SEAN THIS IS A BOTTLENECK
           sub_index = wallet_keys->output_and_derivation_ours(
               derivations[derivation_index], output_target->key, output_index);
           if (sub_index)


### PR DESCRIPTION
This PR is to open the discussion on adding multithreading to wallet3 to improve performance. After putting wallet3 through perf it highlighted 2 functions where wallet3 spent most of its time to scan the chain. `output_and_derivation_ours()` and `generate_key_derivations()`

Making some rough changes to wallet3 and adding threads around add_block resulted in a significant increase in block processing speed. Increasing wallet3 from around 2.5k blocks/second up to 13k blocks/second.
Before:
![Screenshot from 2023-03-27 15-19-50](https://user-images.githubusercontent.com/2188604/227841199-ef83c683-903e-4084-8ce5-24e670f20ed0.png)

After:
![Screenshot from 2023-03-27 15-24-34](https://user-images.githubusercontent.com/2188604/227841246-afe6a786-b72c-4cad-9ace-05be7aa10d41.png)

However processing blocks out of order in this form isn't viable with the wallet outputting incorrect final balances after it finished scanning (in fact every time it resulted in a different balance). I suspect this is due to it ignoring outputs spent because the input hadnt been received yet

I do note that the two bottleneck functions are both in transaction scanning for outputs received and not outputs spent, so we possibly could split the scanning into first stage multithreaded scan of the outputs received, followed by a linear scan of outputs spent.

This is still pretty early days for wallet3 so adding multithreading might not be appropriate yet. But is good to know what the bottlenecks are atm
