### PR TITLE
Fix rewards claim, remove the work-around commit that got left in accidentally

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -411,31 +411,27 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     return payments;
 }
 
-std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings(const std::string& address) {
-    log::trace(logcat, "BlockchainDB_SQLITE::{} for {}", __func__, address);
-    // auto earnings = prepared_maybe_get<int64_t>(R"(
-    // WITH RelevantOxenAddress AS (
-    // SELECT oxen_address
-    // FROM eth_mapping
-    // WHERE eth_address = ?
-    // HAVING height = MAX(height)
-    //)
-    // SELECT amount
-    // FROM batched_payments_accrued
-    // WHERE address = ?
-    // UNION
-    // SELECT bpa.amount
-    // FROM batched_payments_accrued bpa
-    // JOIN RelevantOxenAddress roa ON bpa.address = roa.oxen_address;
-    //)", address, address);
-    auto earnings = prepared_maybe_get<int64_t>(
+static std::pair<uint64_t, uint64_t> get_accrued_earnings(BlockchainSQLite& db, const std::string& address, uint64_t height) {
+    log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
+    auto earnings = db.prepared_maybe_get<int64_t>(
             R"(
         SELECT amount
         FROM batched_payments_accrued
         WHERE address = ?
-    )",
-            address);
+    )", address);
     auto result = std::make_pair(height, static_cast<uint64_t>(earnings.value_or(0) / 1000));
+    return result;
+}
+
+std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings_eth(const crypto::eth_address& address) {
+    std::string address_string = fmt::format("0x{}", tools::type_to_hex(address));
+    auto result = get_accrued_earnings(*this, address_string, height);
+    return result;
+}
+
+std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings_oxen(const account_public_address& address) {
+    std::string address_string = get_account_address_as_str(m_nettype, false /*subaddress*/, address);
+    auto result = get_accrued_earnings(*this, address_string, height);
     return result;
 }
 

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -81,8 +81,12 @@ class BlockchainSQLite : public db::Database {
 
   public:
     // get_accrued_earnings -> queries the database for the amount that has been accrued to
-    // `service_node_address` will return the atomic value in oxen that the service node is owed.
-    std::pair<uint64_t, uint64_t> get_accrued_earnings(const std::string& address);
+    // the Ethereum `address` will return the atomic value in oxen that the service node is owed.
+    std::pair<uint64_t, uint64_t> get_accrued_earnings_eth(const crypto::eth_address& address);
+
+    // See `get_accrued_earnings_eth`
+    std::pair<uint64_t, uint64_t> get_accrued_earnings_oxen(const account_public_address& address);
+
     // get_all_accrued_earnings -> queries the database for all the amount that has been accrued to
     // service nodes will return 2 vectors corresponding to the addresses and the atomic value in
     // oxen that the service nodes are owed.

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -120,7 +120,6 @@ static void logNetworkRequestFailedWarning(
 
 BLSRewardsResponse BLSAggregator::rewards_request(
         const crypto::eth_address& address,
-        const std::string& oxen_address,
         uint64_t amount,
         uint64_t height,
         std::span<const crypto::x25519_public_key> exclude) {
@@ -260,7 +259,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                 work.aggregate_signature.add(response.message_hash_signature);
                 work.signers.push_back(bls_utils::PublicKeyToHex(response.bls_pkey));
             },
-            std::array{oxenc::type_to_hex(address), oxen_address, std::to_string(amount)},
+            std::array{oxenc::type_to_hex(address), std::to_string(amount)},
             exclude);
 
     const auto sig_str = bls_utils::SignatureToHex(work.aggregate_signature);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -61,7 +61,6 @@ class BLSAggregator {
     /// amount is `0` or height is greater than the current blockchain height.
     BLSRewardsResponse rewards_request(
             const crypto::eth_address& address,
-            const std::string& oxen_address,
             uint64_t rewards,
             uint64_t height,
             std::span<const crypto::x25519_public_key> exclude);

--- a/src/bls/bls_omq.cpp
+++ b/src/bls/bls_omq.cpp
@@ -132,14 +132,12 @@ static VerifyDataResult data_parts_count_is_valid(std::span<const T> data, size_
 enum class GetRewardBalanceRequestField
 {
     Address,
-    OxenAddress,
     Amount,
     _count,
 };
 
 struct GetRewardBalanceRequest {
     crypto::eth_address address;
-    std::string oxen_address;
     uint64_t amount;
 };
 
@@ -186,10 +184,6 @@ GetRewardBalanceResponse create_reward_balance_request(
                 oxenc::from_hex(payload.begin(), payload.end(), reinterpret_cast<char*>(&request.address));
             } break;
 
-            case GetRewardBalanceRequestField::OxenAddress: {
-                request.oxen_address = m.data[field_index];
-            } break;
-
             case GetRewardBalanceRequestField::Amount: {
                 VerifyDataResult to_result = payload_to_number("rewards amount", payload, request.amount);
                 if (!to_result.good) {
@@ -205,8 +199,8 @@ GetRewardBalanceResponse create_reward_balance_request(
     }
 
     // NOTE: Get the rewards amount from the DB
-    // std::string address_str = fmt::format("0x{}", request.address);
-    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(request.oxen_address);
+    std::string address_str = fmt::format("0x{}", request.address);
+    auto [batchdb_height, amount] = sql_db->get_accrued_earnings(address_str);
     if (amount == 0) {
         result.error = fmt::format(
                 "OMQ command '{}' requested an address '{}' that has a zero balance in the "

--- a/src/bls/bls_omq.h
+++ b/src/bls/bls_omq.h
@@ -43,7 +43,7 @@ struct GetRewardBalanceResponse {
 
 struct GetRewardBalanceSignatureParts
 {
-    std::string message_to_sign;    // Message in hex that must be signed via BLSSigner::hasHex
+    std::string message_to_hash;    // Message in hex that must be hashed via BLSSigner::hashHex
     crypto::bytes<32> hash_to_sign; // Hash that must be signed via BLSSigner::signHash
 };
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2878,7 +2878,7 @@ BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
 
     auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
     auto [batch_db_height, amount] =
-            get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
+            get_blockchain_storage().sqlite_db()->get_accrued_earnings_eth(eth_address_bytes);
     const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, amount, batch_db_height, exclude);
     return result;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2855,7 +2855,7 @@ core::get_service_node_blacklisted_key_images() const {
     return m_service_node_list.get_blacklisted_key_images();
 }
 //-----------------------------------------------------------------------------------------------
-BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address, const std::string& oxen_address) {
+BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address) {
     std::string_view eth_address_trimmed = oxenc::trim_prefix(eth_address, "0x");
     eth_address_trimmed                  = oxenc::trim_prefix(eth_address_trimmed, "0x");
 
@@ -2878,8 +2878,8 @@ BLSRewardsResponse core::bls_rewards_request(const std::string& eth_address, con
 
     auto exclude = std::span(&m_service_keys.pub_x25519, &m_service_keys.pub_x25519 + 1);
     auto [batch_db_height, amount] =
-            get_blockchain_storage().sqlite_db()->get_accrued_earnings(oxen_address);
-    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, oxen_address, amount, batch_db_height, exclude);
+            get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_address);
+    const auto result = m_bls_aggregator->rewards_request(eth_address_bytes, amount, batch_db_height, exclude);
     return result;
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -951,7 +951,7 @@ class core : public i_miner_handler {
     const std::vector<service_nodes::key_image_blacklist_entry>&
     get_service_node_blacklisted_key_images() const;
 
-    BLSRewardsResponse bls_rewards_request(const std::string& eth_address, const std::string& oxen_address);
+    BLSRewardsResponse bls_rewards_request(const std::string& eth_address);
     aggregateExitResponse aggregate_exit_request(const std::string& bls_key);
     aggregateExitResponse aggregate_liquidation_request(const std::string& bls_key);
     std::vector<std::pair<std::string, uint64_t>> get_bls_pubkeys() const;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -589,10 +589,15 @@ class service_node_list {
             if (it == proofs.end())
                 continue;
             if (const auto& x2_pk = it->second.pubkey_x25519) {
+                bool excluded = false;
                 for (const crypto::x25519_public_key& exclude_key : exclude) {
-                    if (x2_pk == exclude_key)
-                        continue;
+                    if (x2_pk == exclude_key) {
+                        excluded = true;
+                        break;
+                    }
                 }
+                if (excluded)
+                    continue;
                 service_node_address address = {};
                 address.x_pkey = x2_pk;
                 address.ip = it->second.proof ? it->second.proof->public_ip : 0;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3397,8 +3397,10 @@ void core_rpc_server::invoke(
     if (req.addresses.size() > 0) {
         for (const auto& address : req.addresses) {
             uint64_t amount = 0;
-            if (cryptonote::is_valid_address(address, nettype())) {
-                const auto [batch_db_height, amount] = blockchain.sqlite_db()->get_accrued_earnings(address);
+
+            address_parse_info parse_info = {};
+            if (get_account_address_from_str(parse_info, m_core.get_nettype(), address)) {
+                const auto [batch_db_height, amount] = blockchain.sqlite_db()->get_accrued_earnings_oxen(parse_info.address);
                 (void)batch_db_height;
                 at_least_one_succeeded = true;
             }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1204,7 +1204,6 @@ void core_rpc_server::invoke(SUBMIT_TRANSACTION& tx, [[maybe_unused]] rpc_contex
     m_core.get_protocol()->relay_transactions(r, fake_context);
 
     tx.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(START_MINING& start_mining, [[maybe_unused]] rpc_context context) {
@@ -1527,7 +1526,6 @@ void core_rpc_server::invoke(GET_LAST_BLOCK_HEADER& get_last_block_header, rpc_c
     nlohmann::json header_as_json = header;
     get_last_block_header.response["block_header"] = header_as_json;
     get_last_block_header.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 
@@ -1575,7 +1573,6 @@ void core_rpc_server::invoke(
 
     get_block_header_by_hash.response["block_headers"] = block_headers;
     get_block_header_by_hash.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -1615,7 +1612,6 @@ void core_rpc_server::invoke(
     }
     get_block_headers_range.response["headers"] = headers;
     get_block_headers_range.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -1654,7 +1650,6 @@ void core_rpc_server::invoke(
 
     get_block_header_by_height.response["status"] = STATUS_OK;
     get_block_header_by_height.response["block_headers"] = headers;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_BLOCK& get_block, rpc_context context) {
@@ -1717,7 +1712,6 @@ void core_rpc_server::invoke(GET_BLOCK& get_block, rpc_context context) {
     get_block.response["blob"] = oxenc::to_hex(t_serializable_object_to_blob(blk));
     get_block.response["json"] = obj_to_json_str(blk);
     get_block.response["status"] = STATUS_OK;
-    return;
 }
 
 static json json_connection_info(const connection_info& ci) {
@@ -1806,7 +1800,6 @@ void core_rpc_server::invoke(GET_BANS& get_bans, [[maybe_unused]] rpc_context co
     }
 
     get_bans.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BANNED& banned, [[maybe_unused]] rpc_context context) {
@@ -1851,7 +1844,6 @@ void core_rpc_server::invoke(SET_BANS& set_bans, [[maybe_unused]] rpc_context co
         m_p2p.unblock_host(na);
 
     set_bans.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(FLUSH_TRANSACTION_POOL& flush_transaction_pool, [[maybe_unused]] rpc_context context) {
@@ -1916,7 +1908,6 @@ void core_rpc_server::invoke(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_con
 
     get_output_histogram.response["histogram"] = response_histogram;
     get_output_histogram.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_VERSION& version, [[maybe_unused]] rpc_context context) {
@@ -2025,7 +2016,6 @@ void core_rpc_server::invoke(GET_ALTERNATE_CHAINS& get_alternate_chains, [[maybe
     } catch (...) {
         get_alternate_chains.response["status"] = "Error retrieving alternate chains";
     }
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_LIMIT& limit, [[maybe_unused]] rpc_context context) {
@@ -2101,7 +2091,6 @@ void core_rpc_server::invoke(RELAY_TX& relay_tx, [[maybe_unused]] rpc_context co
         status = STATUS_OK;
 
     relay_tx.response["status"] = status;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(SYNC_INFO& sync, [[maybe_unused]] rpc_context context) {
@@ -2449,7 +2438,6 @@ void core_rpc_server::invoke(GET_QUORUM_STATE& get_quorum_state, rpc_context con
 
     get_quorum_state.response["quorums"] = quorums;
     get_quorum_state.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(FLUSH_CACHE& flush_cache, rpc_context context) {
@@ -2483,7 +2471,6 @@ void core_rpc_server::invoke(
 
     get_service_node_registration_cmd_raw.response["registration_cmd"] = registration_cmd;
     get_service_node_registration_cmd_raw.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -2539,7 +2526,6 @@ void core_rpc_server::invoke(
 
     get_service_node_registration_cmd.response["registration_cmd"] = registration_cmd;
     get_service_node_registration_cmd.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -2549,7 +2535,6 @@ void core_rpc_server::invoke(
 
     get_service_node_blacklisted_key_images.response["status"] = STATUS_OK;
     get_service_node_blacklisted_key_images.response["blacklist"] = blacklist;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, [[maybe_unused]] rpc_context context) {
@@ -2563,7 +2548,6 @@ void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, [[maybe_u
             bls_withdrawal_signature_response.signed_message;
     bls_rewards_request.response["signature"] = bls_withdrawal_signature_response.signature;
     bls_rewards_request.response["non_signers_bls_pubkeys"] = m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(bls_withdrawal_signature_response.signers_bls_pubkeys);
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_EXIT_REQUEST& bls_withdrawal_request, [[maybe_unused]] rpc_context context) {
@@ -2575,7 +2559,6 @@ void core_rpc_server::invoke(BLS_EXIT_REQUEST& bls_withdrawal_request, [[maybe_u
             bls_withdrawal_signature_response.signed_message;
     bls_withdrawal_request.response["signature"] = bls_withdrawal_signature_response.signature;
     bls_withdrawal_request.response["non_signers_bls_pubkeys"] = m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(bls_withdrawal_signature_response.signers_bls_pubkeys);
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& bls_withdrawal_request, [[maybe_unused]] rpc_context context) {
@@ -2587,14 +2570,12 @@ void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& bls_withdrawal_request, [[
             bls_withdrawal_signature_response.signed_message;
     bls_withdrawal_request.response["signature"] = bls_withdrawal_signature_response.signature;
     bls_withdrawal_request.response["non_signers_bls_pubkeys"] = m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(bls_withdrawal_signature_response.signers_bls_pubkeys);
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_PUBKEYS& bls_pubkey_request, [[maybe_unused]] rpc_context context) {
     const std::vector<std::pair<std::string, uint64_t>> nodes = m_core.get_bls_pubkeys();
     bls_pubkey_request.response["status"] = STATUS_OK;
     bls_pubkey_request.response["nodes"] = nodes;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, [[maybe_unused]] rpc_context context) {
@@ -2607,7 +2588,6 @@ void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, [[maybe
     bls_registration_request.response["service_node_pubkey"] = bls_registration.service_node_pubkey;
     bls_registration_request.response["service_node_signature"] =
             bls_registration.service_node_signature;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, [[maybe_unused]] rpc_context context) {
@@ -2617,7 +2597,6 @@ void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, [[maybe_unused]
     get_service_keys.response["service_node_ed25519_pubkey"] = tools::type_to_hex(keys.pub_ed25519);
     get_service_keys.response["service_node_x25519_pubkey"] = tools::type_to_hex(keys.pub_x25519);
     get_service_keys.response["status"] = STATUS_OK;
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_SERVICE_PRIVKEYS& get_service_privkeys, [[maybe_unused]] rpc_context context) {
@@ -2629,7 +2608,6 @@ void core_rpc_server::invoke(GET_SERVICE_PRIVKEYS& get_service_privkeys, [[maybe
     get_service_privkeys.response["service_node_x25519_privkey"] =
             tools::type_to_hex(keys.key_x25519);
     get_service_privkeys.response["status"] = STATUS_OK;
-    return;
 }
 
 static time_t reachable_to_time_t(
@@ -3128,8 +3106,6 @@ void core_rpc_server::invoke(GET_CHECKPOINTS& get_checkpoints, rpc_context conte
                             : db.get_checkpoints_range(*start, *end, GET_CHECKPOINTS::MAX_COUNT);
 
     get_checkpoints.response["checkpoints"] = std::move(checkpoints);
-
-    return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_SN_STATE_CHANGES& get_sn_state_changes, [[maybe_unused]] rpc_context context) {
@@ -3380,7 +3356,6 @@ void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_conte
 
     ons_owners_to_names.response["entries"] = entries;
     ons_owners_to_names.response["status"] = STATUS_OK;
-    return;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2539,7 +2539,7 @@ void core_rpc_server::invoke(
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, [[maybe_unused]] rpc_context context) {
     const BLSRewardsResponse bls_withdrawal_signature_response =
-            m_core.bls_rewards_request(bls_rewards_request.request.address, bls_rewards_request.request.oxen_address);
+            m_core.bls_rewards_request(bls_rewards_request.request.address);
     bls_rewards_request.response["status"] = STATUS_OK;
     bls_rewards_request.response["address"] = bls_withdrawal_signature_response.address;
     bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -184,7 +184,7 @@ bool core_rpc_server::check_core_ready() {
     } while (0)
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_HEIGHT& get_height, rpc_context context) {
+void core_rpc_server::invoke(GET_HEIGHT& get_height, [[maybe_unused]] rpc_context context) {
     auto [height, hash] = m_core.get_blockchain_top();
 
     ++height;  // block height to chain height
@@ -192,7 +192,6 @@ void core_rpc_server::invoke(GET_HEIGHT& get_height, rpc_context context) {
     get_height.response["height"] = height;
     get_height.response_hex["hash"] = hash;
 
-    uint64_t immutable_height = 0;
     cryptonote::checkpoint_t checkpoint;
     if (m_core.get_blockchain_storage().get_db().get_immutable_checkpoint(
                 &checkpoint, height - 1)) {
@@ -201,7 +200,7 @@ void core_rpc_server::invoke(GET_HEIGHT& get_height, rpc_context context) {
     }
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
+void core_rpc_server::invoke(GET_INFO& info, [[maybe_unused]] rpc_context context) {
 
     auto [top_height, top_hash] = m_core.get_blockchain_top();
 
@@ -306,7 +305,7 @@ void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
     info.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_NET_STATS& get_net_stats, rpc_context context) {
+void core_rpc_server::invoke(GET_NET_STATS& get_net_stats, [[maybe_unused]] rpc_context context) {
     get_net_stats.response["start_time"] = m_core.get_start_time();
     {
         std::lock_guard lock{
@@ -340,7 +339,7 @@ namespace {
 }  // namespace
 //------------------------------------------------------------------------------------------------------------------------------
 GET_BLOCKS_BIN::response core_rpc_server::invoke(
-        GET_BLOCKS_BIN::request&& req, rpc_context context) {
+        GET_BLOCKS_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_BLOCKS_BIN::response res{};
 
     std::vector<std::pair<
@@ -400,7 +399,7 @@ GET_BLOCKS_BIN::response core_rpc_server::invoke(
     return res;
 }
 GET_ALT_BLOCKS_HASHES_BIN::response core_rpc_server::invoke(
-        GET_ALT_BLOCKS_HASHES_BIN::request&& req, rpc_context context) {
+        GET_ALT_BLOCKS_HASHES_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_ALT_BLOCKS_HASHES_BIN::response res{};
 
     std::vector<block> blks;
@@ -422,7 +421,7 @@ GET_ALT_BLOCKS_HASHES_BIN::response core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 GET_BLOCKS_BY_HEIGHT_BIN::response core_rpc_server::invoke(
-        GET_BLOCKS_BY_HEIGHT_BIN::request&& req, rpc_context context) {
+        GET_BLOCKS_BY_HEIGHT_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_BLOCKS_BY_HEIGHT_BIN::response res{};
 
     res.status = "Failed";
@@ -448,7 +447,7 @@ GET_BLOCKS_BY_HEIGHT_BIN::response core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 GET_HASHES_BIN::response core_rpc_server::invoke(
-        GET_HASHES_BIN::request&& req, rpc_context context) {
+        GET_HASHES_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_HASHES_BIN::response res{};
 
     res.start_height = req.start_height;
@@ -532,7 +531,7 @@ void core_rpc_server::invoke(GET_OUTPUTS& get_outputs, rpc_context context) {
 }
 //------------------------------------------------------------------------------------------------------------------------------
 GET_TX_GLOBAL_OUTPUTS_INDEXES_BIN::response core_rpc_server::invoke(
-        GET_TX_GLOBAL_OUTPUTS_INDEXES_BIN::request&& req, rpc_context context) {
+        GET_TX_GLOBAL_OUTPUTS_INDEXES_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_TX_GLOBAL_OUTPUTS_INDEXES_BIN::response res{};
 
     bool r = m_core.get_tx_outputs_gindexs(req.txid, res.o_indexes);
@@ -858,7 +857,7 @@ static tx_memory_pool::key_images_container get_pool_kis(
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_TRANSACTIONS& get, rpc_context context) {
+void core_rpc_server::invoke(GET_TRANSACTIONS& get, [[maybe_unused]] rpc_context context) {
     std::unordered_set<crypto::hash> missed_txs;
     using split_tx = std::tuple<crypto::hash, std::string, crypto::hash, std::string>;
     std::vector<split_tx> txs;
@@ -1108,7 +1107,7 @@ void core_rpc_server::invoke(GET_TRANSACTIONS& get, rpc_context context) {
     get.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(IS_KEY_IMAGE_SPENT& spent, rpc_context context) {
+void core_rpc_server::invoke(IS_KEY_IMAGE_SPENT& spent, [[maybe_unused]] rpc_context context) {
     spent.response["status"] = STATUS_FAILED;
 
     std::vector<bool> blockchain_spent;
@@ -1142,7 +1141,7 @@ static constexpr auto BLINK_TIMEOUT = "Blink quorum timeout"sv;
 static constexpr auto BLINK_REJECTED = "Transaction rejected by blink quorum"sv;
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SUBMIT_TRANSACTION& tx, rpc_context context) {
+void core_rpc_server::invoke(SUBMIT_TRANSACTION& tx, [[maybe_unused]] rpc_context context) {
     if (!check_core_ready()) {
         tx.response["status"] = STATUS_BUSY;
         return;
@@ -1208,7 +1207,7 @@ void core_rpc_server::invoke(SUBMIT_TRANSACTION& tx, rpc_context context) {
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(START_MINING& start_mining, rpc_context context) {
+void core_rpc_server::invoke(START_MINING& start_mining, [[maybe_unused]] rpc_context context) {
     // CHECK_CORE_READY();
     if (!check_core_ready()) {
         start_mining.response["status"] = STATUS_BUSY;
@@ -1261,7 +1260,7 @@ void core_rpc_server::invoke(START_MINING& start_mining, rpc_context context) {
     start_mining.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(STOP_MINING& stop_mining, rpc_context context) {
+void core_rpc_server::invoke(STOP_MINING& stop_mining, [[maybe_unused]] rpc_context context) {
     cryptonote::miner& miner = m_core.get_miner();
     if (!miner.is_mining()) {
         stop_mining.response["status"] = "Mining never started";
@@ -1277,7 +1276,7 @@ void core_rpc_server::invoke(STOP_MINING& stop_mining, rpc_context context) {
     stop_mining.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(MINING_STATUS& mining_status, rpc_context context) {
+void core_rpc_server::invoke(MINING_STATUS& mining_status, [[maybe_unused]] rpc_context context) {
     const miner& lMiner = m_core.get_miner();
     mining_status.response["active"] = lMiner.is_mining();
     mining_status.response["block_target"] = tools::to_seconds(TARGET_BLOCK_TIME);
@@ -1304,7 +1303,7 @@ void core_rpc_server::invoke(MINING_STATUS& mining_status, rpc_context context) 
     mining_status.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SAVE_BC& save_bc, rpc_context context) {
+void core_rpc_server::invoke(SAVE_BC& save_bc, [[maybe_unused]] rpc_context context) {
     if (!m_core.get_blockchain_storage().store_blockchain()) {
         save_bc.response["status"] = "Error while storing blockchain";
         log::warning(logcat, "{}", save_bc.response["status"].get<std::string_view>());
@@ -1325,7 +1324,7 @@ static nlohmann::json json_peer_info(const nodetool::peerlist_entry& peer) {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_PEER_LIST& pl, rpc_context context) {
+void core_rpc_server::invoke(GET_PEER_LIST& pl, [[maybe_unused]] rpc_context context) {
     std::vector<nodetool::peerlist_entry> white_list, gray_list;
     if (pl.request.public_only)
         m_p2p.get_public_peerlist(gray_list, white_list);
@@ -1346,7 +1345,7 @@ void core_rpc_server::invoke(GET_PEER_LIST& pl, rpc_context context) {
     pl.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SET_LOG_LEVEL& set_log_level, rpc_context context) {
+void core_rpc_server::invoke(SET_LOG_LEVEL& set_log_level, [[maybe_unused]] rpc_context context) {
     if (set_log_level.request.level < 0 || set_log_level.request.level > 4) {
         set_log_level.response["status"] = "Error: log level not valid";
         return;
@@ -1357,7 +1356,7 @@ void core_rpc_server::invoke(SET_LOG_LEVEL& set_log_level, rpc_context context) 
     set_log_level.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SET_LOG_CATEGORIES& set_log_categories, rpc_context context) {
+void core_rpc_server::invoke(SET_LOG_CATEGORIES& set_log_categories, [[maybe_unused]] rpc_context context) {
     oxen::logging::process_categories_string(set_log_categories.request.categories.c_str());
     set_log_categories.response["status"] = STATUS_OK;
 }
@@ -1382,7 +1381,7 @@ void core_rpc_server::invoke(
     get_transaction_pool_hashes.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_TRANSACTION_POOL_STATS& stats, rpc_context context) {
+void core_rpc_server::invoke(GET_TRANSACTION_POOL_STATS& stats, [[maybe_unused]] rpc_context context) {
     auto txpool = m_core.get_pool().get_transaction_stats(stats.request.include_unrelayed);
     json pool_stats{
             {"bytes_total", txpool.bytes_total},
@@ -1407,7 +1406,7 @@ void core_rpc_server::invoke(GET_TRANSACTION_POOL_STATS& stats, rpc_context cont
     stats.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(STOP_DAEMON& stop_daemon, rpc_context context) {
+void core_rpc_server::invoke(STOP_DAEMON& stop_daemon, [[maybe_unused]] rpc_context context) {
     m_p2p.send_stop_signal();
     stop_daemon.response["status"] = STATUS_OK;
 }
@@ -1416,7 +1415,7 @@ void core_rpc_server::invoke(STOP_DAEMON& stop_daemon, rpc_context context) {
 // Oxen
 //
 GET_OUTPUT_BLACKLIST_BIN::response core_rpc_server::invoke(
-        GET_OUTPUT_BLACKLIST_BIN::request&& req, rpc_context context) {
+        GET_OUTPUT_BLACKLIST_BIN::request&& req, [[maybe_unused]] rpc_context context) {
     GET_OUTPUT_BLACKLIST_BIN::response res{};
 
     try {
@@ -1430,12 +1429,12 @@ GET_OUTPUT_BLACKLIST_BIN::response core_rpc_server::invoke(
     return res;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_BLOCK_COUNT& get, rpc_context context) {
+void core_rpc_server::invoke(GET_BLOCK_COUNT& get, [[maybe_unused]] rpc_context context) {
     get.response["count"] = m_core.get_current_blockchain_height();
     get.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_BLOCK_HASH& get, rpc_context context) {
+void core_rpc_server::invoke(GET_BLOCK_HASH& get, [[maybe_unused]] rpc_context context) {
     auto curr_height = m_core.get_current_blockchain_height();
     for (auto h : get.request.heights) {
         if (h >= curr_height)
@@ -1756,7 +1755,7 @@ static json json_connection_info(const connection_info& ci) {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_CONNECTIONS& get_connections, rpc_context context) {
+void core_rpc_server::invoke(GET_CONNECTIONS& get_connections, [[maybe_unused]] rpc_context context) {
     auto& c = get_connections.response["connections"];
     c = json::array();
     for (auto& ci : m_p2p.get_payload_object().get_connections())
@@ -1764,7 +1763,7 @@ void core_rpc_server::invoke(GET_CONNECTIONS& get_connections, rpc_context conte
     get_connections.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(HARD_FORK_INFO& hfinfo, rpc_context context) {
+void core_rpc_server::invoke(HARD_FORK_INFO& hfinfo, [[maybe_unused]] rpc_context context) {
     const auto& blockchain = m_core.get_blockchain_storage();
     auto version = hfinfo.request.version > 0 ? static_cast<hf>(hfinfo.request.version)
                  : hfinfo.request.height > 0 ? blockchain.get_network_version(hfinfo.request.height)
@@ -1779,7 +1778,7 @@ void core_rpc_server::invoke(HARD_FORK_INFO& hfinfo, rpc_context context) {
     hfinfo.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_BANS& get_bans, rpc_context context) {
+void core_rpc_server::invoke(GET_BANS& get_bans, [[maybe_unused]] rpc_context context) {
     auto now = time(nullptr);
     std::map<std::string, time_t> blocked_hosts = m_p2p.get_blocked_hosts();
     for (std::map<std::string, time_t>::const_iterator i = blocked_hosts.begin();
@@ -1810,7 +1809,7 @@ void core_rpc_server::invoke(GET_BANS& get_bans, rpc_context context) {
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BANNED& banned, rpc_context context) {
+void core_rpc_server::invoke(BANNED& banned, [[maybe_unused]] rpc_context context) {
     auto na_parsed = net::get_network_address(banned.request.address, 0);
     if (!na_parsed)
         throw rpc_error{ERROR_WRONG_PARAM, "Unsupported host type"};
@@ -1828,7 +1827,7 @@ void core_rpc_server::invoke(BANNED& banned, rpc_context context) {
     banned.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SET_BANS& set_bans, rpc_context context) {
+void core_rpc_server::invoke(SET_BANS& set_bans, [[maybe_unused]] rpc_context context) {
     epee::net_utils::network_address na;
     // try subnet first
     auto ns_parsed = net::get_ipv4_subnet_address(set_bans.request.host);
@@ -1855,7 +1854,7 @@ void core_rpc_server::invoke(SET_BANS& set_bans, rpc_context context) {
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_context context) {
+void core_rpc_server::invoke(FLUSH_TRANSACTION_POOL& flush_transaction_pool, [[maybe_unused]] rpc_context context) {
     bool failed = false;
     std::vector<crypto::hash> txids;
     if (flush_transaction_pool.request.txids.empty()) {
@@ -1920,12 +1919,12 @@ void core_rpc_server::invoke(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_con
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_VERSION& version, rpc_context context) {
+void core_rpc_server::invoke(GET_VERSION& version, [[maybe_unused]] rpc_context context) {
     version.response["version"] = pack_version(VERSION);
     version.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_SERVICE_NODE_STATUS& sns, rpc_context context) {
+void core_rpc_server::invoke(GET_SERVICE_NODE_STATUS& sns, [[maybe_unused]] rpc_context context) {
     auto [top_height, top_hash] = m_core.get_blockchain_top();
     sns.response["height"] = top_height;
     sns.response_hex["block_hash"] = top_hash;
@@ -1959,7 +1958,7 @@ void core_rpc_server::invoke(GET_SERVICE_NODE_STATUS& sns, rpc_context context) 
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_COINBASE_TX_SUM& get_coinbase_tx_sum, rpc_context context) {
+void core_rpc_server::invoke(GET_COINBASE_TX_SUM& get_coinbase_tx_sum, [[maybe_unused]] rpc_context context) {
     if (auto sums = m_core.get_coinbase_tx_sum(
                 get_coinbase_tx_sum.request.height, get_coinbase_tx_sum.request.count)) {
         std::tie(
@@ -1973,7 +1972,7 @@ void core_rpc_server::invoke(GET_COINBASE_TX_SUM& get_coinbase_tx_sum, rpc_conte
     }
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_FEE_ESTIMATE& get_fee_estimate, rpc_context context) {
+void core_rpc_server::invoke(GET_FEE_ESTIMATE& get_fee_estimate, [[maybe_unused]] rpc_context context) {
     auto fees = m_core.get_blockchain_storage().get_dynamic_base_fee_estimate(
             get_fee_estimate.request.grace_blocks);
     get_fee_estimate.response["fee_per_byte"] = fees.first;
@@ -1987,7 +1986,7 @@ void core_rpc_server::invoke(GET_FEE_ESTIMATE& get_fee_estimate, rpc_context con
     get_fee_estimate.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_ALTERNATE_CHAINS& get_alternate_chains, rpc_context context) {
+void core_rpc_server::invoke(GET_ALTERNATE_CHAINS& get_alternate_chains, [[maybe_unused]] rpc_context context) {
     try {
         std::vector<GET_ALTERNATE_CHAINS::chain_info> chains;
         std::vector<std::pair<Blockchain::block_extended_info, std::vector<crypto::hash>>>
@@ -2029,14 +2028,14 @@ void core_rpc_server::invoke(GET_ALTERNATE_CHAINS& get_alternate_chains, rpc_con
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_LIMIT& limit, rpc_context context) {
+void core_rpc_server::invoke(GET_LIMIT& limit, [[maybe_unused]] rpc_context context) {
     limit.response = {
             {"limit_down", epee::net_utils::connection_basic::get_rate_down_limit()},
             {"limit_up", epee::net_utils::connection_basic::get_rate_up_limit()},
             {"status", STATUS_OK}};
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SET_LIMIT& limit, rpc_context context) {
+void core_rpc_server::invoke(SET_LIMIT& limit, [[maybe_unused]] rpc_context context) {
     // -1 = reset to default
     //  0 = do not modify
     if (limit.request.limit_down != 0)
@@ -2054,26 +2053,26 @@ void core_rpc_server::invoke(SET_LIMIT& limit, rpc_context context) {
             {"status", STATUS_OK}};
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(OUT_PEERS& out_peers, rpc_context context) {
+void core_rpc_server::invoke(OUT_PEERS& out_peers, [[maybe_unused]] rpc_context context) {
     if (out_peers.request.set)
         m_p2p.change_max_out_public_peers(out_peers.request.out_peers);
     out_peers.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(IN_PEERS& in_peers, rpc_context context) {
+void core_rpc_server::invoke(IN_PEERS& in_peers, [[maybe_unused]] rpc_context context) {
     if (in_peers.request.set)
         m_p2p.change_max_in_public_peers(in_peers.request.in_peers);
     in_peers.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(POP_BLOCKS& pop_blocks, rpc_context context) {
+void core_rpc_server::invoke(POP_BLOCKS& pop_blocks, [[maybe_unused]] rpc_context context) {
     m_core.get_blockchain_storage().pop_blocks(pop_blocks.request.nblocks);
 
     pop_blocks.response["height"] = m_core.get_current_blockchain_height();
     pop_blocks.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(RELAY_TX& relay_tx, rpc_context context) {
+void core_rpc_server::invoke(RELAY_TX& relay_tx, [[maybe_unused]] rpc_context context) {
     std::string status = "";
     for (const auto& txid_hex : relay_tx.request.txids) {
         crypto::hash txid;
@@ -2105,7 +2104,7 @@ void core_rpc_server::invoke(RELAY_TX& relay_tx, rpc_context context) {
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(SYNC_INFO& sync, rpc_context context) {
+void core_rpc_server::invoke(SYNC_INFO& sync, [[maybe_unused]] rpc_context context) {
     auto [top_height, top_hash] = m_core.get_blockchain_top();
     sync.response["height"] = top_height + 1;  // turn top block height into blockchain height
     if (auto target_height = m_core.get_target_blockchain_height(); target_height > top_height + 1)
@@ -2247,7 +2246,7 @@ namespace detail {
 
 //------------------------------------------------------------------------------------------------------------------------------
 GET_OUTPUT_DISTRIBUTION::response core_rpc_server::invoke(
-        GET_OUTPUT_DISTRIBUTION::request&& req, rpc_context context, bool binary) {
+        GET_OUTPUT_DISTRIBUTION::request&& req, [[maybe_unused]] rpc_context context, bool binary) {
     GET_OUTPUT_DISTRIBUTION::response res{};
     try {
         // 0 is placeholder for the whole chain
@@ -2297,7 +2296,7 @@ GET_OUTPUT_DISTRIBUTION_BIN::response core_rpc_server::invoke(
     return invoke(std::move(static_cast<GET_OUTPUT_DISTRIBUTION::request&>(req)), context, true);
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(PRUNE_BLOCKCHAIN& prune_blockchain, rpc_context context) {
+void core_rpc_server::invoke(PRUNE_BLOCKCHAIN& prune_blockchain, [[maybe_unused]] rpc_context context) {
     try {
         if (!(prune_blockchain.request.check ? m_core.check_blockchain_pruning()
                                              : m_core.prune_blockchain()))
@@ -2488,7 +2487,7 @@ void core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
-        GET_SERVICE_NODE_REGISTRATION_CMD& get_service_node_registration_cmd, rpc_context context) {
+        GET_SERVICE_NODE_REGISTRATION_CMD& get_service_node_registration_cmd, [[maybe_unused]] rpc_context context) {
     if (!m_core.service_node())
         throw rpc_error{
                 ERROR_WRONG_PARAM,
@@ -2553,7 +2552,7 @@ void core_rpc_server::invoke(
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context context) {
+void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, [[maybe_unused]] rpc_context context) {
     const BLSRewardsResponse bls_withdrawal_signature_response =
             m_core.bls_rewards_request(bls_rewards_request.request.address, bls_rewards_request.request.oxen_address);
     bls_rewards_request.response["status"] = STATUS_OK;
@@ -2567,7 +2566,7 @@ void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_conte
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_EXIT_REQUEST& bls_withdrawal_request, rpc_context context) {
+void core_rpc_server::invoke(BLS_EXIT_REQUEST& bls_withdrawal_request, [[maybe_unused]] rpc_context context) {
     const aggregateExitResponse bls_withdrawal_signature_response =
             m_core.aggregate_exit_request(bls_withdrawal_request.request.bls_key);
     bls_withdrawal_request.response["status"] = STATUS_OK;
@@ -2579,7 +2578,7 @@ void core_rpc_server::invoke(BLS_EXIT_REQUEST& bls_withdrawal_request, rpc_conte
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& bls_withdrawal_request, rpc_context context) {
+void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& bls_withdrawal_request, [[maybe_unused]] rpc_context context) {
     const aggregateExitResponse bls_withdrawal_signature_response =
             m_core.aggregate_liquidation_request(bls_withdrawal_request.request.bls_key);
     bls_withdrawal_request.response["status"] = STATUS_OK;
@@ -2591,14 +2590,14 @@ void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& bls_withdrawal_request, rp
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_PUBKEYS& bls_pubkey_request, rpc_context context) {
+void core_rpc_server::invoke(BLS_PUBKEYS& bls_pubkey_request, [[maybe_unused]] rpc_context context) {
     const std::vector<std::pair<std::string, uint64_t>> nodes = m_core.get_bls_pubkeys();
     bls_pubkey_request.response["status"] = STATUS_OK;
     bls_pubkey_request.response["nodes"] = nodes;
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, rpc_context context) {
+void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, [[maybe_unused]] rpc_context context) {
     const blsRegistrationResponse bls_registration =
             m_core.bls_registration(bls_registration_request.request.address);
     bls_registration_request.response["status"] = STATUS_OK;
@@ -2611,7 +2610,7 @@ void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, rpc_con
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, rpc_context context) {
+void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, [[maybe_unused]] rpc_context context) {
     const auto& keys = m_core.get_service_keys();
     if (keys.pub)
         get_service_keys.response["service_node_pubkey"] = tools::type_to_hex(keys.pub);
@@ -2621,7 +2620,7 @@ void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, rpc_context con
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_SERVICE_PRIVKEYS& get_service_privkeys, rpc_context context) {
+void core_rpc_server::invoke(GET_SERVICE_PRIVKEYS& get_service_privkeys, [[maybe_unused]] rpc_context context) {
     const auto& keys = m_core.get_service_keys();
     if (keys.key)
         get_service_privkeys.response["service_node_privkey"] = tools::type_to_hex(keys.key);
@@ -2910,7 +2909,7 @@ void core_rpc_server::fill_sn_response_entry(
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_SERVICE_NODES& sns, rpc_context context) {
+void core_rpc_server::invoke(GET_SERVICE_NODES& sns, [[maybe_unused]] rpc_context context) {
     auto& req = sns.request;
     sns.response["status"] = STATUS_OK;
     auto [top_height, top_hash] = m_core.get_blockchain_top();
@@ -3039,7 +3038,7 @@ namespace {
 }  // namespace
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(STORAGE_SERVER_PING& storage_server_ping, rpc_context context) {
+void core_rpc_server::invoke(STORAGE_SERVER_PING& storage_server_ping, [[maybe_unused]] rpc_context context) {
     m_core.ss_version = storage_server_ping.request.version;
     storage_server_ping.response["status"] = handle_ping(
             m_core,
@@ -3058,7 +3057,7 @@ void core_rpc_server::invoke(STORAGE_SERVER_PING& storage_server_ping, rpc_conte
             });
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(LOKINET_PING& lokinet_ping, rpc_context context) {
+void core_rpc_server::invoke(LOKINET_PING& lokinet_ping, [[maybe_unused]] rpc_context context) {
     m_core.lokinet_version = lokinet_ping.request.version;
     lokinet_ping.response["status"] = handle_ping(
             m_core,
@@ -3076,7 +3075,7 @@ void core_rpc_server::invoke(LOKINET_PING& lokinet_ping, rpc_context context) {
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
-        GET_STAKING_REQUIREMENT& get_staking_requirement, rpc_context context) {
+        GET_STAKING_REQUIREMENT& get_staking_requirement, [[maybe_unused]] rpc_context context) {
     get_staking_requirement.response["height"] = get_staking_requirement.request.height > 0
                                                        ? get_staking_requirement.request.height
                                                        : m_core.get_current_blockchain_height();
@@ -3133,7 +3132,7 @@ void core_rpc_server::invoke(GET_CHECKPOINTS& get_checkpoints, rpc_context conte
     return;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(GET_SN_STATE_CHANGES& get_sn_state_changes, rpc_context context) {
+void core_rpc_server::invoke(GET_SN_STATE_CHANGES& get_sn_state_changes, [[maybe_unused]] rpc_context context) {
     using blob_t = std::string;
     using block_pair_t = std::pair<blob_t, block>;
     std::vector<block_pair_t> blocks;
@@ -3219,7 +3218,7 @@ void core_rpc_server::invoke(GET_SN_STATE_CHANGES& get_sn_state_changes, rpc_con
     get_sn_state_changes.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(REPORT_PEER_STATUS& report_peer_status, rpc_context context) {
+void core_rpc_server::invoke(REPORT_PEER_STATUS& report_peer_status, [[maybe_unused]] rpc_context context) {
     crypto::public_key pubkey;
     if (!tools::hex_to_type(report_peer_status.request.pubkey, pubkey)) {
         log::error(logcat, "Could not parse public key: {}", report_peer_status.request.pubkey);
@@ -3245,13 +3244,13 @@ void core_rpc_server::invoke(REPORT_PEER_STATUS& report_peer_status, rpc_context
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
-        TEST_TRIGGER_P2P_RESYNC& test_trigger_p2p_resync, rpc_context context) {
+        TEST_TRIGGER_P2P_RESYNC& test_trigger_p2p_resync, [[maybe_unused]] rpc_context context) {
     m_p2p.reset_peer_handshake_timer();
     test_trigger_p2p_resync.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
-        TEST_TRIGGER_UPTIME_PROOF& test_trigger_uptime_proof, rpc_context context) {
+        TEST_TRIGGER_UPTIME_PROOF& test_trigger_uptime_proof, [[maybe_unused]] rpc_context context) {
     if (m_core.get_nettype() != cryptonote::network_type::MAINNET)
         m_core.submit_uptime_proof();
 
@@ -3271,8 +3270,6 @@ void core_rpc_server::invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_conte
     }
 
     std::optional<uint64_t> height = m_core.get_current_blockchain_height();
-    auto hf_version = get_network_version(nettype(), *height);
-
     std::vector<ons::mapping_type> types;
     types.clear();
     if (types.capacity() < ons_names_to_owners.request.type.size())
@@ -3293,8 +3290,7 @@ void core_rpc_server::invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_conte
         const auto& request = ons_names_to_owners.request.name_hash[request_index];
         // This also takes 32 raw bytes, but that is undocumented (because it is painful to pass
         // through json).
-        auto name_hash = ons::name_hash_input_to_base64(
-                ons_names_to_owners.request.name_hash[request_index]);
+        auto name_hash = ons::name_hash_input_to_base64(request);
         if (!name_hash)
             throw rpc_error{
                     ERROR_WRONG_PARAM,
@@ -3388,7 +3384,7 @@ void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_conte
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context context) {
+void core_rpc_server::invoke(ONS_RESOLVE& resolve, [[maybe_unused]] rpc_context context) {
     auto& req = resolve.request;
     if (req.type < 0 || req.type >= tools::enum_count<ons::mapping_type>)
         throw rpc_error{
@@ -3416,7 +3412,7 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context context) {
 }
 
 void core_rpc_server::invoke(
-        GET_ACCRUED_BATCHED_EARNINGS& get_accrued_batched_earnings, rpc_context context) {
+        GET_ACCRUED_BATCHED_EARNINGS& get_accrued_batched_earnings, [[maybe_unused]] rpc_context context) {
     auto& blockchain = m_core.get_blockchain_storage();
     bool at_least_one_succeeded = false;
 

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -489,7 +489,7 @@ void parse_request(GET_SERVICE_NODE_REGISTRATION_CMD& cmd, rpc_input in) {
 }
 
 void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in) {
-    get_values(in, "address", required{cmd.request.address}, "oxen_address", required{cmd.request.oxen_address});
+    get_values(in, "address", required{cmd.request.address});
 }
 
 void parse_request(BLS_EXIT_REQUEST& cmd, rpc_input in) {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2308,7 +2308,6 @@ struct BLS_REWARDS_REQUEST : PUBLIC {
 
     struct request_parameters {
         std::string address;
-        std::string oxen_address;
     } request;
 };
 

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -262,8 +262,8 @@ class Daemon(RPCDaemon):
     def get_bls_pubkeys(self):
         return self.json_rpc("bls_pubkey_request", {}).json()["result"]["nodes"]
 
-    def get_bls_rewards(self, address, oxen_address):
-        return self.json_rpc("bls_rewards_request", {"address": address, "oxen_address": oxen_address}, timeout=1000).json()
+    def get_bls_rewards(self, address):
+        return self.json_rpc("bls_rewards_request", {"address": address}, timeout=1000).json()
 
     def get_exit_request(self, bls_key):
         return self.json_rpc("bls_exit_request", {"bls_key": bls_key}).json()

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -250,7 +250,7 @@ class SNNetwork:
 
         # Claim rewards for Address
         hardhatAccount = self.servicenodecontract.hardhatAccountAddress()
-        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount, self.mike.address())
+        rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount)
         rewardsAccount = rewards["result"]["address"]
         assert rewardsAccount.lower() == hardhatAccount.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhatAccount.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
         vprint(rewards)

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -137,8 +137,6 @@ class SNNetwork:
         with open(configfile, 'w') as filetowrite:
             filetowrite.write('#!/usr/bin/python3\n# -*- coding: utf-8 -*-\nlisten_ip=\"{}\"\nlisten_port=\"{}\"\nwallet_listen_ip=\"{}\"\nwallet_listen_port=\"{}\"\nwallet_address=\"{}\"\nexternal_address=\"{}\"'.format(self.sns[0].listen_ip,self.sns[0].rpc_port,self.mike.listen_ip,self.mike.rpc_port,self.mike.address(),self.bob.address()))
 
-        self.sns[0].get_staking_requirement()
-
         # Mine some blocks; we need 100 per SN registration, and we can nearly 600 on fakenet before
         # it hits HF16 and kills mining rewards.  This lets us submit the first 5 SN registrations a
         # SN (at height 40, which is the earliest we can submit them without getting an occasional
@@ -221,7 +219,10 @@ class SNNetwork:
         ethereum_add_bls_args = self.ethsns[0].get_ethereum_registration_args(self.servicenodecontract.hardhatAccountAddress())
         vprint("Submitted registration on ethereum for service node with pubkey: {}".format(self.ethsns[0].sn_key()))
         result = self.servicenodecontract.addBLSPublicKey(ethereum_add_bls_args)
-        vprint("added node: number of service nodes in contract {}".format(self.servicenodecontract.numberServiceNodes()))
+
+        contract_num_sn = self.servicenodecontract.numberServiceNodes()
+        vprint("added node: number of service nodes in contract {}".format(contract_num_sn))
+        assert self.servicenodecontract.numberServiceNodes() == 13, f"Expected 13 service nodes, received {contract_num_sn}"
 
         # Exit Node
         # exit = self.ethsns[0].get_exit_request(ethereum_add_bls_args["bls_pubkey"])
@@ -243,7 +244,7 @@ class SNNetwork:
         # vprint("liquidated node: number of service nodes in contract {}".format(self.servicenodecontract.numberServiceNodes()))
 
         # Sleep and let pulse quorum do work
-        sleep_time = 30
+        sleep_time = 40
         vprint(f"Sleeping now, awaiting pulse quorum to generate blocks, blockchain height is {self.ethsns[0].height()}");
         time.sleep(sleep_time)
         vprint(f"Waking up after sleeping for {sleep_time}s, blockchain height is {self.ethsns[0].height()}");
@@ -251,9 +252,9 @@ class SNNetwork:
         # Claim rewards for Address
         hardhatAccount = self.servicenodecontract.hardhatAccountAddress()
         rewards        = self.ethsns[0].get_bls_rewards(hardhatAccount)
+        vprint(rewards)
         rewardsAccount = rewards["result"]["address"]
         assert rewardsAccount.lower() == hardhatAccount.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhatAccount.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
-        vprint(rewards)
 
         vprint("Contract rewards before updating has ['available', 'claimed'] respectively: ",
                self.servicenodecontract.recipients(hardhatAccount),


### PR DESCRIPTION
```
Rewards claim was mistakenly working due to leaving a work-around commit
in the git-tree and mistakenly testing the python script and assuming it
worked. After backing out those changes I identified that rewards claim
was still broken due to several bugs of which I have debugged and
incorporated into this PR.

- Ethereum addresses stored in the DB are stored with a 0x prefix. This
  was omitted as we were passing address strings directly through to the
  DB. I've made this type safe and convert at the very last moment to
  ensure we don't hit this bug. In future, it'd be better to store binary
  in the DB.

- The exclude parameter when querying nodes was broken. The code was
  double aggregating the node that was requesting a rewards claim. This
  meant the generated aggregate signature did not match the smart
  contract. This is fixed with the correct break in the for loop.
  Additionally, I've added a trace log to dump out the aggregate pubkey
  and how many keys we aggregated.

- I've added more error checking in general to try and catch problems earlier.
```