### PR TITLE
Fix local devnet python script

### DIFF
--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -77,39 +77,18 @@ bool is_back(const S& str, const More&... more) {
 template <typename T, bool required = false, bool dependent = false, int NUM_DEPS = 1>
 struct arg_descriptor;
 
-template <typename T>
-struct arg_descriptor<T, false> {
+template <typename T, bool required>
+struct arg_descriptor<T, required> {
     using value_type = T;
 
     const char* name;
     const char* description;
     T default_value;
     bool not_use_default;
-};
 
-template <typename T>
-struct arg_descriptor<T, true> {
-    static_assert(!std::is_same_v<T, bool>, "Boolean switch can't be required");
-
-    using value_type = T;
-
-    const char* name;
-    const char* description;
-};
-
-template <typename T>
-struct arg_descriptor<T, false, true> {
-    using value_type = T;
-
-    const char* name;
-    const char* description;
-
-    T default_value;
-
-    const arg_descriptor<bool, false>& ref;
-    std::function<T(bool, bool, T)> depf;
-
-    bool not_use_default;
+    static constexpr void validate() requires std::is_same_v<T, bool> { // NOTE: Evaluated if [T = bool]
+        static_assert(!required, "Boolean switch can't be required");
+    }
 };
 
 template <typename T, int NUM_DEPS>

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -164,4 +164,15 @@ std::string_view find_prefixed_value(It begin, It end, std::string_view prefix) 
         return {};
     return std::string_view{*it}.substr(prefix.size());
 }
+
+/// Safely create a substring from `src`, slicing the string at [pos, pos + size). If pos is
+/// out-of-bounds, the a slice to the end of the string is returned of 0 size. This function hence
+/// guarantees that a valid string will always be returned irrespective of input.
+static std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept {
+    std::string_view result = std::string_view(src.end(), 0);
+    if (pos < src.size()) {
+        result = src.substr(pos, size);
+    }
+    return result;
+}
 }  // namespace tools

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -45,3 +45,6 @@ target_link_libraries(cryptonote_basic
     Boost::serialization
     logging
     extra)
+
+option(USE_LOCAL_DEVNET_ETH_ADDRESSES "Use hardcoded addresses for our Ethereum contracts as if they were deployed on a local-devnet" OFF)
+target_compile_definitions(cryptonote_basic PUBLIC OXEN_USE_LOCAL_DEVNET_ETH_ADDRESSES)

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -508,6 +508,12 @@ namespace config {
         };
 
         inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
