### PR TITLE
Secure bls_rewards_request endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,24 @@ The output of `mdb_dump -s blocks <path to blockchain dir>` and `mdb_dump -s blo
 
 These records are dumped as hex data, where the first line is the key and the second line is the data.
 
+## Testing tools
+
+### Local Devnet
+
+The local devnet script in `utils/local-devnet/service_node_network.py` will
+spin up a series of service nodes that can be interacted with locally for
+testing. This script requires that:
+
+- A development Ethereum environment and node is setup at `localhost:8545`
+  (which is the default for port for these environments). Currently we only
+  support Foundry's `anvil` testnet. (Hardhat's node does not support
+  `eth_getProof` calls).
+
+- The smart contracts are deployed from `oxen-io/eth-sn-contracts` by invoking
+  the `deploy-local` Makefile target.
+
+Thereafter the script can be invoked to launch the local network.
+
 # Known Issues
 
 ## Protocols

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -412,7 +412,7 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
 }
 
 std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings(const std::string& address) {
-    log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
+    log::trace(logcat, "BlockchainDB_SQLITE::{} for {}", __func__, address);
     // auto earnings = prepared_maybe_get<int64_t>(R"(
     // WITH RelevantOxenAddress AS (
     // SELECT oxen_address
@@ -435,7 +435,8 @@ std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings(const std::
         WHERE address = ?
     )",
             address);
-    return std::make_pair(height, static_cast<uint64_t>(earnings.value_or(0) / 1000));
+    auto result = std::make_pair(height, static_cast<uint64_t>(earnings.value_or(0) / 1000));
+    return result;
 }
 
 std::pair<std::vector<std::string>, std::vector<uint64_t>>

--- a/src/bls/CMakeLists.txt
+++ b/src/bls/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(oxen_bls
   bls_signer.cpp
   bls_aggregator.cpp
   bls_utils.cpp
+  bls_omq.cpp
   )
 
 target_link_libraries(oxen_bls
@@ -38,6 +39,7 @@ target_link_libraries(oxen_bls
     cncrypto
     cryptonote_basic
   PRIVATE
+    SQLiteCpp
     common
     logging
     ethyl

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -120,6 +120,7 @@ static void logNetworkRequestFailedWarning(
 
 BLSRewardsResponse BLSAggregator::rewards_request(
         const crypto::eth_address& address,
+        const std::string& oxen_address,
         uint64_t amount,
         uint64_t height,
         std::span<const crypto::x25519_public_key> exclude) {
@@ -259,7 +260,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                 work.aggregate_signature.add(response.message_hash_signature);
                 work.signers.push_back(bls_utils::PublicKeyToHex(response.bls_pkey));
             },
-            std::array{oxenc::type_to_hex(address), std::to_string(amount)},
+            std::array{oxenc::type_to_hex(address), oxen_address, std::to_string(amount)},
             exclude);
 
     const auto sig_str = bls_utils::SignatureToHex(work.aggregate_signature);

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -120,7 +120,6 @@ static void logNetworkRequestFailedWarning(
 
 BLSRewardsResponse BLSAggregator::rewards_request(
         const crypto::eth_address& address,
-        const std::string& oxen_address,
         uint64_t amount,
         uint64_t height,
         std::span<const crypto::x25519_public_key> exclude) {
@@ -260,7 +259,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                 work.aggregate_signature.add(response.message_hash_signature);
                 work.signers.push_back(bls_utils::PublicKeyToHex(response.bls_pkey));
             },
-            std::array{oxenc::type_to_hex(address), oxen_address, std::to_string(amount)},
+            std::array{oxenc::type_to_hex(address), std::to_string(amount)},
             exclude);
 
     const auto sig_str = bls_utils::SignatureToHex(work.aggregate_signature);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -16,7 +16,7 @@ struct aggregateExitResponse {
     std::string signature;
 };
 
-struct aggregateWithdrawalResponse {
+struct AggregateRewardsResponse {
     std::string address;
     uint64_t amount;
     uint64_t height;
@@ -55,9 +55,9 @@ class BLSAggregator {
     /** Request the service node network to sign the requested amount of
      * 'rewards' for the given Ethereum 'address' if by consensus they agree
      * that the amount is valid. This node (the aggregator) will aggregate the
-     * signatures into the response
+     * signatures into the response.
      */
-    aggregateWithdrawalResponse aggregateRewards(const crypto::eth_address& address, uint64_t rewards, uint64_t height);
+    AggregateRewardsResponse aggregateRewards(const crypto::eth_address& address, uint64_t rewards, uint64_t height);
 
     aggregateExitResponse aggregateExit(const std::string& bls_key);
     aggregateExitResponse aggregateLiquidation(const std::string& bls_key);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -57,7 +57,11 @@ class BLSAggregator {
      * that the amount is valid. This node (the aggregator) will aggregate the
      * signatures into the response.
      */
-    AggregateRewardsResponse aggregateRewards(const crypto::eth_address& address, uint64_t rewards, uint64_t height);
+    AggregateRewardsResponse aggregateRewards(
+            const crypto::eth_address& address,
+            uint64_t rewards,
+            uint64_t height,
+            std::span<const crypto::x25519_public_key> exclude);
 
     aggregateExitResponse aggregateExit(const std::string& bls_key);
     aggregateExitResponse aggregateLiquidation(const std::string& bls_key);
@@ -72,5 +76,6 @@ class BLSAggregator {
             std::function<void(
                     const BLSRequestResult& request_result, const std::vector<std::string>& data)>
                     callback,
-            std::span<const std::string> message = {});
+            std::span<const std::string> message = {},
+            std::span<const crypto::x25519_public_key> exclude = {});
 };

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -61,7 +61,6 @@ class BLSAggregator {
     /// amount is `0` or height is greater than the current blockchain height.
     BLSRewardsResponse rewards_request(
             const crypto::eth_address& address,
-            const std::string& oxen_address,
             uint64_t rewards,
             uint64_t height,
             std::span<const crypto::x25519_public_key> exclude);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -16,7 +16,7 @@ struct aggregateExitResponse {
     std::string signature;
 };
 
-struct AggregateRewardsResponse {
+struct BLSRewardsResponse {
     std::string address;
     uint64_t amount;
     uint64_t height;
@@ -52,12 +52,11 @@ class BLSAggregator {
 
     std::vector<std::pair<std::string, std::string>> getPubkeys();
 
-    /** Request the service node network to sign the requested amount of
-     * 'rewards' for the given Ethereum 'address' if by consensus they agree
-     * that the amount is valid. This node (the aggregator) will aggregate the
-     * signatures into the response.
-     */
-    AggregateRewardsResponse aggregateRewards(
+    /// Request the service node network to sign the requested amount of
+    /// 'rewards' for the given Ethereum 'address' if by consensus they agree
+    /// that the amount is valid. This node (the aggregator) will aggregate the
+    /// signatures into the response.
+    BLSRewardsResponse rewards_request(
             const crypto::eth_address& address,
             uint64_t rewards,
             uint64_t height,

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -2,6 +2,7 @@
 
 #include <oxenmq/oxenmq.h>
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -50,7 +51,14 @@ class BLSAggregator {
             std::shared_ptr<BLSSigner> _bls_signer);
 
     std::vector<std::pair<std::string, std::string>> getPubkeys();
-    aggregateWithdrawalResponse aggregateRewards(const std::string& address);
+
+    /** Request the service node network to sign the requested amount of
+     * 'rewards' for the given Ethereum 'address' if by consensus they agree
+     * that the amount is valid. This node (the aggregator) will aggregate the
+     * signatures into the response
+     */
+    aggregateWithdrawalResponse aggregateRewards(const crypto::eth_address& address, uint64_t rewards, uint64_t height);
+
     aggregateExitResponse aggregateExit(const std::string& bls_key);
     aggregateExitResponse aggregateLiquidation(const std::string& bls_key);
     blsRegistrationResponse registration(
@@ -64,5 +72,5 @@ class BLSAggregator {
             std::function<void(
                     const BLSRequestResult& request_result, const std::vector<std::string>& data)>
                     callback,
-            const std::optional<std::string>& message = std::nullopt);
+            std::span<const std::string> message = {});
 };

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -61,6 +61,7 @@ class BLSAggregator {
     /// amount is `0` or height is greater than the current blockchain height.
     BLSRewardsResponse rewards_request(
             const crypto::eth_address& address,
+            const std::string& oxen_address,
             uint64_t rewards,
             uint64_t height,
             std::span<const crypto::x25519_public_key> exclude);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -56,6 +56,9 @@ class BLSAggregator {
     /// 'rewards' for the given Ethereum 'address' if by consensus they agree
     /// that the amount is valid. This node (the aggregator) will aggregate the
     /// signatures into the response.
+    ///
+    /// This function throws an `invalid_argument` exception if `address` is zero or, the `rewards`
+    /// amount is `0` or height is greater than the current blockchain height.
     BLSRewardsResponse rewards_request(
             const crypto::eth_address& address,
             uint64_t rewards,

--- a/src/bls/bls_omq.cpp
+++ b/src/bls/bls_omq.cpp
@@ -132,12 +132,14 @@ static VerifyDataResult data_parts_count_is_valid(std::span<const T> data, size_
 enum class GetRewardBalanceRequestField
 {
     Address,
+    OxenAddress,
     Amount,
     _count,
 };
 
 struct GetRewardBalanceRequest {
     crypto::eth_address address;
+    std::string oxen_address;
     uint64_t amount;
 };
 
@@ -184,6 +186,10 @@ GetRewardBalanceResponse create_reward_balance_request(
                 oxenc::from_hex(payload.begin(), payload.end(), reinterpret_cast<char*>(&request.address));
             } break;
 
+            case GetRewardBalanceRequestField::OxenAddress: {
+                request.oxen_address = m.data[field_index];
+            } break;
+
             case GetRewardBalanceRequestField::Amount: {
                 VerifyDataResult to_result = payload_to_number("rewards amount", payload, request.amount);
                 if (!to_result.good) {
@@ -199,8 +205,8 @@ GetRewardBalanceResponse create_reward_balance_request(
     }
 
     // NOTE: Get the rewards amount from the DB
-    std::string address_str = fmt::format("0x{}", request.address);
-    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(address_str);
+    // std::string address_str = fmt::format("0x{}", request.address);
+    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(request.oxen_address);
     if (amount == 0) {
         result.error = fmt::format(
                 "OMQ command '{}' requested an address '{}' that has a zero balance in the "

--- a/src/bls/bls_omq.cpp
+++ b/src/bls/bls_omq.cpp
@@ -1,0 +1,308 @@
+#include "bls_omq.h"
+
+#include "blockchain_db/sqlite/db_sqlite.h"
+#include "bls/bls_signer.h"
+#include "bls/bls_utils.h"
+#include "common/util.h"
+#include "ethyl/utils.hpp"
+#include "fmt/format.h"
+#include "logging/oxen_logger.h"
+#include "oxenmq/message.h"
+
+static auto logcat = oxen::log::Cat("bls_omq");
+
+namespace oxen::bls {
+std::string get_reward_balance_request_message(BLSSigner* signer, const crypto::eth_address& eth_address, uint64_t amount)
+{
+    std::string result;
+    if (signer) {
+        result = fmt::format(
+                "0x{}{}{}",
+                signer->buildTag(signer->rewardTag),
+                ethyl::utils::padToNBytes(oxenc::type_to_hex(eth_address), 20, ethyl::utils::PaddingDirection::LEFT),
+                ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(amount), ethyl::utils::PaddingDirection::LEFT));
+    }
+    return result;
+}
+
+static void write_and_3_dot_truncate(fmt::memory_buffer& buffer, std::string_view data, size_t threshold_for_3_dots) {
+    if (data.size() > threshold_for_3_dots) {
+        fmt::format_to_n(std::back_inserter(buffer), threshold_for_3_dots, "{}", data);
+        fmt::format_to(std::back_inserter(buffer), "...");
+    } else {
+        fmt::format_to(std::back_inserter(buffer), "{}", data);
+    }
+}
+
+// TODO(doyle): Need to 3 dot truncate because this is all untrusted input
+struct PayloadResult
+{
+    bool good;
+    std::string error;
+};
+
+static PayloadResult payload_is_hex(
+        std::string_view payload_description,
+        std::string_view payload,
+        size_t required_hex_size) {
+    PayloadResult result = {};
+    payload = oxenc::trim_prefix(payload, "0x");
+    payload = oxenc::trim_prefix(payload, "0x");
+
+    if (payload.size() != required_hex_size) {
+        result.error = fmt::format(
+                "Specified an {} '{}' with length {} which does not have the "
+                "correct length ({}) to be an {}",
+                payload_description,
+                payload,
+                payload.size(),
+                required_hex_size,
+                payload_description);
+        return result;
+    }
+
+    if (!oxenc::is_hex(payload)) {
+        result.error = fmt::format(
+                "Specified a {} '{}' which contains non-hex characters",
+                payload_description,
+                payload,
+                payload.size());
+        return result;
+    }
+
+    result.good = true;
+    return result;
+}
+
+static PayloadResult payload_to_number(
+        std::string_view payload_description,
+        std::string_view payload,
+        uint64_t& number) {
+
+    PayloadResult result = {};
+    if (!tools::parse_int(payload, number)) {
+        result.error = fmt::format(
+                "Specified {} '{}' that is not a valid number",
+                payload_description,
+                payload);
+        return result;
+    }
+
+    result.good = true;
+    return result;
+}
+
+enum class GetRewardBalanceRequestField
+{
+    Address,
+    Amount,
+    _count,
+};
+
+struct GetRewardBalanceRequest {
+    crypto::eth_address address;
+    uint64_t amount;
+};
+
+GetRewardBalanceResponse create_reward_balance_request(
+        const oxenmq::Message& m, BLSSigner* signer, cryptonote::BlockchainSQLite* sql_db) {
+
+    GetRewardBalanceResponse result = {};
+    oxen::log::trace(logcat, "Received omq rewards signature request");
+
+    // NOTE: Validate arguments
+    if (!sql_db) {
+        result.error = "Service node does not have a SQL DB setup to handle BLS OMQ requests";
+        return result;
+    }
+
+    if (!signer) {
+        result.error = "Service node does not have a SQL signer setup to handle BLS OMQ requests";
+        return result;
+    }
+
+    // NOTE: Verify the data-segment count
+    size_t field_count = tools::enum_count<GetRewardBalanceRequestField>;
+    if (m.data.size() != field_count) {
+
+        auto fmt_buffer = fmt::memory_buffer();
+        fmt::format_to(
+                std::back_inserter(fmt_buffer),
+                "Bad request: BLS rewards command should have {} part(s), we received {}. The data was:\n",
+                field_count,
+                m.data.size());
+
+        // NOTE: Dump the data
+        for (size_t index = 0; index < m.data.size(); index++) {
+            std::string_view part = m.data[index];
+            fmt::format_to(std::back_inserter(fmt_buffer), "{}{} - ", index ? "\n" : "", index);
+            write_and_3_dot_truncate(fmt_buffer, part, 48);
+        }
+
+        result.error = fmt::to_string(fmt_buffer);
+        return result;
+    }
+
+    // NOTE: Validate and parse the received data
+    const std::string_view cmd = oxen::bls::BLS_OMQ_REWARD_BALANCE_CMD;
+    GetRewardBalanceRequest request = {};
+
+    for (size_t field_index = 0; field_index < field_count; field_index++) {
+        auto field_value = static_cast<GetRewardBalanceRequestField>(field_index);
+        std::string_view payload = m.data[field_index];
+        switch (field_value) {
+            case GetRewardBalanceRequestField::Address: {
+                size_t required_hex_size = sizeof(crypto::eth_address) * 2;
+                PayloadResult to_result = payload_is_hex("BLS public key", payload, required_hex_size);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+                oxenc::from_hex(payload.begin(), payload.end(), reinterpret_cast<char*>(&request.address));
+            } break;
+
+            case GetRewardBalanceRequestField::Amount: {
+                PayloadResult to_result = payload_to_number("rewards amount", payload, request.amount);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+            } break;
+
+            case GetRewardBalanceRequestField::_count: {
+                assert(!"Invalid code path");
+            } break;
+        }
+    }
+
+    // NOTE: Get the rewards amount from the DB
+    std::string address_str = fmt::format("0x{}", request.address);
+    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(address_str);
+    if (amount == 0) {
+        result.error = fmt::format(
+                "OMQ command '{}' requested an address '{}' that has a zero balance in the "
+                "database",
+                cmd,
+                request.address);
+        return result;
+    }
+
+    // NOTE: Verify the amount matches what the invoker requested
+    if (request.amount != amount) {
+        result.error = fmt::format(
+                "OMQ command '{}' requested a reward amount {} for '{}' that does not match the rewards "
+                "amount ({}) from this node's database",
+                cmd,
+                request.amount,
+                request.address,
+                amount);
+        return result;
+    }
+
+    // NOTE: Prepare the signature
+    // bytes memory encodedMessage = abi.encodePacked(rewardTag, recipientAddress, recipientAmount);
+    std::string encoded_message = fmt::format(
+            "0x{}{}{}",
+            signer->buildTag(signer->rewardTag),
+            ethyl::utils::padToNBytes(fmt::format("{}", request.address), 20, ethyl::utils::PaddingDirection::LEFT),
+            ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(amount), ethyl::utils::PaddingDirection::LEFT));
+
+    std::string const message_to_sign =
+            oxen::bls::get_reward_balance_request_message(signer, request.address, amount);
+    crypto::bytes<32> const hash_message = signer->hash(encoded_message);
+
+    // NOTE: Fill a response
+    assert(result.error.empty());
+    result.success                = true;
+    result.status                 = "200";
+    result.address                = request.address;
+    result.amount                 = amount;
+    result.height                 = batchdb_height;
+    result.bls_pkey               = signer->getPublicKey();
+    result.message_hash_signature = signer->signHash(hash_message);
+    return result;
+}
+
+GetRewardBalanceResponse parse_get_reward_balance_response(std::span<const std::string> data) {
+    GetRewardBalanceResponse result = {};
+    size_t field_count = tools::enum_count<GetRewardBalanceResponseField>;
+    if (data.size() != field_count) {
+        return result;
+    }
+
+    // NOTE: Validate and parse the received data
+    for (size_t enum_index = 0; enum_index < field_count; enum_index++) {
+        std::string_view payload = data[enum_index];
+        auto enum_value          = static_cast<oxen::bls::GetRewardBalanceResponseField>(enum_index);
+        switch (enum_value) {
+
+            case oxen::bls::GetRewardBalanceResponseField::Status: {
+                if (payload != "200") {
+                    // TODO(doyle): Better error message
+                    oxen::log::error(
+                            logcat,
+                            "error message received when getting reward balance {} : "
+                            "{}",
+                            data[0],
+                            data[1]);
+                    return result;
+                }
+                result.status = payload;
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::Address: {
+                size_t required_hex_size = sizeof(crypto::bls_public_key) * 2;
+                PayloadResult to_result = payload_is_hex("Ethereum address", payload, required_hex_size);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+                oxenc::from_hex(payload.begin(), payload.end(), reinterpret_cast<char*>(&result.address));
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::Amount: {
+                PayloadResult to_result = payload_to_number("rewards amount", payload, result.height);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::Height: {
+                PayloadResult to_result = payload_to_number("height", payload, result.height);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::BLSPKeyHex: {
+                size_t required_hex_size = sizeof(crypto::bls_public_key) * 2;
+                PayloadResult to_result = payload_is_hex("BLS public key", payload, required_hex_size);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+                result.bls_pkey = bls_utils::HexToPublicKey(payload);
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::MessageHashSignature: {
+                size_t required_hex_size = sizeof(blsSignature) * 2;
+                PayloadResult to_result = payload_is_hex("BLS signature", payload, required_hex_size);
+                if (!to_result.good) {
+                    result.error = std::move(to_result.error);
+                    return result;
+                }
+                result.message_hash_signature = bls_utils::HexToSignature(payload);
+            } break;
+
+            case oxen::bls::GetRewardBalanceResponseField::_count: {
+                assert(!"Invalid code path");
+            } break;
+        }
+    }
+
+    result.success = true;
+    return result;
+}
+}  // namespace oxenbls

--- a/src/bls/bls_omq.cpp
+++ b/src/bls/bls_omq.cpp
@@ -59,7 +59,7 @@ static VerifyDataResult payload_is_hex(
                 "Specified an {} '{}' with length {} which does not have the "
                 "correct length ({}) to be an {}",
                 payload_description,
-                write_and_3_dot_truncate(payload, 128),
+                write_and_3_dot_truncate(payload, 256),
                 payload.size(),
                 required_hex_size,
                 payload_description);
@@ -70,7 +70,7 @@ static VerifyDataResult payload_is_hex(
         result.error = fmt::format(
                 "Specified a {} '{}' which contains non-hex characters",
                 payload_description,
-                write_and_3_dot_truncate(payload, 128),
+                write_and_3_dot_truncate(payload, 256),
                 payload.size());
         return result;
     }
@@ -91,7 +91,7 @@ static VerifyDataResult payload_to_number(
         result.error = fmt::format(
                 "Specified {} '{}' that is not a valid number",
                 payload_description,
-                write_and_3_dot_truncate(payload, 32));
+                write_and_3_dot_truncate(payload, 64));
         return result;
     }
 
@@ -117,7 +117,7 @@ static VerifyDataResult data_parts_count_is_valid(std::span<const T> data, size_
         // NOTE: Dump the data
         for (size_t index = 0; index < data.size(); index++) {
             std::string_view part = data[index];
-            fmt::format_to(std::back_inserter(fmt_buffer), "{}{} - {}", index ? "\n" : "", index, write_and_3_dot_truncate(part, 128));
+            fmt::format_to(std::back_inserter(fmt_buffer), "{}{} - {}", index ? "\n" : "", index, write_and_3_dot_truncate(part, 256));
         }
         result.error = fmt::to_string(fmt_buffer);
     }

--- a/src/bls/bls_omq.cpp
+++ b/src/bls/bls_omq.cpp
@@ -132,14 +132,12 @@ static VerifyDataResult data_parts_count_is_valid(std::span<const T> data, size_
 enum class GetRewardBalanceRequestField
 {
     Address,
-    OxenAddress,
     Amount,
     _count,
 };
 
 struct GetRewardBalanceRequest {
     crypto::eth_address address;
-    std::string oxen_address;
     uint64_t amount;
 };
 
@@ -186,10 +184,6 @@ GetRewardBalanceResponse create_reward_balance_request(
                 oxenc::from_hex(payload.begin(), payload.end(), reinterpret_cast<char*>(&request.address));
             } break;
 
-            case GetRewardBalanceRequestField::OxenAddress: {
-                request.oxen_address = m.data[field_index];
-            } break;
-
             case GetRewardBalanceRequestField::Amount: {
                 VerifyDataResult to_result = payload_to_number("rewards amount", payload, request.amount);
                 if (!to_result.good) {
@@ -205,8 +199,8 @@ GetRewardBalanceResponse create_reward_balance_request(
     }
 
     // NOTE: Get the rewards amount from the DB
-    // std::string address_str = fmt::format("0x{}", request.address);
-    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(request.oxen_address);
+    std::string address_str = fmt::format("0x{}", request.address);
+    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(address_str);
     if (amount == 0) {
         result.error = fmt::format(
                 "OMQ command '{}' requested an address '{}' that has a zero balance in the "

--- a/src/bls/bls_omq.h
+++ b/src/bls/bls_omq.h
@@ -41,9 +41,15 @@ struct GetRewardBalanceResponse {
     ::bls::Signature message_hash_signature;
 };
 
+struct GetRewardBalanceSignatureParts
+{
+    std::string message_to_sign;    // Message in hex that must be signed via BLSSigner::hasHex
+    crypto::bytes<32> hash_to_sign; // Hash that must be signed via BLSSigner::signHash
+};
+
 constexpr static inline std::string_view BLS_OMQ_REWARD_BALANCE_CMD = "bls.get_reward_balance";
 
-std::string get_reward_balance_request_message(
+GetRewardBalanceSignatureParts get_reward_balance_request_message(
         BLSSigner* signer, const crypto::eth_address& address, uint64_t amount);
 GetRewardBalanceResponse create_reward_balance_request(
         const oxenmq::Message& m, BLSSigner* signer, cryptonote::BlockchainSQLite* sql_db);

--- a/src/bls/bls_omq.h
+++ b/src/bls/bls_omq.h
@@ -1,0 +1,51 @@
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "crypto/crypto.h"
+
+#define BLS_ETH
+#define MCLBN_FP_UNIT_SIZE 4
+#define MCLBN_FR_UNIT_SIZE 4
+#include <bls/bls.hpp>
+
+namespace oxenmq {
+class Message;
+};
+namespace cryptonote {
+class BlockchainSQLite;
+};
+class BLSSigner;
+
+namespace oxen::bls {
+
+enum class GetRewardBalanceResponseField
+{
+    Status,
+    Address,
+    Amount,
+    Height,
+    BLSPKeyHex,
+    MessageHashSignature,
+    _count,
+};
+
+struct GetRewardBalanceResponse {
+    bool success;
+    std::string error;  // Set if 'success' is false
+    std::string_view status;
+    crypto::eth_address address;
+    uint64_t amount;
+    uint64_t height;
+    ::bls::PublicKey bls_pkey;
+    ::bls::Signature message_hash_signature;
+};
+
+constexpr static inline std::string_view BLS_OMQ_REWARD_BALANCE_CMD = "bls.get_reward_balance";
+
+std::string get_reward_balance_request_message(
+        BLSSigner* signer, const crypto::eth_address& address, uint64_t amount);
+GetRewardBalanceResponse create_reward_balance_request(
+        const oxenmq::Message& m, BLSSigner* signer, cryptonote::BlockchainSQLite* sql_db);
+GetRewardBalanceResponse parse_get_reward_balance_response(std::span<const std::string> data);
+};  // namespace oxen::bls

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -116,7 +116,7 @@ std::string BLSSigner::proofOfPossession(
     message.append(senderAddressOutput);
     message.append(serviceNodePubkeyHex);
 
-    const crypto::bytes<32> hash = BLSSigner::hash(message);  // Get the hash of the publickey
+    const crypto::bytes<32> hash = BLSSigner::hashHex(message);  // Get the hash of the publickey
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());
     return bls_utils::SignatureToHex(sig);
@@ -134,23 +134,14 @@ bls::PublicKey BLSSigner::getPublicKey() {
     return publicKey;
 }
 
-crypto::bytes<32> BLSSigner::hash(std::string_view in) {
-    // TODO(doyle): hash should take in a string_view
+crypto::bytes<32> BLSSigner::hashHex(std::string_view hex) {
     crypto::bytes<32> result = {};
-    result.data_ = ethyl::utils::hashHex(std::string(in));
+    result.data_ = ethyl::utils::hashHex(hex);
     return result;
 }
 
-crypto::bytes<32> BLSSigner::hashModulus(std::string_view message) {
-    // TODO(doyle): hash should take in a string_view
-    crypto::bytes<32> hash = BLSSigner::hash(std::string(message));
-    mcl::bn::Fp x;
-    x.clear();
-    x.setArrayMask(hash.data(), hash.size());
-    crypto::bytes<32> serialized_hash;
-    uint8_t* hdst = serialized_hash.data();
-    if (x.serialize(hdst, serialized_hash.data_.max_size(), mcl::IoSerialize | mcl::IoBigEndian) ==
-        0)
-        throw std::runtime_error("size of x is zero");
-    return serialized_hash;
+crypto::bytes<32> BLSSigner::hashBytes(std::span<const unsigned char> bytes) {
+    crypto::bytes<32> result = {};
+    result.data_ = ethyl::utils::hashBytes(bytes);
+    return result;
 }

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -66,10 +66,10 @@ void BLSSigner::initCurve() {
 std::string BLSSigner::buildTag(
         std::string_view baseTag, uint32_t chainID, std::string_view contractAddress) {
     std::string_view hexPrefix = "0x";
-    std::string_view contractAddressOutput = utils::trimPrefix(contractAddress, hexPrefix);
-    std::string baseTagHex = utils::toHexString(baseTag);
+    std::string_view contractAddressOutput = ethyl::utils::trimPrefix(contractAddress, hexPrefix);
+    std::string baseTagHex = oxenc::to_hex(baseTag);
     std::string chainIDHex =
-            utils::padTo32Bytes(utils::decimalToHex(chainID), utils::PaddingDirection::LEFT);
+            ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(chainID), ethyl::utils::PaddingDirection::LEFT);
 
     std::string concatenatedTag;
     concatenatedTag.reserve(
@@ -80,8 +80,8 @@ std::string BLSSigner::buildTag(
     concatenatedTag.append(chainIDHex);
     concatenatedTag.append(contractAddressOutput);
 
-    std::array<unsigned char, 32> hash = utils::hash(concatenatedTag);
-    std::string result = utils::toHexString(hash);
+    std::array<unsigned char, 32> hash = ethyl::utils::hashHex(concatenatedTag);
+    std::string result = oxenc::to_hex(hash.begin(), hash.end());
     return result;
 }
 
@@ -99,12 +99,12 @@ std::string BLSSigner::proofOfPossession(
         std::string_view senderEthAddress, std::string_view serviceNodePubkey) {
     std::string fullTag = buildTag(proofOfPossessionTag, chainID, contractAddress);
     std::string_view hexPrefix = "0x";
-    std::string_view senderAddressOutput = utils::trimPrefix(senderEthAddress, hexPrefix);
+    std::string_view senderAddressOutput = ethyl::utils::trimPrefix(senderEthAddress, hexPrefix);
 
     // TODO(doyle): padTo32Bytes should take a string_view
     std::string publicKeyHex = getPublicKeyHex();
     std::string serviceNodePubkeyHex =
-            utils::padTo32Bytes(std::string(serviceNodePubkey), utils::PaddingDirection::LEFT);
+            ethyl::utils::padTo32Bytes(std::string(serviceNodePubkey), ethyl::utils::PaddingDirection::LEFT);
 
     std::string message;
     message.reserve(
@@ -137,7 +137,7 @@ bls::PublicKey BLSSigner::getPublicKey() {
 crypto::bytes<32> BLSSigner::hash(std::string_view in) {
     // TODO(doyle): hash should take in a string_view
     crypto::bytes<32> result = {};
-    result.data_ = utils::hash(std::string(in));
+    result.data_ = ethyl::utils::hashHex(std::string(in));
     return result;
 }
 

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -18,6 +18,8 @@
 #include "crypto/base.h"
 #include "cryptonote_config.h"
 
+#include <span>
+
 class BLSSigner {
   private:
     bls::SecretKey secretKey;
@@ -39,8 +41,8 @@ class BLSSigner {
             std::string_view baseTag, uint32_t chainID, std::string_view contractAddress);
     std::string buildTag(std::string_view baseTag);
 
-    static crypto::bytes<32> hash(std::string_view in);
-    static crypto::bytes<32> hashModulus(std::string_view message);
+    static crypto::bytes<32> hashHex(std::string_view hex);
+    static crypto::bytes<32> hashBytes(std::span<const unsigned char> bytes);
 
     static constexpr inline std::string_view proofOfPossessionTag = "BLS_SIG_TRYANDINCREMENT_POP";
     static constexpr inline std::string_view rewardTag = "BLS_SIG_TRYANDINCREMENT_REWARD";

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -1,6 +1,7 @@
 #include "bls_utils.h"
 
 #include <oxenc/hex.h>
+#include "ethyl/utils.hpp" // TODO(doyle): For trimPrefix
 
 #include <cstring>
 
@@ -17,6 +18,12 @@
 #include <mcl/bn.hpp>
 #undef MCLBN_NO_AUTOLINK
 #pragma GCC diagnostic pop
+
+bls::Signature bls_utils::HexToSignature(std::string_view hex) {
+    bls::Signature result;
+    result.setStr(std::string(hex));
+    return result;
+}
 
 std::string bls_utils::SignatureToHex(const bls::Signature& sig) {
     const mclSize serializedSignatureSize = 32;
@@ -74,5 +81,76 @@ std::string bls_utils::PublicKeyToHex(const bls::PublicKey& publicKey) {
         throw std::runtime_error("size of y is zero");
 
     std::string result = oxenc::to_hex(serializedKeyHex.begin(), serializedKeyHex.end());
+    return result;
+}
+
+bls::PublicKey bls_utils::HexToPublicKey(std::string_view hex) {
+    const size_t BLS_PKEY_COMPONENT_HEX_SIZE = 32 * 2;
+    const size_t BLS_PKEY_HEX_SIZE           = BLS_PKEY_COMPONENT_HEX_SIZE * 2;
+    hex                                      = utils::trimPrefix(hex, "0x");
+
+    if (hex.size() != BLS_PKEY_HEX_SIZE) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key hex '" << hex << "': A serialized BLS key is " << BLS_PKEY_HEX_SIZE << " hex characters, input hex was " << hex.size() << " characters";
+        throw std::runtime_error(stream.str());
+    }
+
+    // NOTE: Divide the 2 keys into the X,Y component
+    std::string_view              pkeyXHex = hex.substr(0,                           BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::string_view              pkeyYHex = hex.substr(BLS_PKEY_COMPONENT_HEX_SIZE, BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::array<unsigned char, 32> pkeyX    = utils::fromHexString32Byte(pkeyXHex);
+    std::array<unsigned char, 32> pkeyY    = utils::fromHexString32Byte(pkeyYHex);
+
+    // NOTE: In `PublicKeyToHex` before we serialize the G1 point, we normalize
+    // the point which divides X, Y by the Z component. This transformation then
+    // converts the divisor to 1 (Z) as the division has already been applied to
+    // X and Y. Here we reconstruct Z as 1.
+    std::array<unsigned char, 32> pkeyZ = {};
+    pkeyZ.data()[0]                     = 1;
+
+    // NOTE: This is the reverse of utils::PublicKeyToHex (above). We serialize
+    // a G1 point to conform the required format to interop directly with
+    // Solidity's BN256G1 library.
+    mcl::bn::G1 g1Point = {};
+    g1Point.clear(); // NOTE: Default init has *uninitialized values*!
+
+    // NOTE: Deserialize the components back into the point.
+    size_t readX = g1Point.x.deserialize(pkeyX.data(), pkeyX.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readY = g1Point.y.deserialize(pkeyY.data(), pkeyY.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readZ = g1Point.z.deserialize(pkeyZ.data(), pkeyZ.size(), mcl::IoSerialize);
+
+    // NOTE: This is hardcoded so it should always succeed, if not something
+    // bad has gone wrong.
+    assert(readZ == pkeyZ.size());
+
+    if (readX != pkeyX.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'x' component '" << pkeyXHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    if (readY != pkeyY.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'y' component '" << pkeyYHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    // TODO: It's impossible to create a bls::PublicKey from a G1 point through
+    // the C++ interface. It allows deserialization from a hex string, but, the
+    // hex string must originally have been serialised through its member
+    // function.
+    //
+    // Since we have a custom format for Solidity, although we can reconstruct
+    // the individual components of the public key in binary we have to go a
+    // roundabout way to restore these bytes into the key.
+    //
+    // const_cast away the pointer which is legal because the original object
+    // was not declared const.
+    bls::PublicKey result = {};
+    blsPublicKey*  rawKey = const_cast<blsPublicKey*>(result.getPtr());
+    std::memcpy(rawKey->v.x.d, g1Point.x.getUnit(), sizeof(rawKey->v.x.d));
+    std::memcpy(rawKey->v.y.d, g1Point.y.getUnit(), sizeof(rawKey->v.y.d));
+    std::memcpy(rawKey->v.z.d, g1Point.z.getUnit(), sizeof(rawKey->v.z.d));
+
     return result;
 }

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -87,7 +87,7 @@ std::string bls_utils::PublicKeyToHex(const bls::PublicKey& publicKey) {
 bls::PublicKey bls_utils::HexToPublicKey(std::string_view hex) {
     const size_t BLS_PKEY_COMPONENT_HEX_SIZE = 32 * 2;
     const size_t BLS_PKEY_HEX_SIZE           = BLS_PKEY_COMPONENT_HEX_SIZE * 2;
-    hex                                      = utils::trimPrefix(hex, "0x");
+    hex                                      = ethyl::utils::trimPrefix(hex, "0x");
 
     if (hex.size() != BLS_PKEY_HEX_SIZE) {
         std::stringstream stream;
@@ -98,8 +98,8 @@ bls::PublicKey bls_utils::HexToPublicKey(std::string_view hex) {
     // NOTE: Divide the 2 keys into the X,Y component
     std::string_view              pkeyXHex = hex.substr(0,                           BLS_PKEY_COMPONENT_HEX_SIZE);
     std::string_view              pkeyYHex = hex.substr(BLS_PKEY_COMPONENT_HEX_SIZE, BLS_PKEY_COMPONENT_HEX_SIZE);
-    std::array<unsigned char, 32> pkeyX    = utils::fromHexString32Byte(pkeyXHex);
-    std::array<unsigned char, 32> pkeyY    = utils::fromHexString32Byte(pkeyYHex);
+    std::array<unsigned char, 32> pkeyX    = ethyl::utils::fromHexString32Byte(pkeyXHex);
+    std::array<unsigned char, 32> pkeyY    = ethyl::utils::fromHexString32Byte(pkeyYHex);
 
     // NOTE: In `PublicKeyToHex` before we serialize the G1 point, we normalize
     // the point which divides X, Y by the Z component. This transformation then

--- a/src/bls/bls_utils.h
+++ b/src/bls/bls_utils.h
@@ -9,5 +9,7 @@ class Signature;
 
 namespace bls_utils {
 std::string PublicKeyToHex(const bls::PublicKey& publicKey);
+bls::PublicKey HexToPublicKey(std::string_view hex);
 std::string SignatureToHex(const bls::Signature& sig);
+bls::Signature HexToSignature(std::string_view hex);
 }  // namespace bls_utils

--- a/src/common/oxen.h
+++ b/src/common/oxen.h
@@ -85,9 +85,6 @@ struct defer_helper {
 #define OXEN_DEFER \
     auto const OXEN_TOKEN_COMBINE(oxen_defer_, __LINE__) = oxen::defer_helper() + [&]()
 
-#define OXEN_CHECK_ERROR(expr, logcat, ...) \
-    ((expr) ? true : (oxen::log::error(logcat, "Check failed '" #expr "'. ", ## __VA_ARGS__), false))
-
 template <typename T, size_t N>
 constexpr size_t array_count(T (&)[N]) {
     return N;

--- a/src/common/oxen.h
+++ b/src/common/oxen.h
@@ -85,6 +85,9 @@ struct defer_helper {
 #define OXEN_DEFER \
     auto const OXEN_TOKEN_COMBINE(oxen_defer_, __LINE__) = oxen::defer_helper() + [&]()
 
+#define OXEN_CHECK_ERROR(expr, logcat, ...) \
+    ((expr) ? true : (oxen::log::error(logcat, "Check failed '" #expr "'. ", ## __VA_ARGS__), false))
+
 template <typename T, size_t N>
 constexpr size_t array_count(T (&)[N]) {
     return N;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -111,4 +111,11 @@ std::string friendly_duration(std::chrono::nanoseconds dur) {
     return friendly;
 }
 
+std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept {
+    std::string_view result = std::string_view(src.end(), 0);
+    if (pos < src.size()) {
+        result = src.substr(pos, size);
+    }
+    return result;
+}
 }  // namespace tools

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -168,11 +168,5 @@ std::string_view find_prefixed_value(It begin, It end, std::string_view prefix) 
 /// Safely create a substring from `src`, slicing the string at [pos, pos + size). If pos is
 /// out-of-bounds, the a slice to the end of the string is returned of 0 size. This function hence
 /// guarantees that a valid string will always be returned irrespective of input.
-static std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept {
-    std::string_view result = std::string_view(src.end(), 0);
-    if (pos < src.size()) {
-        result = src.substr(pos, size);
-    }
-    return result;
-}
+std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept;
 }  // namespace tools

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -46,5 +46,5 @@ target_link_libraries(cryptonote_basic
     logging
     extra)
 
-option(USE_LOCAL_DEVNET_ETH_ADDRESSES "Use hardcoded addresses for our Ethereum contracts as if they were deployed on a local-devnet" OFF)
-target_compile_definitions(cryptonote_basic PUBLIC OXEN_USE_LOCAL_DEVNET_ETH_ADDRESSES)
+option(USE_LOCAL_DEVNET_PARAMS "Use hardcoded addresses for our Ethereum contracts and parameters suitable for deployment on a local-devnet" OFF)
+target_compile_definitions(cryptonote_basic PUBLIC OXEN_USE_LOCAL_DEVNET_PARAMS)

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -120,8 +120,12 @@ bool get_base_block_reward(
         return true;
     }
 
+    #if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+    // NOTE: In devnet, we typically speed past into PoS so we probably don't care about difficulty target management.
+    #else
     static_assert(
             (TARGET_BLOCK_TIME % 1min) == 0s, "difficulty targets must be a multiple of a minute");
+    #endif
 
     uint64_t base_reward = version >= hf::hf17     ? oxen::BLOCK_REWARD_HF17
                          : version >= hf::hf15_ons ? oxen::BLOCK_REWARD_HF15

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -69,7 +69,7 @@ inline constexpr uint64_t SHORT_TERM_BLOCK_WEIGHT_SURGE_FACTOR = 50;
 inline constexpr uint64_t COINBASE_BLOB_RESERVED_SIZE = 600;
 
 #if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
-inline constexpr auto TARGET_BLOCK_TIME = 6s;
+inline constexpr auto TARGET_BLOCK_TIME = 14s;
 #else
 inline constexpr auto TARGET_BLOCK_TIME = 2min;
 #endif

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -68,7 +68,11 @@ inline constexpr uint64_t LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE = 100000;
 inline constexpr uint64_t SHORT_TERM_BLOCK_WEIGHT_SURGE_FACTOR = 50;
 inline constexpr uint64_t COINBASE_BLOB_RESERVED_SIZE = 600;
 
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+inline constexpr auto TARGET_BLOCK_TIME = 6s;
+#else
 inline constexpr auto TARGET_BLOCK_TIME = 2min;
+#endif
 inline constexpr uint64_t BLOCKS_PER_HOUR = 1h / TARGET_BLOCK_TIME;
 inline constexpr uint64_t BLOCKS_PER_DAY = 24h / TARGET_BLOCK_TIME;
 
@@ -508,7 +512,7 @@ namespace config {
 
         inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
 
-#if defined(OXEN_USE_LOCAL_DEVNET_ETH_ADDRESSES)
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
         // NOTE: A local-devnet involves launching typically a local Ethereum
         // blockchain via Hardhat, Ganache or Foundry's Anvil for example.
         // These use local-developer wallets which deploy our rewards contract

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(cryptonote_core
     logging
     extra)
 
-if(PER_BLOCK_CHECKPOINT)
+if (PER_BLOCK_CHECKPOINT)
   target_compile_definitions(cryptonote_core PUBLIC PER_BLOCK_CHECKPOINT)
   target_link_libraries(cryptonote_core PUBLIC blocks)
 endif()

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1603,15 +1603,20 @@ bool Blockchain::validate_miner_transaction(
             return false;
         }
     } else {
-        const auto pool_block_reward =
-                m_l2_tracker->get_pool_block_reward(b.timestamp, b.l2_height);
-        if (b.reward != pool_block_reward) {
-            log::error(
-                    logcat,
-                    "block reward to be batched is incorrect. Block reward is {}, should be {}",
-                    print_money(b.reward),
-                    print_money(pool_block_reward));
-            return false;
+        // NOTE: In SENT era, if provider is not configured- we trust the Service Node quorums to
+        // query the smart contract for the reward amount. Non-service nodes can configure the
+        // provider if they wish to synchronise the network with extra security.
+        if (m_l2_tracker->provider_has_clients()) {
+            const auto pool_block_reward =
+                    m_l2_tracker->get_pool_block_reward(b.timestamp, b.l2_height);
+            if (b.reward != pool_block_reward) {
+                log::error(
+                        logcat,
+                        "block reward to be batched is incorrect. Block reward is {}, should be {}",
+                        print_money(b.reward),
+                        print_money(pool_block_reward));
+                return false;
+            }
         }
     }
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1119,13 +1119,13 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                             // recipientAddress, recipientAmount);
                             std::string encoded_message =
                                     "0x" + m_bls_signer->buildTag(m_bls_signer->rewardTag) +
-                                    utils::padToNBytes(
+                                    ethyl::utils::padToNBytes(
                                             eth_address.substr(2),
                                             20,
-                                            utils::PaddingDirection::LEFT) +
-                                    utils::padTo32Bytes(
-                                            utils::decimalToHex(amount),
-                                            utils::PaddingDirection::LEFT);
+                                            ethyl::utils::PaddingDirection::LEFT) +
+                                    ethyl::utils::padTo32Bytes(
+                                            ethyl::utils::decimalToHex(amount),
+                                            ethyl::utils::PaddingDirection::LEFT);
                             const auto h = m_bls_signer->hash(encoded_message);
                             // Returns status, address, amount, height, bls_pubkey, signed message,
                             // signature
@@ -1192,10 +1192,10 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                             // bytes memory encodedMessage = abi.encodePacked(liquidateTag, blsKey);
                             std::string encoded_message =
                                     "0x" + m_bls_signer->buildTag(m_bls_signer->liquidateTag) +
-                                    utils::padToNBytes(
+                                    ethyl::utils::padToNBytes(
                                             bls_key_requesting_exit,
                                             64,
-                                            utils::PaddingDirection::LEFT);
+                                            ethyl::utils::PaddingDirection::LEFT);
                             const auto h = m_bls_signer->hash(encoded_message);
                             // Data contains -> status, bls_key, bls_pubkey, signed message,
                             // signature

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1145,7 +1145,7 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                             std::string encoded_message =
                                     "0x" + m_bls_signer->buildTag(m_bls_signer->removalTag) +
                                     bls_key_requesting_exit;
-                            const auto h = m_bls_signer->hash(encoded_message);
+                            const auto h = m_bls_signer->hashHex(encoded_message);
                             // Data contains -> status, bls_key, bls_pubkey, signed message,
                             // signature
                             m.send_reply(
@@ -1180,7 +1180,7 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                                             bls_key_requesting_exit,
                                             64,
                                             ethyl::utils::PaddingDirection::LEFT);
-                            const auto h = m_bls_signer->hash(encoded_message);
+                            const auto h = m_bls_signer->hashHex(encoded_message);
                             // Data contains -> status, bls_key, bls_pubkey, signed message,
                             // signature
                             m.send_reply(
@@ -2854,7 +2854,7 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-AggregateRewardsResponse core::aggregate_rewards_request(const std::string& eth_address) {
+BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
     std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
     eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
 
@@ -2878,7 +2878,7 @@ AggregateRewardsResponse core::aggregate_rewards_request(const std::string& eth_
     auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
     auto [batch_db_height, amount] =
             get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
-    const auto result = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height, exclude);
+    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, amount, batch_db_height, exclude);
     return result;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2854,7 +2854,7 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-aggregateWithdrawalResponse core::aggregate_withdrawal_request(const std::string& eth_address) {
+AggregateRewardsResponse core::aggregate_rewards_request(const std::string& eth_address) {
     std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
     eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
 
@@ -2876,8 +2876,8 @@ aggregateWithdrawalResponse core::aggregate_withdrawal_request(const std::string
     }
 
     auto [batch_db_height, amount] = get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
-    const auto resp = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height);
-    return resp;
+    const auto result = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height);
+    return result;
 }
 //-----------------------------------------------------------------------------------------------
 aggregateExitResponse core::aggregate_exit_request(const std::string& bls_key) {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2875,8 +2875,10 @@ AggregateRewardsResponse core::aggregate_rewards_request(const std::string& eth_
         } break;
     }
 
-    auto [batch_db_height, amount] = get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
-    const auto result = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height);
+    auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
+    auto [batch_db_height, amount] =
+            get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
+    const auto result = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height, exclude);
     return result;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1217,11 +1217,12 @@ std::vector<std::string> core::get_removable_nodes()
         bls_pubkeys_in_snl.push_back(tools::type_to_hex(sni.info->bls_public_key));
 
 
-    uint64_t oxen_height = m_blockchain_storage.get_current_blockchain_height();
+    uint64_t oxen_height = m_blockchain_storage.get_current_blockchain_height() - 1;
     std::vector<cryptonote::block> blocks;
     if (!get_blocks(oxen_height, 1, blocks)) {
-        log::error(logcat, "Could not get latest block");
-        throw std::runtime_error("Could not get latest block");
+        std::string msg = fmt::format("Failed to get the latest block at {} to determine the removable Service Nodes", oxen_height);
+        log::error(logcat, "{}", msg);
+        throw std::runtime_error(msg);
     }
     std::vector<std::string> bls_pubkeys_in_smart_contract = m_blockchain_storage.m_l2_tracker->get_all_bls_public_keys(blocks[0].l2_height);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -66,6 +66,8 @@ extern "C" {
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_config.h"
 #include "cryptonote_core.h"
+#include "bls/bls_omq.h"
+#include "bls/bls_utils.h"
 #include "epee/memwipe.h"
 #include "epee/net/local_ip.h"
 #include "epee/warnings.h"
@@ -1093,50 +1095,32 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
 
         m_quorumnet_state = quorumnet_new(*this);
 
+        static constexpr std::string_view OMQ_BAD_REQUEST = "400";
         m_omq->add_category("bls", oxenmq::Access{oxenmq::AuthLevel::none})
                 .add_request_command(
                         "get_reward_balance",
                         [&](oxenmq::Message& m) {
-                            oxen::log::debug(logcat, "Received omq rewards signature request");
-                            if (m.data.size() != 1)
-                                m.send_reply(
-                                        "400",
-                                        "Bad request: BLS rewards command should have one data "
-                                        "part containing the address"
-                                        "(received " +
-                                                std::to_string(m.data.size()) + ")");
+                            oxen::bls::GetRewardBalanceResponse response =
+                                    oxen::bls::create_reward_balance_request(
+                                            m,
+                                            m_bls_signer.get(),
+                                            get_blockchain_storage().sqlite_db().get());
 
-                            std::string eth_address = tools::lowercase_ascii_string(m.data[0]);
-                            if (!eth_address.starts_with("0x")) {
-                                eth_address = "0x" + eth_address;
+                            if (response.success) {
+                                // NOTE: Transmit the response
+                                // TODO(doyle): Binary request/responses
+                                // Returns status, address, amount, height, bls_pubkey, signature
+                                m.send_reply(
+                                        response.status,
+                                        oxenc::type_to_hex(response.address),
+                                        std::to_string(response.amount),
+                                        std::to_string(response.height),
+                                        bls_utils::PublicKeyToHex(response.bls_pkey),
+                                        response.message_hash_signature.getStr());
+                            } else {
+                                oxen::log::trace(logcat, "OMQ command '{}' failed: {}", oxen::bls::BLS_OMQ_REWARD_BALANCE_CMD, response.error);
+                                m.send_reply(OMQ_BAD_REQUEST, std::move(response.error));
                             }
-                            auto [batchdb_height, amount] =
-                                    get_blockchain_storage().sqlite_db()->get_accrued_earnings(
-                                            eth_address);
-                            if (amount == 0)
-                                m.send_reply("400", "Address has a zero balance in the database");
-                            // bytes memory encodedMessage = abi.encodePacked(rewardTag,
-                            // recipientAddress, recipientAmount);
-                            std::string encoded_message =
-                                    "0x" + m_bls_signer->buildTag(m_bls_signer->rewardTag) +
-                                    ethyl::utils::padToNBytes(
-                                            eth_address.substr(2),
-                                            20,
-                                            ethyl::utils::PaddingDirection::LEFT) +
-                                    ethyl::utils::padTo32Bytes(
-                                            ethyl::utils::decimalToHex(amount),
-                                            ethyl::utils::PaddingDirection::LEFT);
-                            const auto h = m_bls_signer->hash(encoded_message);
-                            // Returns status, address, amount, height, bls_pubkey, signed message,
-                            // signature
-                            m.send_reply(
-                                    "200",
-                                    m.data[0],
-                                    std::to_string(amount),
-                                    std::to_string(batchdb_height),
-                                    m_bls_signer->getPublicKeyHex(),
-                                    encoded_message,
-                                    m_bls_signer->signHash(h).getStr());
                         })
                 .add_request_command(
                         "get_exit",
@@ -2870,9 +2854,29 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-aggregateWithdrawalResponse core::aggregate_withdrawal_request(
-        const std::string& ethereum_address) {
-    const auto resp = m_bls_aggregator->aggregateRewards(ethereum_address);
+aggregateWithdrawalResponse core::aggregate_withdrawal_request(const std::string& eth_address) {
+    std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
+    eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
+
+    crypto::eth_address eth_address_bytes = {};
+    switch (auto convert_result = oxenc::hex_to_type(eth_address_trimmed, eth_address_bytes)) {
+        case oxenc::hex_to_type_result::ok: break;
+
+        case oxenc::hex_to_type_result::non_hex_chars: {
+            throw std::runtime_error(fmt::format("Bad ethereum address '{}', address had non-hex characters", eth_address));
+        } break;
+
+        case oxenc::hex_to_type_result::invalid_size: {
+            throw std::runtime_error(fmt::format(
+                    "Bad ethereum address '{}', address had wrong size {}, expected {}",
+                    eth_address,
+                    eth_address.size(),
+                    sizeof(crypto::eth_address) * 2));
+        } break;
+    }
+
+    auto [batch_db_height, amount] = get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
+    const auto resp = m_bls_aggregator->aggregateRewards(eth_address_bytes, amount, batch_db_height);
     return resp;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2855,7 +2855,7 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address, const std::string& oxen_address) {
+BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
     std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
     eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
 
@@ -2878,8 +2878,8 @@ BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address, con
 
     auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
     auto [batch_db_height, amount] =
-            get_blockchain_storage().sqlite_db()->get_accrued_earnings(oxen_address);
-    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, oxen_address, amount, batch_db_height, exclude);
+            get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
+    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, amount, batch_db_height, exclude);
     return result;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2855,7 +2855,7 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
+BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address, const std::string& oxen_address) {
     std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
     eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
 
@@ -2878,8 +2878,8 @@ BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
 
     auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
     auto [batch_db_height, amount] =
-            get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
-    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, amount, batch_db_height, exclude);
+            get_blockchain_storage().sqlite_db()->get_accrued_earnings(oxen_address);
+    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, oxen_address, amount, batch_db_height, exclude);
     return result;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    aggregateWithdrawalResponse aggregate_withdrawal_request(const std::string& ethereum_address);
+    aggregateWithdrawalResponse aggregate_withdrawal_request(const std::string& eth_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    BLSRewardsResponse bls_rewards_request(const std::string& eth_address);
+    BLSRewardsResponse bls_rewards_request(const std::string& eth_address, const std::string& oxen_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    BLSRewardsResponse bls_rewards_request(const std::string& eth_address, const std::string& oxen_address);
+    BLSRewardsResponse bls_rewards_request(const std::string& eth_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    aggregateWithdrawalResponse aggregate_withdrawal_request(const std::string& eth_address);
+    AggregateRewardsResponse aggregate_rewards_request(const std::string& eth_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    AggregateRewardsResponse aggregate_rewards_request(const std::string& eth_address);
+    BLSRewardsResponse bls_rewards_request(const std::string& eth_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -811,9 +811,9 @@ bool get_round_timings(
     times.ideal_timestamp = pulse::time_point(
             times.genesis_timestamp + (cryptonote::TARGET_BLOCK_TIME * delta_height));
 
-#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)  // NOTE: Debug, make next block start relatively soon
     times.r0_timestamp = times.prev_timestamp + service_nodes::PULSE_ROUND_TIME;
-#else  // NOTE: Debug, make next block start relatively soon
+#else
     times.r0_timestamp = std::clamp(
             times.ideal_timestamp,
             times.prev_timestamp + service_nodes::PULSE_MIN_TARGET_BLOCK_TIME,

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -811,13 +811,13 @@ bool get_round_timings(
     times.ideal_timestamp = pulse::time_point(
             times.genesis_timestamp + (cryptonote::TARGET_BLOCK_TIME * delta_height));
 
-#if 1
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+    times.r0_timestamp = times.prev_timestamp + service_nodes::PULSE_ROUND_TIME;
+#else  // NOTE: Debug, make next block start relatively soon
     times.r0_timestamp = std::clamp(
             times.ideal_timestamp,
             times.prev_timestamp + service_nodes::PULSE_MIN_TARGET_BLOCK_TIME,
             times.prev_timestamp + service_nodes::PULSE_MAX_TARGET_BLOCK_TIME);
-#else  // NOTE: Debug, make next block start relatively soon
-    times.r0_timestamp = times.prev_timestamp + service_nodes::PULSE_ROUND_TIME;
 #endif
 
     times.miner_fallback_timestamp = times.r0_timestamp + (service_nodes::PULSE_ROUND_TIME * 255);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3193,8 +3193,11 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
         if (block_leader.key != check_block_leader_pubkey)
             throw std::runtime_error{
-                    "Service node reward winner is incorrect! Expected {}, block has {}"_format(
-                            block_leader.key, check_block_leader_pubkey)};
+                    "Service node reward winner is incorrect! Expected {}, block {} hf{} has {}"_format(
+                            block_leader.key,
+                            height,
+                            static_cast<size_t>(block.major_version),
+                            check_block_leader_pubkey)};
     }
 
     enum struct verify_mode {

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -25,21 +25,28 @@ static auto logcat = log::Cat("service_nodes");
 
 uint64_t get_staking_requirement(cryptonote::network_type nettype, hf hardfork) {
     assert(hardfork >= hf::hf16_pulse);
-    if (nettype == network_type::MAINNET)
-        return hardfork >= hf::hf20 ? SENT_STAKING_REQUIREMENT : OXEN_STAKING_REQUIREMENT;
-    return hardfork >= hf::hf20 ? SENT_STAKING_REQUIREMENT_TESTNET
-                                : OXEN_STAKING_REQUIREMENT_TESTNET;
+    if (hardfork >= hf::hf20) {
+        return nettype == network_type::MAINNET ? SENT_STAKING_REQUIREMENT
+                                                : SENT_STAKING_REQUIREMENT_TESTNET;
+    }
+
+    return nettype == network_type::MAINNET ? OXEN_STAKING_REQUIREMENT
+                                            : OXEN_STAKING_REQUIREMENT_TESTNET;
 }
 
 // TODO(oxen): Move to oxen_economy, this will also need access to oxen::exp2
 uint64_t get_staking_requirement(cryptonote::network_type nettype, uint64_t height) {
-    if (is_hard_fork_at_least(nettype, hf::hf20, height))
-        return nettype == network_type::MAINNET ? SENT_STAKING_REQUIREMENT
-                                                : SENT_STAKING_REQUIREMENT_TESTNET;
-    else if (nettype != cryptonote::network_type::MAINNET)
+    if (is_hard_fork_at_least(nettype, hf::hf20, height)) {
+        return get_staking_requirement(nettype, hf::hf20);
+    }
+
+    if (is_hard_fork_at_least(nettype, hf::hf16_pulse, height)) {
+        return get_staking_requirement(nettype, hf::hf16_pulse);
+    }
+
+    if (nettype != cryptonote::network_type::MAINNET) {
         return OXEN_STAKING_REQUIREMENT_TESTNET;
-    else if (is_hard_fork_at_least(nettype, hf::hf16_pulse, height))
-        return OXEN_STAKING_REQUIREMENT;
+    }
 
     if (is_hard_fork_at_least(nettype, hf::hf13_enforce_checkpoints, height)) {
         constexpr int64_t heights[] = {

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -19,12 +19,12 @@ inline constexpr size_t PULSE_QUORUM_ENTROPY_LAG =
              // quorums.
 #if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
 inline constexpr auto PULSE_ROUND_TIME = cryptonote::TARGET_BLOCK_TIME + 6s;
-inline constexpr auto PULSE_WAIT_FOR_HANDSHAKES_DURATION = 2s;
-inline constexpr auto PULSE_WAIT_FOR_OTHER_VALIDATOR_HANDSHAKES_DURATION = 2s;
-inline constexpr auto PULSE_WAIT_FOR_BLOCK_TEMPLATE_DURATION = 2s;
-inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_HASH_DURATION = 2s;
-inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_DURATION = 2s;
-inline constexpr auto PULSE_WAIT_FOR_SIGNED_BLOCK_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_HANDSHAKES_DURATION = 1s;
+inline constexpr auto PULSE_WAIT_FOR_OTHER_VALIDATOR_HANDSHAKES_DURATION = 1s;
+inline constexpr auto PULSE_WAIT_FOR_BLOCK_TEMPLATE_DURATION = 1s;
+inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_HASH_DURATION = 1s;
+inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_DURATION = 1s;
+inline constexpr auto PULSE_WAIT_FOR_SIGNED_BLOCK_DURATION = 1s;
 #else
 inline constexpr auto PULSE_ROUND_TIME = 60s;
 inline constexpr auto PULSE_WAIT_FOR_HANDSHAKES_DURATION = 10s;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -17,6 +17,15 @@ struct invalid_registration : std::invalid_argument {
 inline constexpr size_t PULSE_QUORUM_ENTROPY_LAG =
         21;  // How many blocks back from the tip of the Blockchain to source entropy for the Pulse
              // quorums.
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+inline constexpr auto PULSE_ROUND_TIME = cryptonote::TARGET_BLOCK_TIME + 6s;
+inline constexpr auto PULSE_WAIT_FOR_HANDSHAKES_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_OTHER_VALIDATOR_HANDSHAKES_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_BLOCK_TEMPLATE_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_HASH_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_DURATION = 2s;
+inline constexpr auto PULSE_WAIT_FOR_SIGNED_BLOCK_DURATION = 2s;
+#else
 inline constexpr auto PULSE_ROUND_TIME = 60s;
 inline constexpr auto PULSE_WAIT_FOR_HANDSHAKES_DURATION = 10s;
 inline constexpr auto PULSE_WAIT_FOR_OTHER_VALIDATOR_HANDSHAKES_DURATION = 10s;
@@ -24,6 +33,7 @@ inline constexpr auto PULSE_WAIT_FOR_BLOCK_TEMPLATE_DURATION = 10s;
 inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_HASH_DURATION = 10s;
 inline constexpr auto PULSE_WAIT_FOR_RANDOM_VALUE_DURATION = 10s;
 inline constexpr auto PULSE_WAIT_FOR_SIGNED_BLOCK_DURATION = 10s;
+#endif
 
 inline constexpr size_t PULSE_QUORUM_NUM_VALIDATORS = 11;
 inline constexpr size_t PULSE_BLOCK_REQUIRED_SIGNATURES =

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -114,7 +114,7 @@ bool L2Tracker::check_state_in_history(uint64_t height, const crypto::hash& stat
 
 bool L2Tracker::check_state_in_history(uint64_t height, const std::string& state_root) {
     if (provider.clients.empty()) {
-        return false;
+        return true;
     }
     std::lock_guard lock{mutex};
     auto it = std::find_if(

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -91,6 +91,8 @@ class L2Tracker {
     std::vector<uint64_t> get_non_signers(const std::vector<std::string>& bls_public_keys);
     std::vector<std::string> get_all_bls_public_keys(uint64_t blockNumber);
 
+    bool provider_has_clients() const { return provider.clients.size(); }
+
     ethyl::Provider provider;
 
   private:

--- a/src/l2_tracker/pool_contract.cpp
+++ b/src/l2_tracker/pool_contract.cpp
@@ -13,10 +13,10 @@ RewardRateResponse PoolContract::RewardRate(uint64_t timestamp, uint64_t ethereu
     ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
     std::string timestampStr =
-            utils::padTo32Bytes(utils::decimalToHex(timestamp), utils::PaddingDirection::LEFT);
+            ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(timestamp), ethyl::utils::PaddingDirection::LEFT);
     // keccak256("rewardRate(uint256)")
     std::string functionABI = "0xcea01962";
     callData.data = functionABI + timestampStr;
     std::string result = provider.callReadFunction(callData, ethereum_block_height);
-    return RewardRateResponse{timestamp, utils::fromHexStringToUint64(result)};
+    return RewardRateResponse{timestamp, ethyl::utils::hexStringToU64(result)};
 }

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -1,6 +1,8 @@
 #include "rewards_contract.h"
 
 #include <ethyl/utils.hpp>
+#include <common/oxen.h>
+#include <common/string_util.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuseless-cast"

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -325,6 +325,36 @@ ContractServiceNode RewardsContract::serviceNodes(uint64_t index, std::string_vi
         return result;
     }
 
+    oxen::log::trace(
+            logcat,
+            "We parsed service node {} with BLS public key {} at height {}.\n"
+            "The service node blob components were:\n"
+            "\n"
+            "  - nextHex:                   {}\n"
+            "  - prevHex:                   {}\n"
+            "  - operatorHex:               {}\n"
+            "  - pubkeyHex:                 {}\n"
+            "  - leaveRequestTimestampHex:  {}\n"
+            "  - depositHex:                {}\n"
+            "  - contributorSize:           {}\n"
+            "  - contributorDataRemaining:  {}\n"
+            "\n"
+            "The raw blob was:\n\n{}"
+            ,
+            index,
+            pubkeyHex,
+            blockNumber
+            ,
+            nextHex,
+            prevHex,
+            operatorHex,
+            pubkeyHex,
+            leaveRequestTimestampHex,
+            depositHex,
+            contributorSizeHex,
+            contributorArrayHex,
+            callResultHex);
+
     for (size_t it = 0; it < contributorArrayHex.size(); it += HEX_PER_CONTRIBUTOR) {
         std::string_view addressHex      = tools::string_safe_substr(contributorArrayHex, it + 0,                ADDRESS_HEX_SIZE);
         std::string_view stakedAmountHex = tools::string_safe_substr(contributorArrayHex, it + ADDRESS_HEX_SIZE, U256_HEX_SIZE);
@@ -361,7 +391,7 @@ ContractServiceNode RewardsContract::serviceNodes(uint64_t index, std::string_vi
 
     // NOTE: Deserialise metadata
     result.leaveRequestTimestamp = ethyl::utils::hexStringToU64(leaveRequestTimestampHex);
-    result.deposit = ethyl::utils::hexStringToU64(depositHex);
+    result.deposit = depositHex;
     result.good = true;
     return result;
 }

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -80,9 +80,9 @@ using TransactionStateChangeVariant = std::variant<
         ServiceNodeDeregisterTx,
         ServiceNodeExitTx>;
 
-class RewardsLogEntry : public LogEntry {
+class RewardsLogEntry : public ethyl::LogEntry {
   public:
-    RewardsLogEntry(const LogEntry& log) : LogEntry(log) {}
+    RewardsLogEntry(const ethyl::LogEntry& log) : ethyl::LogEntry(log) {}
     TransactionType getLogType() const;
     std::optional<TransactionStateChangeVariant> getLogTransaction() const;
 };

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -99,7 +99,7 @@ struct ContractServiceNode {
     crypto::eth_address operatorAddr;
     std::string pubkey;
     uint64_t leaveRequestTimestamp;
-    uint64_t deposit;
+    std::string deposit;
     std::array<Contributor, 10> contributors;
     size_t contributorsSize;
 };

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2554,12 +2554,12 @@ void core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context context) {
-    const aggregateWithdrawalResponse bls_withdrawal_signature_response =
-            m_core.aggregate_withdrawal_request(bls_rewards_request.request.address);
+    const AggregateRewardsResponse bls_withdrawal_signature_response =
+            m_core.aggregate_rewards_request(bls_rewards_request.request.address);
     bls_rewards_request.response["status"] = STATUS_OK;
     bls_rewards_request.response["address"] = bls_withdrawal_signature_response.address;
-    bls_rewards_request.response["height"] = bls_withdrawal_signature_response.height;
     bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;
+    bls_rewards_request.response["height"] = bls_withdrawal_signature_response.height;
     bls_rewards_request.response["signed_message"] =
             bls_withdrawal_signature_response.signed_message;
     bls_rewards_request.response["signature"] = bls_withdrawal_signature_response.signature;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2555,7 +2555,7 @@ void core_rpc_server::invoke(
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context context) {
     const BLSRewardsResponse bls_withdrawal_signature_response =
-            m_core.bls_rewards_request(bls_rewards_request.request.address);
+            m_core.bls_rewards_request(bls_rewards_request.request.address, bls_rewards_request.request.oxen_address);
     bls_rewards_request.response["status"] = STATUS_OK;
     bls_rewards_request.response["address"] = bls_withdrawal_signature_response.address;
     bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2554,8 +2554,8 @@ void core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context context) {
-    const AggregateRewardsResponse bls_withdrawal_signature_response =
-            m_core.aggregate_rewards_request(bls_rewards_request.request.address);
+    const BLSRewardsResponse bls_withdrawal_signature_response =
+            m_core.bls_rewards_request(bls_rewards_request.request.address);
     bls_rewards_request.response["status"] = STATUS_OK;
     bls_rewards_request.response["address"] = bls_withdrawal_signature_response.address;
     bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3427,7 +3427,8 @@ void core_rpc_server::invoke(
         for (const auto& address : req.addresses) {
             uint64_t amount = 0;
             if (cryptonote::is_valid_address(address, nettype())) {
-                const auto [_, amount] = blockchain.sqlite_db()->get_accrued_earnings(address);
+                const auto [batch_db_height, amount] = blockchain.sqlite_db()->get_accrued_earnings(address);
+                (void)batch_db_height;
                 at_least_one_succeeded = true;
             }
             balances[address] = amount;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2555,7 +2555,7 @@ void core_rpc_server::invoke(
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context context) {
     const BLSRewardsResponse bls_withdrawal_signature_response =
-            m_core.bls_rewards_request(bls_rewards_request.request.address, bls_rewards_request.request.oxen_address);
+            m_core.bls_rewards_request(bls_rewards_request.request.address);
     bls_rewards_request.response["status"] = STATUS_OK;
     bls_rewards_request.response["address"] = bls_withdrawal_signature_response.address;
     bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -489,7 +489,7 @@ void parse_request(GET_SERVICE_NODE_REGISTRATION_CMD& cmd, rpc_input in) {
 }
 
 void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in) {
-    get_values(in, "address", required{cmd.request.address}, "oxen_address", required{cmd.request.oxen_address});
+    get_values(in, "address", required{cmd.request.address});
 }
 
 void parse_request(BLS_EXIT_REQUEST& cmd, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -489,7 +489,7 @@ void parse_request(GET_SERVICE_NODE_REGISTRATION_CMD& cmd, rpc_input in) {
 }
 
 void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in) {
-    get_values(in, "address", required{cmd.request.address});
+    get_values(in, "address", required{cmd.request.address}, "oxen_address", required{cmd.request.oxen_address});
 }
 
 void parse_request(BLS_EXIT_REQUEST& cmd, rpc_input in) {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2308,7 +2308,6 @@ struct BLS_REWARDS_REQUEST : PUBLIC {
 
     struct request_parameters {
         std::string address;
-        std::string oxen_address;
     } request;
 };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2308,6 +2308,7 @@ struct BLS_REWARDS_REQUEST : PUBLIC {
 
     struct request_parameters {
         std::string address;
+        std::string oxen_address;
     } request;
 };
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -857,11 +857,6 @@ public:
     cryptonote::block_verification_context bvc = {};
     std::string bd                    = t_serializable_object_to_blob(block);
     std::vector<cryptonote::block> pblocks;
-
-    if (!entry.can_be_added_to_blockchain) {
-        int x = 5;
-    }
-
     if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {bd, {}, {}}), pblocks))
     {
       m_c.handle_incoming_block(bd, &block, bvc, nullptr);

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -770,19 +770,39 @@ public:
   //
   // NOTE: Loki
   //
+  static bool add_to_blockchain_was_valid(std::string_view type, bool can_be_added_to_blockchain, bool added, std::string_view fail_msg)
+  {
+    if (can_be_added_to_blockchain) {
+        if (!added) {
+            oxen::log::warning(
+                    globallogcat,
+                    "Failed to add {} that was marked as being 'valid to add to the "
+                    "blockchain'. Validation rules have failed to permit a valid constructed "
+                    "item. {}",
+                    type,
+                    fail_msg);
+            return false;
+        }
+    } else {
+        if (added) {
+            oxen::log::warning(
+                    globallogcat,
+                    "The {} was added to blockchain but it was marked as 'not being a valid "
+                    "to add to the blockchain'. Validation rules have failed to reject the "
+                    "invalidly constructed item. {}", type, fail_msg);
+            return false;
+        }
+    }
+    return true;
+  }
+
   bool operator()(const oxen_blockchain_addable<cryptonote::checkpoint_t> &entry) const
   {
     log_event("oxen_blockchain_addable<cryptonote::checkpoint_t>");
     cryptonote::Blockchain &blockchain = m_c.get_blockchain_storage();
     bool added = blockchain.update_checkpoint(entry.data);
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat, "{}", entry.fail_msg);
-      else
-        oxen::log::warning(globallogcat, "Failed to add checkpoint (no reason given)");
-      return false;
-    }
+    if (!add_to_blockchain_was_valid("checkpoint", entry.can_be_added_to_blockchain, added, entry.fail_msg))
+        return false;
     return true;
   }
 
@@ -791,14 +811,8 @@ public:
     log_event("oxen_blockchain_addable<service_nodes::quorum_vote_t>");
     cryptonote::vote_verification_context vvc = {};
     bool added = m_c.add_service_node_vote(entry.data, vvc);
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat,  "{}",entry.fail_msg);
-      else
-        oxen::log::warning(globallogcat, "Failed to add service node vote (no reason given)");
-      return false;
-    }
+    if (!add_to_blockchain_was_valid("service node vote", entry.can_be_added_to_blockchain, added, entry.fail_msg))
+        return false;
     return true;
   }
 
@@ -823,13 +837,15 @@ public:
       bvc.m_verifivation_failed = true;
 
     bool added = !bvc.m_verifivation_failed;
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat, "{}", entry.fail_msg);
-      else
-        oxen::log::warning(globallogcat, "Failed to add block with checkpoint (no reason given)");
-      return false;
+    if (!add_to_blockchain_was_valid(
+                fmt::format(
+                        "block {} hf{} w/ checkpoint",
+                        block.height,
+                        static_cast<size_t>(block.major_version)),
+                entry.can_be_added_to_blockchain,
+                added,
+                entry.fail_msg)) {
+        return false;
     }
     return true;
   }
@@ -841,6 +857,11 @@ public:
     cryptonote::block_verification_context bvc = {};
     std::string bd                    = t_serializable_object_to_blob(block);
     std::vector<cryptonote::block> pblocks;
+
+    if (!entry.can_be_added_to_blockchain) {
+        int x = 5;
+    }
+
     if (m_c.prepare_handle_incoming_blocks(std::vector<cryptonote::block_complete_entry>(1, {bd, {}, {}}), pblocks))
     {
       m_c.handle_incoming_block(bd, &block, bvc, nullptr);
@@ -850,13 +871,13 @@ public:
       bvc.m_verifivation_failed = true;
 
     bool added = !bvc.m_verifivation_failed;
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat, "{}", entry.fail_msg);
-      else
-        oxen::log::warning(globallogcat, "Failed to add block (no reason given)");
-      return false;
+    if (!add_to_blockchain_was_valid(
+                fmt::format(
+                        "block {} hf{}", block.height, static_cast<size_t>(block.major_version)),
+                entry.can_be_added_to_blockchain,
+                added,
+                entry.fail_msg)) {
+        return false;
     }
     return true;
   }
@@ -876,13 +897,9 @@ public:
       bvc.m_verifivation_failed = true;
 
     bool added = !bvc.m_verifivation_failed;
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat, "{}", entry.fail_msg);
-      else
-        oxen::log::warning(globallogcat, "Failed to add block (no reason given)");
-      return false;
+    if (!add_to_blockchain_was_valid(
+                "serialized block", entry.can_be_added_to_blockchain, added, entry.fail_msg)) {
+        return false;
     }
     return true;
   }
@@ -897,17 +914,13 @@ public:
     m_c.handle_incoming_tx(t_serializable_object_to_blob(entry.data.tx), tvc, opts);
 
     bool added = (pool_size + 1) == m_c.get_pool().get_transactions_count();
-    if (added != entry.can_be_added_to_blockchain)
-    {
-      if (entry.fail_msg.size())
-        oxen::log::warning(globallogcat, "{}", entry.fail_msg);
-      else if (entry.can_be_added_to_blockchain)
-        oxen::log::warning(globallogcat, "Failed to add transaction that should have been accepted");
-      else
-        oxen::log::warning(globallogcat, "TX adding should have failed, but didn't");
-      return false;
+    if (!add_to_blockchain_was_valid(
+                fmt::format("tx {}", entry.data.tx.hash),
+                entry.can_be_added_to_blockchain,
+                added,
+                entry.fail_msg)) {
+        return false;
     }
-
     return true;
   }
 
@@ -1522,7 +1535,7 @@ struct oxen_chain_generator
   cryptonote::transaction                              create_tx(const cryptonote::account_base &src, const cryptonote::account_public_address &dest, uint64_t amount, uint64_t fee) const;
   cryptonote::transaction                              create_registration_tx(const cryptonote::account_base& src,
                                                                               const cryptonote::keypair& service_node_keys = cryptonote::keypair{hw::get_device("default")},
-                                                                              uint64_t operator_stake = oxen::OXEN_STAKING_REQUIREMENT_TESTNET,
+                                                                              uint64_t operator_stake = static_cast<uint64_t>(-1),
                                                                               uint64_t fee = cryptonote::STAKING_FEE_BASIS,
                                                                               const std::vector<service_nodes::contribution>& contributors = {}) const;
   cryptonote::transaction                              create_staking_tx     (const crypto::public_key& pub_key, const cryptonote::account_base &src, uint64_t amount) const;

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -253,8 +253,8 @@ class Daemon(RPCDaemon):
     def get_bls_pubkeys(self):
         return self.json_rpc("bls_pubkey_request", {}).json()["result"]["nodes"]
 
-    def get_bls_rewards(self, address):
-        return self.json_rpc("bls_rewards_request", {"address": address}, timeout=1000).json()
+    def get_bls_rewards(self, address, oxen_address):
+        return self.json_rpc("bls_rewards_request", {"address": address, "oxen_address": oxen_address}, timeout=1000).json()
 
     def get_exit_request(self, bls_key):
         return self.json_rpc("bls_exit_request", {"bls_key": bls_key}).json()

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -253,8 +253,8 @@ class Daemon(RPCDaemon):
     def get_bls_pubkeys(self):
         return self.json_rpc("bls_pubkey_request", {}).json()["result"]["nodes"]
 
-    def get_bls_rewards(self, address):
-        return self.json_rpc("bls_rewards_request", {"address": address}).json()
+    def get_bls_rewards(self, address, oxen_address):
+        return self.json_rpc("bls_rewards_request", {"address": address, "oxen_address": oxen_address}, timeout=1000).json()
 
     def get_exit_request(self, bls_key):
         return self.json_rpc("bls_exit_request", {"bls_key": bls_key}).json()

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -253,8 +253,8 @@ class Daemon(RPCDaemon):
     def get_bls_pubkeys(self):
         return self.json_rpc("bls_pubkey_request", {}).json()["result"]["nodes"]
 
-    def get_bls_rewards(self, address, oxen_address):
-        return self.json_rpc("bls_rewards_request", {"address": address, "oxen_address": oxen_address}, timeout=1000).json()
+    def get_bls_rewards(self, address):
+        return self.json_rpc("bls_rewards_request", {"address": address}, timeout=1000).json()
 
     def get_exit_request(self, bls_key):
         return self.json_rpc("bls_exit_request", {"bls_key": bls_key}).json()

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -34,6 +34,11 @@ class TransferFailed(RuntimeError):
         self.message = message
         self.json = json
 
+class RPCFailed(RuntimeError):
+    def __init__(self, json):
+        self.message = "RPC request failed"
+        self.json = json
+        super().__init__(self.message)
 
 class RPCDaemon:
     def __init__(self, name):
@@ -129,7 +134,6 @@ class RPCDaemon:
                 if now >= until:
                     raise
 
-
 class Daemon(RPCDaemon):
     base_args = ('--dev-allow-local-ips', '--fixed-difficulty=1', '--devnet', '--non-interactive')
 
@@ -217,10 +221,15 @@ class Daemon(RPCDaemon):
     def height(self):
         return self.rpc("/get_height").json()["height"]
 
+    def get_staking_requirement(self):
+        rpc_result = self.json_rpc("get_staking_requirement").json()
+        if rpc_result["result"]["status"] != "OK":
+            raise RPCFailed(rpc_result)
+        result = rpc_result["result"]["staking_requirement"]
+        return result
 
     def txpool_hashes(self):
         return [x['id_hash'] for x in self.rpc("/get_transaction_pool").json()['transactions']]
-
 
     def ping(self, *, storage=True, lokinet=True):
         """Sends fake storage server and lokinet pings to the running oxend"""
@@ -379,12 +388,12 @@ class Wallet(RPCDaemon):
         return [find_tx(txid) for txid in txids]
 
 
-    def register_sn(self, sn):
+    def register_sn(self, sn, staking_requirement):
         r = sn.json_rpc("get_service_node_registration_cmd", {
             "contributor_addresses": [self.address()],
-            "contributor_amounts": [100000000000],
+            "contributor_amounts": [staking_requirement],
             "operator_cut": "100",
-            "staking_requirement": 100000000000
+            "staking_requirement": staking_requirement
         }).json()
         if 'error' in r:
             raise RuntimeError("Registration cmd generation failed: {}".format(r['error']['message']))
@@ -393,12 +402,12 @@ class Wallet(RPCDaemon):
         if 'error' in r:
             raise RuntimeError("Failed to submit service node registration tx: {}".format(r['error']['message']))
 
-    def register_sn_for_contributions(self, sn, cut, amount):
+    def register_sn_for_contributions(self, sn, cut, amount, staking_requirement):
         r = sn.json_rpc("get_service_node_registration_cmd", {
             "contributor_addresses": [self.address()],
             "contributor_amounts": [amount],
             "operator_cut": str(cut),
-            "staking_requirement": 100000000000
+            "staking_requirement": staking_requirement
         }).json()
         if 'error' in r:
             raise RuntimeError("Registration cmd generation failed: {}".format(r['error']['message']))

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -79,6 +79,7 @@ class ServiceNodeRewardContract:
 
     def addBLSPublicKey(self, args):
         # function addBLSPublicKey(uint256 pkX, uint256 pkY, uint256 sigs0, uint256 sigs1, uint256 sigs2, uint256 sigs3, uint256 serviceNodePubkey, uint256 serviceNodeSignature) public {
+        # function addBLSPublicKey(BN256G1.G1Point blsPubkey, BLSSignatureParams blsSignature, ServiceNodeParams serviceNodeParams, Contributor[] contributors)
         bls_param = {
                 'X': int(args["bls_pubkey"][:64], 16),
                 'Y': int(args["bls_pubkey"][64:128], 16),

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -6,17 +6,26 @@ class ServiceNodeRewardContract:
         self.provider_url = "http://127.0.0.1:8545"
         self.private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Hardhat account #0
         self.web3 = Web3(Web3.HTTPProvider(self.provider_url))
+
         self.contract_address = self.getContractDeployedInLatestBlock()
         self.contract = self.web3.eth.contract(address=self.contract_address, abi=contract_abi)
         self.acc = self.web3.eth.account.from_key(self.private_key)
+
+        self.foundation_pool_address = self.contract.functions.foundationPool().call();
+        self.foundation_pool_contract = self.web3.eth.contract(address=self.foundation_pool_address, abi=foundation_pool_abi)
+
+        # NOTE: Start the rewards contract
         unsent_tx = self.contract.functions.start().build_transaction({
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
         tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+
         self.erc20_address = self.contract.functions.designatedToken().call()
         self.erc20_contract = self.web3.eth.contract(address=self.erc20_address, abi=erc20_contract_abi)
-        unsent_tx = self.erc20_contract.functions.approve(self.contract_address, 15001000000000000000000).build_transaction({
+
+        # NOTE: Approve an amount to be sent from the hardhat account to the contract
+        unsent_tx = self.erc20_contract.functions.approve(self.contract_address, 1_5001_000_000_000_000_000_000).build_transaction({
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
@@ -46,6 +55,28 @@ class ServiceNodeRewardContract:
     def erc20balance(self, address):
         return self.erc20_contract.functions.balanceOf(Web3.to_checksum_address(address)).call()
 
+    def submitSignedTX(self, tx_label, signed_tx):
+        result     = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_receipt = self.web3.eth.wait_for_transaction_receipt(result)
+        self.web3.eth.wait_for_transaction_receipt(result)
+
+        if tx_receipt["status"] == 0:
+            # build a new transaction to replay:
+            tx_to_replay = self.web3.eth.get_transaction(result)
+            replay_tx = {
+                'to':    tx_to_replay['to'],
+                'from':  tx_to_replay['from'],
+                'value': tx_to_replay['value'],
+                'data':  tx_to_replay['input'],
+            }
+
+            try: # replay the transaction locally:
+                self.web3.eth.call(replay_tx, tx_to_replay.blockNumber - 1)
+            except Exception as e:
+                print(f"{tx_label} TX {result} reverted {e}")
+
+        return result
+
     def addBLSPublicKey(self, args):
         # function addBLSPublicKey(uint256 pkX, uint256 pkY, uint256 sigs0, uint256 sigs1, uint256 sigs2, uint256 sigs3, uint256 serviceNodePubkey, uint256 serviceNodeSignature) public {
         bls_param = {
@@ -70,8 +101,7 @@ class ServiceNodeRewardContract:
                         'gas': 2000000,
                         'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Add BLS public key", signed_tx)
         return tx_hash
 
     def initiateRemoveBLSPublicKey(self, service_node_id):
@@ -83,8 +113,7 @@ class ServiceNodeRewardContract:
                         'gas': 2000000,
                         'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Remove BLS public key", signed_tx)
         return tx_hash
 
     def removeBLSPublicKeyWithSignature(self, blsKey, blsSig, ids):
@@ -103,8 +132,7 @@ class ServiceNodeRewardContract:
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Remove BLS public key w/ signature", signed_tx)
         return tx_hash
 
     def liquidateBLSPublicKeyWithSignature(self, blsKey, blsSig, ids):
@@ -123,8 +151,7 @@ class ServiceNodeRewardContract:
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Liquidate BLS public key w/ signature", signed_tx)
         return tx_hash
 
     def seedPublicKeyList(self, args):
@@ -142,8 +169,7 @@ class ServiceNodeRewardContract:
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Seed public key list", signed_tx)
         return tx_hash
 
     def numberServiceNodes(self):
@@ -170,9 +196,9 @@ class ServiceNodeRewardContract:
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.web3.eth.wait_for_transaction_receipt(tx_hash)
+        tx_hash = self.submitSignedTX("Update rewards balance", signed_tx)
         return tx_hash
+
 
     def claimRewards(self):
         unsent_tx = self.contract.functions.claimRewards().build_transaction({
@@ -181,24 +207,7 @@ class ServiceNodeRewardContract:
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        tx_receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash)
-
-        if tx_receipt["status"] == 0:
-            # build a new transaction to replay:
-            tx_to_replay = self.web3.eth.get_transaction(tx_hash)
-            replay_tx = {
-                'to': tx_to_replay['to'],
-                'from': tx_to_replay['from'],
-                'value': tx_to_replay['value'],
-                'data': tx_to_replay['input'],
-            }
-
-            try: # replay the transaction locally:
-                self.web3.eth.call(replay_tx, tx_to_replay.blockNumber - 1)
-            except Exception as e:
-                print(f"Claim rewards TX {tx_hash} reverted {e}")
-
+        tx_hash = self.submitSignedTX("Claim rewards", signed_tx)
         return tx_hash
 
     def getServiceNodeID(self, bls_public_key):
@@ -2194,6 +2203,402 @@ erc20_contract_abi = json.loads("""
           "type": "bool"
         }
       ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]
+""")
+
+foundation_pool_abi = json.loads("""
+[
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "AddressEmptyCode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "AddressInsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FailedInnerCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidInitialization",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotInitializing",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newBeneficiary",
+          "type": "address"
+        }
+      ],
+      "name": "BeneficiaryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "FundsReleased",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferStarted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "ANNUAL_INTEREST_RATE",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "BASIS_POINTS",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SENT",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "acceptOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "beneficiary",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "timeElapsed",
+          "type": "uint256"
+        }
+      ],
+      "name": "calculateInterestAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "calculateReleasedAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "calculateTotalDeposited",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_beneficiary",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_sent",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastPaidOutTime",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "payoutReleased",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "rewardRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newBeneficiary",
+          "type": "address"
+        }
+      ],
+      "name": "setBeneficiary",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalPaidOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
     }

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -245,13 +245,13 @@ class SNNetwork:
         # vprint("liquidated node: number of service nodes in contract {}".format(self.servicenodecontract.numberServiceNodes()))
 
         # Sleep and let pulse quorum do work
-        sleep_time = 150
+        sleep_time = 20
         vprint(f"Sleeping now, awaiting pulse quorum to generate blocks, blockchain height is {self.ethsns[0].height()}");
         time.sleep(sleep_time)
         vprint(f"Waking now {sleep_time}, blockchain height is {self.ethsns[0].height()}");
 
         # Claim rewards for Address
-        rewards = self.ethsns[0].get_bls_rewards(self.servicenodecontract.hardhatAccountAddress())
+        rewards = self.ethsns[0].get_bls_rewards(self.servicenodecontract.hardhatAccountAddress(), self.mike.address())
         vprint(rewards)
         vprint("Balance before claim {}".format(self.servicenodecontract.erc20balance(self.servicenodecontract.hardhatAccountAddress())))
         result = self.servicenodecontract.updateRewardsBalance(

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -244,8 +244,13 @@ class SNNetwork:
         # vprint("Submitted transaction to liquidate service node : {}".format(ethereum_add_bls_args["bls_pubkey"]))
         # vprint("liquidated node: number of service nodes in contract {}".format(self.servicenodecontract.numberServiceNodes()))
 
+        # Sleep and let pulse quorum do work
+        sleep_time = 150
+        vprint(f"Sleeping now, awaiting pulse quorum to generate blocks, blockchain height is {self.ethsns[0].height()}");
+        time.sleep(sleep_time)
+        vprint(f"Waking now {sleep_time}, blockchain height is {self.ethsns[0].height()}");
+
         # Claim rewards for Address
-        time.sleep(10)
         rewards = self.ethsns[0].get_bls_rewards(self.servicenodecontract.hardhatAccountAddress())
         vprint(rewards)
         vprint("Balance before claim {}".format(self.servicenodecontract.erc20balance(self.servicenodecontract.hardhatAccountAddress())))

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -248,7 +248,7 @@ class SNNetwork:
 
         # Claim rewards for Address
         hardhatAccount = self.servicenodecontract.hardhatAccountAddress()
-        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount, self.mike.address())
+        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount)
         rewardsAccount = rewards["result"]["address"]
         assert rewardsAccount.lower() == hardhatAccount.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhatAccount.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
         vprint(rewards)

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -248,7 +248,7 @@ class SNNetwork:
 
         # Claim rewards for Address
         hardhatAccount = self.servicenodecontract.hardhatAccountAddress()
-        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount)
+        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount, self.mike.address())
         rewardsAccount = rewards["result"]["address"]
         assert rewardsAccount.lower() == hardhatAccount.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhatAccount.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
         vprint(rewards)


### PR DESCRIPTION
Various fixes to ensure that bls_rewards_request sanitises all input and various bug fixes encountered during testing.

- Correctly parse out multiple contributors in the `serviceNodes` smart contract call
- Fix ethyl::hexStringToU64 failing on large leading 0 padded strings
- Fix off-by-one in removable nodes prevent nodes from being flushed from the service node list
- Add many more debug logs into the python script
- Update txout check, I believe there will be 0 coinbase transactions after switching to arbitrum HF so I've updated the checks in the ServiceNodeList.
- In rewards request, we aggregate all other nodes and ensure we exclude ourselves from the aggregation process
- Verify returned aggregate parameters from other nodes against our own local signature
- Explicitly use hashHex when we are hashing a hex blob that needs to be decoded into binary first before hashing
- Fix unit tests failing due to changed staking requirement when transitioning into Arbitrum
- Added foundation pool ABI/contract to the local devnet script

More unit tests are succeeding with this branch, there's one failing with the core fee burn which needs more investigation to figure out what is happening there.

The local-devnet python script does _not_ work with this PR. It needs a small temporary patch to be applied. It's broken because when we transition into the Arbitrum hardfork, all the active addresses in the batching DB is still set to Oxen addresses. However the BLS rewards claim is an API designed around matching against Ethereum addresses. This causes the script to fail when trying to query/get rewards. 

As denoted in the screenshot the DB contains Oxen addresses.

![image](https://github.com/oxen-io/oxen-core/assets/12163539/2927a9a9-ba46-4177-8a5b-c36061739ef9)

The small workaround required is the code in this patch which I've removed from this PR to keep the integration branch clean. https://github.com/oxen-io/oxen-core/pull/1677/commits/520980c0adb2182e4eb0ac3b6fc81df451657251 We require the migration code which will convert the stored addresses into Ethereum addresses.

This depends on https://github.com/oxen-io/oxen-encoding/pull/37 and https://github.com/oxen-io/oxen-core/pull/1675