### PR TITLE
Add multiple backup providers in `--ethereum-provider` via `ethyl`

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(db_drivers)
 add_subdirectory(randomx EXCLUDE_FROM_ALL)
 add_subdirectory(date EXCLUDE_FROM_ALL)
 
+set(BLS_ETH ON CACHE BOOL "" FORCE)
 add_subdirectory(bls EXCLUDE_FROM_ALL)
 
 set(JSON_BuildTests OFF CACHE INTERNAL "")

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -533,7 +533,8 @@ bool Blockchain::init(
     if (!m_checkpoints.init(m_nettype, m_db))
         throw std::runtime_error("Failed to initialize checkpoints");
 
-    m_l2_tracker = std::make_shared<L2Tracker>(m_nettype);
+    m_l2_tracker                          = std::make_shared<L2Tracker>(m_nettype);
+    m_l2_tracker->provider.connectTimeout = 2000ms;
     if (ethereum_provider.size()) {
         std::string_view delimiter = ",";
         std::vector<std::string_view> provider_urls = tools::split(ethereum_provider, delimiter, /*trim*/ true);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -533,11 +533,39 @@ bool Blockchain::init(
     if (!m_checkpoints.init(m_nettype, m_db))
         throw std::runtime_error("Failed to initialize checkpoints");
 
-    m_provider = std::make_shared<Provider>("Ethereum Client", ethereum_provider);
-    if (ethereum_provider != "") {
-        m_l2_tracker = std::make_shared<L2Tracker>(m_nettype, m_provider);
-    } else {
-        m_l2_tracker = std::make_shared<L2Tracker>();
+    m_l2_tracker = std::make_shared<L2Tracker>(m_nettype);
+    if (ethereum_provider.size()) {
+        std::string_view delimiter = ",";
+        std::vector<std::string_view> provider_urls = tools::split(ethereum_provider, delimiter, /*trim*/ true);
+
+        auto error_buffer = fmt::memory_buffer();
+        fmt::format_to(std::back_inserter(error_buffer), "Failed to add URL '{}' as an Ethereum provider.", ethereum_provider);
+
+        bool error_in_urls = false;
+        if (provider_urls.size() == 0) {
+            fmt::format_to(std::back_inserter(error_buffer),
+                           " There were no URLs produced after splitting by '{}'.",
+                           delimiter);
+            error_in_urls = true;
+        } else {
+            fmt::format_to(std::back_inserter(error_buffer), " The items that failed were:\n", ethereum_provider);
+            // NOTE: Prepare an error message incase we encounter some
+            for (size_t index = 0; index < provider_urls.size(); index++) {
+                std::string_view url = provider_urls[index];
+                if (!m_l2_tracker->provider.addClient(fmt::format("Eth Client #{}", index), std::string(url))) {
+                    error_in_urls = true;
+                    fmt::format_to(std::back_inserter(error_buffer), "  - '{}'\n", url);
+                }
+            }
+        }
+
+        // NOTE: Handle errors
+        if (error_in_urls || m_l2_tracker->provider.clients.empty()) {
+            log::error(logcat, "{}", fmt::to_string(error_buffer));
+            return false;
+        }
+
+        m_l2_tracker->start();
     }
 
     m_offline = offline;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1290,7 +1290,7 @@ class Blockchain {
     checkpoints m_checkpoints;
 
     // Ethereum client for communicating with L2 blockchain
-    std::shared_ptr<Provider> m_provider;
+    std::shared_ptr<ethyl::Provider> m_provider;
 
     network_type m_nettype;
     bool m_offline;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -158,9 +158,11 @@ static const command_line::arg_descriptor<std::string> arg_public_ip = {
         "service node."};
 static const command_line::arg_descriptor<std::string> arg_ethereum_provider = {
         "ethereum-provider",
-        "Provider on which this service node will query the ethereum blockchain "
-        "when tracking the rewards smart contract. Required if operating as a "
-        "service node."};
+        "Specify a provider by URL(s) on which this service node will query the"
+        "Ethereum blockchain when tracking the rewards smart contract. A "
+        "provider is required if operating as a service node.\n"
+        "Multiple ethereum providers can be specified by comma delimiting the "
+        "URLs for example: '127.0.0.1:8545,127.0.0.1:8546'"};
 static const command_line::arg_descriptor<uint16_t> arg_storage_server_port = {
         "storage-server-port", "Deprecated option, ignored.", 0};
 static const command_line::arg_descriptor<uint16_t, false, true, 2> arg_quorumnet_port = {
@@ -1207,6 +1209,7 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                             tools::type_to_hex(m_service_keys.pub),
                             m_bls_signer->getPublicKeyHex());
                 });
+
     }
 
     quorumnet_init(*this, m_quorumnet_state);

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -64,10 +64,10 @@ class L2Tracker {
     std::thread update_thread;
 
   public:
-    L2Tracker();
-    L2Tracker(const cryptonote::network_type nettype, const std::shared_ptr<Provider>& client);
+    L2Tracker(cryptonote::network_type nettype);
     ~L2Tracker();
 
+    bool start();
     void update_state();
     bool check_state_in_history(uint64_t height, const crypto::hash& state_root);
     bool check_state_in_history(uint64_t height, const std::string& state_root);
@@ -88,6 +88,8 @@ class L2Tracker {
 
     uint64_t get_pool_block_reward(uint64_t timestamp, uint64_t ethereum_block_height);
 
+    ethyl::Provider provider;
+
   private:
     void insert_in_order(State&& new_state);
     void process_logs_for_state(State& state);
@@ -97,6 +99,5 @@ class L2Tracker {
     static std::string_view get_pool_contract_address(const cryptonote::network_type nettype);
     void get_review_transactions();
     void populate_review_transactions(std::shared_ptr<TransactionReviewSession> session);
-    bool service_node = true;
     // END
 };

--- a/src/l2_tracker/pool_contract.cpp
+++ b/src/l2_tracker/pool_contract.cpp
@@ -6,17 +6,17 @@
 
 static auto logcat = oxen::log::Cat("l2_tracker");
 
-PoolContract::PoolContract(std::string _contractAddress, std::shared_ptr<Provider> _provider) :
-        contractAddress(std::move(_contractAddress)), provider(std::move(_provider)) {}
+PoolContract::PoolContract(std::string _contractAddress, ethyl::Provider& _provider) :
+        contractAddress(std::move(_contractAddress)), provider(_provider) {}
 
 RewardRateResponse PoolContract::RewardRate(uint64_t timestamp, uint64_t ethereum_block_height) {
-    ReadCallData callData;
+    ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
     std::string timestampStr =
             utils::padTo32Bytes(utils::decimalToHex(timestamp), utils::PaddingDirection::LEFT);
     // keccak256("rewardRate(uint256)")
     std::string functionABI = "0xcea01962";
     callData.data = functionABI + timestampStr;
-    std::string result = provider->callReadFunction(callData, ethereum_block_height);
+    std::string result = provider.callReadFunction(callData, ethereum_block_height);
     return RewardRateResponse{timestamp, utils::fromHexStringToUint64(result)};
 }

--- a/src/l2_tracker/pool_contract.h
+++ b/src/l2_tracker/pool_contract.h
@@ -15,10 +15,10 @@ class RewardRateResponse {
 
 class PoolContract {
   public:
-    PoolContract(std::string _contractAddress, std::shared_ptr<Provider> _provider);
+    PoolContract(std::string _contractAddress, ethyl::Provider& _provider);
     RewardRateResponse RewardRate(uint64_t timestamp, uint64_t ethereum_block_height);
 
   private:
     std::string contractAddress;
-    std::shared_ptr<Provider> provider;
+    ethyl::Provider& provider;
 };

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -135,16 +135,15 @@ std::optional<TransactionStateChangeVariant> RewardsLogEntry::getLogTransaction(
     }
 }
 
-RewardsContract::RewardsContract(
-        const std::string& _contractAddress, std::shared_ptr<Provider> _provider) :
-        contractAddress(_contractAddress), provider(std::move(_provider)) {}
+RewardsContract::RewardsContract(const std::string& _contractAddress, ethyl::Provider& _provider) :
+        contractAddress(_contractAddress), provider(_provider) {}
 
 StateResponse RewardsContract::State() {
-    return State(provider->getLatestHeight());
+    return State(provider.getLatestHeight());
 }
 
 StateResponse RewardsContract::State(uint64_t height) {
-    std::string blockHash = provider->getContractStorageRoot(contractAddress, height);
+    std::string blockHash = provider.getContractStorageRoot(contractAddress, height);
     // Check if blockHash starts with "0x" and remove it
     if (blockHash.size() >= 2 && blockHash[0] == '0' && blockHash[1] == 'x') {
         blockHash = blockHash.substr(2);  // Skip the first two characters
@@ -155,7 +154,7 @@ StateResponse RewardsContract::State(uint64_t height) {
 std::vector<RewardsLogEntry> RewardsContract::Logs(uint64_t height) {
     std::vector<RewardsLogEntry> logEntries;
     // Make the RPC call
-    const auto logs = provider->getLogs(height, contractAddress);
+    const auto logs = provider.getLogs(height, contractAddress);
 
     for (const auto& log : logs) {
         logEntries.emplace_back(RewardsLogEntry(log));

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -94,7 +94,7 @@ struct StateResponse {
 class RewardsContract {
   public:
     // Constructor
-    RewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);
+    RewardsContract(const std::string& _contractAddress, ethyl::Provider& provider);
 
     StateResponse State();
     StateResponse State(uint64_t height);
@@ -103,5 +103,5 @@ class RewardsContract {
 
   private:
     std::string contractAddress;
-    std::shared_ptr<Provider> provider;
+    ethyl::Provider& provider;
 };


### PR DESCRIPTION
- Augments `--ethereum-provider` to accept multiple URLs delimited by comma e.g: `127.0.0.1:8545,127.0.0.1:8546`
- Fixes the integration branch, `BLS_ETH` was removed when it was fork to an `oxen-io/bls` version which caused BLSSigner to fail initialisation and throw a exception for `blsInit` failing.
- The `bls` submodule wasn't updated to include the ninja build fix which is now updated in this PR