+
+        inline constexpr uint32_t ETHEREUM_CHAIN_ID = 31337;
+        inline constexpr std::string_view ETHEREUM_REWARDS_CONTRACT =
+                "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707";
+        inline constexpr std::string_view ETHEREUM_POOL_CONTRACT =
+                "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0";
     }  // namespace devnet
 
     namespace fakechain {
@@ -653,9 +659,9 @@ inline constexpr network_config devnet_config{
         config::testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         config::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         config::STORE_LONG_TERM_STATE_INTERVAL,
-        config::ETHEREUM_CHAIN_ID,
-        config::ETHEREUM_REWARDS_CONTRACT,
-        config::ETHEREUM_POOL_CONTRACT,
+        config::devnet::ETHEREUM_CHAIN_ID,
+        config::devnet::ETHEREUM_REWARDS_CONTRACT,
+        config::devnet::ETHEREUM_POOL_CONTRACT,
 };
 inline constexpr network_config fakenet_config{
         network_type::FAKECHAIN,

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -38,7 +38,6 @@
 #include <filesystem>
 #include <ratio>
 #include <stdexcept>
-#include <string>
 #include <string_view>
 
 using namespace std::literals;
@@ -509,11 +508,35 @@ namespace config {
 
         inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
 
+#if defined(OXEN_USE_LOCAL_DEVNET_ETH_ADDRESSES)
+        // NOTE: A local-devnet involves launching typically a local Ethereum
+        // blockchain via Hardhat, Ganache or Foundry's Anvil for example.
+        // These use local-developer wallets which deploy our rewards contract
+        // to a deterministic address different from those deployed on a
+        // live-devnet (because the wallets may be live-wallets that produce
+        // different contract addresses).
+        //
+        // These addresses below are the current up-to-date contract addresses
+        // that would be used if deployed on a local-devnet and can be enabled
+        // by defining the macro accordingly.
+        //
+        // A local-devnet can be deployed by running
+        // `utils/local-devnet/service_node_network.py`
+        //
+        // TODO: This is probably best done with a `private_devnet`
+        // configuration type.
+
         inline constexpr uint32_t ETHEREUM_CHAIN_ID = 31337;
         inline constexpr std::string_view ETHEREUM_REWARDS_CONTRACT =
                 "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707";
         inline constexpr std::string_view ETHEREUM_POOL_CONTRACT =
                 "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0";
+#else
+        inline constexpr uint32_t ETHEREUM_CHAIN_ID = config::ETHEREUM_CHAIN_ID;
+        inline constexpr std::string_view ETHEREUM_REWARDS_CONTRACT =
+                config::ETHEREUM_REWARDS_CONTRACT;
+        inline constexpr std::string_view ETHEREUM_POOL_CONTRACT = config::ETHEREUM_POOL_CONTRACT;
+#endif
     }  // namespace devnet
 
     namespace fakechain {

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -91,7 +91,7 @@ void L2Tracker::update_state() {
 
 static constexpr inline std::string_view NO_PROVIDER_CLIENTS_ERROR = "L2 tracker does not have any RPC servers configured for the Ethereum provider. Ensure that `--ethereum_provider` is set to an Ethereum RPC endpoint.";
 std::pair<uint64_t, crypto::hash> L2Tracker::latest_state() {
-    if (!provider.clients.empty()) {
+    if (provider.clients.empty()) {
         oxen::log::error(logcat, NO_PROVIDER_CLIENTS_ERROR);
         throw std::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -19,6 +19,7 @@ struct Contributor {
     crypto::eth_address addr;
     uint64_t amount;
 
+    Contributor() = default;
     Contributor(const crypto::eth_address& address, uint64_t amt) : addr(address), amount(amt) {}
 };
 
@@ -92,12 +93,15 @@ struct StateResponse {
 };
 
 struct ContractServiceNode {
-    uint64_t                      next;
-    uint64_t                      prev;
-    std::array<unsigned char, 20> recipient;
-    std::string                   pubkey;
-    uint64_t                      leaveRequestTimestamp;
-    std::string                   deposit;
+    bool good;
+    uint64_t next;
+    uint64_t prev;
+    crypto::eth_address operatorAddr;
+    std::string pubkey;
+    uint64_t leaveRequestTimestamp;
+    uint64_t deposit;
+    std::array<Contributor, 10> contributors;
+    size_t contributorsSize;
 };
 
 class RewardsContract {

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -280,13 +280,29 @@ contract_abi = json.loads("""
       "type": "error"
     },
     {
-      "inputs": [],
-      "name": "ContractAlreadyActive",
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "serviceNodeID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "contributor",
+          "type": "address"
+        }
+      ],
+      "name": "CallerNotContributor",
       "type": "error"
     },
     {
       "inputs": [],
-      "name": "ContractNotActive",
+      "name": "ContractAlreadyStarted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ContractNotStarted",
       "type": "error"
     },
     {
@@ -411,6 +427,11 @@ contract_abi = json.loads("""
     },
     {
       "inputs": [],
+      "name": "MaxContributorsExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "NotInitializing",
       "type": "error"
     },
@@ -487,6 +508,27 @@ contract_abi = json.loads("""
         }
       ],
       "name": "ServiceNodeDoesntExist",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "serviceNodeID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currenttime",
+          "type": "uint256"
+        }
+      ],
+      "name": "SignatureExpired",
       "type": "error"
     },
     {
@@ -847,6 +889,19 @@ contract_abi = json.loads("""
         {
           "indexed": false,
           "internalType": "uint256",
+          "name": "newExpiry",
+          "type": "uint256"
+        }
+      ],
+      "name": "SignatureExpiryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
           "name": "newRequirement",
           "type": "uint256"
         }
@@ -866,19 +921,6 @@ contract_abi = json.loads("""
       ],
       "name": "Unpaused",
       "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "IsActive",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
     },
     {
       "inputs": [],
@@ -1130,6 +1172,11 @@ contract_abi = json.loads("""
         },
         {
           "internalType": "uint256",
+          "name": "maxContributors_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
           "name": "liquidatorRewardRatio_",
           "type": "uint256"
         },
@@ -1163,12 +1210,20 @@ contract_abi = json.loads("""
       "type": "function"
     },
     {
-      "inputs": [
+      "inputs": [],
+      "name": "isStarted",
+      "outputs": [
         {
-          "internalType": "uint64",
-          "name": "serviceNodeID",
-          "type": "uint64"
-        },
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
         {
           "components": [
             {
@@ -1185,6 +1240,11 @@ contract_abi = json.loads("""
           "internalType": "struct BN256G1.G1Point",
           "name": "blsPubkey",
           "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
         },
         {
           "components": [
@@ -1240,6 +1300,19 @@ contract_abi = json.loads("""
     {
       "inputs": [],
       "name": "liquidatorRewardRatio",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "maxContributors",
       "outputs": [
         {
           "internalType": "uint256",
@@ -1401,11 +1474,6 @@ contract_abi = json.loads("""
     {
       "inputs": [
         {
-          "internalType": "uint64",
-          "name": "serviceNodeID",
-          "type": "uint64"
-        },
-        {
           "components": [
             {
               "internalType": "uint256",
@@ -1421,6 +1489,11 @@ contract_abi = json.loads("""
           "internalType": "struct BN256G1.G1Point",
           "name": "blsPubkey",
           "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
         },
         {
           "components": [
@@ -1507,7 +1580,7 @@ contract_abi = json.loads("""
       "inputs": [
         {
           "internalType": "bytes",
-          "name": "",
+          "name": "blsPublicKey",
           "type": "bytes"
         }
       ],
@@ -1515,7 +1588,7 @@ contract_abi = json.loads("""
       "outputs": [
         {
           "internalType": "uint64",
-          "name": "",
+          "name": "serviceNodeID",
           "type": "uint64"
         }
       ],
@@ -1632,6 +1705,19 @@ contract_abi = json.loads("""
       "inputs": [
         {
           "internalType": "uint256",
+          "name": "newExpiry",
+          "type": "uint256"
+        }
+      ],
+      "name": "setSignatureExpiry",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
           "name": "newRequirement",
           "type": "uint256"
         }
@@ -1639,6 +1725,19 @@ contract_abi = json.loads("""
       "name": "setStakingRequirement",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signatureExpiry",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {
@@ -1755,188 +1854,329 @@ contract_abi = json.loads("""
 """)
 erc20_contract_abi = json.loads("""
 [
-{
-  "anonymous": false,
-  "inputs": [
     {
-      "indexed": true,
-      "internalType": "address",
-      "name": "owner",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalSupply_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "receiverGenesisAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
     },
     {
-      "indexed": true,
-      "internalType": "address",
-      "name": "spender",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
     },
     {
-      "indexed": false,
-      "internalType": "uint256",
-      "name": "value",
-      "type": "uint256"
-    }
-  ],
-  "name": "Approval",
-  "type": "event"
-},
-{
-  "anonymous": false,
-  "inputs": [
-    {
-      "indexed": true,
-      "internalType": "address",
-      "name": "from",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
     },
     {
-      "indexed": true,
-      "internalType": "address",
-      "name": "to",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
     },
     {
-      "indexed": false,
-      "internalType": "uint256",
-      "name": "value",
-      "type": "uint256"
-    }
-  ],
-  "name": "Transfer",
-  "type": "event"
-},
-{
-  "inputs": [
-    {
-      "internalType": "address",
-      "name": "owner",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
     },
     {
-      "internalType": "address",
-      "name": "spender",
-      "type": "address"
-    }
-  ],
-  "name": "allowance",
-  "outputs": [
-    {
-      "internalType": "uint256",
-      "name": "",
-      "type": "uint256"
-    }
-  ],
-  "stateMutability": "view",
-  "type": "function"
-},
-{
-  "inputs": [
-    {
-      "internalType": "address",
-      "name": "spender",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
     },
     {
-      "internalType": "uint256",
-      "name": "value",
-      "type": "uint256"
-    }
-  ],
-  "name": "approve",
-  "outputs": [
-    {
-      "internalType": "bool",
-      "name": "",
-      "type": "bool"
-    }
-  ],
-  "stateMutability": "nonpayable",
-  "type": "function"
-},
-{
-  "inputs": [
-    {
-      "internalType": "address",
-      "name": "account",
-      "type": "address"
-    }
-  ],
-  "name": "balanceOf",
-  "outputs": [
-    {
-      "internalType": "uint256",
-      "name": "",
-      "type": "uint256"
-    }
-  ],
-  "stateMutability": "view",
-  "type": "function"
-},
-{
-  "inputs": [],
-  "name": "totalSupply",
-  "outputs": [
-    {
-      "internalType": "uint256",
-      "name": "",
-      "type": "uint256"
-    }
-  ],
-  "stateMutability": "view",
-  "type": "function"
-},
-{
-  "inputs": [
-    {
-      "internalType": "address",
-      "name": "to",
-      "type": "address"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
     },
     {
-      "internalType": "uint256",
-      "name": "value",
-      "type": "uint256"
-    }
-  ],
-  "name": "transfer",
-  "outputs": [
-    {
-      "internalType": "bool",
-      "name": "",
-      "type": "bool"
-    }
-  ],
-  "stateMutability": "nonpayable",
-  "type": "function"
-},
-{
-  "inputs": [
-    {
-      "internalType": "address",
-      "name": "from",
-      "type": "address"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
     },
     {
-      "internalType": "address",
-      "name": "to",
-      "type": "address"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
     },
     {
-      "internalType": "uint256",
-      "name": "value",
-      "type": "uint256"
-    }
-  ],
-  "name": "transferFrom",
-  "outputs": [
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
     {
-      "internalType": "bool",
-      "name": "",
-      "type": "bool"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     }
-  ],
-  "stateMutability": "nonpayable",
-  "type": "function"
-}
 ]
 """)

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -245,7 +245,7 @@ class SNNetwork:
         # vprint("liquidated node: number of service nodes in contract {}".format(self.servicenodecontract.numberServiceNodes()))
 
         # Claim rewards for Address
-        time.sleep(155)
+        time.sleep(10)
         rewards = self.ethsns[0].get_bls_rewards(self.servicenodecontract.hardhatAccountAddress())
         vprint(rewards)
         vprint("Balance before claim {}".format(self.servicenodecontract.erc20balance(self.servicenodecontract.hardhatAccountAddress())))


### PR DESCRIPTION
There were multiple road-blocking bugs preventing the devnet python script from working which I've worked through

- I updated the contract ABIs hardcoded in the ethereum script (would be nice to automate this)
- Added separate devnet parameters
- Update the parsing code for the service node blob received from the smart contract
- Fix an incorrect negation on `vector::empty()` causing an invalid iterator to be dereferenced and crash a non-service node daemon.

There are still failing unit-tests that are to be investigated. Some of them are because some codepaths require an ethereum provider to be set mandatorily even if they're not a service node. 