### PR TITLE
Correct cache behavior for multiple ONS name lookups.

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7196,7 +7196,7 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         tools::wallet2::ons_detail detail = {
                 static_cast<ons::mapping_type>(mapping["type"]),
                 name,
-                mapping.name_hash};
+                mapping["name_hash"]};
         m_wallet->set_ons_cache_record(detail);
     }
     for (size_t i = last_index + 1; i < args.size(); i++)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7196,7 +7196,7 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         tools::wallet2::ons_detail detail = {
                 static_cast<ons::mapping_type>(mapping["type"]),
                 name,
-                req_params["entries"][0]["name_hash"]};
+                mapping.name_hash};
         m_wallet->set_ons_cache_record(detail);
     }
     for (size_t i = last_index + 1; i < args.size(); i++)


### PR DESCRIPTION
When multiple ONS names are provided in the lookup, the data is consistently updated in cache using the first name_hash instead of being appended with a new name_hash each time.