### PR TITLE
Make more BLS aggregation commands work w/ new binary BLS code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "external/oxen-encoding"]
 	path = external/oxen-encoding
 	url = https://github.com/oxen-io/oxen-encoding.git
+[submodule "external/cpptrace"]
+	path = external/cpptrace
+	url = https://github.com/jeremy-rifkin/cpptrace

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -163,3 +163,8 @@ endif()
 set(ethyl_ENABLE_CRYPTO_LIBRARY FALSE CACHE BOOL "" FORCE)
 add_subdirectory(ethyl)
 
+# NOTE: By default cpptrace is configured to make stack-traces using libdwarf.
+# On this codebase libdward segfaults trying to handle our stack-traces so we
+# switch to a more primitive method, addr2line which does work.
+set(CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE ON CACHE BOOL "")
+add_subdirectory(cpptrace)

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -30,6 +30,7 @@
 #include "blockchain_db.h"
 
 #include <chrono>
+#include <cpptrace/cpptrace.hpp>
 
 #include "checkpoints/checkpoints.h"
 #include "common/string_util.h"
@@ -168,7 +169,7 @@ uint64_t BlockchainDB::add_block(
 
     // sanity
     if (blk.tx_hashes.size() != txs.size())
-        throw std::runtime_error("Inconsistent tx/hashes sizes");
+        throw cpptrace::runtime_error("Inconsistent tx/hashes sizes");
 
     auto started = std::chrono::steady_clock::now();
     crypto::hash blk_hash = get_block_hash(blk);

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -168,7 +168,7 @@ uint64_t BlockchainDB::add_block(
 
     // sanity
     if (blk.tx_hashes.size() != txs.size())
-        throw oxen::runtime_error("Inconsistent tx/hashes sizes");
+        throw oxen::traced<std::runtime_error>("Inconsistent tx/hashes sizes");
 
     auto started = std::chrono::steady_clock::now();
     crypto::hash blk_hash = get_block_hash(blk);

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -30,10 +30,9 @@
 #include "blockchain_db.h"
 
 #include <chrono>
-#include <cpptrace/cpptrace.hpp>
-
 #include "checkpoints/checkpoints.h"
 #include "common/string_util.h"
+#include "common/exception.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_core/service_node_rules.h"
@@ -169,7 +168,7 @@ uint64_t BlockchainDB::add_block(
 
     // sanity
     if (blk.tx_hashes.size() != txs.size())
-        throw cpptrace::runtime_error("Inconsistent tx/hashes sizes");
+        throw oxen::runtime_error("Inconsistent tx/hashes sizes");
 
     auto started = std::chrono::steady_clock::now();
     crypto::hash blk_hash = get_block_hash(blk);

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -9,7 +9,7 @@
 //
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
-//    materials prooxenvided with the distcribution.
+//    materials provided with the distribution.
 //
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -9,7 +9,7 @@
 //
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
-//    materials provided with the distribution.
+//    materials prooxenvided with the distcribution.
 //
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
@@ -30,7 +30,7 @@
 #include <fmt/core.h>
 #include <sodium.h>
 #include <sqlite3.h>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include <cassert>
 
@@ -172,7 +172,7 @@ void BlockchainSQLite::upgrade_schema() {
             constexpr auto error =
                     "Batching db update to add offsets failed: not all addresses were converted";
             log::error(logcat, error);
-            throw cpptrace::runtime_error{error};
+            throw oxen::runtime_error{error};
         }
 
         transaction.commit();
@@ -497,7 +497,7 @@ bool BlockchainSQLite::reward_handler(
     // From here on we calculate everything in milli-atomic OXEN (i.e. thousanths of an atomic
     // OXEN) so that our integer math has minimal loss from integer division.
     if (block.reward > std::numeric_limits<uint64_t>::max() / BATCH_REWARD_FACTOR)
-        throw cpptrace::logic_error{"Reward distribution amount is too large"};
+        throw oxen::logic_error{"Reward distribution amount is too large"};
 
     uint64_t block_reward = block.reward * BATCH_REWARD_FACTOR;
     uint64_t service_node_reward =
@@ -511,7 +511,7 @@ bool BlockchainSQLite::reward_handler(
     // Step 1: Pay out the block producer their tx fees (note that, unlike the below, this applies
     // even if the SN isn't currently payable).
     if (block_reward < service_node_reward && m_nettype != cryptonote::network_type::FAKECHAIN)
-        throw cpptrace::logic_error{"Invalid payment: block reward is too small"};
+        throw oxen::logic_error{"Invalid payment: block reward is too small"};
 
     std::lock_guard a_s_lock{address_str_cache_mutex};
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -30,6 +30,7 @@
 #include <fmt/core.h>
 #include <sodium.h>
 #include <sqlite3.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <cassert>
 
@@ -171,7 +172,7 @@ void BlockchainSQLite::upgrade_schema() {
             constexpr auto error =
                     "Batching db update to add offsets failed: not all addresses were converted";
             log::error(logcat, error);
-            throw std::runtime_error{error};
+            throw cpptrace::runtime_error{error};
         }
 
         transaction.commit();
@@ -496,7 +497,7 @@ bool BlockchainSQLite::reward_handler(
     // From here on we calculate everything in milli-atomic OXEN (i.e. thousanths of an atomic
     // OXEN) so that our integer math has minimal loss from integer division.
     if (block.reward > std::numeric_limits<uint64_t>::max() / BATCH_REWARD_FACTOR)
-        throw std::logic_error{"Reward distribution amount is too large"};
+        throw cpptrace::logic_error{"Reward distribution amount is too large"};
 
     uint64_t block_reward = block.reward * BATCH_REWARD_FACTOR;
     uint64_t service_node_reward =
@@ -510,7 +511,7 @@ bool BlockchainSQLite::reward_handler(
     // Step 1: Pay out the block producer their tx fees (note that, unlike the below, this applies
     // even if the SN isn't currently payable).
     if (block_reward < service_node_reward && m_nettype != cryptonote::network_type::FAKECHAIN)
-        throw std::logic_error{"Invalid payment: block reward is too small"};
+        throw cpptrace::logic_error{"Invalid payment: block reward is too small"};
 
     std::lock_guard a_s_lock{address_str_cache_mutex};
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -172,7 +172,7 @@ void BlockchainSQLite::upgrade_schema() {
             constexpr auto error =
                     "Batching db update to add offsets failed: not all addresses were converted";
             log::error(logcat, error);
-            throw oxen::runtime_error{error};
+            throw oxen::traced<std::runtime_error>{error};
         }
 
         transaction.commit();
@@ -497,7 +497,7 @@ bool BlockchainSQLite::reward_handler(
     // From here on we calculate everything in milli-atomic OXEN (i.e. thousanths of an atomic
     // OXEN) so that our integer math has minimal loss from integer division.
     if (block.reward > std::numeric_limits<uint64_t>::max() / BATCH_REWARD_FACTOR)
-        throw oxen::logic_error{"Reward distribution amount is too large"};
+        throw oxen::traced<std::logic_error>{"Reward distribution amount is too large"};
 
     uint64_t block_reward = block.reward * BATCH_REWARD_FACTOR;
     uint64_t service_node_reward =
@@ -511,7 +511,7 @@ bool BlockchainSQLite::reward_handler(
     // Step 1: Pay out the block producer their tx fees (note that, unlike the below, this applies
     // even if the SN isn't currently payable).
     if (block_reward < service_node_reward && m_nettype != cryptonote::network_type::FAKECHAIN)
-        throw oxen::logic_error{"Invalid payment: block reward is too small"};
+        throw oxen::traced<std::logic_error>{"Invalid payment: block reward is too small"};
 
     std::lock_guard a_s_lock{address_str_cache_mutex};
 

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -111,7 +111,7 @@ target_link_libraries(blockchain_stats PRIVATE blockchain_tools_common_libs date
 
 if (TARGET sodium_vendor OR NOT SODIUM_VERSION VERSION_LESS 1.0.17)
     oxen_add_executable(sn_key_tool "oxen-sn-keys" sn_key_tool.cpp)
-    target_link_libraries(sn_key_tool PRIVATE cpptrace::cpptrace sodium oxenmq::oxenmq oxen::logging oxenc::oxenc)
+    target_link_libraries(sn_key_tool PRIVATE common sodium oxenmq::oxenmq oxen::logging oxenc::oxenc)
 else()
     message(STATUS "Not building oxen-sn-keys tool (requires libsodium >= 1.0.17)")
 endif()

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -111,7 +111,7 @@ target_link_libraries(blockchain_stats PRIVATE blockchain_tools_common_libs date
 
 if (TARGET sodium_vendor OR NOT SODIUM_VERSION VERSION_LESS 1.0.17)
     oxen_add_executable(sn_key_tool "oxen-sn-keys" sn_key_tool.cpp)
-    target_link_libraries(sn_key_tool PRIVATE sodium oxenmq::oxenmq oxen::logging oxenc::oxenc)
+    target_link_libraries(sn_key_tool PRIVATE cpptrace::cpptrace sodium oxenmq::oxenmq oxen::logging oxenc::oxenc)
 else()
     message(STATUS "Not building oxen-sn-keys tool (requires libsodium >= 1.0.17)")
 endif()

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -30,27 +30,25 @@
 #define __STDC_FORMAT_MACROS  // NOTE(oxen): Explicitly define the SCNu64 macro on Mingw
 #endif
 
-#include <fmt/std.h>
+#include <common/command_line.h>
+#include <common/signal_handler.h>
+#include <common/unordered_containers_boost_serialization.h>
+#include <common/exception.h>
+
+#include "blockchain_db/blockchain_db.h"
+#include "blockchain_objects.h"
+#include "cryptonote_basic/cryptonote_boost_serialization.h"
+#include "cryptonote_core/cryptonote_core.h"
+#include "serialization/boost_std_variant.h"
+#include "version.h"
 
 #include <boost/archive/portable_binary_iarchive.hpp>
 #include <boost/archive/portable_binary_oarchive.hpp>
 #include <cinttypes>
 #include <fstream>
+#include <fmt/std.h>
 #include <unordered_map>
 #include <unordered_set>
-#include <cpptrace/cpptrace.hpp>
-
-#include "blockchain_db/blockchain_db.h"
-#include "blockchain_objects.h"
-#include "common/command_line.h"
-#include "common/signal_handler.h"
-#include "common/unordered_containers_boost_serialization.h"
-#include "common/varint.h"
-#include "cryptonote_basic/cryptonote_boost_serialization.h"
-#include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
-#include "serialization/boost_std_variant.h"
-#include "version.h"
 
 namespace po = boost::program_options;
 using namespace cryptonote;
@@ -105,7 +103,7 @@ struct tx_data_t {
                             cryptonote::relative_output_offsets_to_absolute(txin->key_offsets)));
                 else {
                     log::warning(logcat, "Bad vin type in txid {}", get_transaction_hash(tx));
-                    throw cpptrace::runtime_error("Bad vin type");
+                    throw oxen::runtime_error("Bad vin type");
                 }
             }
         }
@@ -115,7 +113,7 @@ struct tx_data_t {
                 vout.push_back(txout->key);
             } else {
                 log::warning(logcat, "Bad vout type in txid {}", get_transaction_hash(tx));
-                throw cpptrace::runtime_error("Bad vout type");
+                throw oxen::runtime_error("Bad vout type");
             }
         }
     }
@@ -212,7 +210,7 @@ static std::unordered_set<ancestor> get_ancestry(
             ancestry.find(txid);
     if (i == ancestry.end()) {
         // log::error(logcat, "txid ancestry not found: {}", txid);
-        // throw cpptrace::runtime_error("txid ancestry not found");
+        // throw oxen::runtime_error("txid ancestry not found");
         return std::unordered_set<ancestor>();
     }
     return i->second;
@@ -392,7 +390,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -440,7 +438,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -38,6 +38,7 @@
 #include <fstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
@@ -104,7 +105,7 @@ struct tx_data_t {
                             cryptonote::relative_output_offsets_to_absolute(txin->key_offsets)));
                 else {
                     log::warning(logcat, "Bad vin type in txid {}", get_transaction_hash(tx));
-                    throw std::runtime_error("Bad vin type");
+                    throw cpptrace::runtime_error("Bad vin type");
                 }
             }
         }
@@ -114,7 +115,7 @@ struct tx_data_t {
                 vout.push_back(txout->key);
             } else {
                 log::warning(logcat, "Bad vout type in txid {}", get_transaction_hash(tx));
-                throw std::runtime_error("Bad vout type");
+                throw cpptrace::runtime_error("Bad vout type");
             }
         }
     }
@@ -211,7 +212,7 @@ static std::unordered_set<ancestor> get_ancestry(
             ancestry.find(txid);
     if (i == ancestry.end()) {
         // log::error(logcat, "txid ancestry not found: {}", txid);
-        // throw std::runtime_error("txid ancestry not found");
+        // throw cpptrace::runtime_error("txid ancestry not found");
         return std::unordered_set<ancestor>();
     }
     return i->second;
@@ -391,7 +392,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -439,7 +440,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -103,7 +103,7 @@ struct tx_data_t {
                             cryptonote::relative_output_offsets_to_absolute(txin->key_offsets)));
                 else {
                     log::warning(logcat, "Bad vin type in txid {}", get_transaction_hash(tx));
-                    throw oxen::runtime_error("Bad vin type");
+                    throw oxen::traced<std::runtime_error>("Bad vin type");
                 }
             }
         }
@@ -113,7 +113,7 @@ struct tx_data_t {
                 vout.push_back(txout->key);
             } else {
                 log::warning(logcat, "Bad vout type in txid {}", get_transaction_hash(tx));
-                throw oxen::runtime_error("Bad vout type");
+                throw oxen::traced<std::runtime_error>("Bad vout type");
             }
         }
     }
@@ -210,7 +210,7 @@ static std::unordered_set<ancestor> get_ancestry(
             ancestry.find(txid);
     if (i == ancestry.end()) {
         // log::error(logcat, "txid ancestry not found: {}", txid);
-        // throw oxen::runtime_error("txid ancestry not found");
+        // throw oxen::traced<std::runtime_error>("txid ancestry not found");
         return std::unordered_set<ancestor>();
     }
     return i->second;
@@ -390,7 +390,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -438,7 +438,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -336,19 +336,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 2);
     if (dbr)
-        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -360,14 +360,14 @@ static bool for_all_transactions(
     if (dbr)
         dbr = mdb_dbi_open(txn, "txs", MDB_INTEGERKEY, &dbi);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi, &cur);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi, &stat);
     if (dbr)
-        throw oxen::runtime_error("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -381,11 +381,11 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to enumerate transactions: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw oxen::runtime_error("Bad key size");
+            throw oxen::traced<std::runtime_error>("Bad key size");
         const uint64_t idx = *(uint64_t*)k.mv_data;
         if (idx < start_idx)
             continue;
@@ -409,7 +409,7 @@ static bool for_all_transactions(
     mdb_cursor_close(cur);
     dbr = mdb_txn_commit(txn);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to commit db transaction: " + std::string(mdb_strerror(dbr)));
     tx_active = false;
     mdb_dbi_close(env, dbi);
@@ -433,19 +433,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 3);
     if (dbr)
-        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -455,26 +455,26 @@ static bool for_all_transactions(
 
     dbr = mdb_dbi_open(txn, "blocks", MDB_INTEGERKEY, &dbi_blocks);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_dbi_open(txn, "txs_pruned", MDB_INTEGERKEY, &dbi_txs);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_cursor_open(txn, dbi_blocks, &cur_blocks);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi_txs, &cur_txs);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi_blocks, &stat);
     if (dbr)
-        throw oxen::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     uint64_t n_blocks = stat.ms_entries;
     dbr = mdb_stat(txn, dbi_txs, &stat);
     if (dbr)
-        throw oxen::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -488,21 +488,21 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to enumerate blocks: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw oxen::runtime_error("Bad key size");
+            throw oxen::traced<std::runtime_error>("Bad key size");
         uint64_t height = *(const uint64_t*)k.mv_data;
         std::string bd;
         bd.assign(reinterpret_cast<char*>(v.mv_data), v.mv_size);
         block b;
         if (!parse_and_validate_block_from_blob(bd, b))
-            throw oxen::runtime_error("Failed to parse block from blob retrieved from the db");
+            throw oxen::traced<std::runtime_error>("Failed to parse block from blob retrieved from the db");
 
         ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
         if (ret)
-            throw oxen::runtime_error{"Failed to fetch transaction {}: {}"_format(
+            throw oxen::traced<std::runtime_error>{"Failed to fetch transaction {}: {}"_format(
                     get_transaction_hash(b.miner_tx), mdb_strerror(ret))};
         op_txs = MDB_NEXT;
 
@@ -515,7 +515,7 @@ static bool for_all_transactions(
             const crypto::hash& txid = b.tx_hashes[i];
             ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
             if (ret)
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "Failed to fetch transaction {}: {}"_format(txid, mdb_strerror(ret))};
             if (start_idx <= tx_idx++) {
                 cryptonote::transaction_prefix tx;
@@ -565,21 +565,21 @@ static uint64_t find_first_diverging_transaction(
     for (int i = 0; i < 2; ++i) {
         dbr = mdb_env_create(&env[i]);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_env_set_maxdbs(env[i], 2);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
         const fs::path& actual_filename = i ? second_filename : first_filename;
         dbr = mdb_env_open(env[i], actual_filename.string().c_str(), 0, 0664);
         if (dbr)
-            throw oxen::runtime_error("Failed to open rings database file '{}': {}"_format(
+            throw oxen::traced<std::runtime_error>("Failed to open rings database file '{}': {}"_format(
                     actual_filename, mdb_strerror(dbr)));
 
         dbr = mdb_txn_begin(env[i], NULL, MDB_RDONLY, &txn[i]);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = true;
 
@@ -587,21 +587,21 @@ static uint64_t find_first_diverging_transaction(
         if (dbr)
             dbr = mdb_dbi_open(txn[i], "txs", MDB_INTEGERKEY, &dbi[i]);
         if (dbr)
-            throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+            throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_open(txn[i], dbi[i], &cur[i]);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
         MDB_stat stat;
         dbr = mdb_stat(txn[i], dbi[i], &stat);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
         n_txes[i] = stat.ms_entries;
     }
 
     if (n_txes[0] == 0 || n_txes[1] == 0)
-        throw oxen::runtime_error("No transaction in the database");
+        throw oxen::traced<std::runtime_error>("No transaction in the database");
     uint64_t lo = 0, hi = std::min(n_txes[0], n_txes[1]) - 1;
     while (lo <= hi) {
         uint64_t mid = (lo + hi) / 2;
@@ -610,11 +610,11 @@ static uint64_t find_first_diverging_transaction(
         k.mv_data = (void*)&mid;
         dbr = mdb_cursor_get(cur[0], &k, &v[0], MDB_SET);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_get(cur[1], &k, &v[1], MDB_SET);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         if (v[0].mv_size == v[1].mv_size && !memcmp(v[0].mv_data, v[1].mv_data, v[0].mv_size))
             lo = mid + 1;
@@ -626,7 +626,7 @@ static uint64_t find_first_diverging_transaction(
         mdb_cursor_close(cur[i]);
         dbr = mdb_txn_commit(txn[i]);
         if (dbr)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = false;
         mdb_dbi_close(env[i], dbi[i]);
@@ -1026,19 +1026,19 @@ static void get_num_outputs(
         rct = 0;
     } else {
         if (dbr)
-            throw oxen::runtime_error("Record 0 not found: " + std::string(mdb_strerror(dbr)));
+            throw oxen::traced<std::runtime_error>("Record 0 not found: " + std::string(mdb_strerror(dbr)));
         mdb_size_t count = 0;
         dbr = mdb_cursor_count(cur, &count);
         if (dbr)
-            throw oxen::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+            throw oxen::traced<std::runtime_error>("Failed to count records: " + std::string(mdb_strerror(dbr)));
         rct = count;
     }
     MDB_stat s;
     dbr = mdb_stat(txn, dbi, &s);
     if (dbr)
-        throw oxen::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to count records: " + std::string(mdb_strerror(dbr)));
     if (s.ms_entries < rct)
-        throw oxen::runtime_error("Inconsistent records: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Inconsistent records: " + std::string(mdb_strerror(dbr)));
     pre_rct = s.ms_entries - rct;
 }
 
@@ -1051,19 +1051,19 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 1);
     if (dbr)
-        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -1074,12 +1074,12 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
     dbr = mdb_dbi_open(txn, "block_info", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED, &dbi);
     mdb_set_dupsort(txn, dbi, compare_uint64);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     uint64_t zero = 0;
     MDB_val k = {sizeof(uint64_t), (void*)&zero}, v;
     dbr = mdb_get(txn, dbi, &k, &v);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to retrieve genesis block: " + std::string(mdb_strerror(dbr)));
     crypto::hash genesis_block_hash = *(const crypto::hash*)(((const uint64_t*)v.mv_data) + 5);
     mdb_dbi_close(env, dbi);
@@ -1280,7 +1280,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <fmt/std.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
@@ -334,19 +335,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 2);
     if (dbr)
-        throw std::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -358,14 +359,14 @@ static bool for_all_transactions(
     if (dbr)
         dbr = mdb_dbi_open(txn, "txs", MDB_INTEGERKEY, &dbi);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi, &cur);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi, &stat);
     if (dbr)
-        throw std::runtime_error("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -379,11 +380,11 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to enumerate transactions: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw std::runtime_error("Bad key size");
+            throw cpptrace::runtime_error("Bad key size");
         const uint64_t idx = *(uint64_t*)k.mv_data;
         if (idx < start_idx)
             continue;
@@ -407,7 +408,7 @@ static bool for_all_transactions(
     mdb_cursor_close(cur);
     dbr = mdb_txn_commit(txn);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to commit db transaction: " + std::string(mdb_strerror(dbr)));
     tx_active = false;
     mdb_dbi_close(env, dbi);
@@ -431,19 +432,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 3);
     if (dbr)
-        throw std::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -453,26 +454,26 @@ static bool for_all_transactions(
 
     dbr = mdb_dbi_open(txn, "blocks", MDB_INTEGERKEY, &dbi_blocks);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_dbi_open(txn, "txs_pruned", MDB_INTEGERKEY, &dbi_txs);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_cursor_open(txn, dbi_blocks, &cur_blocks);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi_txs, &cur_txs);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi_blocks, &stat);
     if (dbr)
-        throw std::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     uint64_t n_blocks = stat.ms_entries;
     dbr = mdb_stat(txn, dbi_txs, &stat);
     if (dbr)
-        throw std::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -486,21 +487,21 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to enumerate blocks: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw std::runtime_error("Bad key size");
+            throw cpptrace::runtime_error("Bad key size");
         uint64_t height = *(const uint64_t*)k.mv_data;
         std::string bd;
         bd.assign(reinterpret_cast<char*>(v.mv_data), v.mv_size);
         block b;
         if (!parse_and_validate_block_from_blob(bd, b))
-            throw std::runtime_error("Failed to parse block from blob retrieved from the db");
+            throw cpptrace::runtime_error("Failed to parse block from blob retrieved from the db");
 
         ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
         if (ret)
-            throw std::runtime_error{"Failed to fetch transaction {}: {}"_format(
+            throw cpptrace::runtime_error{"Failed to fetch transaction {}: {}"_format(
                     get_transaction_hash(b.miner_tx), mdb_strerror(ret))};
         op_txs = MDB_NEXT;
 
@@ -513,7 +514,7 @@ static bool for_all_transactions(
             const crypto::hash& txid = b.tx_hashes[i];
             ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
             if (ret)
-                throw std::runtime_error{
+                throw cpptrace::runtime_error{
                         "Failed to fetch transaction {}: {}"_format(txid, mdb_strerror(ret))};
             if (start_idx <= tx_idx++) {
                 cryptonote::transaction_prefix tx;
@@ -563,21 +564,21 @@ static uint64_t find_first_diverging_transaction(
     for (int i = 0; i < 2; ++i) {
         dbr = mdb_env_create(&env[i]);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_env_set_maxdbs(env[i], 2);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
         const fs::path& actual_filename = i ? second_filename : first_filename;
         dbr = mdb_env_open(env[i], actual_filename.string().c_str(), 0, 0664);
         if (dbr)
-            throw std::runtime_error("Failed to open rings database file '{}': {}"_format(
+            throw cpptrace::runtime_error("Failed to open rings database file '{}': {}"_format(
                     actual_filename, mdb_strerror(dbr)));
 
         dbr = mdb_txn_begin(env[i], NULL, MDB_RDONLY, &txn[i]);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = true;
 
@@ -585,21 +586,21 @@ static uint64_t find_first_diverging_transaction(
         if (dbr)
             dbr = mdb_dbi_open(txn[i], "txs", MDB_INTEGERKEY, &dbi[i]);
         if (dbr)
-            throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+            throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_open(txn[i], dbi[i], &cur[i]);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
         MDB_stat stat;
         dbr = mdb_stat(txn[i], dbi[i], &stat);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
         n_txes[i] = stat.ms_entries;
     }
 
     if (n_txes[0] == 0 || n_txes[1] == 0)
-        throw std::runtime_error("No transaction in the database");
+        throw cpptrace::runtime_error("No transaction in the database");
     uint64_t lo = 0, hi = std::min(n_txes[0], n_txes[1]) - 1;
     while (lo <= hi) {
         uint64_t mid = (lo + hi) / 2;
@@ -608,11 +609,11 @@ static uint64_t find_first_diverging_transaction(
         k.mv_data = (void*)&mid;
         dbr = mdb_cursor_get(cur[0], &k, &v[0], MDB_SET);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_get(cur[1], &k, &v[1], MDB_SET);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         if (v[0].mv_size == v[1].mv_size && !memcmp(v[0].mv_data, v[1].mv_data, v[0].mv_size))
             lo = mid + 1;
@@ -624,7 +625,7 @@ static uint64_t find_first_diverging_transaction(
         mdb_cursor_close(cur[i]);
         dbr = mdb_txn_commit(txn[i]);
         if (dbr)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = false;
         mdb_dbi_close(env[i], dbi[i]);
@@ -1024,19 +1025,19 @@ static void get_num_outputs(
         rct = 0;
     } else {
         if (dbr)
-            throw std::runtime_error("Record 0 not found: " + std::string(mdb_strerror(dbr)));
+            throw cpptrace::runtime_error("Record 0 not found: " + std::string(mdb_strerror(dbr)));
         mdb_size_t count = 0;
         dbr = mdb_cursor_count(cur, &count);
         if (dbr)
-            throw std::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+            throw cpptrace::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
         rct = count;
     }
     MDB_stat s;
     dbr = mdb_stat(txn, dbi, &s);
     if (dbr)
-        throw std::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
     if (s.ms_entries < rct)
-        throw std::runtime_error("Inconsistent records: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Inconsistent records: " + std::string(mdb_strerror(dbr)));
     pre_rct = s.ms_entries - rct;
 }
 
@@ -1049,19 +1050,19 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 1);
     if (dbr)
-        throw std::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -1072,12 +1073,12 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
     dbr = mdb_dbi_open(txn, "block_info", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED, &dbi);
     mdb_set_dupsort(txn, dbi, compare_uint64);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     uint64_t zero = 0;
     MDB_val k = {sizeof(uint64_t), (void*)&zero}, v;
     dbr = mdb_get(txn, dbi, &k, &v);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to retrieve genesis block: " + std::string(mdb_strerror(dbr)));
     crypto::hash genesis_block_hash = *(const crypto::hash*)(((const uint64_t*)v.mv_data) + 5);
     mdb_dbi_close(env, dbi);
@@ -1193,6 +1194,7 @@ static bool export_spent_outputs(MDB_cursor* cur, const fs::path& filename) {
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -1277,7 +1279,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -42,6 +42,7 @@
 #include "common/string_util.h"
 #include "common/unordered_containers_boost_serialization.h"
 #include "common/varint.h"
+#include "common/exception.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/uptime_proof.h"
@@ -335,19 +336,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 2);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -359,14 +360,14 @@ static bool for_all_transactions(
     if (dbr)
         dbr = mdb_dbi_open(txn, "txs", MDB_INTEGERKEY, &dbi);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi, &cur);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi, &stat);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -380,11 +381,11 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to enumerate transactions: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw cpptrace::runtime_error("Bad key size");
+            throw oxen::runtime_error("Bad key size");
         const uint64_t idx = *(uint64_t*)k.mv_data;
         if (idx < start_idx)
             continue;
@@ -408,7 +409,7 @@ static bool for_all_transactions(
     mdb_cursor_close(cur);
     dbr = mdb_txn_commit(txn);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to commit db transaction: " + std::string(mdb_strerror(dbr)));
     tx_active = false;
     mdb_dbi_close(env, dbi);
@@ -432,19 +433,19 @@ static bool for_all_transactions(
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 3);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -454,26 +455,26 @@ static bool for_all_transactions(
 
     dbr = mdb_dbi_open(txn, "blocks", MDB_INTEGERKEY, &dbi_blocks);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_dbi_open(txn, "txs_pruned", MDB_INTEGERKEY, &dbi_txs);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_cursor_open(txn, dbi_blocks, &cur_blocks);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn, dbi_txs, &cur_txs);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     MDB_stat stat;
     dbr = mdb_stat(txn, dbi_blocks, &stat);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     uint64_t n_blocks = stat.ms_entries;
     dbr = mdb_stat(txn, dbi_txs, &stat);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to query txs stat: " + std::string(mdb_strerror(dbr)));
     n_txes = stat.ms_entries;
 
     bool fret = true;
@@ -487,21 +488,21 @@ static bool for_all_transactions(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to enumerate blocks: " + std::string(mdb_strerror(ret)));
 
         if (k.mv_size != sizeof(uint64_t))
-            throw cpptrace::runtime_error("Bad key size");
+            throw oxen::runtime_error("Bad key size");
         uint64_t height = *(const uint64_t*)k.mv_data;
         std::string bd;
         bd.assign(reinterpret_cast<char*>(v.mv_data), v.mv_size);
         block b;
         if (!parse_and_validate_block_from_blob(bd, b))
-            throw cpptrace::runtime_error("Failed to parse block from blob retrieved from the db");
+            throw oxen::runtime_error("Failed to parse block from blob retrieved from the db");
 
         ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
         if (ret)
-            throw cpptrace::runtime_error{"Failed to fetch transaction {}: {}"_format(
+            throw oxen::runtime_error{"Failed to fetch transaction {}: {}"_format(
                     get_transaction_hash(b.miner_tx), mdb_strerror(ret))};
         op_txs = MDB_NEXT;
 
@@ -514,7 +515,7 @@ static bool for_all_transactions(
             const crypto::hash& txid = b.tx_hashes[i];
             ret = mdb_cursor_get(cur_txs, &k, &v, op_txs);
             if (ret)
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Failed to fetch transaction {}: {}"_format(txid, mdb_strerror(ret))};
             if (start_idx <= tx_idx++) {
                 cryptonote::transaction_prefix tx;
@@ -564,21 +565,21 @@ static uint64_t find_first_diverging_transaction(
     for (int i = 0; i < 2; ++i) {
         dbr = mdb_env_create(&env[i]);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_env_set_maxdbs(env[i], 2);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
         const fs::path& actual_filename = i ? second_filename : first_filename;
         dbr = mdb_env_open(env[i], actual_filename.string().c_str(), 0, 0664);
         if (dbr)
-            throw cpptrace::runtime_error("Failed to open rings database file '{}': {}"_format(
+            throw oxen::runtime_error("Failed to open rings database file '{}': {}"_format(
                     actual_filename, mdb_strerror(dbr)));
 
         dbr = mdb_txn_begin(env[i], NULL, MDB_RDONLY, &txn[i]);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = true;
 
@@ -586,21 +587,21 @@ static uint64_t find_first_diverging_transaction(
         if (dbr)
             dbr = mdb_dbi_open(txn[i], "txs", MDB_INTEGERKEY, &dbi[i]);
         if (dbr)
-            throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+            throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_open(txn[i], dbi[i], &cur[i]);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
         MDB_stat stat;
         dbr = mdb_stat(txn[i], dbi[i], &stat);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to query m_block_info: " + std::string(mdb_strerror(dbr)));
         n_txes[i] = stat.ms_entries;
     }
 
     if (n_txes[0] == 0 || n_txes[1] == 0)
-        throw cpptrace::runtime_error("No transaction in the database");
+        throw oxen::runtime_error("No transaction in the database");
     uint64_t lo = 0, hi = std::min(n_txes[0], n_txes[1]) - 1;
     while (lo <= hi) {
         uint64_t mid = (lo + hi) / 2;
@@ -609,11 +610,11 @@ static uint64_t find_first_diverging_transaction(
         k.mv_data = (void*)&mid;
         dbr = mdb_cursor_get(cur[0], &k, &v[0], MDB_SET);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         dbr = mdb_cursor_get(cur[1], &k, &v[1], MDB_SET);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         if (v[0].mv_size == v[1].mv_size && !memcmp(v[0].mv_data, v[1].mv_data, v[0].mv_size))
             lo = mid + 1;
@@ -625,7 +626,7 @@ static uint64_t find_first_diverging_transaction(
         mdb_cursor_close(cur[i]);
         dbr = mdb_txn_commit(txn[i]);
         if (dbr)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to query transaction: " + std::string(mdb_strerror(dbr)));
         tx_active[i] = false;
         mdb_dbi_close(env[i], dbi[i]);
@@ -1025,19 +1026,19 @@ static void get_num_outputs(
         rct = 0;
     } else {
         if (dbr)
-            throw cpptrace::runtime_error("Record 0 not found: " + std::string(mdb_strerror(dbr)));
+            throw oxen::runtime_error("Record 0 not found: " + std::string(mdb_strerror(dbr)));
         mdb_size_t count = 0;
         dbr = mdb_cursor_count(cur, &count);
         if (dbr)
-            throw cpptrace::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+            throw oxen::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
         rct = count;
     }
     MDB_stat s;
     dbr = mdb_stat(txn, dbi, &s);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to count records: " + std::string(mdb_strerror(dbr)));
     if (s.ms_entries < rct)
-        throw cpptrace::runtime_error("Inconsistent records: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Inconsistent records: " + std::string(mdb_strerror(dbr)));
     pre_rct = s.ms_entries - rct;
 }
 
@@ -1050,19 +1051,19 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 1);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, filename.string().c_str(), 0, 0664);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to open rings database file '{}': {}"_format(filename, mdb_strerror(dbr)));
 
     dbr = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     OXEN_DEFER {
         if (tx_active)
@@ -1073,12 +1074,12 @@ static crypto::hash get_genesis_block_hash(const fs::path& filename) {
     dbr = mdb_dbi_open(txn, "block_info", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED, &dbi);
     mdb_set_dupsort(txn, dbi, compare_uint64);
     if (dbr)
-        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     uint64_t zero = 0;
     MDB_val k = {sizeof(uint64_t), (void*)&zero}, v;
     dbr = mdb_get(txn, dbi, &k, &v);
     if (dbr)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Failed to retrieve genesis block: " + std::string(mdb_strerror(dbr)));
     crypto::hash genesis_block_hash = *(const crypto::hash*)(((const uint64_t*)v.mv_data) + 5);
     mdb_dbi_close(env, dbi);
@@ -1194,7 +1195,7 @@ static bool export_spent_outputs(MDB_cursor* cur, const fs::path& filename) {
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -1279,7 +1280,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -26,18 +26,17 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <fmt/std.h>
-#include <cpptrace/cpptrace.hpp>
-
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
-#include "common/command_line.h"
-#include "common/guts.h"
-#include "common/median.h"
-#include "common/varint.h"
 #include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
 #include "version.h"
+
+#include <common/command_line.h>
+#include <common/guts.h>
+#include <common/median.h>
+#include <common/exception.h>
+
+#include <fmt/std.h>
 
 namespace po = boost::program_options;
 using namespace cryptonote;
@@ -45,7 +44,7 @@ using namespace cryptonote;
 static auto logcat = log::Cat("bcutil");
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -101,7 +100,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -133,7 +132,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fmt/std.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
@@ -44,6 +45,7 @@ using namespace cryptonote;
 static auto logcat = log::Cat("bcutil");
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -99,7 +101,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -131,7 +133,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -27,22 +27,22 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <fmt/std.h>
-#include <cpptrace/cpptrace.hpp>
-
 #include "blockchain_objects.h"
 #include "blocksdat_file.h"
 #include "bootstrap_file.h"
-#include "common/command_line.h"
 #include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
 #include "version.h"
+
+#include <common/command_line.h>
+#include <common/exception.h>
+
+#include <fmt/std.h>
 
 namespace po = boost::program_options;
 using namespace blockchain_utils;
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     using namespace oxen;
     auto logcat = log::Cat("bcutil");
 
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -28,6 +28,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fmt/std.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_objects.h"
 #include "blocksdat_file.h"
@@ -41,6 +42,7 @@ namespace po = boost::program_options;
 using namespace blockchain_utils;
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     using namespace oxen;
     auto logcat = log::Cat("bcutil");
 
@@ -102,7 +104,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -130,7 +132,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -36,14 +36,13 @@
 #include <boost/algorithm/string.hpp>
 #include <cstdio>
 #include <fstream>
-#include <cpptrace/cpptrace.hpp>
 
 #include "blocks/blocks.h"
 #include "bootstrap_file.h"
 #include "bootstrap_serialization.h"
+#include "common/exception.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
 #include "cryptonote_protocol/quorumnet.h"
 #include "epee/misc_log_ex.h"
 #include "logging/oxen_logger.h"
@@ -311,14 +310,14 @@ int import_from_file(
         try {
             serialization::parse_binary(std::string_view{buffer1, sizeof(chunk_size)}, chunk_size);
         } catch (const std::exception& e) {
-            throw cpptrace::runtime_error("Error in deserialization of chunk size: "s + e.what());
+            throw oxen::runtime_error("Error in deserialization of chunk size: "s + e.what());
         }
         log::debug(logcat, "chunk_size: {}", chunk_size);
 
         if (chunk_size > BUFFER_SIZE) {
             log::warning(
                     logcat, "WARNING: chunk_size {} > BUFFER_SIZE {}", chunk_size, BUFFER_SIZE);
-            throw cpptrace::runtime_error("Aborting: chunk size exceeds buffer size");
+            throw oxen::runtime_error("Aborting: chunk size exceeds buffer size");
         }
         if (chunk_size > CHUNK_SIZE_WARNING_THRESHOLD) {
             log::info(logcat, "NOTE: chunk_size {} > {}", chunk_size, CHUNK_SIZE_WARNING_THRESHOLD);
@@ -363,7 +362,7 @@ int import_from_file(
             try {
                 serialization::parse_binary(std::string_view{buffer_block, chunk_size}, bp);
             } catch (const std::exception& e) {
-                throw cpptrace::runtime_error("Error in deserialization of chunk"s + e.what());
+                throw oxen::runtime_error("Error in deserialization of chunk"s + e.what());
             }
 
             int display_interval = 1000;
@@ -502,7 +501,7 @@ quitting:
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -616,7 +615,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
 
     oxen::logging::init(log_file_path, log_level);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -36,6 +36,7 @@
 #include <boost/algorithm/string.hpp>
 #include <cstdio>
 #include <fstream>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blocks/blocks.h"
 #include "bootstrap_file.h"
@@ -310,14 +311,14 @@ int import_from_file(
         try {
             serialization::parse_binary(std::string_view{buffer1, sizeof(chunk_size)}, chunk_size);
         } catch (const std::exception& e) {
-            throw std::runtime_error("Error in deserialization of chunk size: "s + e.what());
+            throw cpptrace::runtime_error("Error in deserialization of chunk size: "s + e.what());
         }
         log::debug(logcat, "chunk_size: {}", chunk_size);
 
         if (chunk_size > BUFFER_SIZE) {
             log::warning(
                     logcat, "WARNING: chunk_size {} > BUFFER_SIZE {}", chunk_size, BUFFER_SIZE);
-            throw std::runtime_error("Aborting: chunk size exceeds buffer size");
+            throw cpptrace::runtime_error("Aborting: chunk size exceeds buffer size");
         }
         if (chunk_size > CHUNK_SIZE_WARNING_THRESHOLD) {
             log::info(logcat, "NOTE: chunk_size {} > {}", chunk_size, CHUNK_SIZE_WARNING_THRESHOLD);
@@ -362,7 +363,7 @@ int import_from_file(
             try {
                 serialization::parse_binary(std::string_view{buffer_block, chunk_size}, bp);
             } catch (const std::exception& e) {
-                throw std::runtime_error("Error in deserialization of chunk"s + e.what());
+                throw cpptrace::runtime_error("Error in deserialization of chunk"s + e.what());
             }
 
             int display_interval = 1000;
@@ -501,6 +502,7 @@ quitting:
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -614,7 +616,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
 
     oxen::logging::init(log_file_path, log_level);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -310,14 +310,14 @@ int import_from_file(
         try {
             serialization::parse_binary(std::string_view{buffer1, sizeof(chunk_size)}, chunk_size);
         } catch (const std::exception& e) {
-            throw oxen::runtime_error("Error in deserialization of chunk size: "s + e.what());
+            throw oxen::traced<std::runtime_error>("Error in deserialization of chunk size: "s + e.what());
         }
         log::debug(logcat, "chunk_size: {}", chunk_size);
 
         if (chunk_size > BUFFER_SIZE) {
             log::warning(
                     logcat, "WARNING: chunk_size {} > BUFFER_SIZE {}", chunk_size, BUFFER_SIZE);
-            throw oxen::runtime_error("Aborting: chunk size exceeds buffer size");
+            throw oxen::traced<std::runtime_error>("Aborting: chunk size exceeds buffer size");
         }
         if (chunk_size > CHUNK_SIZE_WARNING_THRESHOLD) {
             log::info(logcat, "NOTE: chunk_size {} > {}", chunk_size, CHUNK_SIZE_WARNING_THRESHOLD);
@@ -362,7 +362,7 @@ int import_from_file(
             try {
                 serialization::parse_binary(std::string_view{buffer_block, chunk_size}, bp);
             } catch (const std::exception& e) {
-                throw oxen::runtime_error("Error in deserialization of chunk"s + e.what());
+                throw oxen::traced<std::runtime_error>("Error in deserialization of chunk"s + e.what());
             }
 
             int display_interval = 1000;
@@ -615,7 +615,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
 
     oxen::logging::init(log_file_path, log_level);

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -29,6 +29,7 @@
 #include <lmdb.h>
 
 #include <array>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
@@ -80,14 +81,14 @@ static void open(MDB_env*& env, const fs::path& path, uint64_t db_flags, bool re
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 32);
     if (dbr)
-        throw std::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, path.string().c_str(), flags, 0664);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to open database file '" + path.string() +
                 "': " + std::string(mdb_strerror(dbr)));
 }
@@ -121,7 +122,7 @@ static void add_size(MDB_env* env, uint64_t bytes) {
 
     int result = mdb_env_set_mapsize(env, new_mapsize);
     if (result)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to set new mapsize to " + std::to_string(new_mapsize) + ": " +
                 std::string(mdb_strerror(result)));
 
@@ -149,11 +150,11 @@ static bool resize_point(size_t nrecords, MDB_env* env, MDB_txn** txn, size_t& b
         return false;
     int dbr = mdb_txn_commit(*txn);
     if (dbr)
-        throw std::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
     check_resize(env, bytes);
     dbr = mdb_txn_begin(env, NULL, 0, txn);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     bytes = 0;
     return true;
@@ -183,35 +184,35 @@ static void copy_table(
 
     dbr = mdb_txn_begin(env0, NULL, MDB_RDONLY, &txn0);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active0 = true;
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_dbi_open(txn0, table, flags, &dbi0);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     if (cmp)
         ((flags & MDB_DUPSORT) ? mdb_set_dupsort : mdb_set_compare)(txn0, dbi0, cmp);
 
     dbr = mdb_dbi_open(txn1, table, flags, &dbi1);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     if (cmp)
         ((flags & MDB_DUPSORT) ? mdb_set_dupsort : mdb_set_compare)(txn1, dbi1, cmp);
 
     dbr = mdb_txn_commit(txn1);
     if (dbr)
-        throw std::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
     tx_active1 = false;
     MDB_stat stats;
     dbr = mdb_env_stat(env0, &stats);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to stat " + std::string(table) +
                 " LMDB table: " + std::string(mdb_strerror(dbr)));
     check_resize(
@@ -220,22 +221,22 @@ static void copy_table(
                     stats.ms_psize);
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_drop(txn1, dbi1, 0);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to empty " + std::string(table) +
                 " LMDB table: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_cursor_open(txn0, dbi0, &cur0);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn1, dbi1, &cur1);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     MDB_val k;
     MDB_val v;
@@ -247,7 +248,7 @@ static void copy_table(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to enumerate " + std::string(table) +
                     " records: " + std::string(mdb_strerror(ret)));
 
@@ -255,13 +256,13 @@ static void copy_table(
         if (resize_point(++nrecords, env1, &txn1, bytes)) {
             dbr = mdb_cursor_open(txn1, dbi1, &cur1);
             if (dbr)
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
         }
 
         ret = mdb_cursor_put(cur1, &k, &v, putflags);
         if (ret)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to write " + std::string(table) +
                     " record: " + std::string(mdb_strerror(ret)));
     }
@@ -280,10 +281,10 @@ static bool is_v1_tx(MDB_cursor* c_txs_pruned, MDB_val* tx_id) {
     MDB_val v;
     int ret = mdb_cursor_get(c_txs_pruned, tx_id, &v, MDB_SET);
     if (ret)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to find transaction pruned data: " + std::string(mdb_strerror(ret)));
     if (v.mv_size == 0)
-        throw std::runtime_error("Invalid transaction pruned data");
+        throw cpptrace::runtime_error("Invalid transaction pruned data");
     return cryptonote::is_v1_tx(std::string_view{(const char*)v.mv_data, v.mv_size});
 }
 
@@ -307,47 +308,47 @@ static void prune(MDB_env* env0, MDB_env* env1) {
 
     dbr = mdb_txn_begin(env0, NULL, MDB_RDONLY, &txn0);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active0 = true;
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_dbi_open(txn0, "txs_pruned", MDB_INTEGERKEY, &dbi0_txs_pruned);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn0, dbi0_txs_pruned, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn0, dbi0_txs_pruned, &cur0_txs_pruned);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn0, "txs_prunable", MDB_INTEGERKEY, &dbi0_txs_prunable);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn0, dbi0_txs_prunable, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn0, dbi0_txs_prunable, &cur0_txs_prunable);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(
             txn0, "tx_indices", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED, &dbi0_tx_indices);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_dupsort(txn0, dbi0_tx_indices, BlockchainLMDB::compare_hash32);
     dbr = mdb_cursor_open(txn0, dbi0_tx_indices, &cur0_tx_indices);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn1, "txs_prunable", MDB_INTEGERKEY, &dbi1_txs_prunable);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn1, dbi1_txs_prunable, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn1, dbi1_txs_prunable, &cur1_txs_prunable);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(
             txn1,
@@ -355,22 +356,22 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED,
             &dbi1_txs_prunable_tip);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_dupsort(txn1, dbi1_txs_prunable_tip, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn1, dbi1_txs_prunable_tip, &cur1_txs_prunable_tip);
     if (dbr)
-        throw std::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_drop(txn1, dbi1_txs_prunable, 0);
     if (dbr)
-        throw std::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_drop(txn1, dbi1_txs_prunable_tip, 0);
     if (dbr)
-        throw std::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn1, "properties", 0, &dbi1_properties);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
 
     MDB_val k, v;
     uint32_t pruning_seed =
@@ -382,15 +383,15 @@ static void prune(MDB_env* env0, MDB_env* env1) {
     v.mv_size = sizeof(pruning_seed);
     dbr = mdb_put(txn1, dbi1_properties, &k, &v, 0);
     if (dbr)
-        throw std::runtime_error("Failed to save pruning seed: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to save pruning seed: " + std::string(mdb_strerror(dbr)));
 
     MDB_stat stats;
     dbr = mdb_dbi_open(txn0, "blocks", 0, &dbi0_blocks);
     if (dbr)
-        throw std::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw cpptrace::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_stat(txn0, dbi0_blocks, &stats);
     if (dbr)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Failed to query size of blocks: " + std::string(mdb_strerror(dbr)));
     mdb_dbi_close(env0, dbi0_blocks);
     const uint64_t blockchain_height = stats.ms_entries;
@@ -403,7 +404,7 @@ static void prune(MDB_env* env0, MDB_env* env1) {
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to enumerate records: " + std::string(mdb_strerror(ret)));
 
         const txindex* ti = (const txindex*)v.mv_data;
@@ -414,7 +415,7 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_val_set(vv, block_height);
             dbr = mdb_cursor_put(cur1_txs_prunable_tip, &kk, &vv, 0);
             if (dbr)
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Failed to write prunable tx tip data: " + std::string(mdb_strerror(dbr)));
             bytes += kk.mv_size + vv.mv_size;
         }
@@ -423,22 +424,22 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_val vv;
             dbr = mdb_cursor_get(cur0_txs_prunable, &kk, &vv, MDB_SET);
             if (dbr)
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Failed to read prunable tx data: " + std::string(mdb_strerror(dbr)));
             bytes += kk.mv_size + vv.mv_size;
             if (resize_point(++nrecords, env1, &txn1, bytes)) {
                 dbr = mdb_cursor_open(txn1, dbi1_txs_prunable, &cur1_txs_prunable);
                 if (dbr)
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
                 dbr = mdb_cursor_open(txn1, dbi1_txs_prunable_tip, &cur1_txs_prunable_tip);
                 if (dbr)
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
             }
             dbr = mdb_cursor_put(cur1_txs_prunable, &kk, &vv, 0);
             if (dbr)
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Failed to write prunable tx data: " + std::string(mdb_strerror(dbr)));
         } else {
             log::debug(logcat, "{}/{} should be pruned, dropping", block_height, blockchain_height);
@@ -505,6 +506,7 @@ static bool parse_db_sync_mode(std::string db_sync_mode, uint64_t& db_flags) {
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -602,7 +604,7 @@ int main(int argc, char* argv[]) {
         BlockchainDB* db = new_db();
         if (db == NULL) {
             log::error(logcat, "Failed to initialize a database");
-            throw std::runtime_error("Failed to initialize a database");
+            throw cpptrace::runtime_error("Failed to initialize a database");
         }
 
         if (n == 1) {

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -81,14 +81,14 @@ static void open(MDB_env*& env, const fs::path& path, uint64_t db_flags, bool re
 
     dbr = mdb_env_create(&env);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_set_maxdbs(env, 32);
     if (dbr)
-        throw oxen::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_env_open(env, path.string().c_str(), flags, 0664);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to open database file '" + path.string() +
                 "': " + std::string(mdb_strerror(dbr)));
 }
@@ -122,7 +122,7 @@ static void add_size(MDB_env* env, uint64_t bytes) {
 
     int result = mdb_env_set_mapsize(env, new_mapsize);
     if (result)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to set new mapsize to " + std::to_string(new_mapsize) + ": " +
                 std::string(mdb_strerror(result)));
 
@@ -150,11 +150,11 @@ static bool resize_point(size_t nrecords, MDB_env* env, MDB_txn** txn, size_t& b
         return false;
     int dbr = mdb_txn_commit(*txn);
     if (dbr)
-        throw oxen::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
     check_resize(env, bytes);
     dbr = mdb_txn_begin(env, NULL, 0, txn);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     bytes = 0;
     return true;
@@ -184,35 +184,35 @@ static void copy_table(
 
     dbr = mdb_txn_begin(env0, NULL, MDB_RDONLY, &txn0);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active0 = true;
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_dbi_open(txn0, table, flags, &dbi0);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     if (cmp)
         ((flags & MDB_DUPSORT) ? mdb_set_dupsort : mdb_set_compare)(txn0, dbi0, cmp);
 
     dbr = mdb_dbi_open(txn1, table, flags, &dbi1);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     if (cmp)
         ((flags & MDB_DUPSORT) ? mdb_set_dupsort : mdb_set_compare)(txn1, dbi1, cmp);
 
     dbr = mdb_txn_commit(txn1);
     if (dbr)
-        throw oxen::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
     tx_active1 = false;
     MDB_stat stats;
     dbr = mdb_env_stat(env0, &stats);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to stat " + std::string(table) +
                 " LMDB table: " + std::string(mdb_strerror(dbr)));
     check_resize(
@@ -221,22 +221,22 @@ static void copy_table(
                     stats.ms_psize);
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_drop(txn1, dbi1, 0);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to empty " + std::string(table) +
                 " LMDB table: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_cursor_open(txn0, dbi0, &cur0);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_cursor_open(txn1, dbi1, &cur1);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     MDB_val k;
     MDB_val v;
@@ -248,7 +248,7 @@ static void copy_table(
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to enumerate " + std::string(table) +
                     " records: " + std::string(mdb_strerror(ret)));
 
@@ -256,13 +256,13 @@ static void copy_table(
         if (resize_point(++nrecords, env1, &txn1, bytes)) {
             dbr = mdb_cursor_open(txn1, dbi1, &cur1);
             if (dbr)
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
         }
 
         ret = mdb_cursor_put(cur1, &k, &v, putflags);
         if (ret)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to write " + std::string(table) +
                     " record: " + std::string(mdb_strerror(ret)));
     }
@@ -281,10 +281,10 @@ static bool is_v1_tx(MDB_cursor* c_txs_pruned, MDB_val* tx_id) {
     MDB_val v;
     int ret = mdb_cursor_get(c_txs_pruned, tx_id, &v, MDB_SET);
     if (ret)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to find transaction pruned data: " + std::string(mdb_strerror(ret)));
     if (v.mv_size == 0)
-        throw oxen::runtime_error("Invalid transaction pruned data");
+        throw oxen::traced<std::runtime_error>("Invalid transaction pruned data");
     return cryptonote::is_v1_tx(std::string_view{(const char*)v.mv_data, v.mv_size});
 }
 
@@ -308,47 +308,47 @@ static void prune(MDB_env* env0, MDB_env* env1) {
 
     dbr = mdb_txn_begin(env0, NULL, MDB_RDONLY, &txn0);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active0 = true;
     dbr = mdb_txn_begin(env1, NULL, 0, &txn1);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
     tx_active1 = true;
 
     dbr = mdb_dbi_open(txn0, "txs_pruned", MDB_INTEGERKEY, &dbi0_txs_pruned);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn0, dbi0_txs_pruned, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn0, dbi0_txs_pruned, &cur0_txs_pruned);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn0, "txs_prunable", MDB_INTEGERKEY, &dbi0_txs_prunable);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn0, dbi0_txs_prunable, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn0, dbi0_txs_prunable, &cur0_txs_prunable);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(
             txn0, "tx_indices", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED, &dbi0_tx_indices);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_dupsort(txn0, dbi0_tx_indices, BlockchainLMDB::compare_hash32);
     dbr = mdb_cursor_open(txn0, dbi0_tx_indices, &cur0_tx_indices);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn1, "txs_prunable", MDB_INTEGERKEY, &dbi1_txs_prunable);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_compare(txn1, dbi1_txs_prunable, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn1, dbi1_txs_prunable, &cur1_txs_prunable);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(
             txn1,
@@ -356,22 +356,22 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED,
             &dbi1_txs_prunable_tip);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     mdb_set_dupsort(txn1, dbi1_txs_prunable_tip, BlockchainLMDB::compare_uint64);
     dbr = mdb_cursor_open(txn1, dbi1_txs_prunable_tip, &cur1_txs_prunable_tip);
     if (dbr)
-        throw oxen::runtime_error("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_drop(txn1, dbi1_txs_prunable, 0);
     if (dbr)
-        throw oxen::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_drop(txn1, dbi1_txs_prunable_tip, 0);
     if (dbr)
-        throw oxen::runtime_error("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to empty LMDB table: " + std::string(mdb_strerror(dbr)));
 
     dbr = mdb_dbi_open(txn1, "properties", 0, &dbi1_properties);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
 
     MDB_val k, v;
     uint32_t pruning_seed =
@@ -383,15 +383,15 @@ static void prune(MDB_env* env0, MDB_env* env1) {
     v.mv_size = sizeof(pruning_seed);
     dbr = mdb_put(txn1, dbi1_properties, &k, &v, 0);
     if (dbr)
-        throw oxen::runtime_error("Failed to save pruning seed: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to save pruning seed: " + std::string(mdb_strerror(dbr)));
 
     MDB_stat stats;
     dbr = mdb_dbi_open(txn0, "blocks", 0, &dbi0_blocks);
     if (dbr)
-        throw oxen::runtime_error("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
+        throw oxen::traced<std::runtime_error>("Failed to open LMDB dbi: " + std::string(mdb_strerror(dbr)));
     dbr = mdb_stat(txn0, dbi0_blocks, &stats);
     if (dbr)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Failed to query size of blocks: " + std::string(mdb_strerror(dbr)));
     mdb_dbi_close(env0, dbi0_blocks);
     const uint64_t blockchain_height = stats.ms_entries;
@@ -404,7 +404,7 @@ static void prune(MDB_env* env0, MDB_env* env1) {
         if (ret == MDB_NOTFOUND)
             break;
         if (ret)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to enumerate records: " + std::string(mdb_strerror(ret)));
 
         const txindex* ti = (const txindex*)v.mv_data;
@@ -415,7 +415,7 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_val_set(vv, block_height);
             dbr = mdb_cursor_put(cur1_txs_prunable_tip, &kk, &vv, 0);
             if (dbr)
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Failed to write prunable tx tip data: " + std::string(mdb_strerror(dbr)));
             bytes += kk.mv_size + vv.mv_size;
         }
@@ -424,22 +424,22 @@ static void prune(MDB_env* env0, MDB_env* env1) {
             MDB_val vv;
             dbr = mdb_cursor_get(cur0_txs_prunable, &kk, &vv, MDB_SET);
             if (dbr)
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Failed to read prunable tx data: " + std::string(mdb_strerror(dbr)));
             bytes += kk.mv_size + vv.mv_size;
             if (resize_point(++nrecords, env1, &txn1, bytes)) {
                 dbr = mdb_cursor_open(txn1, dbi1_txs_prunable, &cur1_txs_prunable);
                 if (dbr)
-                    throw oxen::runtime_error(
+                    throw oxen::traced<std::runtime_error>(
                             "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
                 dbr = mdb_cursor_open(txn1, dbi1_txs_prunable_tip, &cur1_txs_prunable_tip);
                 if (dbr)
-                    throw oxen::runtime_error(
+                    throw oxen::traced<std::runtime_error>(
                             "Failed to create LMDB cursor: " + std::string(mdb_strerror(dbr)));
             }
             dbr = mdb_cursor_put(cur1_txs_prunable, &kk, &vv, 0);
             if (dbr)
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Failed to write prunable tx data: " + std::string(mdb_strerror(dbr)));
         } else {
             log::debug(logcat, "{}/{} should be pruned, dropping", block_height, blockchain_height);
@@ -604,7 +604,7 @@ int main(int argc, char* argv[]) {
         BlockchainDB* db = new_db();
         if (db == NULL) {
             log::error(logcat, "Failed to initialize a database");
-            throw oxen::runtime_error("Failed to initialize a database");
+            throw oxen::traced<std::runtime_error>("Failed to initialize a database");
         }
 
         if (n == 1) {

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
 
     const fs::path filename =

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -37,6 +37,8 @@
 #include "serialization/crypto.h"
 #include "version.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace po = boost::program_options;
 using namespace cryptonote;
 
@@ -92,6 +94,7 @@ static std::map<uint64_t, uint64_t> load_outputs(const fs::path& filename) {
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -165,7 +168,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
 
     const fs::path filename =

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -32,12 +32,12 @@
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
-#include "common/command_line.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "serialization/crypto.h"
 #include "version.h"
 
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.hpp>
+#include <common/command_line.h>
 
 namespace po = boost::program_options;
 using namespace cryptonote;
@@ -94,7 +94,7 @@ static std::map<uint64_t, uint64_t> load_outputs(const fs::path& filename) {
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
 
     const fs::path filename =

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -139,7 +139,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
 
     const fs::path filename = tools::utf8_path(opt_data_dir) / db->get_db_name();
@@ -275,10 +275,10 @@ int main(int argc, char* argv[]) {
         currsz += bd.size();
         for (const auto& tx_id : blk.tx_hashes) {
             if (!tx_id) {
-                throw oxen::runtime_error("Aborting: null txid");
+                throw oxen::traced<std::runtime_error>("Aborting: null txid");
             }
             if (!db->get_pruned_tx_blob(tx_id, bd)) {
-                throw oxen::runtime_error("Aborting: tx not found");
+                throw oxen::traced<std::runtime_error>("Aborting: tx not found");
             }
             transaction tx;
             if (!parse_and_validate_tx_base_from_blob(bd, tx)) {

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -26,22 +26,19 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <date/date.h>
-#include <fmt/std.h>
+#include "blockchain_objects.h"
+#include "cryptonote_core/cryptonote_core.h"
+#include "version.h"
+
+#include <common/exception.h>
+#include <common/command_line.h>
+#include <common/signal_handler.h>
+#include <common/varint.h>
 
 #include <boost/algorithm/string.hpp>
+#include <date/date.h>
+#include <fmt/std.h>
 #include <chrono>
-#include <cpptrace/cpptrace.hpp>
-
-#include "blockchain_db/blockchain_db.h"
-#include "blockchain_objects.h"
-#include "common/command_line.h"
-#include "common/signal_handler.h"
-#include "common/varint.h"
-#include "cryptonote_basic/cryptonote_boost_serialization.h"
-#include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
-#include "version.h"
 
 namespace po = boost::program_options;
 using namespace cryptonote;
@@ -49,7 +46,7 @@ using namespace cryptonote;
 static bool stop_requested = false;
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     static auto logcat = log::Cat("bcutil");
 
     TRY_ENTRY();
@@ -118,7 +115,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -142,7 +139,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
 
     const fs::path filename = tools::utf8_path(opt_data_dir) / db->get_db_name();
@@ -278,10 +275,10 @@ int main(int argc, char* argv[]) {
         currsz += bd.size();
         for (const auto& tx_id : blk.tx_hashes) {
             if (!tx_id) {
-                throw cpptrace::runtime_error("Aborting: null txid");
+                throw oxen::runtime_error("Aborting: null txid");
             }
             if (!db->get_pruned_tx_blob(tx_id, bd)) {
-                throw cpptrace::runtime_error("Aborting: tx not found");
+                throw oxen::runtime_error("Aborting: tx not found");
             }
             transaction tx;
             if (!parse_and_validate_tx_base_from_blob(bd, tx)) {

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -31,6 +31,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <chrono>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
@@ -48,6 +49,7 @@ using namespace cryptonote;
 static bool stop_requested = false;
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     static auto logcat = log::Cat("bcutil");
 
     TRY_ENTRY();
@@ -116,7 +118,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -140,7 +142,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
 
     const fs::path filename = tools::utf8_path(opt_data_dir) / db->get_db_name();
@@ -276,10 +278,10 @@ int main(int argc, char* argv[]) {
         currsz += bd.size();
         for (const auto& tx_id : blk.tx_hashes) {
             if (!tx_id) {
-                throw std::runtime_error("Aborting: null txid");
+                throw cpptrace::runtime_error("Aborting: null txid");
             }
             if (!db->get_pruned_tx_blob(tx_id, bd)) {
-                throw std::runtime_error("Aborting: tx not found");
+                throw cpptrace::runtime_error("Aborting: tx not found");
             }
             transaction tx;
             if (!parse_and_validate_tx_base_from_blob(bd, tx)) {

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -27,16 +27,15 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <fmt/std.h>
-#include <cpptrace/cpptrace.hpp>
-
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
-#include "common/command_line.h"
-#include "common/varint.h"
 #include "cryptonote_core/cryptonote_core.h"
-#include "cryptonote_core/uptime_proof.h"
 #include "version.h"
+
+#include <common/exception.h>
+#include <common/command_line.h>
+
+#include <fmt/std.h>
 
 namespace po = boost::program_options;
 using namespace cryptonote;
@@ -78,7 +77,7 @@ struct reference {
 };
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -133,7 +132,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -165,7 +164,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw cpptrace::runtime_error("Failed to initialize a database");
+        throw oxen::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw oxen::runtime_error("Failed to initialize a database");
+        throw oxen::traced<std::runtime_error>("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -28,6 +28,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fmt/std.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_objects.h"
@@ -77,6 +78,7 @@ struct reference {
 };
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     epee::string_tools::set_module_name_and_folder(argv[0]);
@@ -131,7 +133,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");
@@ -163,7 +165,7 @@ int main(int argc, char* argv[]) {
     BlockchainDB* db = new_db();
     if (db == NULL) {
         log::error(logcat, "Failed to initialize a database");
-        throw std::runtime_error("Failed to initialize a database");
+        throw cpptrace::runtime_error("Failed to initialize a database");
     }
     log::warning(logcat, "database: LMDB");
 

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -30,6 +30,7 @@
 #include "bootstrap_file.h"
 
 #include <fmt/std.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "bootstrap_serialization.h"
 #include "serialization/binary_utils.h"  // dump_binary(), parse_binary()
@@ -112,7 +113,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(file_magic);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Error in serialization of file magic: "s + e.what());
+        throw cpptrace::runtime_error("Error in serialization of file magic: "s + e.what());
     }
     *m_raw_data_file << blob;
 
@@ -139,7 +140,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(bd_size);
     } catch (const std::exception& e) {
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Error in serialization of bootstrap::file_info size: "s + e.what());
     }
     output_stream_header << blob;
@@ -152,7 +153,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(bd_size);
     } catch (const std::exception& e) {
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Error in serialization of bootstrap::blocks_info size: "s + e.what());
     }
     output_stream_header << blob;
@@ -180,7 +181,7 @@ void BootstrapFile::flush_chunk() {
     try {
         blob = serialization::dump_binary(chunk_size);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Error in serialization of chunk size: "s + e.what());
+        throw cpptrace::runtime_error("Error in serialization of chunk size: "s + e.what());
     }
     *m_raw_data_file << blob;
 
@@ -199,7 +200,7 @@ void BootstrapFile::flush_chunk() {
                 m_cur_height,
                 chunk_size,
                 num_chars_written);
-        throw std::runtime_error("Error writing chunk");
+        throw cpptrace::runtime_error("Error writing chunk");
     }
 
     m_buffer.clear();
@@ -221,7 +222,7 @@ void BootstrapFile::write_block(block& block) {
     // now add all regular transactions
     for (const auto& tx_id : block.tx_hashes) {
         if (!tx_id) {
-            throw std::runtime_error("Aborting: null txid");
+            throw cpptrace::runtime_error("Aborting: null txid");
         }
         transaction tx = m_blockchain_storage->get_db().get_tx(tx_id);
 
@@ -331,18 +332,18 @@ uint64_t BootstrapFile::seek_to_first_chunk(std::ifstream& import_file) {
     char buf1[2048];
     import_file.read(buf1, sizeof(file_magic));
     if (!import_file)
-        throw std::runtime_error("Error reading expected number of bytes");
+        throw cpptrace::runtime_error("Error reading expected number of bytes");
     str1.assign(buf1, sizeof(file_magic));
 
     try {
         serialization::parse_binary(str1, file_magic);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Error in deserialization of file_magic: "s + e.what());
+        throw cpptrace::runtime_error("Error in deserialization of file_magic: "s + e.what());
     }
 
     if (file_magic != blockchain_raw_magic) {
         log::error(logcat, "bootstrap file not recognized");
-        throw std::runtime_error("Aborting");
+        throw cpptrace::runtime_error("Aborting");
     } else
         log::info(logcat, "bootstrap file recognized");
 
@@ -351,25 +352,25 @@ uint64_t BootstrapFile::seek_to_first_chunk(std::ifstream& import_file) {
     import_file.read(buf1, sizeof(buflen_file_info));
     str1.assign(buf1, sizeof(buflen_file_info));
     if (!import_file)
-        throw std::runtime_error("Error reading expected number of bytes");
+        throw cpptrace::runtime_error("Error reading expected number of bytes");
     try {
         serialization::parse_binary(str1, buflen_file_info);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Error in deserialization of buflen_file_info: "s + e.what());
+        throw cpptrace::runtime_error("Error in deserialization of buflen_file_info: "s + e.what());
     }
     log::info(logcat, "bootstrap::file_info size: {}", buflen_file_info);
 
     if (buflen_file_info > sizeof(buf1))
-        throw std::runtime_error("Error: bootstrap::file_info size exceeds buffer size");
+        throw cpptrace::runtime_error("Error: bootstrap::file_info size exceeds buffer size");
     import_file.read(buf1, buflen_file_info);
     if (!import_file)
-        throw std::runtime_error("Error reading expected number of bytes");
+        throw cpptrace::runtime_error("Error reading expected number of bytes");
     str1.assign(buf1, buflen_file_info);
     bootstrap::file_info bfi;
     try {
         serialization::parse_binary(str1, bfi);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Error in deserialization of bootstrap::file_info: "s + e.what());
+        throw cpptrace::runtime_error("Error in deserialization of bootstrap::file_info: "s + e.what());
     }
     log::info(
             logcat,
@@ -405,7 +406,7 @@ uint64_t BootstrapFile::count_bytes(
         try {
             serialization::parse_binary(str1, chunk_size);
         } catch (const std::exception& e) {
-            throw std::runtime_error("Error in deserialization of chunk_size: "s + e.what());
+            throw cpptrace::runtime_error("Error in deserialization of chunk_size: "s + e.what());
         }
         log::debug(logcat, "chunk_size: {}", chunk_size);
 
@@ -418,7 +419,7 @@ uint64_t BootstrapFile::count_bytes(
                     BUFFER_SIZE,
                     h - 1,
                     bytes_read);
-            throw std::runtime_error("Aborting: chunk size exceeds buffer size");
+            throw cpptrace::runtime_error("Aborting: chunk size exceeds buffer size");
         }
         if (chunk_size > CHUNK_SIZE_WARNING_THRESHOLD) {
             std::cout << refresh_string;
@@ -437,7 +438,7 @@ uint64_t BootstrapFile::count_bytes(
                     chunk_size,
                     h - 1,
                     bytes_read);
-            throw std::runtime_error("Aborting");
+            throw cpptrace::runtime_error("Aborting");
         }
         // skip to next expected block size value
         import_file.seekg(chunk_size, std::ios_base::cur);
@@ -448,7 +449,7 @@ uint64_t BootstrapFile::count_bytes(
                     "ERROR: unexpected end of file: bytes read before error: {} of chunk_size {}",
                     import_file.gcount(),
                     chunk_size);
-            throw std::runtime_error("Aborting");
+            throw cpptrace::runtime_error("Aborting");
         }
         bytes_read += chunk_size;
         h += NUM_BLOCKS_PER_CHUNK;
@@ -471,7 +472,7 @@ uint64_t BootstrapFile::count_blocks(
         const fs::path& import_file_path, std::streampos& start_pos, uint64_t& seek_height) {
     if (std::error_code ec; !fs::exists(import_file_path, ec)) {
         log::error(logcat, "bootstrap file not found: {}", import_file_path);
-        throw std::runtime_error("Aborting");
+        throw cpptrace::runtime_error("Aborting");
     }
     std::ifstream import_file{import_file_path, std::ios::binary};
 
@@ -479,7 +480,7 @@ uint64_t BootstrapFile::count_blocks(
     uint64_t h = 0;
     if (import_file.fail()) {
         log::error(logcat, "import_file.open() fail");
-        throw std::runtime_error("Aborting");
+        throw cpptrace::runtime_error("Aborting");
     }
 
     uint64_t full_header_size;  // 4 byte magic + length of header structures

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -30,8 +30,8 @@
 #include "bootstrap_file.h"
 
 #include <fmt/std.h>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "bootstrap_serialization.h"
 #include "serialization/binary_utils.h"  // dump_binary(), parse_binary()
 
@@ -113,7 +113,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(file_magic);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error("Error in serialization of file magic: "s + e.what());
+        throw oxen::runtime_error("Error in serialization of file magic: "s + e.what());
     }
     *m_raw_data_file << blob;
 
@@ -140,7 +140,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(bd_size);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Error in serialization of bootstrap::file_info size: "s + e.what());
     }
     output_stream_header << blob;
@@ -153,7 +153,7 @@ bool BootstrapFile::initialize_file() {
     try {
         blob = serialization::dump_binary(bd_size);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Error in serialization of bootstrap::blocks_info size: "s + e.what());
     }
     output_stream_header << blob;
@@ -181,7 +181,7 @@ void BootstrapFile::flush_chunk() {
     try {
         blob = serialization::dump_binary(chunk_size);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error("Error in serialization of chunk size: "s + e.what());
+        throw oxen::runtime_error("Error in serialization of chunk size: "s + e.what());
     }
     *m_raw_data_file << blob;
 
@@ -200,7 +200,7 @@ void BootstrapFile::flush_chunk() {
                 m_cur_height,
                 chunk_size,
                 num_chars_written);
-        throw cpptrace::runtime_error("Error writing chunk");
+        throw oxen::runtime_error("Error writing chunk");
     }
 
     m_buffer.clear();
@@ -222,7 +222,7 @@ void BootstrapFile::write_block(block& block) {
     // now add all regular transactions
     for (const auto& tx_id : block.tx_hashes) {
         if (!tx_id) {
-            throw cpptrace::runtime_error("Aborting: null txid");
+            throw oxen::runtime_error("Aborting: null txid");
         }
         transaction tx = m_blockchain_storage->get_db().get_tx(tx_id);
 
@@ -332,18 +332,18 @@ uint64_t BootstrapFile::seek_to_first_chunk(std::ifstream& import_file) {
     char buf1[2048];
     import_file.read(buf1, sizeof(file_magic));
     if (!import_file)
-        throw cpptrace::runtime_error("Error reading expected number of bytes");
+        throw oxen::runtime_error("Error reading expected number of bytes");
     str1.assign(buf1, sizeof(file_magic));
 
     try {
         serialization::parse_binary(str1, file_magic);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error("Error in deserialization of file_magic: "s + e.what());
+        throw oxen::runtime_error("Error in deserialization of file_magic: "s + e.what());
     }
 
     if (file_magic != blockchain_raw_magic) {
         log::error(logcat, "bootstrap file not recognized");
-        throw cpptrace::runtime_error("Aborting");
+        throw oxen::runtime_error("Aborting");
     } else
         log::info(logcat, "bootstrap file recognized");
 
@@ -352,25 +352,25 @@ uint64_t BootstrapFile::seek_to_first_chunk(std::ifstream& import_file) {
     import_file.read(buf1, sizeof(buflen_file_info));
     str1.assign(buf1, sizeof(buflen_file_info));
     if (!import_file)
-        throw cpptrace::runtime_error("Error reading expected number of bytes");
+        throw oxen::runtime_error("Error reading expected number of bytes");
     try {
         serialization::parse_binary(str1, buflen_file_info);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error("Error in deserialization of buflen_file_info: "s + e.what());
+        throw oxen::runtime_error("Error in deserialization of buflen_file_info: "s + e.what());
     }
     log::info(logcat, "bootstrap::file_info size: {}", buflen_file_info);
 
     if (buflen_file_info > sizeof(buf1))
-        throw cpptrace::runtime_error("Error: bootstrap::file_info size exceeds buffer size");
+        throw oxen::runtime_error("Error: bootstrap::file_info size exceeds buffer size");
     import_file.read(buf1, buflen_file_info);
     if (!import_file)
-        throw cpptrace::runtime_error("Error reading expected number of bytes");
+        throw oxen::runtime_error("Error reading expected number of bytes");
     str1.assign(buf1, buflen_file_info);
     bootstrap::file_info bfi;
     try {
         serialization::parse_binary(str1, bfi);
     } catch (const std::exception& e) {
-        throw cpptrace::runtime_error("Error in deserialization of bootstrap::file_info: "s + e.what());
+        throw oxen::runtime_error("Error in deserialization of bootstrap::file_info: "s + e.what());
     }
     log::info(
             logcat,
@@ -406,7 +406,7 @@ uint64_t BootstrapFile::count_bytes(
         try {
             serialization::parse_binary(str1, chunk_size);
         } catch (const std::exception& e) {
-            throw cpptrace::runtime_error("Error in deserialization of chunk_size: "s + e.what());
+            throw oxen::runtime_error("Error in deserialization of chunk_size: "s + e.what());
         }
         log::debug(logcat, "chunk_size: {}", chunk_size);
 
@@ -419,7 +419,7 @@ uint64_t BootstrapFile::count_bytes(
                     BUFFER_SIZE,
                     h - 1,
                     bytes_read);
-            throw cpptrace::runtime_error("Aborting: chunk size exceeds buffer size");
+            throw oxen::runtime_error("Aborting: chunk size exceeds buffer size");
         }
         if (chunk_size > CHUNK_SIZE_WARNING_THRESHOLD) {
             std::cout << refresh_string;
@@ -438,7 +438,7 @@ uint64_t BootstrapFile::count_bytes(
                     chunk_size,
                     h - 1,
                     bytes_read);
-            throw cpptrace::runtime_error("Aborting");
+            throw oxen::runtime_error("Aborting");
         }
         // skip to next expected block size value
         import_file.seekg(chunk_size, std::ios_base::cur);
@@ -449,7 +449,7 @@ uint64_t BootstrapFile::count_bytes(
                     "ERROR: unexpected end of file: bytes read before error: {} of chunk_size {}",
                     import_file.gcount(),
                     chunk_size);
-            throw cpptrace::runtime_error("Aborting");
+            throw oxen::runtime_error("Aborting");
         }
         bytes_read += chunk_size;
         h += NUM_BLOCKS_PER_CHUNK;
@@ -472,7 +472,7 @@ uint64_t BootstrapFile::count_blocks(
         const fs::path& import_file_path, std::streampos& start_pos, uint64_t& seek_height) {
     if (std::error_code ec; !fs::exists(import_file_path, ec)) {
         log::error(logcat, "bootstrap file not found: {}", import_file_path);
-        throw cpptrace::runtime_error("Aborting");
+        throw oxen::runtime_error("Aborting");
     }
     std::ifstream import_file{import_file_path, std::ios::binary};
 
@@ -480,7 +480,7 @@ uint64_t BootstrapFile::count_blocks(
     uint64_t h = 0;
     if (import_file.fail()) {
         log::error(logcat, "import_file.open() fail");
-        throw cpptrace::runtime_error("Aborting");
+        throw oxen::runtime_error("Aborting");
     }
 
     uint64_t full_header_size;  // 4 byte magic + length of header structures

--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -14,8 +14,8 @@ extern "C" {
 #include <optional>
 #include <string>
 #include <string_view>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/fs.h"
 
 std::string_view arg0;
@@ -397,7 +397,7 @@ int restore(bool ed25519, std::list<std::string_view> args) {
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     arg0 = argv[0];
     if (argc < 2)
         return usage(1, "No command specified!");

--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <optional>
 #include <string>
 #include <string_view>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/fs.h"
 
@@ -396,6 +397,7 @@ int restore(bool ed25519, std::list<std::string_view> args) {
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     arg0 = argv[0];
     if (argc < 2)
         return usage(1, "No command specified!");

--- a/src/blocks/CMakeLists.txt
+++ b/src/blocks/CMakeLists.txt
@@ -33,4 +33,4 @@ endforeach()
 
 configure_file(blocks.cpp.in blocks.cpp @ONLY)
 add_library(blocks "${CMAKE_CURRENT_BINARY_DIR}/blocks.cpp")
-target_link_libraries(blocks PRIVATE extra)
+target_link_libraries(blocks PRIVATE cpptrace::cpptrace extra)

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -45,11 +45,11 @@ BLSRegistrationResponse BLSAggregator::registration(
         const crypto::eth_address& sender, const crypto::public_key& serviceNodePubkey) const {
     auto& signer = core.get_bls_signer();
     return BLSRegistrationResponse{
-            signer.getCryptoPubkey(),
-            signer.proofOfPossession(sender, serviceNodePubkey),
-            sender,
-            serviceNodePubkey,
-            crypto::null<crypto::ed25519_signature>};
+            .bls_pubkey = signer.getCryptoPubkey(),
+            .proof_of_possession = signer.proofOfPossession(sender, serviceNodePubkey),
+            .address = sender,
+            .sn_pubkey = serviceNodePubkey,
+            .ed_signature = crypto::null<crypto::ed25519_signature>};
 }
 
 void BLSAggregator::nodesRequest(

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -137,6 +137,18 @@ static bool extract_1part_msg(
     return false;
 }
 
+static std::vector<uint8_t> get_reward_balance_msg_to_sign(cryptonote::network_type nettype, const crypto::eth_address& eth_addr, std::array<std::byte, 32> amount_be)
+{
+    // TODO(doyle): See BLSSigner::proofOfPossession
+    const auto tag = BLSSigner::buildTagHash(BLSSigner::rewardTag, nettype);
+    std::vector<uint8_t> result;
+    result.reserve(tag.size() + eth_addr.size() + amount_be.size());
+    result.insert(result.end(), tag.begin(), tag.end());
+    result.insert(result.end(), eth_addr.begin(), eth_addr.end());
+    result.insert(result.end(), reinterpret_cast<uint8_t *>(amount_be.begin()), reinterpret_cast<uint8_t *>(amount_be.end()));
+    return result;
+}
+
 void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq rewards signature request");
 
@@ -156,17 +168,10 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     // where everything is in bytes, and recipientAmount is a 32-byte big
     // endian integer value.
     auto& signer = core.get_bls_signer();
-    const auto tag = signer.buildTagHash(signer.rewardTag);
-
-    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
     std::array<std::byte, 32> amount_be = tools::encode_integer_be<32>(amount);
 
-    std::vector<uint8_t> msg;
-    msg.reserve(tag.size() + eth_addr.size() + amount_be.size());
-    msg.insert(msg.end(), tag.begin(), tag.end());
-    msg.insert(msg.end(), eth_addr.begin(), eth_addr.end());
-    msg.insert(msg.end(), reinterpret_cast<uint8_t *>(amount_be.begin()), reinterpret_cast<uint8_t *>(amount_be.end()));
-    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
+    std::vector<uint8_t> msg = get_reward_balance_msg_to_sign(core.get_nettype(), eth_addr, amount_be);
+    crypto::bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // Address requesting balance
@@ -190,8 +195,12 @@ static std::string dump_bls_rewards_response(const BLSRewardsResponse &item)
             "  - amount:      {}\n"
             "  - height:      {}\n"
             "  - signature:   {}\n"
-            "  - signed_hash: {}\n"_format(
-                    item.address, item.amount, item.height, item.signature, item.signed_hash);
+            "  - msg_to_sign: {}\n"_format(
+                    item.address,
+                    item.amount,
+                    item.height,
+                    item.signature,
+                    oxenc::to_hex(item.msg_to_sign.begin(), item.msg_to_sign.end()));
     return result;
 }
 
@@ -245,9 +254,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     result.address = address;
     result.amount = amount;
     result.height = height;
-    result.signed_hash = keccak(
-            BLSSigner::buildTagHash(BLSSigner::rewardTag, core.get_nettype()),
-            result.address, tools::encode_integer_be<32>(amount));
+    result.msg_to_sign = get_reward_balance_msg_to_sign(core.get_nettype(), result.address, tools::encode_integer_be<32>(amount));
 
     // `nodesRequest` dispatches to a threadpool hence we require synchronisation:
     std::mutex sig_mutex;
@@ -285,18 +292,18 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                                     "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
                                             result.amount, result.height, response.amount, response.height)};
 
-                    bls::Signature bls_sig = bls_utils::from_crypto_signature(response.signature);
-
-                    // TODO(doyle): Fix this
-                    // if (!BLSSigner::verifyHash(nettype,
-                    //             bls_sig,
-                    //             bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
-                    //             result.signed_hash))
-                    //     throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}."_format(
-                    //             request_result.sn.bls_pubkey)};
+                    if (!BLSSigner::verifyMsg(
+                                nettype,
+                                response.signature,
+                                request_result.sn.bls_pubkey,
+                                result.msg_to_sign)) {
+                        throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}."_format(
+                                request_result.sn.bls_pubkey)};
+                    }
 
                     {
                         std::lock_guard lock{sig_mutex};
+                        bls::Signature bls_sig = bls_utils::from_crypto_signature(response.signature);
                         aggSig.add(bls_sig);
                         result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
                     }
@@ -353,6 +360,23 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     return result;
 }
 
+static std::vector<uint8_t> get_exit_msg_to_sign(cryptonote::network_type nettype, BLSAggregator::ExitType type, const crypto::bls_public_key& exiting_pk)
+{
+    // TODO(doyle): See BLSSigner::proofOfPossession
+    crypto::hash tag{};
+    if (type == BLSAggregator::ExitType::Normal) {
+        tag = BLSSigner::buildTagHash(BLSSigner::removalTag, nettype);
+    } else {
+        assert(type == BLSAggregator::ExitType::Liquidate);
+        tag = BLSSigner::buildTagHash(BLSSigner::liquidateTag, nettype);
+    }
+    std::vector<uint8_t> result;
+    result.reserve(tag.size() + exiting_pk.size());
+    result.insert(result.end(), tag.begin(), tag.end());
+    result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
+    return result;
+}
+
 void BLSAggregator::get_exit(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq exit signature request");
 
@@ -369,14 +393,9 @@ void BLSAggregator::get_exit(oxenmq::Message& m) {
     }
 
     auto& signer = core.get_bls_signer();
-    const auto tag = signer.buildTagHash(signer.removalTag);
 
-    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
-    std::vector<uint8_t> msg;
-    msg.reserve(tag.size() + exiting_pk.size());
-    msg.insert(msg.end(), tag.begin(), tag.end());
-    msg.insert(msg.end(), exiting_pk.begin(), exiting_pk.end());
-    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
+    std::vector<uint8_t> msg = get_exit_msg_to_sign(core.get_nettype(), BLSAggregator::ExitType::Normal, exiting_pk);
+    crypto::bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // exiting BLS pubkey:
@@ -402,14 +421,8 @@ void BLSAggregator::get_liquidation(oxenmq::Message& m) {
     }
 
     auto& signer = core.get_bls_signer();
-    const auto tag = signer.buildTagHash(signer.liquidateTag);
-
-    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
-    std::vector<uint8_t> msg;
-    msg.reserve(tag.size() + liquidating_pk.size());
-    msg.insert(msg.end(), tag.begin(), tag.end());
-    msg.insert(msg.end(), liquidating_pk.begin(), liquidating_pk.end());
-    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
+    std::vector<uint8_t> msg = get_exit_msg_to_sign(core.get_nettype(), BLSAggregator::ExitType::Liquidate, liquidating_pk);
+    crypto::bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // BLS key of the node being liquidated:
@@ -422,11 +435,11 @@ void BLSAggregator::get_liquidation(oxenmq::Message& m) {
 
 // Common code for exit and liquidation requests, which only differ in three ways:
 // - the endpoint they go to;
-// - the tag that gets used in the signed hash; and
+// - the tag that gets used in the msg_to_sign hash; and
 // - the key under which the signed pubkey gets confirmed back to us.
 AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
         const crypto::bls_public_key& bls_pubkey,
-        std::string_view hash_tag,
+        ExitType type,
         std::string_view endpoint,
         std::string_view pubkey_key) {
 
@@ -437,8 +450,7 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 
     AggregateExitResponse result;
     result.exit_pubkey = bls_pubkey;
-    result.signed_hash =
-            crypto::keccak(BLSSigner::buildTagHash(hash_tag, core.get_nettype()), bls_pubkey);
+    result.msg_to_sign = get_exit_msg_to_sign(core.get_nettype(), type, bls_pubkey);
 
     std::mutex signers_mutex;
     bls::Signature aggSig;
@@ -447,7 +459,7 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
     nodesRequest(
             endpoint,
             tools::view_guts(bls_pubkey),
-            [endpoint, pubkey_key, &aggSig, &result, &signers_mutex](
+            [endpoint, pubkey_key, &aggSig, &result, &signers_mutex, nettype = core.get_nettype()](
                     const BLSRequestResult& request_result, const std::vector<std::string>& data) {
 
                 try {
@@ -463,18 +475,18 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
                     auto sig = tools::make_from_guts<crypto::bls_signature>(
                             d.require<std::string_view>("signature"));
 
-                    auto bls_sig = bls_utils::from_crypto_signature(sig);
-
-                    if (!bls_sig.verifyHash(
-                                bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
-                                result.signed_hash.data(),
-                                result.signed_hash.size()))
+                    if (!BLSSigner::verifyMsg(
+                                nettype, sig, request_result.sn.bls_pubkey, result.msg_to_sign)) {
                         throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
                                 request_result.sn.bls_pubkey)};
+                    }
 
-                    std::lock_guard<std::mutex> lock(signers_mutex);
-                    aggSig.add(bls_sig);
-                    result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
+                    {
+                        std::lock_guard<std::mutex> lock(signers_mutex);
+                        bls::Signature bls_sig = bls_utils::from_crypto_signature(sig);
+                        aggSig.add(bls_sig);
+                        result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
+                    }
                 } catch (const std::exception& e) {
                     oxen::log::warning(
                             logcat,
@@ -508,11 +520,11 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 }
 
 AggregateExitResponse BLSAggregator::aggregateExit(const crypto::bls_public_key& bls_pubkey) {
-    return aggregateExitOrLiquidate(bls_pubkey, BLSSigner::removalTag, "bls.get_exit", "exit");
+    return aggregateExitOrLiquidate(bls_pubkey, BLSAggregator::ExitType::Normal, "bls.get_exit", "exit");
 }
 
 AggregateExitResponse BLSAggregator::aggregateLiquidation(
         const crypto::bls_public_key& bls_pubkey) {
     return aggregateExitOrLiquidate(
-            bls_pubkey, BLSSigner::liquidateTag, "bls.get_liquidation", "liquidate");
+            bls_pubkey, BLSAggregator::ExitType::Liquidate, "bls.get_liquidation", "liquidate");
 }

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -1,17 +1,18 @@
 #include "bls_aggregator.h"
 
+#include <bls/bls_signer.h>
+#include <bls/bls_utils.h>
+#include <common/exception.h>
+#include <common/bigint.h>
+#include <common/guts.h>
+#include <common/string_util.h>
+#include <crypto/crypto.h>
+#include <cryptonote_core/cryptonote_core.h>
+
+#include <ethyl/utils.hpp>
+#include <logging/oxen_logger.h>
 #include <oxenc/bt_producer.h>
-
-#include "bls/bls_utils.h"
-#include "common/exception.h"
-#include "common/bigint.h"
-#include "common/guts.h"
-#include "common/string_util.h"
-#include "crypto/crypto.h"
-#include "cryptonote_core/cryptonote_core.h"
-#include "ethyl/utils.hpp"
-#include "logging/oxen_logger.h"
-
+#include <oxenmq/oxenmq.h>
 
 #define BLS_ETH
 #define MCLBN_FP_UNIT_SIZE 4

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -157,7 +157,16 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     // endian integer value.
     auto& signer = core.get_bls_signer();
     const auto tag = signer.buildTagHash(signer.rewardTag);
-    const auto sig = signer.signHash(keccak(tag, eth_addr, tools::encode_integer_be<32>(amount)));
+
+    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
+    std::array<std::byte, 32> amount_be = tools::encode_integer_be<32>(amount);
+
+    std::vector<uint8_t> msg;
+    msg.reserve(tag.size() + eth_addr.size() + amount_be.size());
+    msg.insert(msg.end(), tag.begin(), tag.end());
+    msg.insert(msg.end(), eth_addr.begin(), eth_addr.end());
+    msg.insert(msg.end(), reinterpret_cast<uint8_t *>(amount_be.begin()), reinterpret_cast<uint8_t *>(amount_be.end()));
+    const auto sig = signer.signSig2(msg);
 
     oxenc::bt_dict_producer d;
     // Address requesting balance
@@ -332,7 +341,13 @@ void BLSAggregator::get_exit(oxenmq::Message& m) {
 
     auto& signer = core.get_bls_signer();
     const auto tag = signer.buildTagHash(signer.removalTag);
-    const auto sig = signer.signHash(keccak(tag, exiting_pk));
+
+    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
+    std::vector<uint8_t> msg;
+    msg.reserve(tag.size() + exiting_pk.size());
+    msg.insert(msg.end(), tag.begin(), tag.end());
+    msg.insert(msg.end(), exiting_pk.begin(), exiting_pk.end());
+    const auto sig = signer.signSig2(msg);
 
     oxenc::bt_dict_producer d;
     // exiting BLS pubkey:
@@ -359,7 +374,13 @@ void BLSAggregator::get_liquidation(oxenmq::Message& m) {
 
     auto& signer = core.get_bls_signer();
     const auto tag = signer.buildTagHash(signer.liquidateTag);
-    const auto sig = signer.signHash(keccak(tag, liquidating_pk));
+
+    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
+    std::vector<uint8_t> msg;
+    msg.reserve(tag.size() + liquidating_pk.size());
+    msg.insert(msg.end(), tag.begin(), tag.end());
+    msg.insert(msg.end(), liquidating_pk.begin(), liquidating_pk.end());
+    const auto sig = signer.signSig2(msg);
 
     oxenc::bt_dict_producer d;
     // BLS key of the node being liquidated:

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -224,7 +224,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
     // NOTE: Validate the arguments
     if (address == crypto::null<crypto::eth_address>) {
-        throw oxen::invalid_argument(fmt::format(
+        throw oxen::traced<std::invalid_argument>(fmt::format(
                 "Aggregating a rewards request for the zero address for {} SENT at height {} is "
                 "invalid because address is invalid. Request rejected",
                 address,
@@ -234,7 +234,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (amount == 0) {
-        throw oxen::invalid_argument(fmt::format(
+        throw oxen::traced<std::invalid_argument>(fmt::format(
                 "Aggregating a rewards request for '{}' for 0 SENT at height {} is invalid because "
                 "no rewards are available. Request rejected.",
                 address,
@@ -242,7 +242,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (height > service_node_list.height()) {
-        throw oxen::invalid_argument(fmt::format(
+        throw oxen::traced<std::invalid_argument>(fmt::format(
                 "Aggregating a rewards request for '{}' for {} SENT at height {} is invalid "
                 "because the height is greater than the blockchain height {}. Request rejected",
                 address,
@@ -274,7 +274,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                 bool partially_parsed = true;
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw oxen::runtime_error{
+                        throw oxen::traced<std::runtime_error>{
                                 "Error retrieving reward balance: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
@@ -287,9 +287,9 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                             d.require<std::string_view>("signature"));
 
                     if (response.address != result.address)
-                        throw oxen::runtime_error{"Response ETH address {} does not match the request address {}"_format(response.address, result.address)};
+                        throw oxen::traced<std::runtime_error>{"Response ETH address {} does not match the request address {}"_format(response.address, result.address)};
                     if (response.amount != result.amount || response.height != result.height)
-                        throw oxen::runtime_error{
+                        throw oxen::traced<std::runtime_error>{
                                     "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
                                             result.amount, result.height, response.amount, response.height)};
 
@@ -298,7 +298,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                                 response.signature,
                                 request_result.sn.bls_pubkey,
                                 result.msg_to_sign)) {
-                        throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}."_format(
+                        throw oxen::traced<std::runtime_error>{"Invalid BLS signature for BLS pubkey {}."_format(
                                 request_result.sn.bls_pubkey)};
                     }
 
@@ -323,17 +323,11 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                             dump_bls_rewards_response(response));
 
                 } catch (const std::exception& e) {
-                    std::string what_msg;
-                    if (const auto* oxen_exception = dynamic_cast<const oxen::exception*>(&e))
-                        what_msg = oxen_exception->what();
-                    else
-                        what_msg = e.what();
-
                     oxen::log::warning(
                             logcat,
                             "Reward balance response rejected from {}: {}\nWe requested: {}\nThe response had{}: {}",
                             request_result.sn.sn_pubkey,
-                            what_msg,
+                            e.what(),
                             dump_bls_rewards_response(result),
                             partially_parsed ? " (partially parsed)" : "",
                             dump_bls_rewards_response(response));
@@ -361,46 +355,104 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     return result;
 }
 
-static std::vector<uint8_t> get_exit_msg_to_sign(cryptonote::network_type nettype, BLSAggregator::ExitType type, const crypto::bls_public_key& exiting_pk)
+static std::vector<uint8_t> get_exit_msg_to_sign(cryptonote::network_type nettype, BLSAggregator::ExitType type, const crypto::bls_public_key& exiting_pk, uint64_t unix_timestamp)
 {
     // TODO(doyle): See BLSSigner::proofOfPossession
     crypto::hash tag{};
+    std::vector<uint8_t> result;
     if (type == BLSAggregator::ExitType::Normal) {
         tag = BLSSigner::buildTagHash(BLSSigner::removalTag, nettype);
+        result.reserve(tag.size() + exiting_pk.size() + sizeof(unix_timestamp));
+        result.insert(result.end(), tag.begin(), tag.end());
+        result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
+        auto unix_timestamp_it = reinterpret_cast<uint8_t *>(&unix_timestamp);
+        result.insert(result.end(), unix_timestamp_it, unix_timestamp_it + sizeof(unix_timestamp));
     } else {
         assert(type == BLSAggregator::ExitType::Liquidate);
         tag = BLSSigner::buildTagHash(BLSSigner::liquidateTag, nettype);
+        result.reserve(tag.size() + exiting_pk.size());
+        result.insert(result.end(), tag.begin(), tag.end());
+        result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
     }
-    std::vector<uint8_t> result;
-    result.reserve(tag.size() + exiting_pk.size());
-    result.insert(result.end(), tag.begin(), tag.end());
-    result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
+    return result;
+}
+
+struct BLSExitRequest
+{
+    bool good;
+    crypto::bls_public_key exiting_pk;
+    std::chrono::seconds timestamp;
+};
+
+static BLSExitRequest extract_exit_request(oxenmq::Message& m)
+{
+    BLSExitRequest result{};
+    if (m.data.size() != 1) {
+        m.send_reply(
+                "400",
+                "Bad request: {} command should have one data part; received {}"_format(
+                        "BLS exit", m.data.size()));
+        return result;
+    }
+
+    try {
+        oxenc::bt_dict_consumer d{m.data[0]};
+        result.exiting_pk =
+                tools::make_from_guts<crypto::bls_public_key>(d.require<std::string_view>("bls_"
+                                                                                          "pubke"
+                                                                                          "y"));
+        result.timestamp = std::chrono::seconds(
+                tools::make_from_guts<uint64_t>(d.require<std::string_view>("timestamp")));
+    } catch (const std::exception& e) {
+        m.send_reply(
+                "400",
+                "Bad request: BLS exit command specified bad bls pubkey or timestamp: {}"_format(
+                        e.what()));
+        return result;
+    }
+
+    // NOTE: Check if the request is too old. If it's too old we will reject it
+    std::chrono::duration unix_now = std::chrono::high_resolution_clock::now().time_since_epoch();
+    std::chrono::duration time_since_initial_request =
+            result.timestamp > unix_now ? result.timestamp - unix_now : unix_now - result.timestamp;
+    if (time_since_initial_request > service_nodes::BLS_MAX_TIME_ALLOWED_FOR_EXIT_REQUEST) {
+        m.send_reply(
+                "400",
+                "Bad request: BLS exit was too old to consider signing, the request was {} old"_format(
+                        time_since_initial_request.count()));
+        return result;
+    }
+
+    result.good = true;
     return result;
 }
 
 void BLSAggregator::get_exit(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq exit signature request");
-
-    crypto::bls_public_key exiting_pk;
-    if (!extract_1part_msg(m, exiting_pk, "BLS exit", "BLS pubkey"))
+    BLSExitRequest exit_request = extract_exit_request(m);
+    if (!exit_request.good)
         return;
 
     // right not its approving everything
-    if (!core.is_node_removable(exiting_pk)) {
+    if (!core.is_node_removable(exit_request.exiting_pk)) {
         m.send_reply(
                 "403",
-                "Forbidden: The BLS pubkey {} is not currently removable."_format(exiting_pk));
+                "Forbidden: The BLS pubkey {} is not currently removable."_format(exit_request.exiting_pk));
         return;
     }
 
     auto& signer = core.get_bls_signer();
 
-    std::vector<uint8_t> msg = get_exit_msg_to_sign(core.get_nettype(), BLSAggregator::ExitType::Normal, exiting_pk);
+    std::vector<uint8_t> msg = get_exit_msg_to_sign(
+            core.get_nettype(),
+            BLSAggregator::ExitType::Normal,
+            exit_request.exiting_pk,
+            exit_request.timestamp.count());
     crypto::bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // exiting BLS pubkey:
-    d.append("exit", tools::view_guts(exiting_pk));
+    d.append("exit", tools::view_guts(exit_request.exiting_pk));
     // signature of *this* snode of the exiting pubkey:
     d.append("signature", tools::view_guts(sig));
 
@@ -409,25 +461,28 @@ void BLSAggregator::get_exit(oxenmq::Message& m) {
 
 void BLSAggregator::get_liquidation(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq liquidation signature request");
-
-    crypto::bls_public_key liquidating_pk;
-    if (!extract_1part_msg(m, liquidating_pk, "BLS exit", "BLS pubkey"))
+    BLSExitRequest exit_request = extract_exit_request(m);
+    if (!exit_request.good)
         return;
 
-    if (!core.is_node_liquidatable(liquidating_pk)) {
+    if (!core.is_node_liquidatable(exit_request.exiting_pk)) {
         m.send_reply(
                 "403",
-                "Forbidden: The BLS key {} is not currently liquidatable"_format(liquidating_pk));
+                "Forbidden: The BLS key {} is not currently liquidatable"_format(exit_request.exiting_pk));
         return;
     }
 
     auto& signer = core.get_bls_signer();
-    std::vector<uint8_t> msg = get_exit_msg_to_sign(core.get_nettype(), BLSAggregator::ExitType::Liquidate, liquidating_pk);
+    std::vector<uint8_t> msg = get_exit_msg_to_sign(
+            core.get_nettype(),
+            BLSAggregator::ExitType::Liquidate,
+            exit_request.exiting_pk,
+            exit_request.timestamp.count());
     crypto::bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // BLS key of the node being liquidated:
-    d.append("liquidate", tools::view_guts(liquidating_pk));
+    d.append("liquidate", tools::view_guts(exit_request.exiting_pk));
     // signature of *this* snode of the liquidating pubkey:
     d.append("signature", tools::view_guts(sig));
 
@@ -451,34 +506,39 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 
     AggregateExitResponse result;
     result.exit_pubkey = bls_pubkey;
-    result.msg_to_sign = get_exit_msg_to_sign(core.get_nettype(), type, bls_pubkey);
+    result.timestamp   = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    result.msg_to_sign = get_exit_msg_to_sign(core.get_nettype(), type, bls_pubkey, result.timestamp);
 
     std::mutex signers_mutex;
     bls::Signature aggSig;
     aggSig.clear();
 
+    oxenc::bt_dict_producer message_dict;
+    message_dict.append("bls_pubkey", tools::view_guts(bls_pubkey));
+    message_dict.append("timestamp", tools::view_guts(result.timestamp));
+
     nodesRequest(
             endpoint,
-            tools::view_guts(bls_pubkey),
+            std::move(message_dict).str(),
             [endpoint, pubkey_key, &aggSig, &result, &signers_mutex, nettype = core.get_nettype()](
                     const BLSRequestResult& request_result, const std::vector<std::string>& data) {
 
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw oxen::runtime_error{
+                        throw oxen::traced<std::runtime_error>{
                                 "Request returned an error: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
                     if (result.exit_pubkey != tools::make_from_guts<crypto::bls_public_key>(
                                                       d.require<std::string_view>(pubkey_key)))
-                        throw oxen::runtime_error{"BLS pubkey does not match the request"};
+                        throw oxen::traced<std::runtime_error>{"BLS pubkey does not match the request"};
 
                     auto sig = tools::make_from_guts<crypto::bls_signature>(
                             d.require<std::string_view>("signature"));
 
                     if (!BLSSigner::verifyMsg(
                                 nettype, sig, request_result.sn.bls_pubkey, result.msg_to_sign)) {
-                        throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
+                        throw oxen::traced<std::runtime_error>{"Invalid BLS signature for BLS pubkey {}"_format(
                                 request_result.sn.bls_pubkey)};
                     }
 

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -166,13 +166,13 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     msg.insert(msg.end(), tag.begin(), tag.end());
     msg.insert(msg.end(), eth_addr.begin(), eth_addr.end());
     msg.insert(msg.end(), reinterpret_cast<uint8_t *>(amount_be.begin()), reinterpret_cast<uint8_t *>(amount_be.end()));
-    const auto sig = signer.signSig2(msg);
+    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
 
     oxenc::bt_dict_producer d;
     // Address requesting balance
     d.append("address", tools::view_guts(eth_addr));
     // Balance
-    d.append("balance", amount);
+    d.append("amount", amount);
     // Height of balance
     d.append("height", batchdb_height);
     // Signature of addr + balance
@@ -181,19 +181,19 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     m.send_reply("200", std::move(d).str());
 }
 
-/*
-static void logNetworkRequestFailedWarning(
-        const BLSRequestResult& result, std::string_view omq_cmd) {
-    std::string ip_string = epee::string_tools::get_ip_string_from_int32(result.sn_address.ip);
-    oxen::log::trace(
-            logcat,
-            "OMQ network request to {}:{} failed when executing '{}'",
-            ip_string,
-            std::to_string(result.sn_address.port),
-            omq_cmd);
+static std::string dump_bls_rewards_response(const BLSRewardsResponse &item)
+{
+    std::string result =
+            "BLS rewards response was:\n"
+            "\n"
+            "  - address:     {}\n"
+            "  - amount:      {}\n"
+            "  - height:      {}\n"
+            "  - signature:   {}\n"
+            "  - signed_hash: {}\n"_format(
+                    item.address, item.amount, item.height, item.signature, item.signed_hash);
+    return result;
 }
-*/
-
 
 BLSRewardsResponse BLSAggregator::rewards_request(
         const crypto::eth_address& address) {
@@ -259,9 +259,11 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     nodesRequest(
             "bls.get_reward_balance",
             tools::view_guts(address),
-            [&aggSig, &result, &sig_mutex](
+            [&aggSig, &result, &sig_mutex, nettype = core.get_nettype()](
                     const BLSRequestResult& request_result, const std::vector<std::string>& data) {
 
+                BLSRewardsResponse response = {};
+                bool partially_parsed = true;
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
                         throw oxen::runtime_error{
@@ -269,37 +271,64 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                     oxenc::bt_dict_consumer d{data[1]};
 
-                    auto bal = d.require<uint64_t>("balance");
-                    auto hei = d.require<uint64_t>("height");
-                    auto sig = tools::make_from_guts<crypto::bls_signature>(
+                    response.address = tools::make_from_guts<crypto::eth_address>(
+                            d.require<std::string_view>("address"));
+                    response.amount = d.require<uint64_t>("amount");
+                    response.height = d.require<uint64_t>("height");
+                    response.signature = tools::make_from_guts<crypto::bls_signature>(
                             d.require<std::string_view>("signature"));
 
-                    if (result.address != tools::make_from_guts<crypto::eth_address>(
-                                                  d.require<std::string_view>("address")))
-                        throw oxen::runtime_error{"ETH address does not match the request"};
-                    if (result.amount != bal || hei != result.height)
+                    if (response.address != result.address)
+                        throw oxen::runtime_error{"Response ETH address {} does not match the request address {}"_format(response.address, result.address)};
+                    if (response.amount != result.amount || response.height != result.height)
                         throw oxen::runtime_error{
                                     "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
-                                            result.amount, result.height, bal, hei)};
+                                            result.amount, result.height, response.amount, response.height)};
 
-                    auto bls_sig = bls_utils::from_crypto_signature(sig);
-                    if (!bls_sig.verifyHash(
-                                bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
-                                result.signed_hash.data(),
-                                result.signed_hash.size()))
-                        throw oxen::runtime_error{
-                                "Invalid BLS signature for BLS pubkey {}"_format(
-                                        request_result.sn.bls_pubkey)};
+                    bls::Signature bls_sig = bls_utils::from_crypto_signature(response.signature);
 
-                    std::lock_guard lock{sig_mutex};
-                    aggSig.add(bls_sig);
-                    result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
+                    // TODO(doyle): Fix this
+                    // if (!BLSSigner::verifyHash(nettype,
+                    //             bls_sig,
+                    //             bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
+                    //             result.signed_hash))
+                    //     throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}."_format(
+                    //             request_result.sn.bls_pubkey)};
+
+                    {
+                        std::lock_guard lock{sig_mutex};
+                        aggSig.add(bls_sig);
+                        result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
+                    }
+
+                    partially_parsed = false;
+
+                    oxen::log::trace(
+                            logcat,
+                            "Reward balance response accepted from {} (BLS {} XKEY {} {}:{})\nWe requested: {}\nThe response had: {}",
+                            request_result.sn.sn_pubkey,
+                            request_result.sn.bls_pubkey,
+                            request_result.sn.x_pubkey,
+                            request_result.sn.ip,
+                            request_result.sn.port,
+                            dump_bls_rewards_response(result),
+                            dump_bls_rewards_response(response));
+
                 } catch (const std::exception& e) {
+                    std::string what_msg;
+                    if (const auto* oxen_exception = dynamic_cast<const oxen::exception*>(&e))
+                        what_msg = oxen_exception->what();
+                    else
+                        what_msg = e.what();
+
                     oxen::log::warning(
                             logcat,
-                            "Reward balance response rejected from {}: {}",
+                            "Reward balance response rejected from {}: {}\nWe requested: {}\nThe response had{}: {}",
                             request_result.sn.sn_pubkey,
-                            e.what());
+                            what_msg,
+                            dump_bls_rewards_response(result),
+                            partially_parsed ? " (partially parsed)" : "",
+                            dump_bls_rewards_response(response));
                 }
             });
 
@@ -347,7 +376,7 @@ void BLSAggregator::get_exit(oxenmq::Message& m) {
     msg.reserve(tag.size() + exiting_pk.size());
     msg.insert(msg.end(), tag.begin(), tag.end());
     msg.insert(msg.end(), exiting_pk.begin(), exiting_pk.end());
-    const auto sig = signer.signSig2(msg);
+    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
 
     oxenc::bt_dict_producer d;
     // exiting BLS pubkey:
@@ -380,7 +409,7 @@ void BLSAggregator::get_liquidation(oxenmq::Message& m) {
     msg.reserve(tag.size() + liquidating_pk.size());
     msg.insert(msg.end(), tag.begin(), tag.end());
     msg.insert(msg.end(), liquidating_pk.begin(), liquidating_pk.end());
-    const auto sig = signer.signSig2(msg);
+    crypto::bls_signature sig = bls_utils::to_crypto_signature(signer.signSig2(msg));
 
     oxenc::bt_dict_producer d;
     // BLS key of the node being liquidated:

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -1,5 +1,7 @@
 #include "bls_aggregator.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 #include <oxenc/bt_producer.h>
 
 #include "bls/bls_utils.h"
@@ -10,6 +12,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "ethyl/utils.hpp"
 #include "logging/oxen_logger.h"
+
 
 #define BLS_ETH
 #define MCLBN_FP_UNIT_SIZE 4
@@ -203,7 +206,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
     // NOTE: Validate the arguments
     if (address == crypto::null<crypto::eth_address>) {
-        throw std::invalid_argument(fmt::format(
+        throw cpptrace::invalid_argument(fmt::format(
                 "Aggregating a rewards request for the zero address for {} SENT at height {} is "
                 "invalid because address is invalid. Request rejected",
                 address,
@@ -213,7 +216,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (amount == 0) {
-        throw std::invalid_argument(fmt::format(
+        throw cpptrace::invalid_argument(fmt::format(
                 "Aggregating a rewards request for '{}' for 0 SENT at height {} is invalid because "
                 "no rewards are available. Request rejected.",
                 address,
@@ -221,7 +224,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (height > service_node_list.height()) {
-        throw std::invalid_argument(fmt::format(
+        throw cpptrace::invalid_argument(fmt::format(
                 "Aggregating a rewards request for '{}' for {} SENT at height {} is invalid "
                 "because the height is greater than the blockchain height {}. Request rejected",
                 address,
@@ -253,7 +256,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw std::runtime_error{
+                        throw cpptrace::runtime_error{
                                 "Error retrieving reward balance: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
@@ -265,9 +268,9 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                     if (result.address != tools::make_from_guts<crypto::eth_address>(
                                                   d.require<std::string_view>("address")))
-                        throw std::runtime_error{"ETH address does not match the request"};
+                        throw cpptrace::runtime_error{"ETH address does not match the request"};
                     if (result.amount != bal || hei != result.height)
-                        throw std::runtime_error{
+                        throw cpptrace::runtime_error{
                                     "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
                                             result.amount, result.height, bal, hei)};
 
@@ -276,7 +279,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                                 bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
                                 result.signed_hash.data(),
                                 result.signed_hash.size()))
-                        throw std::runtime_error{
+                        throw cpptrace::runtime_error{
                                 "Invalid BLS signature for BLS pubkey {}"_format(
                                         request_result.sn.bls_pubkey)};
 
@@ -400,13 +403,13 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw std::runtime_error{
+                        throw cpptrace::runtime_error{
                                 "Request returned an error: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
                     if (result.exit_pubkey != tools::make_from_guts<crypto::bls_public_key>(
                                                       d.require<std::string_view>(pubkey_key)))
-                        throw std::runtime_error{"BLS pubkey does not match the request"};
+                        throw cpptrace::runtime_error{"BLS pubkey does not match the request"};
 
                     auto sig = tools::make_from_guts<crypto::bls_signature>(
                             d.require<std::string_view>("signature"));
@@ -417,7 +420,7 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
                                 bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
                                 result.signed_hash.data(),
                                 result.signed_hash.size()))
-                        throw std::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
+                        throw cpptrace::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
                                 request_result.sn.bls_pubkey)};
 
                     std::lock_guard<std::mutex> lock(signers_mutex);

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -126,7 +126,7 @@ static bool extract_1part_msg(
         return true;
     }
     if (m.data[0].size() == sizeof(T)) {
-        tools::make_from_guts<T>(m.data[0]);
+        val = tools::make_from_guts<T>(m.data[0]);
         return true;
     }
 
@@ -147,7 +147,7 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     auto [batchdb_height, amount] =
             core.get_blockchain_storage().sqlite_db()->get_accrued_earnings(eth_addr);
     if (amount == 0) {
-        m.send_reply("400", "Address has a zero balance in the database");
+        m.send_reply("400", "Address '{}' has a zero balance in the database"_format(eth_addr));
         return;
     }
 

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -1,10 +1,9 @@
 #include "bls_aggregator.h"
 
-#include <cpptrace/cpptrace.hpp>
-
 #include <oxenc/bt_producer.h>
 
 #include "bls/bls_utils.h"
+#include "common/exception.h"
 #include "common/bigint.h"
 #include "common/guts.h"
 #include "common/string_util.h"
@@ -206,7 +205,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
     // NOTE: Validate the arguments
     if (address == crypto::null<crypto::eth_address>) {
-        throw cpptrace::invalid_argument(fmt::format(
+        throw oxen::invalid_argument(fmt::format(
                 "Aggregating a rewards request for the zero address for {} SENT at height {} is "
                 "invalid because address is invalid. Request rejected",
                 address,
@@ -216,7 +215,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (amount == 0) {
-        throw cpptrace::invalid_argument(fmt::format(
+        throw oxen::invalid_argument(fmt::format(
                 "Aggregating a rewards request for '{}' for 0 SENT at height {} is invalid because "
                 "no rewards are available. Request rejected.",
                 address,
@@ -224,7 +223,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     }
 
     if (height > service_node_list.height()) {
-        throw cpptrace::invalid_argument(fmt::format(
+        throw oxen::invalid_argument(fmt::format(
                 "Aggregating a rewards request for '{}' for {} SENT at height {} is invalid "
                 "because the height is greater than the blockchain height {}. Request rejected",
                 address,
@@ -256,7 +255,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw cpptrace::runtime_error{
+                        throw oxen::runtime_error{
                                 "Error retrieving reward balance: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
@@ -268,9 +267,9 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                     if (result.address != tools::make_from_guts<crypto::eth_address>(
                                                   d.require<std::string_view>("address")))
-                        throw cpptrace::runtime_error{"ETH address does not match the request"};
+                        throw oxen::runtime_error{"ETH address does not match the request"};
                     if (result.amount != bal || hei != result.height)
-                        throw cpptrace::runtime_error{
+                        throw oxen::runtime_error{
                                     "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
                                             result.amount, result.height, bal, hei)};
 
@@ -279,7 +278,7 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                                 bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
                                 result.signed_hash.data(),
                                 result.signed_hash.size()))
-                        throw cpptrace::runtime_error{
+                        throw oxen::runtime_error{
                                 "Invalid BLS signature for BLS pubkey {}"_format(
                                         request_result.sn.bls_pubkey)};
 
@@ -403,13 +402,13 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 
                 try {
                     if (!request_result.success || data.size() != 2 || data[0] != "200")
-                        throw cpptrace::runtime_error{
+                        throw oxen::runtime_error{
                                 "Request returned an error: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
                     if (result.exit_pubkey != tools::make_from_guts<crypto::bls_public_key>(
                                                       d.require<std::string_view>(pubkey_key)))
-                        throw cpptrace::runtime_error{"BLS pubkey does not match the request"};
+                        throw oxen::runtime_error{"BLS pubkey does not match the request"};
 
                     auto sig = tools::make_from_guts<crypto::bls_signature>(
                             d.require<std::string_view>("signature"));
@@ -420,7 +419,7 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
                                 bls_utils::from_crypto_pubkey(request_result.sn.bls_pubkey),
                                 result.signed_hash.data(),
                                 result.signed_hash.size()))
-                        throw cpptrace::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
+                        throw oxen::runtime_error{"Invalid BLS signature for BLS pubkey {}"_format(
                                 request_result.sn.bls_pubkey)};
 
                     std::lock_guard<std::mutex> lock(signers_mutex);

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -11,7 +11,7 @@
 #include "cryptonote_core/service_node_list.h"
 
 struct AggregateSigned {
-    crypto::hash signed_hash;
+    std::vector<uint8_t> msg_to_sign;
     std::vector<crypto::bls_public_key> signers_bls_pubkeys;
     crypto::bls_signature signature;
 };
@@ -63,6 +63,12 @@ class BLSAggregator {
     BLSRegistrationResponse registration(
             const crypto::eth_address& sender, const crypto::public_key& serviceNodePubkey) const;
 
+    enum class ExitType
+    {
+        Normal,
+        Liquidate,
+    };
+
   private:
     void get_reward_balance(oxenmq::Message& m);
     void get_exit(oxenmq::Message& m);
@@ -70,7 +76,7 @@ class BLSAggregator {
 
     AggregateExitResponse aggregateExitOrLiquidate(
             const crypto::bls_public_key& bls_pubkey,
-            std::string_view hash_tag,
+            ExitType type,
             std::string_view endpoint,
             std::string_view pubkey_key);
 

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -18,6 +18,7 @@ struct AggregateSigned {
 
 struct AggregateExitResponse : AggregateSigned {
     crypto::bls_public_key exit_pubkey;
+    uint64_t timestamp;
 };
 
 struct BLSRewardsResponse : AggregateSigned {

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <oxenmq/oxenmq.h>
-
-#include <span>
 #include <string>
 #include <vector>
 
-#include "bls_signer.h"
 #include "crypto/crypto.h"
 #include "cryptonote_core/service_node_list.h"
+
+namespace oxenmq {
+class OxenMq;
+}
 
 struct AggregateSigned {
     std::vector<uint8_t> msg_to_sign;

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -59,6 +59,181 @@ std::string BLSSigner::buildTagHex(std::string_view baseTag) const {
     return buildTagHex(baseTag, nettype);
 }
 
+static void expand_message_xmd_keccak256(
+        std::span<uint8_t> out, std::span<const uint8_t> msg, std::span<const uint8_t> dst)
+{
+    // NOTE: Setup parameters (note: Our implementation restricts the output to <= 256 bytes)
+    const size_t KECCAK256_OUTPUT_SIZE = 256 / 8;
+    const uint16_t len_in_bytes        = static_cast<uint16_t>(out.size());
+    const size_t b_in_bytes            = KECCAK256_OUTPUT_SIZE; // the output size of H [Keccak] in bits
+    const size_t ell                   = len_in_bytes / b_in_bytes;
+
+    // NOTE: Assert invariants
+    assert((out.size() % KECCAK256_OUTPUT_SIZE) == 0 && 0 < out.size() && out.size() <= 256);
+    assert(dst.size() <= 255);
+
+    // NOTE: Construct (4) Z_pad
+    //
+    //   s_in_bytes = Input Block Size     = 1088 bits = 136 bytes
+    //   Z_pad      = I2OSP(0, s_in_bytes) = [0 .. INPUT_BLOCK_SIZE) => {0 .. 0}
+    const        size_t  INPUT_BLOCK_SIZE        = 136;
+    static const uint8_t Z_pad[INPUT_BLOCK_SIZE] = {};
+
+    // NOTE: Construct (5) l_i_b_str
+    //
+    //   l_i_b_str    = I2OSP(len_in_bytes, 2) => output length expressed in big
+    //                  endian in 2 bytes.
+    uint16_t l_i_b_str = oxenc::host_to_big(static_cast<uint16_t>(out.size()));
+
+    // NOTE: Construct I2OSP(len(DST), 1) for DST_prime
+    //   DST_prime          = (DST || I2OSP(len(DST), 1)
+    //   I2OSP(len(DST), 1) = DST length expressed in big endian as 1 byte.
+    uint8_t I2OSP_0_1 = 0;
+    uint8_t I2OSP_len_dst = static_cast<uint8_t>(dst.size());
+
+    // NOTE: Construct (7) b0 = H(msg_prime)
+    uint8_t b0[KECCAK256_OUTPUT_SIZE] = {};
+    {
+        // NOTE: Construct (6) msg_prime = Z_pad || msg || l_i_b_str || I2OSP(0, 1) || DST_prime
+        KECCAK_CTX msg_prime = {};
+        keccak_init(&msg_prime);
+        keccak_update(&msg_prime, Z_pad, sizeof(Z_pad));
+        keccak_update(&msg_prime, msg.data(), msg.size());
+        keccak_update(&msg_prime, reinterpret_cast<uint8_t *>(&l_i_b_str), sizeof(l_i_b_str));
+        keccak_update(&msg_prime, &I2OSP_0_1, sizeof(I2OSP_0_1));
+        keccak_update(&msg_prime, dst.data(), dst.size());
+        keccak_update(&msg_prime, &I2OSP_len_dst, sizeof(I2OSP_len_dst));
+
+        // NOTE: Executes H(msg_prime)
+        keccak_finish(&msg_prime, b0, sizeof(b0));
+    }
+
+    // NOTE: Construct (8) b1 = H(b0 || I2OSP(1, 1) || DST_prime)
+    uint8_t b1[KECCAK256_OUTPUT_SIZE] = {};
+    {
+        uint8_t I2OSP_1_1 = 1;
+        KECCAK_CTX ctx    = {};
+        keccak_init(&ctx);
+        keccak_update(&ctx, b0, sizeof(b0));
+        keccak_update(&ctx, &I2OSP_1_1, sizeof(I2OSP_1_1));
+        keccak_update(&ctx, dst.data(), dst.size());
+        keccak_update(&ctx, &I2OSP_len_dst, sizeof(I2OSP_len_dst));
+
+        // NOTE: Executes H(...)
+        keccak_finish(&ctx, b1, sizeof(b1));
+    }
+
+    // NOTE: Construct (11) uniform_bytes = b1 ... b_ell
+    std::memcpy(out.data(), b1, sizeof(b1));
+
+    for (size_t i = 1; i < ell; i++) {
+
+        // NOTE: Construct strxor(b0, b(i-1))
+        uint8_t strxor_b0_bi[KECCAK256_OUTPUT_SIZE] = {};
+        for (size_t j = 0; j < KECCAK256_OUTPUT_SIZE; j++) {
+            strxor_b0_bi[j] = b0[j] ^ out[KECCAK256_OUTPUT_SIZE * (i - 1) + j];
+        }
+
+        // NOTE: Construct (10) bi = H(strxor(b0, b(i - 1)) || I2OSP(i, 1) || DST_prime)
+        uint8_t bi[KECCAK256_OUTPUT_SIZE] = {};
+        {
+            uint8_t I2OSP_i_1 = static_cast<uint8_t>(i + 1);
+            KECCAK_CTX ctx    = {};
+            keccak_init(&ctx);
+            keccak_update(&ctx, strxor_b0_bi, sizeof(strxor_b0_bi));
+            keccak_update(&ctx, &I2OSP_i_1, sizeof(I2OSP_i_1));
+            keccak_update(&ctx, dst.data(), dst.size());
+            keccak_update(&ctx, &I2OSP_len_dst, sizeof(I2OSP_len_dst));
+
+            // NOTE: Executes H(...)
+            keccak_finish(&ctx, bi, sizeof(bi));
+        }
+
+        // NOTE: Transfer bi to uniform_bytes
+        std::memcpy(out.data() + KECCAK256_OUTPUT_SIZE * i, bi, sizeof(bi));
+    }
+}
+
+
+static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8_t> hashToG2Tag) {
+
+    mcl::bn::G2 result = {};
+    result.clear();
+
+    std::vector<uint8_t> messageWithI(msg.size() + 1);
+    std::memcpy(messageWithI.data(), msg.data(), msg.size());
+
+    for (uint8_t increment = 0;; increment++) {
+        messageWithI[messageWithI.size() - 1] = increment;
+
+        // NOTE: Solidity's BN256G2.hashToField(msg, tag) => x1, x2
+        mcl::bn::Fp x1 = {}, x2 = {};
+        {
+            uint8_t expandedBytes[96] = {};
+            expand_message_xmd_keccak256(expandedBytes, messageWithI, hashToG2Tag);
+
+            bool b;
+            x1.setBigEndianMod(&b, expandedBytes + 0,  48);
+            assert(b);
+            x2.setBigEndianMod(&b, expandedBytes + 48, 48);
+            assert(b);
+        }
+
+        // NOTE: herumi/bls MapTo::mapToEC
+        mcl::bn::G2::Fp x = mcl::bn::G2::Fp(x1, x2);
+        mcl::bn::G2::Fp y;
+        mcl::bn::G2::getWeierstrass(y, x);
+        if (mcl::bn::G2::Fp::squareRoot(y, y)) {
+            bool b;
+            result.set(&b, x, y, false);
+            assert(b);
+            return result; // Successfully mapped to curve, exit the loop
+        }
+    }
+
+    return result;
+}
+
+bls::Signature BLSSigner::signSig2(std::span<const uint8_t> msg) const {
+    // NOTE: This is herumi's 'blsSignHash' deconstructed to its primitive
+    // function calls but instead of executing herumi's 'tryAndIncMapTo' which
+    // maps a hash to a point we execute our own mapping function. herumi's
+    // method increments the x-coordinate to try and map the point.
+    //
+    // This approach does not follow the original BLS paper's construction of the
+    // hash to curve method which does `H(m||i)` e.g. it hashes the message with
+    // an integer appended on the end. This integer is incremented and the
+    // message is re-hashed if the resulting hash could not be mapped onto the
+    // field.
+
+    // NOTE: mcl::bn::blsSignHash(...) -> toG(...)
+    // Map a string of `bytes` to a point on the curve for BLS
+    mcl::bn::G2 Hm;
+    {
+        crypto::hash tag = buildTagHash(hashToG2Tag);
+        Hm = map_to_g2(msg, tag);
+        mcl::bn::BN::param.mapTo.mulByCofactor(Hm);
+    }
+
+    // NOTE: mcl::bn::blsSignHash(...) -> GmulCT(...) -> G2::mulCT
+    bls::Signature result = {};
+    result.clear();
+    {
+        mcl::bn::Fr s;
+        std::memcpy(const_cast<uint64_t*>(s.getUnit()), &secretKey.getPtr()->v, sizeof(s));
+        static_assert(sizeof(s) == sizeof(secretKey.getPtr()->v));
+
+        mcl::bn::G2 g2;
+        mcl::bn::G2::mulCT(g2, Hm, s);
+        std::memcpy(&result.getPtr()->v.x, &g2.x, sizeof(g2.x));
+        std::memcpy(&result.getPtr()->v.y, &g2.y, sizeof(g2.y));
+        std::memcpy(&result.getPtr()->v.z, &g2.z, sizeof(g2.z));
+        static_assert(sizeof(g2) == sizeof(result.getPtr()->v));
+    }
+
+    return result;
+}
+
 bls::Signature BLSSigner::signHashSig(const crypto::hash& hash) const {
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());
@@ -72,10 +247,18 @@ crypto::bls_signature BLSSigner::signHash(const crypto::hash& hash) const {
 crypto::bls_signature BLSSigner::proofOfPossession(
         crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) const {
     auto tag = buildTagHash(proofOfPossessionTag);
-    auto hash = crypto::keccak(tag, getCryptoPubkey(), sender, serviceNodePubkey);
 
-    bls::Signature sig;
-    secretKey.signHash(sig, hash.data(), hash.size());
+    crypto::bls_public_key bls_pkey = getCryptoPubkey();
+
+    // TODO(doyle): Pass in a array of spans to avoid having to do this allocation.
+    std::vector<uint8_t> msg;
+    msg.reserve(tag.size() + bls_pkey.size() + sender.size() + serviceNodePubkey.size());
+    msg.insert(msg.end(), tag.begin(), tag.end());
+    msg.insert(msg.end(), bls_pkey.begin(), bls_pkey.end());
+    msg.insert(msg.end(), sender.begin(), sender.end());
+    msg.insert(msg.end(), serviceNodePubkey.begin(), serviceNodePubkey.end());
+
+    bls::Signature sig = signSig2(msg);
     return bls_utils::to_crypto_signature(sig);
 }
 

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -234,6 +234,30 @@ bls::Signature BLSSigner::signSig2(std::span<const uint8_t> msg) const {
     return result;
 }
 
+bool BLSSigner::verifyHash(cryptonote::network_type nettype, const bls::Signature& signature, const bls::PublicKey &pubKey, std::span<const uint8_t> hash)
+{
+    // NOTE: blsVerifyHash => if (cast(&pub->v)->isZero()) return 0;
+    if (blsPublicKeyIsZero(pubKey.getPtr()))
+        return false;
+
+    // NOTE: blsVerifyHash => toG(*cast(&Hm.v), h, size)
+    mcl::bn::G2 Hm;
+    {
+        crypto::hash tag = BLSSigner::buildTagHash(BLSSigner::hashToG2Tag, nettype);
+        Hm = map_to_g2(hash, tag);
+        mcl::bn::BN::param.mapTo.mulByCofactor(Hm);
+    }
+
+    // NOTE: Create the hm_signature to verify pairing by copying the G2 element in to the signature
+    blsSignature hm_signature{};
+    std::memcpy(&hm_signature.v, &Hm, sizeof(Hm));
+    static_assert(sizeof(hm_signature.v) == sizeof(Hm));
+
+    // NOTE: blsVerifyHash => blsVerifyPairing(sig, &Hm, pub);
+    bool result = blsVerifyPairing(signature.getPtr(), &hm_signature, pubKey.getPtr());
+    return result;
+}
+
 bls::Signature BLSSigner::signHashSig(const crypto::hash& hash) const {
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -279,7 +279,7 @@ bool BLSSigner::verifyMsg(cryptonote::network_type nettype, const crypto::bls_si
 }
 
 crypto::bls_signature BLSSigner::proofOfPossession(
-        crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) const {
+        const crypto::eth_address& sender, const crypto::public_key& serviceNodePubkey) const {
     auto tag = buildTagHash(proofOfPossessionTag);
 
     crypto::bls_public_key bls_pkey = getCryptoPubkey();
@@ -314,19 +314,19 @@ crypto::bls_signature BLSSigner::proofOfPossession(
     return result;
 }
 
-std::string BLSSigner::getPublicKeyHex() const {
+std::string BLSSigner::getPubkeyHex() const {
     auto pk = getCryptoPubkey();
     return oxenc::to_hex(pk.begin(), pk.end());
 }
 
-bls::PublicKey BLSSigner::getPublicKey() const {
+bls::PublicKey BLSSigner::getPubkey() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
     return publicKey;
 }
 
 crypto::bls_public_key BLSSigner::getCryptoPubkey() const {
-    return bls_utils::to_crypto_pubkey(getPublicKey());
+    return bls_utils::to_crypto_pubkey(getPubkey());
 }
 
 crypto::bls_secret_key BLSSigner::getCryptoSeckey() const {

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -166,10 +166,11 @@ static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8
     for (uint8_t increment = 0;; increment++) {
         messageWithI[messageWithI.size() - 1] = increment;
 
-        // NOTE: Solidity's BN256G2.hashToField(msg, tag) => x1, x2
+        // NOTE: Solidity's BN256G2.hashToField(msg, tag) => (x1, x2, b)
         mcl::bn::Fp x1 = {}, x2 = {};
+        bool b = false;
         {
-            uint8_t expandedBytes[96] = {};
+            uint8_t expandedBytes[128] = {};
             expand_message_xmd_keccak256(expandedBytes, messageWithI, hashToG2Tag);
 
             bool b;
@@ -177,17 +178,21 @@ static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8
             assert(b);
             x2.setBigEndianMod(&b, expandedBytes + 48, 48);
             assert(b);
+
+            b = ((expandedBytes[127] & 1) == 1);
         }
 
         // NOTE: herumi/bls MapTo::mapToEC
         mcl::bn::G2::Fp x = mcl::bn::G2::Fp(x1, x2);
         mcl::bn::G2::Fp y;
         mcl::bn::G2::getWeierstrass(y, x);
-        if (mcl::bn::G2::Fp::squareRoot(y, y)) {
-            bool b;
-            result.set(&b, x, y, false);
-            assert(b);
-            return result; // Successfully mapped to curve, exit the loop
+        if (mcl::bn::G2::Fp::squareRoot(y, y)) { // Check if this is a point
+            if (b)                               // Let b => {0, 1} to choose between the two roots.
+                y = -y;
+            bool converted;
+            result.set(&converted, x, y, false);
+            assert(converted);
+            return result;                       // Successfully mapped to curve, exit the loop
         }
     }
 

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -173,11 +173,11 @@ static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8
             uint8_t expandedBytes[128] = {};
             expand_message_xmd_keccak256(expandedBytes, messageWithI, hashToG2Tag);
 
-            bool b;
-            x1.setBigEndianMod(&b, expandedBytes + 0,  48);
-            assert(b);
-            x2.setBigEndianMod(&b, expandedBytes + 48, 48);
-            assert(b);
+            bool converted;
+            x1.setBigEndianMod(&converted, expandedBytes + 0,  48);
+            assert(converted);
+            x2.setBigEndianMod(&converted, expandedBytes + 48, 48);
+            assert(converted);
 
             b = ((expandedBytes[127] & 1) == 1);
         }

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -47,7 +47,7 @@ crypto::hash BLSSigner::buildTagHash(std::string_view baseTag, cryptonote::netwo
             ethyl::utils::fromHexString(config.ETHEREUM_REWARDS_CONTRACT));
 }
 
-crypto::hash BLSSigner::buildTagHash(std::string_view baseTag) {
+crypto::hash BLSSigner::buildTagHash(std::string_view baseTag) const {
     return buildTagHash(baseTag, nettype);
 }
 
@@ -55,22 +55,22 @@ std::string BLSSigner::buildTagHex(std::string_view baseTag, cryptonote::network
     return tools::hex_guts(buildTagHash(baseTag, nettype));
 }
 
-std::string BLSSigner::buildTagHex(std::string_view baseTag) {
+std::string BLSSigner::buildTagHex(std::string_view baseTag) const {
     return buildTagHex(baseTag, nettype);
 }
 
-bls::Signature BLSSigner::signHashSig(const crypto::hash& hash) {
+bls::Signature BLSSigner::signHashSig(const crypto::hash& hash) const {
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());
     return sig;
 }
 
-crypto::bls_signature BLSSigner::signHash(const crypto::hash& hash) {
+crypto::bls_signature BLSSigner::signHash(const crypto::hash& hash) const {
     return bls_utils::to_crypto_signature(signHashSig(hash));
 }
 
 crypto::bls_signature BLSSigner::proofOfPossession(
-        crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) {
+        crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) const {
     auto tag = buildTagHash(proofOfPossessionTag);
     auto hash = crypto::keccak(tag, getCryptoPubkey(), sender, serviceNodePubkey);
 
@@ -79,22 +79,22 @@ crypto::bls_signature BLSSigner::proofOfPossession(
     return bls_utils::to_crypto_signature(sig);
 }
 
-std::string BLSSigner::getPublicKeyHex() {
+std::string BLSSigner::getPublicKeyHex() const {
     auto pk = getCryptoPubkey();
     return oxenc::to_hex(pk.begin(), pk.end());
 }
 
-bls::PublicKey BLSSigner::getPublicKey() {
+bls::PublicKey BLSSigner::getPublicKey() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
     return publicKey;
 }
 
-crypto::bls_public_key BLSSigner::getCryptoPubkey() {
+crypto::bls_public_key BLSSigner::getCryptoPubkey() const {
     return bls_utils::to_crypto_pubkey(getPublicKey());
 }
 
-crypto::bls_secret_key BLSSigner::getCryptoSeckey() {
+crypto::bls_secret_key BLSSigner::getCryptoSeckey() const {
     std::string sec_key = secretKey.getStr(mcl::IoSerialize | mcl::IoBigEndian);
     assert(sec_key.size() == sizeof(crypto::bls_secret_key));
 

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -31,22 +31,22 @@ class BLSSigner {
     explicit BLSSigner(
             const cryptonote::network_type nettype, const crypto::bls_secret_key* key = nullptr);
 
-    bls::Signature signHashSig(const crypto::hash& hash);
-    crypto::bls_signature signHash(const crypto::hash& hash);
+    bls::Signature signHashSig(const crypto::hash& hash) const;
+    crypto::bls_signature signHash(const crypto::hash& hash) const;
     crypto::bls_signature proofOfPossession(
-            crypto::eth_address sender, const crypto::public_key& serviceNodePubkey);
-    std::string getPublicKeyHex();
-    bls::PublicKey getPublicKey();
+            crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) const;
+    std::string getPublicKeyHex() const;
+    bls::PublicKey getPublicKey() const;
 
     // Gets the public key as our crypto::bls_public_key type
-    crypto::bls_public_key getCryptoPubkey();
+    crypto::bls_public_key getCryptoPubkey() const;
     // Gets the secret key as our crypto::bls_secret_key type
-    crypto::bls_secret_key getCryptoSeckey();
+    crypto::bls_secret_key getCryptoSeckey() const;
 
     static std::string buildTagHex(std::string_view baseTag, cryptonote::network_type nettype);
     static crypto::hash buildTagHash(std::string_view baseTag, cryptonote::network_type nettype);
-    std::string buildTagHex(std::string_view baseTag);
-    crypto::hash buildTagHash(std::string_view baseTag);
+    std::string buildTagHex(std::string_view baseTag) const;
+    crypto::hash buildTagHash(std::string_view baseTag) const;
 
     static constexpr inline std::string_view proofOfPossessionTag = "BLS_SIG_TRYANDINCREMENT_POP";
     static constexpr inline std::string_view rewardTag = "BLS_SIG_TRYANDINCREMENT_REWARD";

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -32,6 +32,7 @@ class BLSSigner {
             const cryptonote::network_type nettype, const crypto::bls_secret_key* key = nullptr);
 
     bls::Signature signSig2(std::span<const uint8_t> msg) const;
+    static bool verifyHash(cryptonote::network_type nettype, const bls::Signature& signature, const bls::PublicKey &pubKey, std::span<const uint8_t> hash);
 
     bls::Signature signHashSig(const crypto::hash& hash) const;
     crypto::bls_signature signHash(const crypto::hash& hash) const;

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <crypto/crypto.h>
+#include <cryptonote_config.h>
+
 #define BLS_ETH
 #define MCLBN_FP_UNIT_SIZE 4
 #define MCLBN_FR_UNIT_SIZE 4
@@ -13,9 +16,6 @@
 #include <mcl/bn.hpp>
 #undef MCLBN_NO_AUTOLINK
 #pragma GCC diagnostic pop
-
-#include "crypto/crypto.h"
-#include "cryptonote_config.h"
 
 #include <span>
 

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -44,10 +44,16 @@ class BLSSigner {
     // public BLS `pubkey`.
     static bool verifyMsg(cryptonote::network_type nettype, const crypto::bls_signature& signature, const crypto::bls_public_key &pubkey, std::span<const uint8_t> msg);
 
+    // Create a proof signing over the `sender` and `serviceNodePubkey` that this class is in
+    // possession of the secret component of the associated public key.
     crypto::bls_signature proofOfPossession(
-            crypto::eth_address sender, const crypto::public_key& serviceNodePubkey) const;
-    std::string getPublicKeyHex() const;
-    bls::PublicKey getPublicKey() const;
+            const crypto::eth_address& sender, const crypto::public_key& serviceNodePubkey) const;
+
+    // Gets the public key in hex representation
+    std::string getPubkeyHex() const;
+
+    // Gets the public key in herumi/bls representation
+    bls::PublicKey getPubkey() const;
 
     // Gets the public key as our crypto::bls_public_key type
     crypto::bls_public_key getCryptoPubkey() const;

--- a/src/bls/bls_signer.h
+++ b/src/bls/bls_signer.h
@@ -31,6 +31,8 @@ class BLSSigner {
     explicit BLSSigner(
             const cryptonote::network_type nettype, const crypto::bls_secret_key* key = nullptr);
 
+    bls::Signature signSig2(std::span<const uint8_t> msg) const;
+
     bls::Signature signHashSig(const crypto::hash& hash) const;
     crypto::bls_signature signHash(const crypto::hash& hash) const;
     crypto::bls_signature proofOfPossession(
@@ -52,4 +54,5 @@ class BLSSigner {
     static constexpr inline std::string_view rewardTag = "BLS_SIG_TRYANDINCREMENT_REWARD";
     static constexpr inline std::string_view removalTag = "BLS_SIG_TRYANDINCREMENT_REMOVE";
     static constexpr inline std::string_view liquidateTag = "BLS_SIG_TRYANDINCREMENT_LIQUIDATE";
+    static constexpr inline std::string_view hashToG2Tag = "BLS_SIG_HASH_TO_FIELD_TAG";
 };

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -1,6 +1,7 @@
 #include "bls_utils.h"
 
 #include <oxenc/hex.h>
+#include <oxenc/endian.h>
 
 #include <cstring>
 #include <type_traits>

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -158,15 +158,6 @@ bls::PublicKey from_crypto_pubkey(const crypto::bls_public_key& pk) {
     return from_normalized_crypto<bls::PublicKey, mcl::bn::G1>(pk);
 }
 
-[[nodiscard]] bool verify(
-        const crypto::bls_signature& sig,
-        const crypto::hash& hash,
-        const crypto::bls_public_key& pk) {
-    init();
-
-    return from_crypto_signature(sig).verifyHash(from_crypto_pubkey(pk), hash.data(), hash.size());
-}
-
 std::string PublicKeyToHex(const bls::PublicKey& publicKey) {
     auto pk = to_crypto_pubkey(publicKey);
     return oxenc::to_hex(pk.begin(), pk.end());

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "common/guts.h"
+#include "common/exception.h"
 #include "crypto/crypto.h"
 
 #define BLS_ETH
@@ -84,9 +85,9 @@ static CryptoT to_normalized_crypto(const BLS_T& in) {
     Gx point = *point_in;
     point.normalize();
     if (point.x.serialize(x.data(), x.size(), BLS_MODE_BINARY) == 0)
-        throw std::runtime_error("size of x is zero");
+        throw oxen::runtime_error("size of x is zero");
     if (point.y.serialize(y.data(), y.size(), BLS_MODE_BINARY) == 0)
-        throw std::runtime_error("size of y is zero");
+        throw oxen::runtime_error("size of y is zero");
 
     return serialized;
 }
@@ -142,7 +143,7 @@ static BLS_T from_normalized_crypto(const CryptoT& in) {
 
     assert(readZ == z.size());
     if (bool x_fail = readX != x.size(); x_fail || readY != x.size())
-        throw std::runtime_error{
+        throw oxen::runtime_error{
                 "Failed to deserialize BLS {} component from input value '{:x}'"_format(
                         x_fail ? 'x' : 'y', in)};
     return bls;
@@ -173,5 +174,4 @@ std::string SignatureToHex(const bls::Signature& sig) {
     auto s = to_crypto_signature(sig);
     return oxenc::to_hex(s.begin(), s.end());
 }
-
 }  // namespace bls_utils

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -157,13 +157,4 @@ bls::Signature from_crypto_signature(const crypto::bls_signature& sig) {
 bls::PublicKey from_crypto_pubkey(const crypto::bls_public_key& pk) {
     return from_normalized_crypto<bls::PublicKey, mcl::bn::G1>(pk);
 }
-
-std::string PublicKeyToHex(const bls::PublicKey& publicKey) {
-    auto pk = to_crypto_pubkey(publicKey);
-    return oxenc::to_hex(pk.begin(), pk.end());
-}
-std::string SignatureToHex(const bls::Signature& sig) {
-    auto s = to_crypto_signature(sig);
-    return oxenc::to_hex(s.begin(), s.end());
-}
 }  // namespace bls_utils

--- a/src/bls/bls_utils.cpp
+++ b/src/bls/bls_utils.cpp
@@ -86,9 +86,9 @@ static CryptoT to_normalized_crypto(const BLS_T& in) {
     Gx point = *point_in;
     point.normalize();
     if (point.x.serialize(x.data(), x.size(), BLS_MODE_BINARY) == 0)
-        throw oxen::runtime_error("size of x is zero");
+        throw oxen::traced<std::runtime_error>("size of x is zero");
     if (point.y.serialize(y.data(), y.size(), BLS_MODE_BINARY) == 0)
-        throw oxen::runtime_error("size of y is zero");
+        throw oxen::traced<std::runtime_error>("size of y is zero");
 
     return serialized;
 }
@@ -144,7 +144,7 @@ static BLS_T from_normalized_crypto(const CryptoT& in) {
 
     assert(readZ == z.size());
     if (bool x_fail = readX != x.size(); x_fail || readY != x.size())
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Failed to deserialize BLS {} component from input value '{:x}'"_format(
                         x_fail ? 'x' : 'y', in)};
     return bls;

--- a/src/bls/bls_utils.h
+++ b/src/bls/bls_utils.h
@@ -33,5 +33,4 @@ std::string SignatureToHex(const bls::Signature& sig);
         const crypto::bls_signature& sig,
         const crypto::hash& hash,
         const crypto::bls_public_key& pk);
-
 }  // namespace bls_utils

--- a/src/bls/bls_utils.h
+++ b/src/bls/bls_utils.h
@@ -26,11 +26,4 @@ std::string PublicKeyToHex(const bls::PublicKey& publicKey);
 crypto::bls_signature to_crypto_signature(const bls::Signature& sig);
 bls::Signature from_crypto_signature(const crypto::bls_signature& sig);
 std::string SignatureToHex(const bls::Signature& sig);
-
-/// Verifies a signed hash, taking the crypto:: primitive types.  Returns true if the signature
-/// passes, false if verification fails.
-[[nodiscard]] bool verify(
-        const crypto::bls_signature& sig,
-        const crypto::hash& hash,
-        const crypto::bls_public_key& pk);
 }  // namespace bls_utils

--- a/src/bls/bls_utils.h
+++ b/src/bls/bls_utils.h
@@ -21,9 +21,7 @@ void init();
 
 crypto::bls_public_key to_crypto_pubkey(const bls::PublicKey& publicKey);
 bls::PublicKey from_crypto_pubkey(const crypto::bls_public_key& pk);
-std::string PublicKeyToHex(const bls::PublicKey& publicKey);
 
 crypto::bls_signature to_crypto_signature(const bls::Signature& sig);
 bls::Signature from_crypto_signature(const crypto::bls_signature& sig);
-std::string SignatureToHex(const bls::Signature& sig);
 }  // namespace bls_utils

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 target_link_libraries(common
   PUBLIC
-    cpptrace::cpptrace
+    $<$<CONFIG:Debug>:cpptrace::cpptrace>
     cncrypto
     oxenmq::oxenmq
     oxen::logging

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 
 target_link_libraries(common
   PUBLIC
+    cpptrace::cpptrace
     cncrypto
     oxenmq::oxenmq
     oxen::logging

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(common
   command_line.cpp
   error.cpp
   expect.cpp
+  exception.cpp
   file.cpp
   i18n.cpp
   json_binary_proxy.cpp

--- a/src/common/apply_permutation.h
+++ b/src/common/apply_permutation.h
@@ -34,8 +34,8 @@
 
 #include <functional>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
 
+#include "exception.h"
 #include "logging/oxen_logger.h"
 
 namespace tools {
@@ -46,7 +46,7 @@ void apply_permutation(std::vector<size_t> permutation, const F& swap) {
     for (size_t n = 0; n < permutation.size(); ++n)
         if (std::find(permutation.begin(), permutation.end(), n) == permutation.end()) {
             log::error(globallogcat, "Bad permutation");
-            throw cpptrace::runtime_error("Bad permutation");
+            throw oxen::runtime_error("Bad permutation");
             return;
         }
 
@@ -66,7 +66,7 @@ template <typename T>
 void apply_permutation(const std::vector<size_t>& permutation, std::vector<T>& v) {
     if (permutation.size() != v.size()) {
         log::error(globallogcat, "Mismatched vector sizes");
-        throw cpptrace::runtime_error("Mismatched vector sizes");
+        throw oxen::runtime_error("Mismatched vector sizes");
         return;
     }
     apply_permutation(permutation, [&v](size_t i0, size_t i1) { std::swap(v[i0], v[i1]); });

--- a/src/common/apply_permutation.h
+++ b/src/common/apply_permutation.h
@@ -34,6 +34,7 @@
 
 #include <functional>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "logging/oxen_logger.h"
 
@@ -45,7 +46,7 @@ void apply_permutation(std::vector<size_t> permutation, const F& swap) {
     for (size_t n = 0; n < permutation.size(); ++n)
         if (std::find(permutation.begin(), permutation.end(), n) == permutation.end()) {
             log::error(globallogcat, "Bad permutation");
-            throw std::runtime_error("Bad permutation");
+            throw cpptrace::runtime_error("Bad permutation");
             return;
         }
 
@@ -65,7 +66,7 @@ template <typename T>
 void apply_permutation(const std::vector<size_t>& permutation, std::vector<T>& v) {
     if (permutation.size() != v.size()) {
         log::error(globallogcat, "Mismatched vector sizes");
-        throw std::runtime_error("Mismatched vector sizes");
+        throw cpptrace::runtime_error("Mismatched vector sizes");
         return;
     }
     apply_permutation(permutation, [&v](size_t i0, size_t i1) { std::swap(v[i0], v[i1]); });

--- a/src/common/apply_permutation.h
+++ b/src/common/apply_permutation.h
@@ -46,7 +46,7 @@ void apply_permutation(std::vector<size_t> permutation, const F& swap) {
     for (size_t n = 0; n < permutation.size(); ++n)
         if (std::find(permutation.begin(), permutation.end(), n) == permutation.end()) {
             log::error(globallogcat, "Bad permutation");
-            throw oxen::runtime_error("Bad permutation");
+            throw oxen::traced<std::runtime_error>("Bad permutation");
             return;
         }
 
@@ -66,7 +66,7 @@ template <typename T>
 void apply_permutation(const std::vector<size_t>& permutation, std::vector<T>& v) {
     if (permutation.size() != v.size()) {
         log::error(globallogcat, "Mismatched vector sizes");
-        throw oxen::runtime_error("Mismatched vector sizes");
+        throw oxen::traced<std::runtime_error>("Mismatched vector sizes");
         return;
     }
     apply_permutation(permutation, [&v](size_t i0, size_t i1) { std::swap(v[i0], v[i1]); });

--- a/src/common/bigint.h
+++ b/src/common/bigint.h
@@ -36,7 +36,7 @@ template <size_t Bytes>
 uint64_t decode_integer_be(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 8; i++)
         if (be_val[i] != std::byte{0})
-            throw oxen::overflow_error{"integer too large for u64"};
+            throw oxen::overflow_error{"Big endian integer too large for u64"};
     return oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8));
 }
 
@@ -47,7 +47,7 @@ template <size_t Bytes>
 uint64_t decode_integer_le(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 8; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw oxen::overflow_error{"integer too large for u64"};
+            throw oxen::overflow_error{"Little endian integer too large for u64"};
     return oxenc::load_little_to_host<uint64_t>(le_val.data());
 }
 

--- a/src/common/bigint.h
+++ b/src/common/bigint.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "exception.h"
+
 #include <oxenc/endian.h>
 
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <cpptrace/cpptrace.hpp>
 
 namespace tools {
 
@@ -35,7 +36,7 @@ template <size_t Bytes>
 uint64_t decode_integer_be(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 8; i++)
         if (be_val[i] != std::byte{0})
-            throw cpptrace::overflow_error{"integer too large for u64"};
+            throw oxen::overflow_error{"integer too large for u64"};
     return oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8));
 }
 
@@ -46,7 +47,7 @@ template <size_t Bytes>
 uint64_t decode_integer_le(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 8; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw cpptrace::overflow_error{"integer too large for u64"};
+            throw oxen::overflow_error{"integer too large for u64"};
     return oxenc::load_little_to_host<uint64_t>(le_val.data());
 }
 
@@ -79,7 +80,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_be128(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 16; i++)
         if (be_val[i] != std::byte{0})
-            throw cpptrace::overflow_error{"integer too large for u128"};
+            throw oxen::overflow_error{"integer too large for u128"};
     return {oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 16)),
             oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8))};
 }
@@ -92,7 +93,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_le128(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 16; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw cpptrace::overflow_error{"integer too large for u128"};
+            throw oxen::overflow_error{"integer too large for u128"};
     return {oxenc::load_little_to_host<uint64_t>(le_val.data() + 8),
             oxenc::load_little_to_host<uint64_t>(le_val.data())};
 }

--- a/src/common/bigint.h
+++ b/src/common/bigint.h
@@ -5,7 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 namespace tools {
 
@@ -35,7 +35,7 @@ template <size_t Bytes>
 uint64_t decode_integer_be(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 8; i++)
         if (be_val[i] != std::byte{0})
-            throw std::overflow_error{"integer too large for u64"};
+            throw cpptrace::overflow_error{"integer too large for u64"};
     return oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8));
 }
 
@@ -46,7 +46,7 @@ template <size_t Bytes>
 uint64_t decode_integer_le(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 8; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw std::overflow_error{"integer too large for u64"};
+            throw cpptrace::overflow_error{"integer too large for u64"};
     return oxenc::load_little_to_host<uint64_t>(le_val.data());
 }
 
@@ -79,7 +79,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_be128(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 16; i++)
         if (be_val[i] != std::byte{0})
-            throw std::overflow_error{"integer too large for u128"};
+            throw cpptrace::overflow_error{"integer too large for u128"};
     return {oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 16)),
             oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8))};
 }
@@ -92,7 +92,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_le128(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 16; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw std::overflow_error{"integer too large for u128"};
+            throw cpptrace::overflow_error{"integer too large for u128"};
     return {oxenc::load_little_to_host<uint64_t>(le_val.data() + 8),
             oxenc::load_little_to_host<uint64_t>(le_val.data())};
 }

--- a/src/common/bigint.h
+++ b/src/common/bigint.h
@@ -36,7 +36,7 @@ template <size_t Bytes>
 uint64_t decode_integer_be(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 8; i++)
         if (be_val[i] != std::byte{0})
-            throw oxen::overflow_error{"Big endian integer too large for u64"};
+            throw oxen::traced<std::overflow_error>{"Big endian integer too large for u64"};
     return oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8));
 }
 
@@ -47,7 +47,7 @@ template <size_t Bytes>
 uint64_t decode_integer_le(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 8; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw oxen::overflow_error{"Little endian integer too large for u64"};
+            throw oxen::traced<std::overflow_error>{"Little endian integer too large for u64"};
     return oxenc::load_little_to_host<uint64_t>(le_val.data());
 }
 
@@ -80,7 +80,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_be128(const std::array<std::byte, Bytes>& be_val) {
     for (size_t i = 0; i < Bytes - 16; i++)
         if (be_val[i] != std::byte{0})
-            throw oxen::overflow_error{"integer too large for u128"};
+            throw oxen::traced<std::overflow_error>{"integer too large for u128"};
     return {oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 16)),
             oxenc::load_big_to_host<uint64_t>(be_val.data() + (be_val.size() - 8))};
 }
@@ -93,7 +93,7 @@ template <size_t Bytes>
 std::pair<uint64_t, uint64_t> decode_integer_le128(const std::array<std::byte, Bytes>& le_val) {
     for (size_t i = 16; i < Bytes; i++)
         if (le_val[i] != std::byte{0})
-            throw oxen::overflow_error{"integer too large for u128"};
+            throw oxen::traced<std::overflow_error>{"integer too large for u128"};
     return {oxenc::load_little_to_host<uint64_t>(le_val.data() + 8),
             oxenc::load_little_to_host<uint64_t>(le_val.data())};
 }

--- a/src/common/combinator.cpp
+++ b/src/common/combinator.cpp
@@ -34,7 +34,7 @@ namespace tools {
 
 uint64_t combinations_count(uint32_t k, uint32_t n) {
     if (k > n) {
-        throw std::runtime_error("k must not be greater than n");
+        throw cpptrace::runtime_error("k must not be greater than n");
     }
 
     uint64_t c = 1;

--- a/src/common/combinator.cpp
+++ b/src/common/combinator.cpp
@@ -34,7 +34,7 @@ namespace tools {
 
 uint64_t combinations_count(uint32_t k, uint32_t n) {
     if (k > n) {
-        throw oxen::runtime_error("k must not be greater than n");
+        throw std::runtime_error("k must not be greater than n");
     }
 
     uint64_t c = 1;

--- a/src/common/combinator.cpp
+++ b/src/common/combinator.cpp
@@ -34,7 +34,7 @@ namespace tools {
 
 uint64_t combinations_count(uint32_t k, uint32_t n) {
     if (k > n) {
-        throw cpptrace::runtime_error("k must not be greater than n");
+        throw oxen::runtime_error("k must not be greater than n");
     }
 
     uint64_t c = 1;

--- a/src/common/combinator.h
+++ b/src/common/combinator.h
@@ -30,10 +30,11 @@
 
 #pragma once
 
+#include "exception.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
 
 namespace tools {
 
@@ -57,11 +58,11 @@ class Combinator {
 template <typename T>
 std::vector<std::vector<T>> Combinator<T>::combine(size_t k) {
     if (k > origin.size()) {
-        throw cpptrace::runtime_error("k must be smaller than elements number");
+        throw oxen::runtime_error("k must be smaller than elements number");
     }
 
     if (k == 0) {
-        throw cpptrace::runtime_error("k must be greater than zero");
+        throw oxen::runtime_error("k must be greater than zero");
     }
 
     combinations.clear();

--- a/src/common/combinator.h
+++ b/src/common/combinator.h
@@ -58,11 +58,11 @@ class Combinator {
 template <typename T>
 std::vector<std::vector<T>> Combinator<T>::combine(size_t k) {
     if (k > origin.size()) {
-        throw oxen::runtime_error("k must be smaller than elements number");
+        throw oxen::traced<std::runtime_error>("k must be smaller than elements number");
     }
 
     if (k == 0) {
-        throw oxen::runtime_error("k must be greater than zero");
+        throw oxen::traced<std::runtime_error>("k must be greater than zero");
     }
 
     combinations.clear();

--- a/src/common/combinator.h
+++ b/src/common/combinator.h
@@ -32,8 +32,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <stdexcept>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 namespace tools {
 
@@ -57,11 +57,11 @@ class Combinator {
 template <typename T>
 std::vector<std::vector<T>> Combinator<T>::combine(size_t k) {
     if (k > origin.size()) {
-        throw std::runtime_error("k must be smaller than elements number");
+        throw cpptrace::runtime_error("k must be smaller than elements number");
     }
 
     if (k == 0) {
-        throw std::runtime_error("k must be greater than zero");
+        throw cpptrace::runtime_error("k must be greater than zero");
     }
 
     combinations.clear();

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -1,0 +1,92 @@
+#include "exception.h"
+
+#include <fmt/core.h>
+#include <sstream>
+#include <iostream>
+
+namespace oxen {
+
+void on_terminate_handler()
+{
+    // TODO: Support std::nested_exception?
+    try {
+        auto ptr = std::current_exception();
+        if (ptr) {
+            std::rethrow_exception(ptr);
+        } else {
+            fmt::println(stderr, "Terminate called without an active exception");
+        }
+    } catch (cpptrace::exception& e) {
+        fmt::println(stderr, "Terminate called after throwing an instance of {}: {}\n", cpptrace::demangle(typeid(e).name()), e.what());
+    } catch (std::exception& e) {
+        fmt::println(stderr, "Terminate called after throwing an instance of {}: {}\n", cpptrace::demangle(typeid(e).name()), e.what());
+    }
+    std::flush(std::cerr);
+    abort();
+}
+
+exception::exception(std::string&& msg, cpptrace::raw_trace&& trace) :
+        raw_trace(trace), user_msg(msg) {}
+
+const char* exception::what() const noexcept {
+    if (what_msg.empty()) {
+        std::ostringstream oss;
+        raw_trace.resolve().print_with_snippets(oss, /*colour*/ false);
+        what_msg = user_msg + std::string(":\n") + oss.str();
+    }
+    return what_msg.c_str();
+}
+
+const cpptrace::raw_trace& exception::trace() const noexcept {
+    return raw_trace;
+}
+
+logic_error::logic_error(std::string msg, cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+domain_error::domain_error(std::string msg, cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+invalid_argument::invalid_argument(std::string msg, cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+length_error::length_error(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+out_of_range::out_of_range(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+runtime_error::runtime_error(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+range_error::range_error(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+overflow_error::overflow_error(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+underflow_error::underflow_error(
+        std::string msg,
+        cpptrace::raw_trace&& trace) noexcept :
+        exception(std::move(msg), std::move(trace)) {}
+
+system_error::system_error(int error_code, std::string msg, cpptrace::raw_trace&& trace) noexcept :
+        exception(
+                msg + ": " + std::error_code(error_code, std::generic_category()).message(),
+                std::move(trace)),
+        ec(std::error_code(error_code, std::generic_category())) {}
+
+const std::error_code& system_error::code() const noexcept {
+    return ec;
+}
+};  // namespace oxen

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -31,7 +31,11 @@ exception::exception(std::string&& msg, cpptrace::raw_trace&& trace) :
 const char* exception::what() const noexcept {
     if (what_msg.empty()) {
         std::ostringstream oss;
+        #if defined(NDEBUG)
+        raw_trace.resolve().print(oss, /*colour*/ false);
+        #else
         raw_trace.resolve().print_with_snippets(oss, /*colour*/ false);
+        #endif
         what_msg = user_msg + std::string(":\n") + oss.str();
     }
     return what_msg.c_str();

--- a/src/common/exception.h
+++ b/src/common/exception.h
@@ -29,7 +29,7 @@ void on_terminate_handler();
 struct exception : public std::exception {
     exception(std::string&& msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256));
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256));
 
     const char* what() const noexcept override;
 
@@ -49,63 +49,63 @@ struct logic_error : public exception {
     logic_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct domain_error : public exception {
     domain_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct invalid_argument : public exception {
     invalid_argument(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct length_error : public exception {
     length_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct out_of_range : public exception {
     out_of_range(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct runtime_error : public exception {
     runtime_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct range_error : public exception {
     range_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct overflow_error : public exception {
     overflow_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct underflow_error : public exception {
     underflow_error(
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 };
 
 struct system_error : public exception {
@@ -113,7 +113,7 @@ struct system_error : public exception {
             int error_code,
             std::string msg,
             cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
 
     const std::error_code& code() const noexcept;
 

--- a/src/common/exception.h
+++ b/src/common/exception.h
@@ -1,20 +1,16 @@
 #pragma once
 
-#include <cpptrace/cpptrace.hpp>
 #include <exception>
 #include <string>
-#include <system_error>
+#include <string_view>
 
-// Custom exception implementations that store the stacktrace of the exception
-// at the call-site that it was thrown at. This implementation is based off
-// cpptrace's implementation and we also use cpptrace as a library for
-// generating cross-platform stack traces.
-//
-// Our implementatin is the same as cpptrace with the added feature that we dump
-// the stack trace with inline code-snippets for the call-site that threw the
-// exception instead of just the stack trace itself.
+#if 1
+#include <cpptrace/cpptrace.hpp>
+#endif
 
 namespace oxen {
+
+std::string make_traced_msg(std::string_view what, const cpptrace::raw_trace& trace);
 
 // Catches application termination and dumps a stack-trace where possible.
 // It must be registered as the handler on startup, preferrably in main() e.g.
@@ -26,97 +22,40 @@ namespace oxen {
 // thrown from one of the types in this file.
 void on_terminate_handler();
 
-struct exception : public std::exception {
-    exception(std::string&& msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256));
+// oxen::exception extends a standard exception object adding stack trace
+// information to it, when in a debug build.  For release builds, the
+// oxen::exception<T> is simply a typedef for a T.
+#if 0
+template <std::derived_from<std::exception> StdExcept>
+using exception = StdExcept;
+#else
+template <std::derived_from<std::exception> StdExcept>
+class exception : public StdExcept {
+  public:
+    template <typename... Args>
+    explicit exception(Args&&... args) :
+            StdExcept{std::forward<Args>(args)...},
+            raw_trace{cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)} {}
 
-    const char* what() const noexcept override;
+    const char* what() const noexcept override {
+        if (what_msg.empty())
+            what_msg = make_traced_msg(StdExcept::what(), raw_trace);
+        return what_msg.c_str();
+    }
 
-    const cpptrace::raw_trace& trace() const noexcept;
+    const cpptrace::raw_trace& trace() const noexcept { return raw_trace; }
 
-    cpptrace::raw_trace raw_trace;
-
+  private:
     // Cache of the string to be printed when 'what' is called because we store
-    // the stack trace as a list of U64 addresses.
+    // the stack trace as a list of U64 addresses and only construct the full
+    // trace string on demand.
     mutable std::string what_msg;
 
-    // The message created when the exception was thrown.
-    std::string user_msg;
+    cpptrace::raw_trace raw_trace;
 };
 
-struct logic_error : public exception {
-    logic_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
+template <std::derived_from<std::exception> StdExcept>
+using traced = exception<StdExcept>;
 
-struct domain_error : public exception {
-    domain_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct invalid_argument : public exception {
-    invalid_argument(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct length_error : public exception {
-    length_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct out_of_range : public exception {
-    out_of_range(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct runtime_error : public exception {
-    runtime_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct range_error : public exception {
-    range_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct overflow_error : public exception {
-    overflow_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct underflow_error : public exception {
-    underflow_error(
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-};
-
-struct system_error : public exception {
-    system_error(
-            int error_code,
-            std::string msg,
-            cpptrace::raw_trace&& trace =
-                    cpptrace::generate_raw_trace(/*skip*/ 0, /*max_depth*/ 256)) noexcept;
-
-    const std::error_code& code() const noexcept;
-
-    std::error_code ec;
-};
+#endif
 }  // namespace oxen

--- a/src/common/exception.h
+++ b/src/common/exception.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cpptrace/cpptrace.hpp>
+#include <exception>
+#include <string>
+#include <system_error>
+
+// Custom exception implementations that store the stacktrace of the exception
+// at the call-site that it was thrown at. This implementation is based off
+// cpptrace's implementation and we also use cpptrace as a library for
+// generating cross-platform stack traces.
+//
+// Our implementatin is the same as cpptrace with the added feature that we dump
+// the stack trace with inline code-snippets for the call-site that threw the
+// exception instead of just the stack trace itself.
+
+namespace oxen {
+
+// Catches application termination and dumps a stack-trace where possible.
+// It must be registered as the handler on startup, preferrably in main() e.g.
+//
+//   std::set_terminate(oxen::on_terminate_handler)
+//
+// This implementation is mostly copied from cpptrace's
+// `register_terminate_handler` except that we look for `oxen::` exceptions
+// thrown from one of the types in this file.
+void on_terminate_handler();
+
+struct exception : public std::exception {
+    exception(std::string&& msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256));
+
+    const char* what() const noexcept override;
+
+    const cpptrace::raw_trace& trace() const noexcept;
+
+    cpptrace::raw_trace raw_trace;
+
+    // Cache of the string to be printed when 'what' is called because we store
+    // the stack trace as a list of U64 addresses.
+    mutable std::string what_msg;
+
+    // The message created when the exception was thrown.
+    std::string user_msg;
+};
+
+struct logic_error : public exception {
+    logic_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct domain_error : public exception {
+    domain_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct invalid_argument : public exception {
+    invalid_argument(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct length_error : public exception {
+    length_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct out_of_range : public exception {
+    out_of_range(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct runtime_error : public exception {
+    runtime_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct range_error : public exception {
+    range_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct overflow_error : public exception {
+    overflow_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct underflow_error : public exception {
+    underflow_error(
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+};
+
+struct system_error : public exception {
+    system_error(
+            int error_code,
+            std::string msg,
+            cpptrace::raw_trace&& trace =
+                    cpptrace::generate_raw_trace(/*skip*/ 1, /*max_depth*/ 256)) noexcept;
+
+    const std::error_code& code() const noexcept;
+
+    std::error_code ec;
+};
+}  // namespace oxen

--- a/src/common/expect.cpp
+++ b/src/common/expect.cpp
@@ -28,7 +28,7 @@
 #include "expect.h"
 
 #include <string>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/fs.h"
 
@@ -58,7 +58,7 @@ namespace {
 
 void expect::throw_(std::error_code ec, const char* msg, const char* file, unsigned line) {
     if (msg || file)
-        throw cpptrace::system_error{ec.value(), generate_error(msg, file, line)};
-    throw cpptrace::system_error{ec.value(), msg};
+        throw oxen::system_error{ec.value(), generate_error(msg, file, line)};
+    throw oxen::system_error{ec.value(), msg};
 }
 }  // namespace detail

--- a/src/common/expect.cpp
+++ b/src/common/expect.cpp
@@ -28,6 +28,7 @@
 #include "expect.h"
 
 #include <string>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/fs.h"
 
@@ -57,7 +58,7 @@ namespace {
 
 void expect::throw_(std::error_code ec, const char* msg, const char* file, unsigned line) {
     if (msg || file)
-        throw std::system_error{ec, generate_error(msg, file, line)};
-    throw std::system_error{ec};
+        throw cpptrace::system_error{ec.value(), generate_error(msg, file, line)};
+    throw cpptrace::system_error{ec.value(), msg};
 }
 }  // namespace detail

--- a/src/common/expect.cpp
+++ b/src/common/expect.cpp
@@ -58,7 +58,7 @@ namespace {
 
 void expect::throw_(std::error_code ec, const char* msg, const char* file, unsigned line) {
     if (msg || file)
-        throw oxen::system_error{ec.value(), generate_error(msg, file, line)};
-    throw oxen::system_error{ec.value(), msg};
+        throw oxen::traced<std::system_error>{ec, generate_error(msg, file, line)};
+    throw oxen::traced<std::system_error>{ec, msg};
 }
 }  // namespace detail

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -78,8 +78,11 @@ T make_from_guts(const Spannable& s) {
 template <safe_to_memcpy T, byte_spannable Spannable>
 void load_from_hex_guts(const Spannable& s, T& x, bool check_hex = true) {
     std::span<const typename Spannable::value_type> span{s};
-    if (s.size() != sizeof(T) * 2 || (check_hex && !oxenc::is_hex(span.begin(), span.end())))
-        throw oxen::runtime_error{"Cannot reconstitute type from hex: wrong size or invalid hex"};
+    if (s.size() != sizeof(T) * 2)
+        throw oxen::runtime_error{"Cannot reconstitute type from hex: wrong size ({} vs {}) for type"_format(s.size(), sizeof(T) * 2)};
+
+    if (check_hex && !oxenc::is_hex(span.begin(), span.end()))
+        throw oxen::runtime_error{"Cannot reconstitute type from hex: invalid hex characters"_format(s)};
     oxenc::from_hex(span.begin(), span.end(), reinterpret_cast<char*>(&x));
 }
 

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "common/format.h"
 #include "common/exception.h"
 #include "epee/span.h"  // epee
 
@@ -65,7 +66,7 @@ template <safe_to_memcpy T, byte_spannable Spannable>
 T make_from_guts(const Spannable& s) {
     std::span<const typename Spannable::value_type> span{s};
     if (s.size() != sizeof(T))
-        throw oxen::runtime_error{"Cannot reconstitute type: wrong data size for type"};
+        throw oxen::runtime_error{"Cannot reconstitute type: wrong data size ({} vs {}) for type"_format(s.size(), sizeof(T))};
     T x;
     std::memcpy(static_cast<void*>(&x), s.data(), sizeof(T));
     return x;
@@ -278,10 +279,15 @@ constexpr detail::tuple_without_skips<T...> split_hex_into(std::string_view hex_
 
     constexpr auto min_size = 2 * (detail::split_guts_piece_size<T>() + ...);
     if ((detail::final_is_string_view<T...> ? hex_in.size() < min_size
-                                            : hex_in.size() != min_size) ||
-        !oxenc::is_hex(hex_in))
+                                            : hex_in.size() != min_size)) {
         throw oxen::runtime_error{
-                "Invalid split_hex_into string input: incorrect hex string size or invalid hex"};
+                "Invalid split_hex_into string input: incorrect hex string size (hex_in {}, min_size {})"_format(hex_in.size(), min_size)};
+    }
+
+    if (!oxenc::is_hex(hex_in)) {
+        throw oxen::runtime_error{
+                "Invalid split_hex_into string input: invalid hex characters encountered"};
+    }
 
     detail::tuple_without_skips<T...> result;
     detail::load_split_tuple_hex<0, T...>(result, hex_in);

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -66,7 +66,7 @@ template <safe_to_memcpy T, byte_spannable Spannable>
 T make_from_guts(const Spannable& s) {
     std::span<const typename Spannable::value_type> span{s};
     if (s.size() != sizeof(T))
-        throw oxen::runtime_error{"Cannot reconstitute type: wrong data size ({} vs {}) for type"_format(s.size(), sizeof(T))};
+        throw oxen::traced<std::runtime_error>{"Cannot reconstitute type: wrong data size ({} vs {}) for type"_format(s.size(), sizeof(T))};
     T x;
     std::memcpy(static_cast<void*>(&x), s.data(), sizeof(T));
     return x;
@@ -79,10 +79,10 @@ template <safe_to_memcpy T, byte_spannable Spannable>
 void load_from_hex_guts(const Spannable& s, T& x, bool check_hex = true) {
     std::span<const typename Spannable::value_type> span{s};
     if (s.size() != sizeof(T) * 2)
-        throw oxen::runtime_error{"Cannot reconstitute type from hex: wrong size ({} vs {}) for type"_format(s.size(), sizeof(T) * 2)};
+        throw oxen::traced<std::runtime_error>{"Cannot reconstitute type from hex: wrong size ({} vs {}) for type"_format(s.size(), sizeof(T) * 2)};
 
     if (check_hex && !oxenc::is_hex(span.begin(), span.end()))
-        throw oxen::runtime_error{"Cannot reconstitute type from hex: invalid hex characters"_format(s)};
+        throw oxen::traced<std::runtime_error>{"Cannot reconstitute type from hex: invalid hex characters"_format(s)};
     oxenc::from_hex(span.begin(), span.end(), reinterpret_cast<char*>(&x));
 }
 
@@ -260,7 +260,7 @@ constexpr detail::tuple_without_skips<T...> split_guts_into(const Spannable& s) 
     if ((detail::final_is_string_view<T...> || detail::final_is_ignore<T...>)
                 ? span.size() < min_size
                 : span.size() != min_size)
-        throw oxen::runtime_error{"Invalid split_guts_into string size"};
+        throw oxen::traced<std::runtime_error>{"Invalid split_guts_into string size"};
 
     detail::tuple_without_skips<T...> result;
     detail::load_split_tuple<0, T...>(
@@ -283,12 +283,12 @@ constexpr detail::tuple_without_skips<T...> split_hex_into(std::string_view hex_
     constexpr auto min_size = 2 * (detail::split_guts_piece_size<T>() + ...);
     if ((detail::final_is_string_view<T...> ? hex_in.size() < min_size
                                             : hex_in.size() != min_size)) {
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Invalid split_hex_into string input: incorrect hex string size (hex_in {}, min_size {})"_format(hex_in.size(), min_size)};
     }
 
     if (!oxenc::is_hex(hex_in)) {
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Invalid split_hex_into string input: invalid hex characters encountered"};
     }
 

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "common/exception.h"
 #include "epee/span.h"  // epee
 
 namespace tools {
@@ -64,7 +65,7 @@ template <safe_to_memcpy T, byte_spannable Spannable>
 T make_from_guts(const Spannable& s) {
     std::span<const typename Spannable::value_type> span{s};
     if (s.size() != sizeof(T))
-        throw std::runtime_error{"Cannot reconstitute type: wrong data size for type"};
+        throw oxen::runtime_error{"Cannot reconstitute type: wrong data size for type"};
     T x;
     std::memcpy(static_cast<void*>(&x), s.data(), sizeof(T));
     return x;
@@ -77,7 +78,7 @@ template <safe_to_memcpy T, byte_spannable Spannable>
 void load_from_hex_guts(const Spannable& s, T& x, bool check_hex = true) {
     std::span<const typename Spannable::value_type> span{s};
     if (s.size() != sizeof(T) * 2 || (check_hex && !oxenc::is_hex(span.begin(), span.end())))
-        throw std::runtime_error{"Cannot reconstitute type from hex: wrong size or invalid hex"};
+        throw oxen::runtime_error{"Cannot reconstitute type from hex: wrong size or invalid hex"};
     oxenc::from_hex(span.begin(), span.end(), reinterpret_cast<char*>(&x));
 }
 
@@ -255,7 +256,7 @@ constexpr detail::tuple_without_skips<T...> split_guts_into(const Spannable& s) 
     if ((detail::final_is_string_view<T...> || detail::final_is_ignore<T...>)
                 ? span.size() < min_size
                 : span.size() != min_size)
-        throw std::runtime_error{"Invalid split_guts_into string size"};
+        throw oxen::runtime_error{"Invalid split_guts_into string size"};
 
     detail::tuple_without_skips<T...> result;
     detail::load_split_tuple<0, T...>(
@@ -279,7 +280,7 @@ constexpr detail::tuple_without_skips<T...> split_hex_into(std::string_view hex_
     if ((detail::final_is_string_view<T...> ? hex_in.size() < min_size
                                             : hex_in.size() != min_size) ||
         !oxenc::is_hex(hex_in))
-        throw std::runtime_error{
+        throw oxen::runtime_error{
                 "Invalid split_hex_into string input: incorrect hex string size or invalid hex"};
 
     detail::tuple_without_skips<T...> result;

--- a/src/common/json_binary_proxy.cpp
+++ b/src/common/json_binary_proxy.cpp
@@ -1,7 +1,6 @@
 #include "json_binary_proxy.h"
 
-#include <cpptrace/cpptrace.hpp>
-
+#include <common/exception.h>
 #include <oxenc/base64.h>
 #include <oxenc/hex.h>
 
@@ -33,7 +32,7 @@ void load_binary_parameter_impl(
         }
     }
 
-    throw cpptrace::runtime_error{"Invalid binary value: unexpected size and/or encoding"};
+    throw oxen::runtime_error{"Invalid binary value: unexpected size and/or encoding"};
 }
 
 nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
@@ -42,7 +41,7 @@ nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
         case fmt::hex: return e = oxenc::to_hex(binary_data);
         case fmt::base64: return e = oxenc::to_base64(binary_data);
     }
-    throw cpptrace::runtime_error{"Internal error: invalid binary encoding"};
+    throw oxen::runtime_error{"Internal error: invalid binary encoding"};
 }
 
 }  // namespace tools

--- a/src/common/json_binary_proxy.cpp
+++ b/src/common/json_binary_proxy.cpp
@@ -1,5 +1,7 @@
 #include "json_binary_proxy.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 #include <oxenc/base64.h>
 #include <oxenc/hex.h>
 
@@ -31,7 +33,7 @@ void load_binary_parameter_impl(
         }
     }
 
-    throw std::runtime_error{"Invalid binary value: unexpected size and/or encoding"};
+    throw cpptrace::runtime_error{"Invalid binary value: unexpected size and/or encoding"};
 }
 
 nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
@@ -40,7 +42,7 @@ nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
         case fmt::hex: return e = oxenc::to_hex(binary_data);
         case fmt::base64: return e = oxenc::to_base64(binary_data);
     }
-    throw std::runtime_error{"Internal error: invalid binary encoding"};
+    throw cpptrace::runtime_error{"Internal error: invalid binary encoding"};
 }
 
 }  // namespace tools

--- a/src/common/json_binary_proxy.cpp
+++ b/src/common/json_binary_proxy.cpp
@@ -32,7 +32,7 @@ void load_binary_parameter_impl(
         }
     }
 
-    throw oxen::runtime_error{"Invalid binary value: unexpected size and/or encoding"};
+    throw oxen::traced<std::runtime_error>{"Invalid binary value: unexpected size and/or encoding"};
 }
 
 nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
@@ -41,7 +41,7 @@ nlohmann::json& json_binary_proxy::operator=(std::string_view binary_data) {
         case fmt::hex: return e = oxenc::to_hex(binary_data);
         case fmt::base64: return e = oxenc::to_base64(binary_data);
     }
-    throw oxen::runtime_error{"Internal error: invalid binary encoding"};
+    throw oxen::traced<std::runtime_error>{"Internal error: invalid binary encoding"};
 }
 
 }  // namespace tools

--- a/src/common/json_binary_proxy.h
+++ b/src/common/json_binary_proxy.h
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 #include <unordered_set>
+#include <cpptrace/cpptrace.hpp>
 
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
@@ -156,7 +157,7 @@ struct adl_serializer<T> {
     static_assert(std::is_trivially_copyable_v<T> && std::has_unique_object_representations_v<T>);
 
     static void to_json(json&, const T&) {
-        throw std::logic_error{"Internal error: binary types are not directly serializable"};
+        throw cpptrace::logic_error{"Internal error: binary types are not directly serializable"};
     }
     static void from_json(const json& j, T& val) {
         tools::load_binary_parameter(j.get<std::string_view>(), false /*no raw*/, val);

--- a/src/common/json_binary_proxy.h
+++ b/src/common/json_binary_proxy.h
@@ -157,7 +157,7 @@ struct adl_serializer<T> {
     static_assert(std::is_trivially_copyable_v<T> && std::has_unique_object_representations_v<T>);
 
     static void to_json(json&, const T&) {
-        throw oxen::logic_error{"Internal error: binary types are not directly serializable"};
+        throw oxen::traced<std::logic_error>{"Internal error: binary types are not directly serializable"};
     }
     static void from_json(const json& j, T& val) {
         tools::load_binary_parameter(j.get<std::string_view>(), false /*no raw*/, val);

--- a/src/common/json_binary_proxy.h
+++ b/src/common/json_binary_proxy.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <oxenc/common.h>
+#include <common/exception.h>
 
 #include <nlohmann/json.hpp>
 #include <string_view>
 #include <unordered_set>
-#include <cpptrace/cpptrace.hpp>
 
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
@@ -157,7 +157,7 @@ struct adl_serializer<T> {
     static_assert(std::is_trivially_copyable_v<T> && std::has_unique_object_representations_v<T>);
 
     static void to_json(json&, const T&) {
-        throw cpptrace::logic_error{"Internal error: binary types are not directly serializable"};
+        throw oxen::logic_error{"Internal error: binary types are not directly serializable"};
     }
     static void from_json(const json& j, T& val) {
         tools::load_binary_parameter(j.get<std::string_view>(), false /*no raw*/, val);

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -57,7 +57,7 @@ const std::type_info& variant_type(const std::variant<T...>& v) {
 #ifndef BROKEN_APPLE_VARIANT
     throw std::bad_variant_access{};
 #else
-    throw oxen::runtime_error{"Bad variant access"};
+    throw oxen::traced<std::runtime_error>{"Bad variant access"};
 #endif
 }
 

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <oxenc/variant.h>
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 #include <array>
 #include <string>
@@ -57,7 +57,7 @@ const std::type_info& variant_type(const std::variant<T...>& v) {
 #ifndef BROKEN_APPLE_VARIANT
     throw std::bad_variant_access{};
 #else
-    throw cpptrace::runtime_error{"Bad variant access"};
+    throw oxen::runtime_error{"Bad variant access"};
 #endif
 }
 

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <oxenc/variant.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <array>
 #include <string>
@@ -56,7 +57,7 @@ const std::type_info& variant_type(const std::variant<T...>& v) {
 #ifndef BROKEN_APPLE_VARIANT
     throw std::bad_variant_access{};
 #else
-    throw std::runtime_error{"Bad variant access"};
+    throw cpptrace::runtime_error{"Bad variant access"};
 #endif
 }
 

--- a/src/common/oxen.cpp
+++ b/src/common/oxen.cpp
@@ -484,3 +484,4 @@ double oxen::round(double x) {
     }
     return z;
 }
+

--- a/src/common/oxen.cpp
+++ b/src/common/oxen.cpp
@@ -484,4 +484,3 @@ double oxen::round(double x) {
     }
     return z;
 }
-

--- a/src/common/oxen.h
+++ b/src/common/oxen.h
@@ -94,7 +94,6 @@ template <typename T, size_t N>
 constexpr size_t char_count(T (&)[N]) {
     return N - 1;
 }
-
 };  // namespace oxen
 
 #endif  // OXEN_H

--- a/src/common/oxen.h
+++ b/src/common/oxen.h
@@ -94,6 +94,7 @@ template <typename T, size_t N>
 constexpr size_t char_count(T (&)[N]) {
     return N - 1;
 }
+
 };  // namespace oxen
 
 #endif  // OXEN_H

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(cncrypto
     epee
     randomx
     Boost::thread
+    cpptrace::cpptrace
     sodium
   PRIVATE
     logging

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(cncrypto
     epee
     randomx
     Boost::thread
-    cpptrace::cpptrace
+    $<$<CONFIG:Debug>:cpptrace::cpptrace>
     sodium
   PRIVATE
     logging

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -378,13 +378,13 @@ void generate_tx_proof(
     ge_p3 B_p3;
     ge_p3 D_p3;
     if (ge_frombytes_vartime(&R_p3, R.data()) != 0)
-        throw oxen::runtime_error("tx pubkey is invalid");
+        throw oxen::traced<std::runtime_error>("tx pubkey is invalid");
     if (ge_frombytes_vartime(&A_p3, A.data()) != 0)
-        throw oxen::runtime_error("recipient view pubkey is invalid");
+        throw oxen::traced<std::runtime_error>("recipient view pubkey is invalid");
     if (B && ge_frombytes_vartime(&B_p3, B->data()) != 0)
-        throw oxen::runtime_error("recipient spend pubkey is invalid");
+        throw oxen::traced<std::runtime_error>("recipient spend pubkey is invalid");
     if (ge_frombytes_vartime(&D_p3, D.data()) != 0)
-        throw oxen::runtime_error("key derivation is invalid");
+        throw oxen::traced<std::runtime_error>("key derivation is invalid");
 #if !defined(NDEBUG)
     {
         assert(sc_check(r.data()) == 0);

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -43,8 +43,8 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/varint.h"
 #include "epee/warnings.h"
 extern "C" {
@@ -378,13 +378,13 @@ void generate_tx_proof(
     ge_p3 B_p3;
     ge_p3 D_p3;
     if (ge_frombytes_vartime(&R_p3, R.data()) != 0)
-        throw cpptrace::runtime_error("tx pubkey is invalid");
+        throw oxen::runtime_error("tx pubkey is invalid");
     if (ge_frombytes_vartime(&A_p3, A.data()) != 0)
-        throw cpptrace::runtime_error("recipient view pubkey is invalid");
+        throw oxen::runtime_error("recipient view pubkey is invalid");
     if (B && ge_frombytes_vartime(&B_p3, B->data()) != 0)
-        throw cpptrace::runtime_error("recipient spend pubkey is invalid");
+        throw oxen::runtime_error("recipient spend pubkey is invalid");
     if (ge_frombytes_vartime(&D_p3, D.data()) != 0)
-        throw cpptrace::runtime_error("key derivation is invalid");
+        throw oxen::runtime_error("key derivation is invalid");
 #if !defined(NDEBUG)
     {
         assert(sc_check(r.data()) == 0);

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -43,6 +43,7 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/varint.h"
 #include "epee/warnings.h"
@@ -377,13 +378,13 @@ void generate_tx_proof(
     ge_p3 B_p3;
     ge_p3 D_p3;
     if (ge_frombytes_vartime(&R_p3, R.data()) != 0)
-        throw std::runtime_error("tx pubkey is invalid");
+        throw cpptrace::runtime_error("tx pubkey is invalid");
     if (ge_frombytes_vartime(&A_p3, A.data()) != 0)
-        throw std::runtime_error("recipient view pubkey is invalid");
+        throw cpptrace::runtime_error("recipient view pubkey is invalid");
     if (B && ge_frombytes_vartime(&B_p3, B->data()) != 0)
-        throw std::runtime_error("recipient spend pubkey is invalid");
+        throw cpptrace::runtime_error("recipient spend pubkey is invalid");
     if (ge_frombytes_vartime(&D_p3, D.data()) != 0)
-        throw std::runtime_error("key derivation is invalid");
+        throw cpptrace::runtime_error("key derivation is invalid");
 #if !defined(NDEBUG)
     {
         assert(sc_check(r.data()) == 0);

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -1,9 +1,9 @@
 #include "cryptonote_basic.h"
 
-#include <oxenc/endian.h>
-#include <cpptrace/cpptrace.hpp>
-
 #include "cryptonote_format_utils.h"
+
+#include <oxenc/endian.h>
+#include <common/exception.h>
 
 namespace cryptonote {
 
@@ -21,7 +21,7 @@ std::vector<crypto::public_key> transaction_prefix::get_public_keys() const {
     std::vector<cryptonote::tx_extra_field> fields;
 
     if (!parse_tx_extra(extra, fields)) {
-        throw cpptrace::invalid_argument("Failed to parse tx_extra of a transaction.");
+        throw oxen::invalid_argument("Failed to parse tx_extra of a transaction.");
     }
 
     std::vector<crypto::public_key> keys;

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -1,6 +1,7 @@
 #include "cryptonote_basic.h"
 
 #include <oxenc/endian.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "cryptonote_format_utils.h"
 
@@ -20,7 +21,7 @@ std::vector<crypto::public_key> transaction_prefix::get_public_keys() const {
     std::vector<cryptonote::tx_extra_field> fields;
 
     if (!parse_tx_extra(extra, fields)) {
-        throw std::invalid_argument("Failed to parse tx_extra of a transaction.");
+        throw cpptrace::invalid_argument("Failed to parse tx_extra of a transaction.");
     }
 
     std::vector<crypto::public_key> keys;

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -21,7 +21,7 @@ std::vector<crypto::public_key> transaction_prefix::get_public_keys() const {
     std::vector<cryptonote::tx_extra_field> fields;
 
     if (!parse_tx_extra(extra, fields)) {
-        throw oxen::invalid_argument("Failed to parse tx_extra of a transaction.");
+        throw oxen::traced<std::invalid_argument>("Failed to parse tx_extra of a transaction.");
     }
 
     std::vector<crypto::public_key> keys;

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -195,7 +195,7 @@ class transaction_prefix {
     FIELD(vout)
     if (version >= txversion::v3_per_output_unlock_times &&
         vout.size() != output_unlock_times.size()) {
-        throw oxen::invalid_argument{"v3 tx without correct unlock times"};
+        throw oxen::traced<std::invalid_argument>{"v3 tx without correct unlock times"};
     }
     FIELD(extra)
     if (version >= txversion::v4_tx_types)
@@ -289,21 +289,21 @@ class transaction final : public transaction_prefix {
             signatures.resize(vin.size());
         bool signatures_expected = !signatures.empty();
         if (signatures_expected && vin.size() != signatures.size())
-            throw oxen::invalid_argument{"Incorrect number of signatures"};
+            throw oxen::traced<std::invalid_argument>{"Incorrect number of signatures"};
 
         const size_t vin_sigs = pruned ? 0 : vin.size();
         for (size_t i = 0; i < vin_sigs; ++i) {
             size_t signature_size = get_signature_size(vin[i]);
             if (!signatures_expected) {
                 if (signature_size > 0)
-                    throw oxen::invalid_argument{"Invalid unexpected signature"};
+                    throw oxen::traced<std::invalid_argument>{"Invalid unexpected signature"};
                 continue;
             }
 
             if (Archive::is_deserializer)
                 signatures[i].resize(signature_size);
             else if (signature_size != signatures[i].size())
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "Invalid signature size (expected " + std::to_string(signature_size) +
                         ", have " + std::to_string(signatures[i].size()) + ")"};
 
@@ -447,7 +447,7 @@ void serialize_value(Archive& ar, block& b) {
     field(ar, "miner_tx", b.miner_tx);
     field(ar, "tx_hashes", b.tx_hashes);
     if (b.tx_hashes.size() > MAX_TX_PER_BLOCK)
-        throw oxen::invalid_argument{"too many txs in block"};
+        throw oxen::traced<std::invalid_argument>{"too many txs in block"};
     if (b.major_version >= hf::hf16_pulse)
         field(ar, "signatures", b.signatures);
     if (b.major_version >= hf::hf19_reward_batching) {

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -34,8 +34,8 @@
 
 #include <atomic>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/format.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
@@ -195,7 +195,7 @@ class transaction_prefix {
     FIELD(vout)
     if (version >= txversion::v3_per_output_unlock_times &&
         vout.size() != output_unlock_times.size()) {
-        throw cpptrace::invalid_argument{"v3 tx without correct unlock times"};
+        throw oxen::invalid_argument{"v3 tx without correct unlock times"};
     }
     FIELD(extra)
     if (version >= txversion::v4_tx_types)
@@ -289,21 +289,21 @@ class transaction final : public transaction_prefix {
             signatures.resize(vin.size());
         bool signatures_expected = !signatures.empty();
         if (signatures_expected && vin.size() != signatures.size())
-            throw cpptrace::invalid_argument{"Incorrect number of signatures"};
+            throw oxen::invalid_argument{"Incorrect number of signatures"};
 
         const size_t vin_sigs = pruned ? 0 : vin.size();
         for (size_t i = 0; i < vin_sigs; ++i) {
             size_t signature_size = get_signature_size(vin[i]);
             if (!signatures_expected) {
                 if (signature_size > 0)
-                    throw cpptrace::invalid_argument{"Invalid unexpected signature"};
+                    throw oxen::invalid_argument{"Invalid unexpected signature"};
                 continue;
             }
 
             if (Archive::is_deserializer)
                 signatures[i].resize(signature_size);
             else if (signature_size != signatures[i].size())
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "Invalid signature size (expected " + std::to_string(signature_size) +
                         ", have " + std::to_string(signatures[i].size()) + ")"};
 
@@ -447,7 +447,7 @@ void serialize_value(Archive& ar, block& b) {
     field(ar, "miner_tx", b.miner_tx);
     field(ar, "tx_hashes", b.tx_hashes);
     if (b.tx_hashes.size() > MAX_TX_PER_BLOCK)
-        throw cpptrace::invalid_argument{"too many txs in block"};
+        throw oxen::invalid_argument{"too many txs in block"};
     if (b.major_version >= hf::hf16_pulse)
         field(ar, "signatures", b.signatures);
     if (b.major_version >= hf::hf19_reward_batching) {

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/format.h"
 #include "crypto/crypto.h"
@@ -194,7 +195,7 @@ class transaction_prefix {
     FIELD(vout)
     if (version >= txversion::v3_per_output_unlock_times &&
         vout.size() != output_unlock_times.size()) {
-        throw std::invalid_argument{"v3 tx without correct unlock times"};
+        throw cpptrace::invalid_argument{"v3 tx without correct unlock times"};
     }
     FIELD(extra)
     if (version >= txversion::v4_tx_types)
@@ -288,21 +289,21 @@ class transaction final : public transaction_prefix {
             signatures.resize(vin.size());
         bool signatures_expected = !signatures.empty();
         if (signatures_expected && vin.size() != signatures.size())
-            throw std::invalid_argument{"Incorrect number of signatures"};
+            throw cpptrace::invalid_argument{"Incorrect number of signatures"};
 
         const size_t vin_sigs = pruned ? 0 : vin.size();
         for (size_t i = 0; i < vin_sigs; ++i) {
             size_t signature_size = get_signature_size(vin[i]);
             if (!signatures_expected) {
                 if (signature_size > 0)
-                    throw std::invalid_argument{"Invalid unexpected signature"};
+                    throw cpptrace::invalid_argument{"Invalid unexpected signature"};
                 continue;
             }
 
             if (Archive::is_deserializer)
                 signatures[i].resize(signature_size);
             else if (signature_size != signatures[i].size())
-                throw std::invalid_argument{
+                throw cpptrace::invalid_argument{
                         "Invalid signature size (expected " + std::to_string(signature_size) +
                         ", have " + std::to_string(signatures[i].size()) + ")"};
 
@@ -446,7 +447,7 @@ void serialize_value(Archive& ar, block& b) {
     field(ar, "miner_tx", b.miner_tx);
     field(ar, "tx_hashes", b.tx_hashes);
     if (b.tx_hashes.size() > MAX_TX_PER_BLOCK)
-        throw std::invalid_argument{"too many txs in block"};
+        throw cpptrace::invalid_argument{"too many txs in block"};
     if (b.major_version >= hf::hf16_pulse)
         field(ar, "signatures", b.signatures);
     if (b.major_version >= hf::hf19_reward_batching) {

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -37,6 +37,7 @@
 #include <boost/algorithm/string.hpp>
 #include <limits>
 #include <variant>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/i18n.h"
 #include "common/meta.h"
@@ -59,7 +60,7 @@ using namespace crypto;
     {                                                                 \
         if (!(expr)) {                                                \
             log::warning(logcat, frmt, __VA_ARGS__);                  \
-            throw std::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw cpptrace::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 
@@ -282,7 +283,7 @@ bool parse_and_validate_tx_from_blob(
 bool is_v1_tx(const std::string_view tx_blob) {
     uint64_t version;
     if (tools::read_varint(tx_blob, version) <= 0)
-        throw std::runtime_error("Internal error getting transaction version");
+        throw cpptrace::runtime_error("Internal error getting transaction version");
     return version <= 1;
 }
 //---------------------------------------------------------------
@@ -1474,7 +1475,7 @@ crypto::hash get_pruned_transaction_hash(
         const transaction& t, const crypto::hash& pruned_data_hash) {
     // v1 transactions hash the entire blob
     if (t.version < txversion::v2_ringct)
-        throw std::runtime_error("Hash for pruned v1 tx cannot be calculated");
+        throw cpptrace::runtime_error("Hash for pruned v1 tx cannot be calculated");
 
     // v2 transactions hash different parts together, than hash the set of those hashes
     crypto::hash hashes[3];

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -61,7 +61,7 @@ using namespace crypto;
     {                                                                 \
         if (!(expr)) {                                                \
             log::warning(logcat, frmt, __VA_ARGS__);                  \
-            throw oxen::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw oxen::traced<std::runtime_error>(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 
@@ -284,7 +284,7 @@ bool parse_and_validate_tx_from_blob(
 bool is_v1_tx(const std::string_view tx_blob) {
     uint64_t version;
     if (tools::read_varint(tx_blob, version) <= 0)
-        throw oxen::runtime_error("Internal error getting transaction version");
+        throw oxen::traced<std::runtime_error>("Internal error getting transaction version");
     return version <= 1;
 }
 //---------------------------------------------------------------
@@ -1476,7 +1476,7 @@ crypto::hash get_pruned_transaction_hash(
         const transaction& t, const crypto::hash& pruned_data_hash) {
     // v1 transactions hash the entire blob
     if (t.version < txversion::v2_ringct)
-        throw oxen::runtime_error("Hash for pruned v1 tx cannot be calculated");
+        throw oxen::traced<std::runtime_error>("Hash for pruned v1 tx cannot be calculated");
 
     // v2 transactions hash different parts together, than hash the set of those hashes
     crypto::hash hashes[3];

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -37,10 +37,11 @@
 #include <boost/algorithm/string.hpp>
 #include <limits>
 #include <variant>
-#include <cpptrace/cpptrace.hpp>
 
-#include "common/i18n.h"
-#include "common/meta.h"
+#include <common/i18n.h>
+#include <common/meta.h>
+#include <common/exception.h>
+
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/verification_context.h"
@@ -60,7 +61,7 @@ using namespace crypto;
     {                                                                 \
         if (!(expr)) {                                                \
             log::warning(logcat, frmt, __VA_ARGS__);                  \
-            throw cpptrace::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw oxen::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 
@@ -283,7 +284,7 @@ bool parse_and_validate_tx_from_blob(
 bool is_v1_tx(const std::string_view tx_blob) {
     uint64_t version;
     if (tools::read_varint(tx_blob, version) <= 0)
-        throw cpptrace::runtime_error("Internal error getting transaction version");
+        throw oxen::runtime_error("Internal error getting transaction version");
     return version <= 1;
 }
 //---------------------------------------------------------------
@@ -1475,7 +1476,7 @@ crypto::hash get_pruned_transaction_hash(
         const transaction& t, const crypto::hash& pruned_data_hash) {
     // v1 transactions hash the entire blob
     if (t.version < txversion::v2_ringct)
-        throw cpptrace::runtime_error("Hash for pruned v1 tx cannot be calculated");
+        throw oxen::runtime_error("Hash for pruned v1 tx cannot be calculated");
 
     // v2 transactions hash different parts together, than hash the set of those hashes
     crypto::hash hashes[3];

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -152,6 +152,7 @@ static constexpr std::array devnet_hard_forks = {
         hard_fork{hf::hf18, 0, 256, 1716310018},
         hard_fork{hf::hf19_reward_batching, 0, 257, 1716310019},
         hard_fork{hf::hf20_eth_transition, 0, 379, 1716310020},
+        hard_fork{hf::hf21_eth, 0, 409, 1716310020},
 };
 
 template <size_t N>

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -33,12 +33,12 @@
 #include "crypto/crypto.h"
 #include "cryptonote_basic.h"
 #include "oxen_economy.h"
+#include "common/exception.h"
 #include "serialization/binary_archive.h"
 #include "serialization/binary_utils.h"
 #include "serialization/serialization.h"
 #include "serialization/variant.h"
 
-#include <cpptrace/cpptrace.hpp>
 
 namespace cryptonote {
 
@@ -195,14 +195,14 @@ void serialize_value(Archive& ar, tx_extra_padding& pad) {
                                    // tag part of the padding
 
     if (remaining > TX_EXTRA_PADDING_MAX_COUNT - 1)  // - 1 as above.
-        throw cpptrace::invalid_argument{"tx_extra_padding size is larger than maximum allowed"};
+        throw oxen::invalid_argument{"tx_extra_padding size is larger than maximum allowed"};
 
     char buf[TX_EXTRA_PADDING_MAX_COUNT - 1] = {};
     ar.serialize_blob(buf, remaining);
 
     if (Archive::is_deserializer) {
         if (std::string_view{buf, remaining}.find_first_not_of('\0') != std::string::npos)
-            throw cpptrace::invalid_argument{"Invalid non-0 padding byte"};
+            throw oxen::invalid_argument{"Invalid non-0 padding byte"};
         pad.size = remaining + 1;
     }
 }
@@ -221,7 +221,7 @@ struct tx_extra_nonce {
     BEGIN_SERIALIZE()
     FIELD(nonce)
     if (TX_EXTRA_NONCE_MAX_COUNT < nonce.size())
-        throw cpptrace::invalid_argument{"invalid extra nonce: too long"};
+        throw oxen::invalid_argument{"invalid extra nonce: too long"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -195,14 +195,14 @@ void serialize_value(Archive& ar, tx_extra_padding& pad) {
                                    // tag part of the padding
 
     if (remaining > TX_EXTRA_PADDING_MAX_COUNT - 1)  // - 1 as above.
-        throw oxen::invalid_argument{"tx_extra_padding size is larger than maximum allowed"};
+        throw oxen::traced<std::invalid_argument>{"tx_extra_padding size is larger than maximum allowed"};
 
     char buf[TX_EXTRA_PADDING_MAX_COUNT - 1] = {};
     ar.serialize_blob(buf, remaining);
 
     if (Archive::is_deserializer) {
         if (std::string_view{buf, remaining}.find_first_not_of('\0') != std::string::npos)
-            throw oxen::invalid_argument{"Invalid non-0 padding byte"};
+            throw oxen::traced<std::invalid_argument>{"Invalid non-0 padding byte"};
         pad.size = remaining + 1;
     }
 }
@@ -221,7 +221,7 @@ struct tx_extra_nonce {
     BEGIN_SERIALIZE()
     FIELD(nonce)
     if (TX_EXTRA_NONCE_MAX_COUNT < nonce.size())
-        throw oxen::invalid_argument{"invalid extra nonce: too long"};
+        throw oxen::traced<std::invalid_argument>{"invalid extra nonce: too long"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -38,6 +38,8 @@
 #include "serialization/serialization.h"
 #include "serialization/variant.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace cryptonote {
 
 constexpr size_t TX_EXTRA_PADDING_MAX_COUNT = 255, TX_EXTRA_NONCE_MAX_COUNT = 255;
@@ -193,14 +195,14 @@ void serialize_value(Archive& ar, tx_extra_padding& pad) {
                                    // tag part of the padding
 
     if (remaining > TX_EXTRA_PADDING_MAX_COUNT - 1)  // - 1 as above.
-        throw std::invalid_argument{"tx_extra_padding size is larger than maximum allowed"};
+        throw cpptrace::invalid_argument{"tx_extra_padding size is larger than maximum allowed"};
 
     char buf[TX_EXTRA_PADDING_MAX_COUNT - 1] = {};
     ar.serialize_blob(buf, remaining);
 
     if (Archive::is_deserializer) {
         if (std::string_view{buf, remaining}.find_first_not_of('\0') != std::string::npos)
-            throw std::invalid_argument{"Invalid non-0 padding byte"};
+            throw cpptrace::invalid_argument{"Invalid non-0 padding byte"};
         pad.size = remaining + 1;
     }
 }
@@ -219,7 +221,7 @@ struct tx_extra_nonce {
     BEGIN_SERIALIZE()
     FIELD(nonce)
     if (TX_EXTRA_NONCE_MAX_COUNT < nonce.size())
-        throw std::invalid_argument{"invalid extra nonce: too long"};
+        throw cpptrace::invalid_argument{"invalid extra nonce: too long"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -758,7 +758,7 @@ inline constexpr const network_config& get_config(network_type nettype) {
         case network_type::TESTNET: return testnet_config;
         case network_type::DEVNET: return devnet_config;
         case network_type::FAKECHAIN: return fakenet_config;
-        default: throw oxen::runtime_error{"Invalid network type"};
+        default: throw oxen::traced<std::runtime_error>{"Invalid network type"};
     }
 }
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -37,8 +37,8 @@
 #include <cstdint>
 #include <filesystem>
 #include <ratio>
-#include <stdexcept>
 #include <string_view>
+#include <cpptrace/cpptrace.hpp>
 
 using namespace std::literals;
 
@@ -757,7 +757,7 @@ inline constexpr const network_config& get_config(network_type nettype) {
         case network_type::TESTNET: return testnet_config;
         case network_type::DEVNET: return devnet_config;
         case network_type::FAKECHAIN: return fakenet_config;
-        default: throw std::runtime_error{"Invalid network type"};
+        default: throw cpptrace::runtime_error{"Invalid network type"};
     }
 }
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -38,7 +38,8 @@
 #include <filesystem>
 #include <ratio>
 #include <string_view>
-#include <cpptrace/cpptrace.hpp>
+
+#include <common/exception.h>
 
 using namespace std::literals;
 
@@ -757,7 +758,7 @@ inline constexpr const network_config& get_config(network_type nettype) {
         case network_type::TESTNET: return testnet_config;
         case network_type::DEVNET: return devnet_config;
         case network_type::FAKECHAIN: return fakenet_config;
-        default: throw cpptrace::runtime_error{"Invalid network type"};
+        default: throw oxen::runtime_error{"Invalid network type"};
     }
 }
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -40,7 +40,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
-#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "common/boost_serialization_helper.h"

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -339,7 +339,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems() {
         start_height_options.push_back(sqlite_height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw oxen::logic_error("Blockchain missing SQLite Database");
+            throw oxen::traced<std::logic_error>("Blockchain missing SQLite Database");
     }
     // If the batching database falls behind it NEEDS the service node list information at that
     // point in time
@@ -531,7 +531,7 @@ bool Blockchain::init(
     m_nettype = test_options != NULL ? network_type::FAKECHAIN : nettype;
 
     if (!m_checkpoints.init(m_nettype, m_db))
-        throw oxen::runtime_error("Failed to initialize checkpoints");
+        throw oxen::traced<std::runtime_error>("Failed to initialize checkpoints");
 
     m_l2_tracker                          = std::make_shared<L2Tracker>(m_nettype);
     m_l2_tracker->provider.connectTimeout = 2000ms;
@@ -578,7 +578,7 @@ bool Blockchain::init(
         m_sqlite_db = std::move(sqlite_db);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw oxen::logic_error("Blockchain missing SQLite Database");
+            throw oxen::traced<std::logic_error>("Blockchain missing SQLite Database");
     }
 
     // if the blockchain is new, add the genesis block
@@ -665,7 +665,7 @@ bool Blockchain::init(
                 m_db->pop_block(popped_block, popped_txs);
                 if (!m_service_node_list.pop_batching_rewards_block(popped_block)) {
                     log::error(logcat, "Failed to pop to batch rewards DB. throwing");
-                    throw oxen::runtime_error("Failed to pop to batch reward DB.");
+                    throw oxen::traced<std::runtime_error>("Failed to pop to batch reward DB.");
                 }
             }
             // anything that could cause this to throw is likely catastrophic,
@@ -856,7 +856,7 @@ block Blockchain::pop_block_from_blockchain(bool pop_batching_rewards = true) {
 
     if (pop_batching_rewards && !m_service_node_list.pop_batching_rewards_block(popped_block)) {
         log::error(logcat, "Failed to pop to batch rewards DB");
-        throw oxen::runtime_error("Failed to pop batch rewards DB");
+        throw oxen::traced<std::runtime_error>("Failed to pop batch rewards DB");
     }
 
     m_ons_db.block_detach(*this, m_db->height());
@@ -1011,7 +1011,7 @@ bool Blockchain::get_block_by_hash(const crypto::hash& h, block& blk, bool* orph
         if (m_db->get_alt_block(h, &data, &blob, nullptr /*checkpoint*/)) {
             if (!cryptonote::parse_and_validate_block_from_blob(blob, blk)) {
                 log::error(logcat, "Found block {} in alt chain, but failed to parse it", h);
-                throw oxen::runtime_error("Found block in alt chain, but failed to parse it");
+                throw oxen::traced<std::runtime_error>("Found block in alt chain, but failed to parse it");
             }
             if (orphan)
                 *orphan = true;
@@ -1502,7 +1502,7 @@ bool Blockchain::validate_miner_transaction(
             batched_sn_payments = m_sqlite_db->get_sn_payments(height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw oxen::logic_error("Blockchain missing SQLite Database");
+            throw oxen::traced<std::logic_error>("Blockchain missing SQLite Database");
     }
     miner_tx_info hook_data{b, reward_parts, batched_sn_payments};
     for (const auto& hook : m_validate_miner_tx_hooks) {
@@ -3170,7 +3170,7 @@ size_t get_transaction_version(const std::string& bd) {
     const char* end = begin + bd.size();
     int read = tools::read_varint(begin, end, version);
     if (read <= 0)
-        throw oxen::runtime_error("Internal error getting transaction version");
+        throw oxen::traced<std::runtime_error>("Internal error getting transaction version");
     return version;
 }
 //------------------------------------------------------------------
@@ -5356,7 +5356,7 @@ bool Blockchain::handle_block_to_main_chain(
         }
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw oxen::logic_error("Blockchain missing SQLite Database");
+            throw oxen::traced<std::logic_error>("Blockchain missing SQLite Database");
     }
 
     if (hf_version >= cryptonote::feature::ETH_BLS)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1583,7 +1583,7 @@ bool Blockchain::validate_miner_transaction(
         base_reward = money_in_use - reward_parts.miner_fee;
     }
 
-    if (version >= cryptonote::feature::ETH_BLS && b.l2_height < m_l2_tracker->get_last_l2_height()) {
+    if (version >= feature::ETH_BLS && b.l2_height < m_l2_tracker->get_last_l2_height()) {
         log::error(logcat, "block l2 height needs to be above the last blocks l2 height, l2_height: {} last_height: {}", b.l2_height, m_l2_tracker->get_last_l2_height());
         return false;
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -47,7 +47,7 @@
 #include "common/guts.h"
 #include "common/lock.h"
 #include "common/median.h"
-#include "common/meta.h"
+#include "common/exception.h"
 #include "common/pruning.h"
 #include "common/rules.h"
 #include "common/sha256sum.h"
@@ -340,7 +340,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems() {
         start_height_options.push_back(sqlite_height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw cpptrace::logic_error("Blockchain missing SQLite Database");
+            throw oxen::logic_error("Blockchain missing SQLite Database");
     }
     // If the batching database falls behind it NEEDS the service node list information at that
     // point in time
@@ -532,7 +532,7 @@ bool Blockchain::init(
     m_nettype = test_options != NULL ? network_type::FAKECHAIN : nettype;
 
     if (!m_checkpoints.init(m_nettype, m_db))
-        throw cpptrace::runtime_error("Failed to initialize checkpoints");
+        throw oxen::runtime_error("Failed to initialize checkpoints");
 
     m_l2_tracker                          = std::make_shared<L2Tracker>(m_nettype);
     m_l2_tracker->provider.connectTimeout = 2000ms;
@@ -579,7 +579,7 @@ bool Blockchain::init(
         m_sqlite_db = std::move(sqlite_db);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw cpptrace::logic_error("Blockchain missing SQLite Database");
+            throw oxen::logic_error("Blockchain missing SQLite Database");
     }
 
     // if the blockchain is new, add the genesis block
@@ -666,7 +666,7 @@ bool Blockchain::init(
                 m_db->pop_block(popped_block, popped_txs);
                 if (!m_service_node_list.pop_batching_rewards_block(popped_block)) {
                     log::error(logcat, "Failed to pop to batch rewards DB. throwing");
-                    throw cpptrace::runtime_error("Failed to pop to batch reward DB.");
+                    throw oxen::runtime_error("Failed to pop to batch reward DB.");
                 }
             }
             // anything that could cause this to throw is likely catastrophic,
@@ -857,7 +857,7 @@ block Blockchain::pop_block_from_blockchain(bool pop_batching_rewards = true) {
 
     if (pop_batching_rewards && !m_service_node_list.pop_batching_rewards_block(popped_block)) {
         log::error(logcat, "Failed to pop to batch rewards DB");
-        throw cpptrace::runtime_error("Failed to pop batch rewards DB");
+        throw oxen::runtime_error("Failed to pop batch rewards DB");
     }
 
     m_ons_db.block_detach(*this, m_db->height());
@@ -1012,7 +1012,7 @@ bool Blockchain::get_block_by_hash(const crypto::hash& h, block& blk, bool* orph
         if (m_db->get_alt_block(h, &data, &blob, nullptr /*checkpoint*/)) {
             if (!cryptonote::parse_and_validate_block_from_blob(blob, blk)) {
                 log::error(logcat, "Found block {} in alt chain, but failed to parse it", h);
-                throw cpptrace::runtime_error("Found block in alt chain, but failed to parse it");
+                throw oxen::runtime_error("Found block in alt chain, but failed to parse it");
             }
             if (orphan)
                 *orphan = true;
@@ -1503,7 +1503,7 @@ bool Blockchain::validate_miner_transaction(
             batched_sn_payments = m_sqlite_db->get_sn_payments(height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw cpptrace::logic_error("Blockchain missing SQLite Database");
+            throw oxen::logic_error("Blockchain missing SQLite Database");
     }
     miner_tx_info hook_data{b, reward_parts, batched_sn_payments};
     for (const auto& hook : m_validate_miner_tx_hooks) {
@@ -3171,7 +3171,7 @@ size_t get_transaction_version(const std::string& bd) {
     const char* end = begin + bd.size();
     int read = tools::read_varint(begin, end, version);
     if (read <= 0)
-        throw cpptrace::runtime_error("Internal error getting transaction version");
+        throw oxen::runtime_error("Internal error getting transaction version");
     return version;
 }
 //------------------------------------------------------------------
@@ -5357,7 +5357,7 @@ bool Blockchain::handle_block_to_main_chain(
         }
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw cpptrace::logic_error("Blockchain missing SQLite Database");
+            throw oxen::logic_error("Blockchain missing SQLite Database");
     }
 
     if (hf_version >= cryptonote::feature::ETH_BLS)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/blockchain_db.h"
 #include "common/boost_serialization_helper.h"
@@ -339,7 +340,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems() {
         start_height_options.push_back(sqlite_height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw std::logic_error("Blockchain missing SQLite Database");
+            throw cpptrace::logic_error("Blockchain missing SQLite Database");
     }
     // If the batching database falls behind it NEEDS the service node list information at that
     // point in time
@@ -531,7 +532,7 @@ bool Blockchain::init(
     m_nettype = test_options != NULL ? network_type::FAKECHAIN : nettype;
 
     if (!m_checkpoints.init(m_nettype, m_db))
-        throw std::runtime_error("Failed to initialize checkpoints");
+        throw cpptrace::runtime_error("Failed to initialize checkpoints");
 
     m_l2_tracker                          = std::make_shared<L2Tracker>(m_nettype);
     m_l2_tracker->provider.connectTimeout = 2000ms;
@@ -578,7 +579,7 @@ bool Blockchain::init(
         m_sqlite_db = std::move(sqlite_db);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw std::logic_error("Blockchain missing SQLite Database");
+            throw cpptrace::logic_error("Blockchain missing SQLite Database");
     }
 
     // if the blockchain is new, add the genesis block
@@ -665,7 +666,7 @@ bool Blockchain::init(
                 m_db->pop_block(popped_block, popped_txs);
                 if (!m_service_node_list.pop_batching_rewards_block(popped_block)) {
                     log::error(logcat, "Failed to pop to batch rewards DB. throwing");
-                    throw std::runtime_error("Failed to pop to batch reward DB.");
+                    throw cpptrace::runtime_error("Failed to pop to batch reward DB.");
                 }
             }
             // anything that could cause this to throw is likely catastrophic,
@@ -856,7 +857,7 @@ block Blockchain::pop_block_from_blockchain(bool pop_batching_rewards = true) {
 
     if (pop_batching_rewards && !m_service_node_list.pop_batching_rewards_block(popped_block)) {
         log::error(logcat, "Failed to pop to batch rewards DB");
-        throw std::runtime_error("Failed to pop batch rewards DB");
+        throw cpptrace::runtime_error("Failed to pop batch rewards DB");
     }
 
     m_ons_db.block_detach(*this, m_db->height());
@@ -1011,7 +1012,7 @@ bool Blockchain::get_block_by_hash(const crypto::hash& h, block& blk, bool* orph
         if (m_db->get_alt_block(h, &data, &blob, nullptr /*checkpoint*/)) {
             if (!cryptonote::parse_and_validate_block_from_blob(blob, blk)) {
                 log::error(logcat, "Found block {} in alt chain, but failed to parse it", h);
-                throw std::runtime_error("Found block in alt chain, but failed to parse it");
+                throw cpptrace::runtime_error("Found block in alt chain, but failed to parse it");
             }
             if (orphan)
                 *orphan = true;
@@ -1502,7 +1503,7 @@ bool Blockchain::validate_miner_transaction(
             batched_sn_payments = m_sqlite_db->get_sn_payments(height);
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw std::logic_error("Blockchain missing SQLite Database");
+            throw cpptrace::logic_error("Blockchain missing SQLite Database");
     }
     miner_tx_info hook_data{b, reward_parts, batched_sn_payments};
     for (const auto& hook : m_validate_miner_tx_hooks) {
@@ -3170,7 +3171,7 @@ size_t get_transaction_version(const std::string& bd) {
     const char* end = begin + bd.size();
     int read = tools::read_varint(begin, end, version);
     if (read <= 0)
-        throw std::runtime_error("Internal error getting transaction version");
+        throw cpptrace::runtime_error("Internal error getting transaction version");
     return version;
 }
 //------------------------------------------------------------------
@@ -5356,7 +5357,7 @@ bool Blockchain::handle_block_to_main_chain(
         }
     } else {
         if (m_nettype != network_type::FAKECHAIN)
-            throw std::logic_error("Blockchain missing SQLite Database");
+            throw cpptrace::logic_error("Blockchain missing SQLite Database");
     }
 
     if (hf_version >= cryptonote::feature::ETH_BLS)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2032,13 +2032,13 @@ void Blockchain::add_ethereum_transactions_to_tx_pool() {
                             contributors.emplace_back(contributor.addr, contributor.amount);
 
                         tx_extra_ethereum_new_service_node new_service_node = {
-                                0,
-                                arg.bls_pubkey,
-                                arg.eth_address,
-                                arg.sn_pubkey,
-                                arg.sn_signature,
-                                arg.fee,
-                                contributors};
+                                .version = 0,
+                                .bls_pubkey = arg.bls_pubkey,
+                                .eth_address = arg.eth_address,
+                                .service_node_pubkey = arg.sn_pubkey,
+                                .signature = arg.sn_signature,
+                                .fee = arg.fee,
+                                .contributors = contributors};
                         cryptonote::add_new_service_node_to_tx_extra(tx.extra, new_service_node);
 
                     } else if constexpr (std::is_same_v<T, ServiceNodeLeaveRequestTx>) {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2036,7 +2036,7 @@ void Blockchain::add_ethereum_transactions_to_tx_pool() {
                                 .bls_pubkey = arg.bls_pubkey,
                                 .eth_address = arg.eth_address,
                                 .service_node_pubkey = arg.sn_pubkey,
-                                .signature = arg.sn_signature,
+                                .signature = arg.ed_signature,
                                 .fee = arg.fee,
                                 .contributors = contributors};
                         cryptonote::add_new_service_node_to_tx_extra(tx.extra, new_service_node);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -40,6 +40,7 @@
 #include <csignal>
 #include <iomanip>
 #include <unordered_set>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/guts.h"
 
@@ -211,7 +212,7 @@ static const command_line::arg_descriptor<uint64_t> arg_store_quorum_history = {
 // Loads stubs that fail if invoked.  The stubs are replaced in the
 // cryptonote_protocol/quorumnet.cpp glue code.
 [[noreturn]] static void need_core_init(std::string_view stub_name) {
-    throw std::logic_error(
+    throw cpptrace::logic_error(
             "Internal error: core callback initialization was not performed for "s +
             std::string(stub_name));
 }
@@ -1013,9 +1014,9 @@ bool core::init_service_keys() {
             sc_reduce32(pk_sh_data);
             std::memcpy(keys.key.data(), pk_sh_data, 32);
             if (!crypto::secret_key_to_public_key(keys.key, keys.pub))
-                throw std::runtime_error{"Failed to derive primary key from ed25519 key"};
+                throw cpptrace::runtime_error{"Failed to derive primary key from ed25519 key"};
             if (std::memcmp(keys.pub.data(), keys.pub_ed25519.data(), 32))
-                throw std::runtime_error{
+                throw cpptrace::runtime_error{
                         "Internal error: unexpected primary pubkey and ed25519 pubkey mismatch"};
         } else if (!init_key(
                            m_config_folder / "key",
@@ -1023,7 +1024,7 @@ bool core::init_service_keys() {
                            keys.pub,
                            crypto::secret_key_to_public_key,
                            [](crypto::secret_key& key, crypto::public_key& pubkey) {
-                               throw std::runtime_error{
+                               throw cpptrace::runtime_error{
                                        "Internal error: old-style public keys are no longer "
                                        "generated"};
                            }))
@@ -1166,7 +1167,7 @@ std::vector<crypto::bls_public_key> core::get_removable_nodes() {
                     "Failed to get the latest block at {} to determine the removable Service Nodes"_format(
                             oxen_height);
             log::error(logcat, "{}", msg);
-            throw std::runtime_error{msg};
+            throw cpptrace::runtime_error{std::move(msg)};
         }
         l2_height = blocks[0].l2_height;
     }
@@ -2129,10 +2130,10 @@ bool core::handle_uptime_proof(
         // should be non-zero.
         if (m_nettype == network_type::DEVNET) {
             if (proof->storage_omq_port != 0 || proof->storage_https_port != 0)
-                throw std::runtime_error{"Invalid storage port(s) in proof: devnet storage ports must be 0"};
+                throw oxen::runtime_error{"Invalid storage port(s) in proof: devnet storage ports must be 0"};
         } else {
             if (proof->storage_omq_port == 0 || proof->storage_https_port == 0)
-                throw std::runtime_error{"Invalid storage port(s) in proof: storage ports cannot be 0"};
+                throw oxen::runtime_error{"Invalid storage port(s) in proof: storage ports cannot be 0"};
         }
 
     } catch (const std::exception& e) {
@@ -2289,7 +2290,7 @@ block_complete_entry get_block_complete_entry(block& b, tx_memory_pool& pool) {
         std::string txblob;
         if (!pool.get_transaction(tx_hash, txblob) || txblob.size() == 0) {
             oxen::log::error(logcat, "Transaction {} not found in pool", tx_hash);
-            throw std::runtime_error("Transaction not found in pool");
+            throw cpptrace::runtime_error("Transaction not found in pool");
         }
         bce.txs.push_back(txblob);
     }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -52,7 +52,7 @@ extern "C" {
 
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/sqlite/db_sqlite.h"
-#include "bls/bls_utils.h"
+#include "bls/bls_signer.h"
 #include "checkpoints/checkpoints.h"
 #include "common/base58.h"
 #include "common/command_line.h"

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -988,7 +988,7 @@ bool core::init_service_keys() {
                     sk = bls_signer->getCryptoSeckey();
                     pk = bls_signer->getCryptoPubkey();
                 },
-                keys.bls_signer))
+                m_bls_signer))
         return false;
 
     // Legacy primary SN key file; we only load this if it exists, otherwise we use `key_ed25519`
@@ -2090,6 +2090,7 @@ bool core::submit_uptime_proof() {
     if (!m_service_node)
         return true;
 
+    assert(m_bls_signer.get() && "Service Nodes have a BLS signer defined");
     try {
         cryptonote_connection_context fake_context{};
         bool relayed;
@@ -2103,7 +2104,8 @@ bool core::submit_uptime_proof() {
                 storage_omq_port(),
                 ss_version,
                 m_quorumnet_port,
-                lokinet_version);
+                lokinet_version,
+                *m_bls_signer.get());
         auto req = proof.generate_request(hf_version);
         relayed = get_protocol()->relay_uptime_proof(req, fake_context);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -212,7 +212,7 @@ static const command_line::arg_descriptor<uint64_t> arg_store_quorum_history = {
 // Loads stubs that fail if invoked.  The stubs are replaced in the
 // cryptonote_protocol/quorumnet.cpp glue code.
 [[noreturn]] static void need_core_init(std::string_view stub_name) {
-    throw oxen::logic_error(
+    throw oxen::traced<std::logic_error>(
             "Internal error: core callback initialization was not performed for "s +
             std::string(stub_name));
 }
@@ -1014,9 +1014,9 @@ bool core::init_service_keys() {
             sc_reduce32(pk_sh_data);
             std::memcpy(keys.key.data(), pk_sh_data, 32);
             if (!crypto::secret_key_to_public_key(keys.key, keys.pub))
-                throw oxen::runtime_error{"Failed to derive primary key from ed25519 key"};
+                throw oxen::traced<std::runtime_error>{"Failed to derive primary key from ed25519 key"};
             if (std::memcmp(keys.pub.data(), keys.pub_ed25519.data(), 32))
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "Internal error: unexpected primary pubkey and ed25519 pubkey mismatch"};
         } else if (!init_key(
                            m_config_folder / "key",
@@ -1024,7 +1024,7 @@ bool core::init_service_keys() {
                            keys.pub,
                            crypto::secret_key_to_public_key,
                            [](crypto::secret_key& key, crypto::public_key& pubkey) {
-                               throw oxen::runtime_error{
+                               throw oxen::traced<std::runtime_error>{
                                        "Internal error: old-style public keys are no longer "
                                        "generated"};
                            }))
@@ -1167,7 +1167,7 @@ std::vector<crypto::bls_public_key> core::get_removable_nodes() {
                     "Failed to get the latest block at {} to determine the removable Service Nodes"_format(
                             oxen_height);
             log::error(logcat, "{}", msg);
-            throw oxen::runtime_error{std::move(msg)};
+            throw oxen::traced<std::runtime_error>{std::move(msg)};
         }
         l2_height = blocks[0].l2_height;
     }
@@ -2132,10 +2132,10 @@ bool core::handle_uptime_proof(
         // should be non-zero.
         if (m_nettype == network_type::DEVNET) {
             if (proof->storage_omq_port != 0 || proof->storage_https_port != 0)
-                throw oxen::runtime_error{"Invalid storage port(s) in proof: devnet storage ports must be 0"};
+                throw oxen::traced<std::runtime_error>{"Invalid storage port(s) in proof: devnet storage ports must be 0"};
         } else {
             if (proof->storage_omq_port == 0 || proof->storage_https_port == 0)
-                throw oxen::runtime_error{"Invalid storage port(s) in proof: storage ports cannot be 0"};
+                throw oxen::traced<std::runtime_error>{"Invalid storage port(s) in proof: storage ports cannot be 0"};
         }
 
     } catch (const std::exception& e) {
@@ -2292,7 +2292,7 @@ block_complete_entry get_block_complete_entry(block& b, tx_memory_pool& pool) {
         std::string txblob;
         if (!pool.get_transaction(tx_hash, txblob) || txblob.size() == 0) {
             oxen::log::error(logcat, "Transaction {} not found in pool", tx_hash);
-            throw oxen::runtime_error("Transaction not found in pool");
+            throw oxen::traced<std::runtime_error>("Transaction not found in pool");
         }
         bce.txs.push_back(txblob);
     }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -40,7 +40,7 @@
 #include <csignal>
 #include <iomanip>
 #include <unordered_set>
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 #include "common/guts.h"
 
@@ -212,7 +212,7 @@ static const command_line::arg_descriptor<uint64_t> arg_store_quorum_history = {
 // Loads stubs that fail if invoked.  The stubs are replaced in the
 // cryptonote_protocol/quorumnet.cpp glue code.
 [[noreturn]] static void need_core_init(std::string_view stub_name) {
-    throw cpptrace::logic_error(
+    throw oxen::logic_error(
             "Internal error: core callback initialization was not performed for "s +
             std::string(stub_name));
 }
@@ -1014,9 +1014,9 @@ bool core::init_service_keys() {
             sc_reduce32(pk_sh_data);
             std::memcpy(keys.key.data(), pk_sh_data, 32);
             if (!crypto::secret_key_to_public_key(keys.key, keys.pub))
-                throw cpptrace::runtime_error{"Failed to derive primary key from ed25519 key"};
+                throw oxen::runtime_error{"Failed to derive primary key from ed25519 key"};
             if (std::memcmp(keys.pub.data(), keys.pub_ed25519.data(), 32))
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Internal error: unexpected primary pubkey and ed25519 pubkey mismatch"};
         } else if (!init_key(
                            m_config_folder / "key",
@@ -1024,7 +1024,7 @@ bool core::init_service_keys() {
                            keys.pub,
                            crypto::secret_key_to_public_key,
                            [](crypto::secret_key& key, crypto::public_key& pubkey) {
-                               throw cpptrace::runtime_error{
+                               throw oxen::runtime_error{
                                        "Internal error: old-style public keys are no longer "
                                        "generated"};
                            }))
@@ -1167,7 +1167,7 @@ std::vector<crypto::bls_public_key> core::get_removable_nodes() {
                     "Failed to get the latest block at {} to determine the removable Service Nodes"_format(
                             oxen_height);
             log::error(logcat, "{}", msg);
-            throw cpptrace::runtime_error{std::move(msg)};
+            throw oxen::runtime_error{std::move(msg)};
         }
         l2_height = blocks[0].l2_height;
     }
@@ -2290,7 +2290,7 @@ block_complete_entry get_block_complete_entry(block& b, tx_memory_pool& pool) {
         std::string txblob;
         if (!pool.get_transaction(tx_hash, txblob) || txblob.size() == 0) {
             oxen::log::error(logcat, "Transaction {} not found in pool", tx_hash);
-            throw cpptrace::runtime_error("Transaction not found in pool");
+            throw oxen::runtime_error("Transaction not found in pool");
         }
         bce.txs.push_back(txblob);
     }

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -25,11 +25,11 @@
 #include <ctime>
 #include <future>
 #include <mutex>
-#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain.h"
 #include "bls/bls_aggregator.h"
 #include "common/command_line.h"
+#include "common/exception.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/connection_context.h"
@@ -753,7 +753,7 @@ class core : public i_miner_handler {
     /// node.
     BLSSigner& get_bls_signer() {
         if (!m_bls_signer)
-            throw cpptrace::logic_error{"Not a service node: no BLS Signer available"};
+            throw oxen::logic_error{"Not a service node: no BLS Signer available"};
         return *m_bls_signer;
     }
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <future>
 #include <mutex>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain.h"
 #include "bls/bls_aggregator.h"
@@ -752,7 +753,7 @@ class core : public i_miner_handler {
     /// node.
     BLSSigner& get_bls_signer() {
         if (!m_bls_signer)
-            throw std::logic_error{"Not a service node: no BLS Signer available"};
+            throw cpptrace::logic_error{"Not a service node: no BLS Signer available"};
         return *m_bls_signer;
     }
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -753,7 +753,7 @@ class core : public i_miner_handler {
     /// node.
     BLSSigner& get_bls_signer() {
         if (!m_bls_signer)
-            throw oxen::logic_error{"Not a service node: no BLS Signer available"};
+            throw oxen::traced<std::logic_error>{"Not a service node: no BLS Signer available"};
         return *m_bls_signer;
     }
 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -29,13 +29,15 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
-#include <boost/serialization/utility.hpp>
-#include <boost/serialization/vector.hpp>
-
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/verification_context.h"
 #include "cryptonote_core/service_node_list.h"
 #include "ringct/rctOps.h"
+
+#include <common/exception.h>
+
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
 
 namespace cryptonote {
 //---------------------------------------------------------------
@@ -219,7 +221,7 @@ struct tx_source_entry {
     FIELD(multisig_kLRki)
 
     if (real_output >= outputs.size())
-        throw cpptrace::invalid_argument{"invalid real_output size"};
+        throw oxen::invalid_argument{"invalid real_output size"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -219,7 +219,7 @@ struct tx_source_entry {
     FIELD(multisig_kLRki)
 
     if (real_output >= outputs.size())
-        throw std::invalid_argument{"invalid real_output size"};
+        throw cpptrace::invalid_argument{"invalid real_output size"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -221,7 +221,7 @@ struct tx_source_entry {
     FIELD(multisig_kLRki)
 
     if (real_output >= outputs.size())
-        throw oxen::invalid_argument{"invalid real_output size"};
+        throw oxen::traced<std::invalid_argument>{"invalid real_output size"};
     END_SERIALIZE()
 };
 

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -1200,7 +1200,7 @@ mapping_value::mapping_value() : buffer{0}, encrypted(false), len(0) {}
 
 std::string name_hash_bytes_to_base64(std::string_view bytes) {
     if (bytes.size() != NAME_HASH_SIZE)
-        throw oxen::runtime_error{"Invalid name hash: expected exactly 32 bytes"};
+        throw oxen::traced<std::runtime_error>{"Invalid name hash: expected exactly 32 bytes"};
     return oxenc::to_base64(bytes);
 }
 

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -16,6 +16,7 @@
 #include <cpptrace/cpptrace.hpp>
 
 #include "common/oxen.h"
+#include "common/exception.h"
 #include "common/string_util.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -1199,7 +1200,7 @@ mapping_value::mapping_value() : buffer{0}, encrypted(false), len(0) {}
 
 std::string name_hash_bytes_to_base64(std::string_view bytes) {
     if (bytes.size() != NAME_HASH_SIZE)
-        throw cpptrace::runtime_error{"Invalid name hash: expected exactly 32 bytes"};
+        throw oxen::runtime_error{"Invalid name hash: expected exactly 32 bytes"};
     return oxenc::to_base64(bytes);
 }
 

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <variant>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/oxen.h"
 #include "common/string_util.h"
@@ -1198,7 +1199,7 @@ mapping_value::mapping_value() : buffer{0}, encrypted(false), len(0) {}
 
 std::string name_hash_bytes_to_base64(std::string_view bytes) {
     if (bytes.size() != NAME_HASH_SIZE)
-        throw std::runtime_error{"Invalid name hash: expected exactly 32 bytes"};
+        throw cpptrace::runtime_error{"Invalid name hash: expected exactly 32 bytes"};
     return oxenc::to_base64(bytes);
 }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1537,7 +1537,6 @@ validate_and_get_ethereum_registration(
     if (!maybe_reg)
         throw oxen::runtime_error("Could not extract registration details from transaction");
     auto& reg = *maybe_reg;
-
     uint64_t staking_requirement = get_staking_requirement(nettype, block_height);
 
     validate_registration(hf_version, nettype, staking_requirement, block_timestamp, reg);
@@ -3992,6 +3991,17 @@ bool service_node_list::handle_uptime_proof(
 
     if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
         x25519_pkey = derived_x25519_pubkey;
+
+    if (vers.first == hf::hf20_eth_transition) {
+        // NOTE: In the transition, we're collecting the BLS pubkeys, we will persist these into the
+        // service node info to bootstrap the keys. Post transition, Arbitrum is activated and BLS
+        // keys of a node will be available in the registration and updated when a node is
+        // registered.
+        if (it->second->bls_public_key != proof->pubkey_bls) {
+            auto& info = duplicate_info(it->second);
+            info.bls_public_key = proof->pubkey_bls;
+        }
+    }
 
     return true;
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3939,12 +3939,40 @@ bool service_node_list::handle_uptime_proof(
 
     if (now <= std::chrono::system_clock::from_time_t(iproof.timestamp) +
                        std::chrono::seconds{netconf.UPTIME_PROOF_FREQUENCY} / 2) {
-        log::debug(
-                logcat,
-                "Rejecting uptime proof from {}: already received one uptime proof for this node "
-                "recently",
-                proof->pubkey);
-        return false;
+
+        bool override_timestamp_frequency = false;
+
+        // NOTE: In the local devnet we rapidly advance past multiple hard-forks to reach the
+        // ETH_TRANSITION hardfork. At this hard-fork the BLS keys are transmitted around the
+        // network with a proof-of-possession ensuring that each node that will participate in the
+        // new network will be added to the new network under their new moniker.
+        //
+        // The local-devnet reaches the transition stage very quickly (<1min) and has a need to
+        // re-submit uptime proofs upon entering the transition hardfork. This time-gate blocks the
+        // uptime proofs from propagating and causes the devnet to migrate the Ethereum w/ no BLS
+        // keys populated.
+        //
+        // This causes all BLS requests like rewards claim to fail. Having this check here
+        // overides that and ensures that in the devnet, when we arrive at the hardfork we're
+        // permitted to submit the proof with the keys.
+        //
+        // Note that prior to this branch here, the key has been validated to be non-null and that
+        // the node has the secret key. This code will only permit an 'early' proof if the
+        // receipient has not received the BLS key for the sender yet.
+#if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
+        if (vers.first == feature::ETH_TRANSITION)
+            override_timestamp_frequency =
+                    it->second->bls_public_key == crypto::null<crypto::bls_public_key>;
+#endif
+
+        if (!override_timestamp_frequency) {
+            log::debug(
+                    logcat,
+                    "Rejecting uptime proof from {}: already received one uptime proof for this node "
+                    "recently",
+                    proof->pubkey);
+            return false;
+        }
     }
 
     if (m_service_node_keys && proof->pubkey == m_service_node_keys->pub) {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -35,7 +35,6 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
-#include <cpptrace/cpptrace.hpp>
 
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
@@ -48,6 +47,7 @@ extern "C" {
 
 #include "blockchain.h"
 #include "bls/bls_utils.h"
+#include "common/exception.h"
 #include "common/i18n.h"
 #include "common/lock.h"
 #include "common/random.h"
@@ -1475,7 +1475,7 @@ validate_and_get_ethereum_registration(
 
     auto maybe_reg = eth_reg_tx_extract_fields(hf_version, tx);
     if (!maybe_reg)
-        throw cpptrace::runtime_error("Could not extract registration details from transaction");
+        throw oxen::runtime_error("Could not extract registration details from transaction");
     auto& reg = *maybe_reg;
 
     uint64_t staking_requirement = get_staking_requirement(nettype, block_height);
@@ -1502,7 +1502,7 @@ validate_and_get_ethereum_registration(
                         logcat,
                         "Invalid registration: duplicate reserved address in registration (tx {})",
                         cryptonote::get_transaction_hash(tx));
-                throw cpptrace::runtime_error("duplicate reserved address in registration");
+                throw oxen::runtime_error("duplicate reserved address in registration");
             }
         }
 
@@ -2137,7 +2137,7 @@ void service_node_list::verify_block(
                 alt_block ? &alt_quorums : nullptr);
 
         if (!quorum)
-            throw cpptrace::runtime_error{"Failed to get testing quorum checkpoint for {} {}"_format(
+            throw oxen::runtime_error{"Failed to get testing quorum checkpoint for {} {}"_format(
                     block_type, cryptonote::get_block_hash(block))};
 
         bool failed_checkpoint_verify =
@@ -2153,7 +2153,7 @@ void service_node_list::verify_block(
         }
 
         if (failed_checkpoint_verify)
-            throw cpptrace::runtime_error{"Service node checkpoint failed verification for {} {}"_format(
+            throw oxen::runtime_error{"Service node checkpoint failed verification for {} {}"_format(
                     block_type, cryptonote::get_block_hash(block))};
     }
 
@@ -2167,7 +2167,7 @@ void service_node_list::verify_block(
         if (alt_block) {
             cryptonote::block prev_block;
             if (!find_block_in_db(m_blockchain.get_db(), block.prev_id, prev_block))
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Alt block {} references previous block {} not available in DB."_format(
                                 cryptonote::get_block_hash(block), block.prev_id)};
 
@@ -2178,7 +2178,7 @@ void service_node_list::verify_block(
         }
 
         if (!pulse::get_round_timings(m_blockchain, height, prev_timestamp, timings))
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Failed to query the block data for Pulse timings to validate incoming {} at height {}"_format(
                             block_type, height)};
     }
@@ -2254,7 +2254,7 @@ void service_node_list::verify_block(
     }
 
     if (!result)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Failed to verify block components for incoming {} at height {}"_format(
                         block_type, height)};
 }
@@ -2283,9 +2283,9 @@ void service_node_list::block_add(
             std::shared_ptr<const quorum> quorum =
                     get_quorum(quorum_type::pulse, block_height, false, nullptr);
             if (!quorum)
-                throw cpptrace::runtime_error{"Unexpected Pulse error: quorum was not generated"};
+                throw oxen::runtime_error{"Unexpected Pulse error: quorum was not generated"};
             if (quorum->validators.empty())
-                throw cpptrace::runtime_error{"Unexpected Pulse error: quorum was empty"};
+                throw oxen::runtime_error{"Unexpected Pulse error: quorum was empty"};
             for (size_t validator_index = 0;
                  validator_index < service_nodes::PULSE_QUORUM_NUM_VALIDATORS;
                  validator_index++) {
@@ -3089,7 +3089,7 @@ static void verify_coinbase_tx_output(
         cryptonote::account_public_address const& receiver,
         uint64_t reward) {
     if (output_index >= miner_tx.vout.size())
-        throw cpptrace::out_of_range{
+        throw oxen::out_of_range{
                 "Output Index: {}, indexes out of bounds in vout array with size: {}"_format(
                         output_index, miner_tx.vout.size())};
 
@@ -3100,12 +3100,12 @@ static void verify_coinbase_tx_output(
     // 1 ULP difference in the reward calculations.
     // TODO(oxen): eliminate all FP math from reward calculations
     if (!within_one(output.amount, reward))
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Service node reward amount incorrect. Should be {}, is: {}"_format(
                         cryptonote::print_money(reward), cryptonote::print_money(output.amount))};
 
     if (!std::holds_alternative<cryptonote::txout_to_key>(output.target))
-        throw cpptrace::runtime_error{"Service node output target type should be txout_to_key"};
+        throw oxen::runtime_error{"Service node output target type should be txout_to_key"};
 
     // NOTE: Loki uses the governance key in the one-time ephemeral key
     // derivation for both Pulse Block Producer/Queued Service Node Winner rewards
@@ -3114,13 +3114,13 @@ static void verify_coinbase_tx_output(
     cryptonote::keypair gov_key = cryptonote::get_deterministic_keypair_from_height(height);
 
     if (!crypto::generate_key_derivation(receiver.m_view_public_key, gov_key.sec, derivation))
-        throw cpptrace::runtime_error{"Failed to generate key derivation"};
+        throw oxen::runtime_error{"Failed to generate key derivation"};
     if (!crypto::derive_public_key(
                 derivation, output_index, receiver.m_spend_public_key, out_eph_public_key))
-        throw cpptrace::runtime_error{"Failed derive public key"};
+        throw oxen::runtime_error{"Failed derive public key"};
 
     if (var::get<cryptonote::txout_to_key>(output.target).key != out_eph_public_key)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Invalid service node reward at output: {}, output key, specifies wrong key"_format(
                         output_index)};
 }
@@ -3147,7 +3147,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
         auto const check_block_leader_pubkey =
                 cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
         if (block_leader.key != check_block_leader_pubkey)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Service node reward winner is incorrect! Expected {}, block {} hf{} has {}"_format(
                             block_leader.key,
                             height,
@@ -3180,7 +3180,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 entropy,
                 block.pulse.round);
         if (!verify_pulse_quorum_sizes(pulse_quorum))
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Pulse block received but Pulse has insufficient nodes for quorum, block hash {}, height {}"_format(
                             cryptonote::get_block_hash(block), height)};
 
@@ -3191,7 +3191,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                      : verify_mode::pulse_different_block_producer;
 
         if (block.pulse.round == 0 && (mode == verify_mode::pulse_different_block_producer))
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "The block producer in pulse round 0 should be the same node as the block leader: {}, actual producer: {}"_format(
                             block_leader.key, block_producer_key)};
     }
@@ -3238,7 +3238,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
         case verify_mode::pulse_different_block_producer: {
             auto info_it = m_state.service_nodes_infos.find(block_producer_key);
             if (info_it == m_state.service_nodes_infos.end())
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "The pulse block producer for round {:d} is not current a Service Node: {}"_format(
                                 block.pulse.round, block_producer_key)};
 
@@ -3268,7 +3268,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
     }
 
     if (miner_tx.vout.size() != expected_vouts_size)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Expected {} block, the miner TX specifies a different amount of outputs vs the expected: {}, miner tx outputs: {}"_format(
                         mode == verify_mode::miner                            ? "miner"sv
                         : mode == verify_mode::batched_sn_rewards             ? "batch reward"sv
@@ -3281,7 +3281,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                         miner_tx.vout.size())};
 
     if (hf_version >= hf::hf16_pulse && reward_parts.base_miner != 0)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Miner reward is incorrect expected 0 reward, block specified {}"_format(
                         cryptonote::print_money(reward_parts.base_miner))};
 
@@ -3376,19 +3376,19 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 const auto& batch_payment = batched_sn_payments[vout_index];
 
                 if (!std::holds_alternative<cryptonote::txout_to_key>(vout.target))
-                    throw cpptrace::runtime_error{
+                    throw oxen::runtime_error{
                             "Service node output target type should be txout_to_key"};
 
                 constexpr uint64_t max_amount =
                         std::numeric_limits<uint64_t>::max() / cryptonote::BATCH_REWARD_FACTOR;
                 if (vout.amount > max_amount)
-                    throw cpptrace::runtime_error{
+                    throw oxen::runtime_error{
                             "Batched reward payout invalid: exceeds maximum possible payout size"};
 
                 auto paid_amount = vout.amount * cryptonote::BATCH_REWARD_FACTOR;
                 total_payout_in_vouts += paid_amount;
                 if (paid_amount != batch_payment.amount)
-                    throw cpptrace::runtime_error{
+                    throw oxen::runtime_error{
                             "Batched reward payout incorrect: expected {}, not {}"_format(
                                     batch_payment.amount, paid_amount)};
 
@@ -3398,16 +3398,16 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                             deterministic_keypair,
                             vout_index,
                             out_eph_public_key))
-                    throw cpptrace::runtime_error{"Failed to generate output one-time public key"};
+                    throw oxen::runtime_error{"Failed to generate output one-time public key"};
 
                 const auto& out_to_key = var::get<cryptonote::txout_to_key>(vout.target);
                 if (tools::view_guts(out_to_key) != tools::view_guts(out_eph_public_key))
-                    throw cpptrace::runtime_error{
+                    throw oxen::runtime_error{
                             "Output Ephermeral Public Key does not match (payment to wrong "
                             "recipient)"};
             }
             if (total_payout_in_vouts != total_payout_in_our_db)
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Total service node reward amount incorrect: expected {}, not {}"_format(
                                 total_payout_in_our_db, total_payout_in_vouts)};
         } break;
@@ -3456,11 +3456,11 @@ void service_node_list::alt_block_add(const cryptonote::block_add_info& info) {
     }
 
     if (!starting_state)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Received alt block but couldn't find parent state in historical state"};
 
     if (starting_state->block_hash != block.prev_id)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Unexpected state_t's hash: {}, does not match the block prev hash: {}"_format(
                         starting_state->block_hash, block.prev_id)};
 
@@ -4044,7 +4044,7 @@ crypto::public_key service_node_list::bls_public_key_lookup(
 
     if (!found) {
         log::error(logcat, "Could not find bls pubkey: {}", bls_pubkey);
-        throw cpptrace::runtime_error("Could not find bls key");
+        throw oxen::runtime_error("Could not find bls key");
     }
 
     return found_pk;
@@ -4173,7 +4173,7 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
         block_hash{state.block_hash},
         sn_list{snl} {
     if (!sn_list)
-        throw cpptrace::logic_error("Cannot deserialize a state_t without a service_node_list");
+        throw oxen::logic_error("Cannot deserialize a state_t without a service_node_list");
     if (state.version == state_serialized::version_t::version_0)
         block_hash = sn_list->m_blockchain.get_block_id_by_height(height);
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1535,7 +1535,7 @@ validate_and_get_ethereum_registration(
 
     auto maybe_reg = eth_reg_tx_extract_fields(hf_version, tx);
     if (!maybe_reg)
-        throw oxen::runtime_error("Could not extract registration details from transaction");
+        throw oxen::traced<std::runtime_error>("Could not extract registration details from transaction");
     auto& reg = *maybe_reg;
     uint64_t staking_requirement = get_staking_requirement(nettype, block_height);
 
@@ -1557,7 +1557,7 @@ validate_and_get_ethereum_registration(
         auto& [addr, amount] = *it;
         for (auto it2 = std::next(it); it2 != reg.eth_contributions.end(); ++it2) {
             if (it2->first == addr) {
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Invalid registration: Duplicate reserved address in registration in "
                         "transaction '{}':\n{}"_format(
                         cryptonote::get_transaction_hash(tx),
@@ -2196,7 +2196,7 @@ void service_node_list::verify_block(
                 alt_block ? &alt_quorums : nullptr);
 
         if (!quorum)
-            throw oxen::runtime_error{"Failed to get testing quorum checkpoint for {} {}"_format(
+            throw oxen::traced<std::runtime_error>{"Failed to get testing quorum checkpoint for {} {}"_format(
                     block_type, cryptonote::get_block_hash(block))};
 
         bool failed_checkpoint_verify =
@@ -2212,7 +2212,7 @@ void service_node_list::verify_block(
         }
 
         if (failed_checkpoint_verify)
-            throw oxen::runtime_error{"Service node checkpoint failed verification for {} {}"_format(
+            throw oxen::traced<std::runtime_error>{"Service node checkpoint failed verification for {} {}"_format(
                     block_type, cryptonote::get_block_hash(block))};
     }
 
@@ -2226,7 +2226,7 @@ void service_node_list::verify_block(
         if (alt_block) {
             cryptonote::block prev_block;
             if (!find_block_in_db(m_blockchain.get_db(), block.prev_id, prev_block))
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "Alt block {} references previous block {} not available in DB."_format(
                                 cryptonote::get_block_hash(block), block.prev_id)};
 
@@ -2237,7 +2237,7 @@ void service_node_list::verify_block(
         }
 
         if (!pulse::get_round_timings(m_blockchain, height, prev_timestamp, timings))
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Failed to query the block data for Pulse timings to validate incoming {} at height {}"_format(
                             block_type, height)};
     }
@@ -2313,7 +2313,7 @@ void service_node_list::verify_block(
     }
 
     if (!result)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Failed to verify block components for incoming {} at height {}"_format(
                         block_type, height)};
 }
@@ -2342,9 +2342,9 @@ void service_node_list::block_add(
             std::shared_ptr<const quorum> quorum =
                     get_quorum(quorum_type::pulse, block_height, false, nullptr);
             if (!quorum)
-                throw oxen::runtime_error{"Unexpected Pulse error: quorum was not generated"};
+                throw oxen::traced<std::runtime_error>{"Unexpected Pulse error: quorum was not generated"};
             if (quorum->validators.empty())
-                throw oxen::runtime_error{"Unexpected Pulse error: quorum was empty"};
+                throw oxen::traced<std::runtime_error>{"Unexpected Pulse error: quorum was empty"};
             for (size_t validator_index = 0;
                  validator_index < service_nodes::PULSE_QUORUM_NUM_VALIDATORS;
                  validator_index++) {
@@ -3148,7 +3148,7 @@ static void verify_coinbase_tx_output(
         cryptonote::account_public_address const& receiver,
         uint64_t reward) {
     if (output_index >= miner_tx.vout.size())
-        throw oxen::out_of_range{
+        throw oxen::traced<std::out_of_range>{
                 "Output Index: {}, indexes out of bounds in vout array with size: {}"_format(
                         output_index, miner_tx.vout.size())};
 
@@ -3159,12 +3159,12 @@ static void verify_coinbase_tx_output(
     // 1 ULP difference in the reward calculations.
     // TODO(oxen): eliminate all FP math from reward calculations
     if (!within_one(output.amount, reward))
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Service node reward amount incorrect. Should be {}, is: {}"_format(
                         cryptonote::print_money(reward), cryptonote::print_money(output.amount))};
 
     if (!std::holds_alternative<cryptonote::txout_to_key>(output.target))
-        throw oxen::runtime_error{"Service node output target type should be txout_to_key"};
+        throw oxen::traced<std::runtime_error>{"Service node output target type should be txout_to_key"};
 
     // NOTE: Loki uses the governance key in the one-time ephemeral key
     // derivation for both Pulse Block Producer/Queued Service Node Winner rewards
@@ -3173,13 +3173,13 @@ static void verify_coinbase_tx_output(
     cryptonote::keypair gov_key = cryptonote::get_deterministic_keypair_from_height(height);
 
     if (!crypto::generate_key_derivation(receiver.m_view_public_key, gov_key.sec, derivation))
-        throw oxen::runtime_error{"Failed to generate key derivation"};
+        throw oxen::traced<std::runtime_error>{"Failed to generate key derivation"};
     if (!crypto::derive_public_key(
                 derivation, output_index, receiver.m_spend_public_key, out_eph_public_key))
-        throw oxen::runtime_error{"Failed derive public key"};
+        throw oxen::traced<std::runtime_error>{"Failed derive public key"};
 
     if (var::get<cryptonote::txout_to_key>(output.target).key != out_eph_public_key)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Invalid service node reward at output: {}, output key, specifies wrong key"_format(
                         output_index)};
 }
@@ -3206,7 +3206,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
         auto const check_block_leader_pubkey =
                 cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
         if (block_leader.key != check_block_leader_pubkey)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Service node reward winner is incorrect! Expected {}, block {} hf{} has {}"_format(
                             block_leader.key,
                             height,
@@ -3239,7 +3239,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 entropy,
                 block.pulse.round);
         if (!verify_pulse_quorum_sizes(pulse_quorum))
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Pulse block received but Pulse has insufficient nodes for quorum, block hash {}, height {}"_format(
                             cryptonote::get_block_hash(block), height)};
 
@@ -3250,7 +3250,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                      : verify_mode::pulse_different_block_producer;
 
         if (block.pulse.round == 0 && (mode == verify_mode::pulse_different_block_producer))
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "The block producer in pulse round 0 should be the same node as the block leader: {}, actual producer: {}"_format(
                             block_leader.key, block_producer_key)};
     }
@@ -3297,7 +3297,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
         case verify_mode::pulse_different_block_producer: {
             auto info_it = m_state.service_nodes_infos.find(block_producer_key);
             if (info_it == m_state.service_nodes_infos.end())
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "The pulse block producer for round {:d} is not current a Service Node: {}"_format(
                                 block.pulse.round, block_producer_key)};
 
@@ -3327,7 +3327,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
     }
 
     if (miner_tx.vout.size() != expected_vouts_size)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Expected {} block, the miner TX specifies a different amount of outputs vs the expected: {}, miner tx outputs: {}"_format(
                         mode == verify_mode::miner                            ? "miner"sv
                         : mode == verify_mode::batched_sn_rewards             ? "batch reward"sv
@@ -3340,7 +3340,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                         miner_tx.vout.size())};
 
     if (hf_version >= hf::hf16_pulse && reward_parts.base_miner != 0)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Miner reward is incorrect expected 0 reward, block specified {}"_format(
                         cryptonote::print_money(reward_parts.base_miner))};
 
@@ -3435,19 +3435,19 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 const auto& batch_payment = batched_sn_payments[vout_index];
 
                 if (!std::holds_alternative<cryptonote::txout_to_key>(vout.target))
-                    throw oxen::runtime_error{
+                    throw oxen::traced<std::runtime_error>{
                             "Service node output target type should be txout_to_key"};
 
                 constexpr uint64_t max_amount =
                         std::numeric_limits<uint64_t>::max() / cryptonote::BATCH_REWARD_FACTOR;
                 if (vout.amount > max_amount)
-                    throw oxen::runtime_error{
+                    throw oxen::traced<std::runtime_error>{
                             "Batched reward payout invalid: exceeds maximum possible payout size"};
 
                 auto paid_amount = vout.amount * cryptonote::BATCH_REWARD_FACTOR;
                 total_payout_in_vouts += paid_amount;
                 if (paid_amount != batch_payment.amount)
-                    throw oxen::runtime_error{
+                    throw oxen::traced<std::runtime_error>{
                             "Batched reward payout incorrect: expected {}, not {}"_format(
                                     batch_payment.amount, paid_amount)};
 
@@ -3457,16 +3457,16 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                             deterministic_keypair,
                             vout_index,
                             out_eph_public_key))
-                    throw oxen::runtime_error{"Failed to generate output one-time public key"};
+                    throw oxen::traced<std::runtime_error>{"Failed to generate output one-time public key"};
 
                 const auto& out_to_key = var::get<cryptonote::txout_to_key>(vout.target);
                 if (tools::view_guts(out_to_key) != tools::view_guts(out_eph_public_key))
-                    throw oxen::runtime_error{
+                    throw oxen::traced<std::runtime_error>{
                             "Output Ephermeral Public Key does not match (payment to wrong "
                             "recipient)"};
             }
             if (total_payout_in_vouts != total_payout_in_our_db)
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "Total service node reward amount incorrect: expected {}, not {}"_format(
                                 total_payout_in_our_db, total_payout_in_vouts)};
         } break;
@@ -3515,11 +3515,11 @@ void service_node_list::alt_block_add(const cryptonote::block_add_info& info) {
     }
 
     if (!starting_state)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Received alt block but couldn't find parent state in historical state"};
 
     if (starting_state->block_hash != block.prev_id)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Unexpected state_t's hash: {}, does not match the block prev hash: {}"_format(
                         starting_state->block_hash, block.prev_id)};
 
@@ -4144,7 +4144,7 @@ crypto::public_key service_node_list::bls_public_key_lookup(
 
     if (!found) {
         log::error(logcat, "Could not find bls pubkey: {}", bls_pubkey);
-        throw oxen::runtime_error("Could not find bls key");
+        throw oxen::traced<std::runtime_error>("Could not find bls key");
     }
 
     return found_pk;
@@ -4273,7 +4273,7 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
         block_hash{state.block_hash},
         sn_list{snl} {
     if (!sn_list)
-        throw oxen::logic_error("Cannot deserialize a state_t without a service_node_list");
+        throw oxen::traced<std::logic_error>("Cannot deserialize a state_t without a service_node_list");
     if (state.version == state_serialized::version_t::version_0)
         block_hash = sn_list->m_blockchain.get_block_id_by_height(height);
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -369,6 +369,55 @@ std::optional<registration_details> reg_tx_extract_fields(const cryptonote::tran
     return reg;
 }
 
+static std::string log_registration_details(cryptonote::network_type nettype, const registration_details& reg)
+{
+    fmt::memory_buffer buffer{};
+    fmt::format_to(
+            std::back_inserter(buffer),
+            "- SN Pubkey:       {}\n"
+            "- Reserved(s):     {}\n",
+            reg.service_node_pubkey,
+            reg.reserved.size());
+
+    for (size_t index = 0; index < reg.reserved.size(); index++) {
+        const contribution& contrib = reg.reserved[index];
+        std::string address = cryptonote::get_account_address_as_str(nettype, /*subaddress*/ false, contrib.first);
+        fmt::format_to(
+                std::back_inserter(buffer),
+                "  - {:02} [{}, {}]\n",
+                index,
+                address,
+                contrib.second);
+    }
+
+    fmt::format_to(
+            std::back_inserter(buffer),
+            "- Uses Portions:   {}\n"
+            "- Signature:       {}\n"
+            "- Contribution(s): {}\n",
+            reg.uses_portions,
+            reg.ed_signature,
+            reg.eth_contributions.size());
+
+    for (size_t index = 0; index < reg.eth_contributions.size(); index++) {
+        const eth_contribution& contrib = reg.eth_contributions[index];
+        fmt::format_to(
+                std::back_inserter(buffer),
+                "  - {:02} [{}, {}]\n",
+                index,
+                contrib.first,
+                contrib.second);
+    }
+
+    fmt::format_to(
+            std::back_inserter(buffer),
+            "- BLS Pubkey:      {}\n",
+            reg.bls_pubkey);
+
+    std::string result = fmt::to_string(buffer);
+    return result;
+}
+
 std::optional<registration_details> eth_reg_tx_extract_fields(
         hf hf_version, const cryptonote::transaction& tx) {
     cryptonote::tx_extra_ethereum_new_service_node registration;
@@ -514,15 +563,27 @@ crypto::hash get_registration_hash(const registration_details& registration) {
 }
 
 void validate_registration_signature(const registration_details& registration) {
-    auto hash = get_registration_hash(registration);
     if (!crypto::check_key(registration.service_node_pubkey))
         throw invalid_registration{"Service Node Key is not a valid public key ({})"_format(
                 registration.service_node_pubkey)};
 
-    if (!crypto::check_signature(hash, registration.service_node_pubkey, registration.signature))
-        throw invalid_registration{
-                "Registration signature verification failed for pubkey/hash: {}/{}"_format(
-                        registration.service_node_pubkey, hash)};
+    if (registration.uses_portions || registration.hf < static_cast<uint64_t>(cryptonote::feature::ETH_BLS)) {
+        auto hash = get_registration_hash(registration);
+        if (!crypto::check_signature(hash, registration.service_node_pubkey, registration.signature))
+            throw invalid_registration{
+                    "Registration signature verification failed for pubkey/hash: {}/{}"_format(
+                            registration.service_node_pubkey, hash)};
+    } else {
+        auto reg_msg = get_registration_message_for_signing(registration);
+        if (crypto_sign_ed25519_verify_detached(registration.signature.data(),
+                                                reg_msg.data(),
+                                                reg_msg.size(),
+                                                registration.service_node_pubkey.data()) != 0) {
+            throw invalid_registration{
+                    "Registration signature verification failed for pubkey: {}"_format(
+                            registration.service_node_pubkey)};
+        }
+    }
 }
 
 struct parsed_tx_contribution {
@@ -1497,11 +1558,11 @@ validate_and_get_ethereum_registration(
         auto& [addr, amount] = *it;
         for (auto it2 = std::next(it); it2 != reg.eth_contributions.end(); ++it2) {
             if (it2->first == addr) {
-                log::info(
-                        logcat,
-                        "Invalid registration: duplicate reserved address in registration (tx {})",
-                        cryptonote::get_transaction_hash(tx));
-                throw oxen::runtime_error("duplicate reserved address in registration");
+                throw oxen::runtime_error(
+                        "Invalid registration: Duplicate reserved address in registration in "
+                        "transaction '{}':\n{}"_format(
+                        cryptonote::get_transaction_hash(tx),
+                        log_registration_details(nettype, reg)));
             }
         }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3966,6 +3966,17 @@ bool service_node_list::handle_uptime_proof(
                     proof->pubkey);
     }
 
+    if (vers.first == hf::hf20_eth_transition) {
+        // NOTE: In the transition, we're collecting the BLS pubkeys, we will persist these into the
+        // service node info to bootstrap the keys. Post transition, Arbitrum is activated and BLS
+        // keys of a node will be available in the registration and updated when a node is
+        // registered.
+        if (it->second->bls_public_key != proof->pubkey_bls) {
+            auto& info = duplicate_info(it->second);
+            info.bls_public_key = proof->pubkey_bls;
+        }
+    }
+
     auto old_x25519 = iproof.pubkey_x25519;
     if (iproof.update(
                 std::chrono::system_clock::to_time_t(now),
@@ -3991,17 +4002,6 @@ bool service_node_list::handle_uptime_proof(
 
     if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
         x25519_pkey = derived_x25519_pubkey;
-
-    if (vers.first == hf::hf20_eth_transition) {
-        // NOTE: In the transition, we're collecting the BLS pubkeys, we will persist these into the
-        // service node info to bootstrap the keys. Post transition, Arbitrum is activated and BLS
-        // keys of a node will be available in the registration and updated when a node is
-        // registered.
-        if (it->second->bls_public_key != proof->pubkey_bls) {
-            auto& info = duplicate_info(it->second);
-            info.bls_public_key = proof->pubkey_bls;
-        }
-    }
 
     return true;
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -47,11 +47,11 @@ extern "C" {
 
 #include "blockchain.h"
 #include "bls/bls_utils.h"
+#include "bls/bls_signer.h"
 #include "common/exception.h"
 #include "common/i18n.h"
 #include "common/lock.h"
 #include "common/random.h"
-#include "common/scoped_message_writer.h"
 #include "common/util.h"
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_basic/tx_extra.h"
@@ -67,7 +67,6 @@ extern "C" {
 #include "service_node_rules.h"
 #include "service_node_swarm.h"
 #include "uptime_proof.h"
-#include "version.h"
 
 using cryptonote::hf;
 namespace feature = cryptonote::feature;
@@ -3620,7 +3619,8 @@ uptime_proof::Proof service_node_list::generate_uptime_proof(
         uint16_t storage_omq_port,
         std::array<uint16_t, 3> ss_version,
         uint16_t quorumnet_port,
-        std::array<uint16_t, 3> lokinet_version) const {
+        std::array<uint16_t, 3> lokinet_version,
+        const BLSSigner& signer) const {
     const auto& keys = *m_service_node_keys;
     return uptime_proof::Proof{
             hardfork,
@@ -3630,7 +3630,8 @@ uptime_proof::Proof service_node_list::generate_uptime_proof(
             ss_version,
             quorumnet_port,
             lokinet_version,
-            keys};
+            keys,
+            signer};
 }
 
 template <typename T>

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3908,7 +3908,8 @@ bool service_node_list::handle_uptime_proof(
         }
 
         auto pop_hash = crypto::keccak(proof->pubkey_bls, proof->pubkey);
-        if (!bls_utils::verify(proof->pop_bls, pop_hash, proof->pubkey_bls)) {
+        if (!BLSSigner::verifyMsg(
+                    m_blockchain.nettype(), proof->pop_bls, proof->pubkey_bls, pop_hash)) {
             log::debug(
                     logcat,
                     "Rejecting uptime proof from {}: BLS proof of possession verification failed",
@@ -3940,7 +3941,6 @@ bool service_node_list::handle_uptime_proof(
     if (now <= std::chrono::system_clock::from_time_t(iproof.timestamp) +
                        std::chrono::seconds{netconf.UPTIME_PROOF_FREQUENCY} / 2) {
 
-        bool override_timestamp_frequency = false;
 
         // NOTE: In the local devnet we rapidly advance past multiple hard-forks to reach the
         // ETH_TRANSITION hardfork. At this hard-fork the BLS keys are transmitted around the
@@ -3959,13 +3959,13 @@ bool service_node_list::handle_uptime_proof(
         // Note that prior to this branch here, the key has been validated to be non-null and that
         // the node has the secret key. This code will only permit an 'early' proof if the
         // receipient has not received the BLS key for the sender yet.
+        bool reject_proof = true;
 #if defined(OXEN_USE_LOCAL_DEVNET_PARAMS)
         if (vers.first == feature::ETH_TRANSITION)
-            override_timestamp_frequency =
-                    it->second->bls_public_key == crypto::null<crypto::bls_public_key>;
+            reject_proof = it->second->bls_public_key != crypto::null<crypto::bls_public_key>;
 #endif
 
-        if (!override_timestamp_frequency) {
+        if (reject_proof) {
             log::debug(
                     logcat,
                     "Rejecting uptime proof from {}: already received one uptime proof for this node "
@@ -3994,7 +3994,7 @@ bool service_node_list::handle_uptime_proof(
                     proof->pubkey);
     }
 
-    if (vers.first == hf::hf20_eth_transition) {
+    if (vers.first == feature::ETH_TRANSITION) {
         // NOTE: In the transition, we're collecting the BLS pubkeys, we will persist these into the
         // service node info to bootstrap the keys. Post transition, Arbitrum is activated and BLS
         // keys of a node will be available in the registration and updated when a node is

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -35,7 +35,6 @@
 #include <string_view>
 #include <span>
 
-#include "bls/bls_signer.h"
 #include "common/util.h"
 #include "crypto/crypto.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -460,7 +459,6 @@ struct service_node_keys {
     /// staking contract.
     crypto::bls_secret_key key_bls;
     crypto::bls_public_key pub_bls;
-    std::shared_ptr<BLSSigner> bls_signer;
 };
 
 class service_node_list {
@@ -625,7 +623,8 @@ class service_node_list {
             uint16_t storage_omq_port,
             std::array<uint16_t, 3> ss_version,
             uint16_t quorumnet_port,
-            std::array<uint16_t, 3> lokinet_version) const;
+            std::array<uint16_t, 3> lokinet_version,
+            const BLSSigner& signer) const;
 
     bool handle_uptime_proof(
             std::unique_ptr<uptime_proof::Proof> proof,

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -600,7 +600,7 @@ class service_node_list {
             assert(x_pk); // Should always be set to non-null if we have a proof
             *out++ = service_node_address{
                     pk_info.first,
-                    proof.pubkey_bls,
+                    pk_info.second->bls_public_key,
                     it->second.pubkey_x25519,
                     proof.public_ip,
                     proof.qnet_port};

--- a/src/cryptonote_core/service_node_rules.cpp
+++ b/src/cryptonote_core/service_node_rules.cpp
@@ -305,10 +305,10 @@ std::optional<double> parse_fee_percent(std::string_view fee) {
 uint16_t percent_to_basis_points(std::string percent_string) {
     const auto percent = parse_fee_percent(percent_string);
     if (!percent)
-        throw invalid_registration{"could not parse fee percent"};
+        throw oxen::traced<invalid_registration>{"could not parse fee percent"};
 
     if (*percent < 0.0 || *percent > 100.0)
-        throw invalid_registration{"fee percent out of bounds"};
+        throw oxen::traced<invalid_registration>{"fee percent out of bounds"};
 
     auto basis_points =
             static_cast<uint16_t>(std::lround(*percent / 100.0 * cryptonote::STAKING_FEE_BASIS));

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -2,7 +2,7 @@
 
 #include <chrono>
 
-#include "crypto/crypto.h"
+#include "common/exception.h"
 #include "cryptonote_config.h"
 #include "oxen_economy.h"
 #include "service_node_voting.h"
@@ -10,8 +10,8 @@
 namespace service_nodes {
 
 // validate_registration* and convert_registration_args functions throws this on error:
-struct invalid_registration : std::invalid_argument {
-    using std::invalid_argument::invalid_argument;
+struct invalid_registration : oxen::invalid_argument {
+    using oxen::invalid_argument::invalid_argument;
 };
 
 inline constexpr size_t PULSE_QUORUM_ENTROPY_LAG =

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -2,7 +2,6 @@
 
 #include <chrono>
 
-#include "common/exception.h"
 #include "cryptonote_config.h"
 #include "oxen_economy.h"
 #include "service_node_voting.h"
@@ -10,8 +9,8 @@
 namespace service_nodes {
 
 // validate_registration* and convert_registration_args functions throws this on error:
-struct invalid_registration : oxen::invalid_argument {
-    using oxen::invalid_argument::invalid_argument;
+struct invalid_registration : std::invalid_argument {
+    using std::invalid_argument::invalid_argument;
 };
 
 inline constexpr size_t PULSE_QUORUM_ENTROPY_LAG =
@@ -305,6 +304,11 @@ inline constexpr uint8_t THRESHOLD_SECONDS_OUT_OF_SYNC = 30;
 
 // If the below percentage of service nodes are out of sync we will consider our clock out of sync
 inline constexpr uint8_t MAXIMUM_EXTERNAL_OUT_OF_SYNC = 80;
+
+// When a service node receives a request to sign an exit request for a BLS node, this values
+// determines how old that request is allowed to be from the time it was initiated to us receiving
+// it, that we will consider signing it.
+inline constexpr std::chrono::seconds BLS_MAX_TIME_ALLOWED_FOR_EXIT_REQUEST = std::chrono::minutes(3);
 
 // The SN operator must contribute at least 25% of the node's requirement, expressed as portions
 // (for pre-HF19 registrations).

--- a/src/cryptonote_core/tx_blink.cpp
+++ b/src/cryptonote_core/tx_blink.cpp
@@ -29,6 +29,7 @@
 #include "tx_blink.h"
 
 #include <algorithm>
+#include <cpptrace/cpptrace.hpp>
 
 #include "../cryptonote_basic/cryptonote_format_utils.h"
 #include "common/util.h"
@@ -40,9 +41,9 @@ using namespace service_nodes;
 
 static void check_args(blink_tx::subquorum q, int position, const char* func_name) {
     if (q < blink_tx::subquorum::base || q >= blink_tx::subquorum::_count)
-        throw std::invalid_argument("Invalid sub-quorum value passed to " + std::string(func_name));
+        throw cpptrace::invalid_argument("Invalid sub-quorum value passed to " + std::string(func_name));
     if (position < 0 || position >= BLINK_SUBQUORUM_SIZE)
-        throw std::invalid_argument("Invalid voter position passed to " + std::string(func_name));
+        throw cpptrace::invalid_argument("Invalid voter position passed to " + std::string(func_name));
 }
 
 crypto::public_key blink_tx::get_sn_pubkey(
@@ -72,7 +73,7 @@ crypto::hash blink_tx::hash(bool approved) const {
 
 void blink_tx::limit_signatures(subquorum q, size_t max_size) {
     if (max_size > BLINK_SUBQUORUM_SIZE)
-        throw std::domain_error("Internal error: too many potential blink signers!");
+        throw cpptrace::domain_error("Internal error: too many potential blink signers!");
     else if (max_size < BLINK_SUBQUORUM_SIZE)
         for (size_t i = max_size; i < BLINK_SUBQUORUM_SIZE; i++)
             signatures_[static_cast<uint8_t>(q)][i].status = signature_status::rejected;
@@ -170,7 +171,7 @@ void blink_tx::fill_serialization_data(
 crypto::hash blink_tx::tx_hash_visitor::operator()(const transaction& tx) const {
     crypto::hash h;
     if (!cryptonote::get_transaction_hash(tx, h))
-        throw std::runtime_error("Failed to calculate transaction hash");
+        throw cpptrace::runtime_error("Failed to calculate transaction hash");
     return h;
 }
 

--- a/src/cryptonote_core/tx_blink.cpp
+++ b/src/cryptonote_core/tx_blink.cpp
@@ -41,9 +41,9 @@ using namespace service_nodes;
 
 static void check_args(blink_tx::subquorum q, int position, const char* func_name) {
     if (q < blink_tx::subquorum::base || q >= blink_tx::subquorum::_count)
-        throw oxen::invalid_argument("Invalid sub-quorum value passed to " + std::string(func_name));
+        throw oxen::traced<std::invalid_argument>("Invalid sub-quorum value passed to " + std::string(func_name));
     if (position < 0 || position >= BLINK_SUBQUORUM_SIZE)
-        throw oxen::invalid_argument("Invalid voter position passed to " + std::string(func_name));
+        throw oxen::traced<std::invalid_argument>("Invalid voter position passed to " + std::string(func_name));
 }
 
 crypto::public_key blink_tx::get_sn_pubkey(
@@ -73,7 +73,7 @@ crypto::hash blink_tx::hash(bool approved) const {
 
 void blink_tx::limit_signatures(subquorum q, size_t max_size) {
     if (max_size > BLINK_SUBQUORUM_SIZE)
-        throw oxen::domain_error("Internal error: too many potential blink signers!");
+        throw oxen::traced<std::domain_error>("Internal error: too many potential blink signers!");
     else if (max_size < BLINK_SUBQUORUM_SIZE)
         for (size_t i = max_size; i < BLINK_SUBQUORUM_SIZE; i++)
             signatures_[static_cast<uint8_t>(q)][i].status = signature_status::rejected;
@@ -171,7 +171,7 @@ void blink_tx::fill_serialization_data(
 crypto::hash blink_tx::tx_hash_visitor::operator()(const transaction& tx) const {
     crypto::hash h;
     if (!cryptonote::get_transaction_hash(tx, h))
-        throw oxen::runtime_error("Failed to calculate transaction hash");
+        throw oxen::traced<std::runtime_error>("Failed to calculate transaction hash");
     return h;
 }
 

--- a/src/cryptonote_core/tx_blink.cpp
+++ b/src/cryptonote_core/tx_blink.cpp
@@ -29,9 +29,9 @@
 #include "tx_blink.h"
 
 #include <algorithm>
-#include <cpptrace/cpptrace.hpp>
 
 #include "../cryptonote_basic/cryptonote_format_utils.h"
+#include "common/exception.h"
 #include "common/util.h"
 #include "service_node_list.h"
 
@@ -41,9 +41,9 @@ using namespace service_nodes;
 
 static void check_args(blink_tx::subquorum q, int position, const char* func_name) {
     if (q < blink_tx::subquorum::base || q >= blink_tx::subquorum::_count)
-        throw cpptrace::invalid_argument("Invalid sub-quorum value passed to " + std::string(func_name));
+        throw oxen::invalid_argument("Invalid sub-quorum value passed to " + std::string(func_name));
     if (position < 0 || position >= BLINK_SUBQUORUM_SIZE)
-        throw cpptrace::invalid_argument("Invalid voter position passed to " + std::string(func_name));
+        throw oxen::invalid_argument("Invalid voter position passed to " + std::string(func_name));
 }
 
 crypto::public_key blink_tx::get_sn_pubkey(
@@ -73,7 +73,7 @@ crypto::hash blink_tx::hash(bool approved) const {
 
 void blink_tx::limit_signatures(subquorum q, size_t max_size) {
     if (max_size > BLINK_SUBQUORUM_SIZE)
-        throw cpptrace::domain_error("Internal error: too many potential blink signers!");
+        throw oxen::domain_error("Internal error: too many potential blink signers!");
     else if (max_size < BLINK_SUBQUORUM_SIZE)
         for (size_t i = max_size; i < BLINK_SUBQUORUM_SIZE; i++)
             signatures_[static_cast<uint8_t>(q)][i].status = signature_status::rejected;
@@ -171,7 +171,7 @@ void blink_tx::fill_serialization_data(
 crypto::hash blink_tx::tx_hash_visitor::operator()(const transaction& tx) const {
     crypto::hash h;
     if (!cryptonote::get_transaction_hash(tx, h))
-        throw cpptrace::runtime_error("Failed to calculate transaction hash");
+        throw oxen::runtime_error("Failed to calculate transaction hash");
     return h;
 }
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <unordered_set>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
@@ -312,7 +313,7 @@ bool tx_memory_pool::add_tx(
     std::unique_lock lock{m_transactions_lock};
     if (blob.size() == 0) {
         oxen::log::error(logcat, "Could not add to txpool, blob is empty of tx: {}", id);
-        throw std::runtime_error("Could not add to txpool, blob empty");
+        throw cpptrace::runtime_error("Could not add to txpool, blob empty");
     }
 
     if (tx.version == txversion::v0) {
@@ -1712,7 +1713,7 @@ bool tx_memory_pool::is_transaction_ready_to_go(
         cryptonote::transaction& operator()() {
             if (!parsed) {
                 if (!parse_and_validate_tx_from_blob(txblob, tx))
-                    throw std::runtime_error("failed to parse transaction blob");
+                    throw cpptrace::runtime_error("failed to parse transaction blob");
                 tx.set_hash(txid);
                 parsed = true;
             }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -34,13 +34,13 @@
 #include <algorithm>
 #include <unordered_set>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/locked_txn.h"
 #include "common/boost_serialization_helper.h"
 #include "common/lock.h"
+#include "common/exception.h"
 #include "common/median.h"
 #include "common/util.h"
 #include "crypto/hash.h"
@@ -313,7 +313,7 @@ bool tx_memory_pool::add_tx(
     std::unique_lock lock{m_transactions_lock};
     if (blob.size() == 0) {
         oxen::log::error(logcat, "Could not add to txpool, blob is empty of tx: {}", id);
-        throw cpptrace::runtime_error("Could not add to txpool, blob empty");
+        throw oxen::runtime_error("Could not add to txpool, blob empty");
     }
 
     if (tx.version == txversion::v0) {
@@ -1713,7 +1713,7 @@ bool tx_memory_pool::is_transaction_ready_to_go(
         cryptonote::transaction& operator()() {
             if (!parsed) {
                 if (!parse_and_validate_tx_from_blob(txblob, tx))
-                    throw cpptrace::runtime_error("failed to parse transaction blob");
+                    throw oxen::runtime_error("failed to parse transaction blob");
                 tx.set_hash(txid);
                 parsed = true;
             }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -313,7 +313,7 @@ bool tx_memory_pool::add_tx(
     std::unique_lock lock{m_transactions_lock};
     if (blob.size() == 0) {
         oxen::log::error(logcat, "Could not add to txpool, blob is empty of tx: {}", id);
-        throw oxen::runtime_error("Could not add to txpool, blob empty");
+        throw oxen::traced<std::runtime_error>("Could not add to txpool, blob empty");
     }
 
     if (tx.version == txversion::v0) {
@@ -1713,7 +1713,7 @@ bool tx_memory_pool::is_transaction_ready_to_go(
         cryptonote::transaction& operator()() {
             if (!parsed) {
                 if (!parse_and_validate_tx_from_blob(txblob, tx))
-                    throw oxen::runtime_error("failed to parse transaction blob");
+                    throw oxen::traced<std::runtime_error>("failed to parse transaction blob");
                 tx.set_hash(txid);
                 parsed = true;
             }

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -3,8 +3,8 @@
 #include <oxenc/bt_producer.h>
 
 #include "common/guts.h"
-#include "common/string_util.h"
 #include "common/exception.h"
+#include "bls/bls_signer.h"
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
 #include "epee/string_tools.h"
@@ -32,7 +32,8 @@ Proof::Proof(
         const std::array<uint16_t, 3> ss_version,
         uint16_t quorumnet_port,
         const std::array<uint16_t, 3> lokinet_version,
-        const service_nodes::service_node_keys& keys) :
+        const service_nodes::service_node_keys& keys,
+        const BLSSigner& bls_signer) :
         version{OXEN_VERSION},
         storage_server_version{ss_version},
         lokinet_version{lokinet_version},
@@ -47,7 +48,7 @@ Proof::Proof(
 
     if (hardfork == feature::ETH_TRANSITION) {
         assert(keys.pub_bls);
-        pop_bls = keys.bls_signer->signHash(crypto::keccak(keys.pub_bls, keys.pub));
+        pop_bls = bls_signer.signHash(crypto::keccak(keys.pub_bls, keys.pub));
     }
 
     serialized_proof = bt_encode_uptime_proof(hardfork);

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -88,7 +88,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     if (auto ip = proof.require<std::string>("ip");
         !epee::string_tools::get_ip_int32_from_string(public_ip, ip) || public_ip == 0)
-        throw oxen::runtime_error{"Invalid IP address in proof"};
+        throw oxen::traced<std::runtime_error>{"Invalid IP address in proof"};
 
     lokinet_version = proof.require<std::array<uint16_t, 3>>("lv");
 
@@ -103,7 +103,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     qnet_port = proof.require<uint16_t>("q");
     if (qnet_port == 0)
-        throw oxen::runtime_error{"Invalid omq port in proof"};
+        throw oxen::traced<std::runtime_error>{"Invalid omq port in proof"};
 
     // Unlike qnet_port, these *can* be zero (on devnet); but this is checked elsewhere.
     storage_https_port = proof.require<uint16_t>("shp");

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -48,7 +48,7 @@ Proof::Proof(
 
     if (hardfork == feature::ETH_TRANSITION) {
         assert(keys.pub_bls);
-        pop_bls = bls_signer.signHash(crypto::keccak(keys.pub_bls, keys.pub));
+        pop_bls = bls_signer.signMsg(crypto::keccak(keys.pub_bls, keys.pub));
     }
 
     serialized_proof = bt_encode_uptime_proof(hardfork);

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -1,6 +1,7 @@
 #include "uptime_proof.h"
 
 #include <oxenc/bt_producer.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/guts.h"
 #include "common/string_util.h"
@@ -85,7 +86,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     if (auto ip = proof.require<std::string>("ip");
         !epee::string_tools::get_ip_int32_from_string(public_ip, ip) || public_ip == 0)
-        throw std::runtime_error{"Invalid IP address in proof"};
+        throw cpptrace::runtime_error{"Invalid IP address in proof"};
 
     lokinet_version = proof.require<std::array<uint16_t, 3>>("lv");
 
@@ -100,7 +101,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     qnet_port = proof.require<uint16_t>("q");
     if (qnet_port == 0)
-        throw std::runtime_error{"Invalid omq port in proof"};
+        throw cpptrace::runtime_error{"Invalid omq port in proof"};
 
     // Unlike qnet_port, these *can* be zero (on devnet); but this is checked elsewhere.
     storage_https_port = proof.require<uint16_t>("shp");

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -1,16 +1,17 @@
 #include "uptime_proof.h"
+#include "service_node_list.h"
+
+
+#include <common/guts.h>
+#include <common/exception.h>
+#include <crypto/crypto.h>
+#include <cryptonote_config.h>
+#include <epee/string_tools.h>
+#include <logging/oxen_logger.h>
+#include <version.h>
+#include <bls/bls_signer.h>
 
 #include <oxenc/bt_producer.h>
-
-#include "common/guts.h"
-#include "common/exception.h"
-#include "bls/bls_signer.h"
-#include "crypto/crypto.h"
-#include "cryptonote_config.h"
-#include "epee/string_tools.h"
-#include "logging/oxen_logger.h"
-#include "service_node_list.h"
-#include "version.h"
 
 extern "C" {
 #include <sodium/crypto_sign.h>

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -1,10 +1,10 @@
 #include "uptime_proof.h"
 
 #include <oxenc/bt_producer.h>
-#include <cpptrace/cpptrace.hpp>
 
 #include "common/guts.h"
 #include "common/string_util.h"
+#include "common/exception.h"
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
 #include "epee/string_tools.h"
@@ -86,7 +86,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     if (auto ip = proof.require<std::string>("ip");
         !epee::string_tools::get_ip_int32_from_string(public_ip, ip) || public_ip == 0)
-        throw cpptrace::runtime_error{"Invalid IP address in proof"};
+        throw oxen::runtime_error{"Invalid IP address in proof"};
 
     lokinet_version = proof.require<std::array<uint16_t, 3>>("lv");
 
@@ -101,7 +101,7 @@ Proof::Proof(cryptonote::hf hardfork, std::string_view serialized_proof) {
 
     qnet_port = proof.require<uint16_t>("q");
     if (qnet_port == 0)
-        throw cpptrace::runtime_error{"Invalid omq port in proof"};
+        throw oxen::runtime_error{"Invalid omq port in proof"};
 
     // Unlike qnet_port, these *can* be zero (on devnet); but this is checked elsewhere.
     storage_https_port = proof.require<uint16_t>("shp");

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -4,10 +4,9 @@
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 
 namespace service_nodes {
-
 struct service_node_keys;
-
 }
+class BLSSigner;
 
 namespace uptime_proof {
 
@@ -64,7 +63,8 @@ class Proof {
           std::array<uint16_t, 3> ss_version,
           uint16_t quorumnet_port,
           std::array<uint16_t, 3> lokinet_version,
-          const service_nodes::service_node_keys& keys);
+          const service_nodes::service_node_keys& keys,
+          const BLSSigner& bls_signer);
 
     Proof(cryptonote::hf hardfork, std::string_view serialized_proof);
     std::string bt_encode_uptime_proof(cryptonote::hf hardfork) const;

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -113,7 +113,7 @@ namespace {
 
         std::string fullBlob;
         if (!epee::serialization::store_t_to_binary(request, fullBlob))
-            throw oxen::runtime_error{"Failed to serialize to epee binary format"};
+            throw oxen::traced<std::runtime_error>{"Failed to serialize to epee binary format"};
 
         return fullBlob;
     }
@@ -471,7 +471,7 @@ notify::notify(
         zone_(std::make_shared<detail::zone>(
                 service, std::move(p2p), std::move(noise), is_public)) {
     if (!zone_->p2p)
-        throw oxen::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
+        throw oxen::traced<std::logic_error>{"cryptonote::levin::notify cannot have nullptr p2p argument"};
 
     if (!zone_->noise.view.empty()) {
         const auto now = std::chrono::steady_clock::now();

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -32,10 +32,8 @@
 #include <boost/system/system_error.hpp>
 #include <chrono>
 #include <deque>
-#include <stdexcept>
-#include <cpptrace/cpptrace.hpp>
 
-#include "common/expect.h"
+#include "common/exception.h"
 #include "common/varint.h"
 #include "crypto/random.h"
 #include "cryptonote_basic/connection_context.h"
@@ -115,7 +113,7 @@ namespace {
 
         std::string fullBlob;
         if (!epee::serialization::store_t_to_binary(request, fullBlob))
-            throw cpptrace::runtime_error{"Failed to serialize to epee binary format"};
+            throw oxen::runtime_error{"Failed to serialize to epee binary format"};
 
         return fullBlob;
     }
@@ -473,7 +471,7 @@ notify::notify(
         zone_(std::make_shared<detail::zone>(
                 service, std::move(p2p), std::move(noise), is_public)) {
     if (!zone_->p2p)
-        throw cpptrace::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
+        throw oxen::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
 
     if (!zone_->noise.view.empty()) {
         const auto now = std::chrono::steady_clock::now();

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -33,6 +33,7 @@
 #include <chrono>
 #include <deque>
 #include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/expect.h"
 #include "common/varint.h"
@@ -114,7 +115,7 @@ namespace {
 
         std::string fullBlob;
         if (!epee::serialization::store_t_to_binary(request, fullBlob))
-            throw std::runtime_error{"Failed to serialize to epee binary format"};
+            throw cpptrace::runtime_error{"Failed to serialize to epee binary format"};
 
         return fullBlob;
     }
@@ -472,7 +473,7 @@ notify::notify(
         zone_(std::make_shared<detail::zone>(
                 service, std::move(p2p), std::move(noise), is_public)) {
     if (!zone_->p2p)
-        throw std::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
+        throw cpptrace::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
 
     if (!zone_->noise.view.empty()) {
         const auto now = std::chrono::steady_clock::now();

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -34,8 +34,8 @@
 
 #include <iterator>
 #include <shared_mutex>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/random.h"
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_config.h"
@@ -151,7 +151,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         E result = static_cast<E>(get_int<std::underlying_type_t<E>>(d.at(key)));
         if (result < E::_count)
             return result;
-        throw cpptrace::invalid_argument("invalid enum value for field " + key);
+        throw oxen::invalid_argument("invalid enum value for field " + key);
     }
 
     struct prepared_relay_destinations {
@@ -586,16 +586,16 @@ E get_enum(const bt_dict &d, const std::string &key) {
         vote.block_height = get_int<uint64_t>(d.at("h"));
         vote.group = get_enum<quorum_group>(d, "g");
         if (vote.group == quorum_group::invalid)
-            throw cpptrace::invalid_argument("invalid vote group");
+            throw oxen::invalid_argument("invalid vote group");
         vote.index_in_group = get_int<uint16_t>(d.at("i"));
         auto& sig = var::get<std::string>(d.at("s"));
         if (sig.size() != sizeof(vote.signature))
-            throw cpptrace::invalid_argument("invalid vote signature size");
+            throw oxen::invalid_argument("invalid vote signature size");
         std::memcpy(&vote.signature, sig.data(), sizeof(vote.signature));
         if (vote.type == quorum_type::checkpointing) {
             auto& bh = var::get<std::string>(d.at("bh"));
             if (bh.size() != vote.checkpoint.block_hash.size())
-                throw cpptrace::invalid_argument("invalid vote checkpoint block hash");
+                throw oxen::invalid_argument("invalid vote checkpoint block hash");
             std::memcpy(vote.checkpoint.block_hash.data(), bh.data(), bh.size());
         } else {
             vote.state_change.worker_index = get_int<uint16_t>(d.at("wi"));
@@ -727,7 +727,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
     // Obtains the blink quorums, verifies that they are of an acceptable size, and verifies the
     // given input quorum checksum matches the computed checksum for the quorums (if provided),
     // otherwise sets the given output checksum (if provided) to the calculated value.  Throws
-    // cpptrace::runtime_error on failure.
+    // oxen::runtime_error on failure.
     quorum_array get_blink_quorums(
             uint64_t blink_height,
             const service_node_list& snl,
@@ -743,13 +743,13 @@ E get_enum(const bt_dict &d, const std::string &key) {
             auto height =
                     blink_tx::quorum_height(blink_height, static_cast<blink_tx::subquorum>(qi));
             if (!height)
-                throw cpptrace::runtime_error("too early in blockchain to create a quorum");
+                throw oxen::runtime_error("too early in blockchain to create a quorum");
             result[qi] = snl.get_quorum(quorum_type::blink, height);
             if (!result[qi])
-                throw cpptrace::runtime_error("failed to obtain a blink quorum");
+                throw oxen::runtime_error("failed to obtain a blink quorum");
             auto& v = result[qi]->validators;
             if (v.size() < BLINK_MIN_VOTES || v.size() > BLINK_SUBQUORUM_SIZE)
-                throw cpptrace::runtime_error("not enough blink nodes to form a quorum");
+                throw oxen::runtime_error("not enough blink nodes to form a quorum");
             local_checksum += quorum_checksum(v, qi * BLINK_SUBQUORUM_SIZE);
         }
         log::trace(
@@ -759,7 +759,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
         if (input_checksum) {
             if (*input_checksum != local_checksum)
-                throw cpptrace::runtime_error{"wrong quorum checksum: expected {}, received {}"_format(
+                throw oxen::runtime_error{"wrong quorum checksum: expected {}, received {}"_format(
                         local_checksum, *input_checksum)};
 
             log::trace(logcat, "Blink quorum checksum matched");
@@ -1188,7 +1188,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         try {
             blink_quorums =
                     get_blink_quorums(blink_height, qnet.core.get_service_node_list(), &checksum);
-        } catch (const cpptrace::runtime_error& e) {
+        } catch (const oxen::runtime_error& e) {
             log::info(logcat, "Rejecting blink tx: {}", e.what());
             if (tag)
                 m.send_back(
@@ -1375,29 +1375,29 @@ E get_enum(const bt_dict &d, const std::string &key) {
             std::list<pending_signature>& signatures,
             Consume consume) {
         if (!data.skip_until(key))
-            throw cpptrace::invalid_argument{
+            throw oxen::invalid_argument{
                     "Invalid blink signature data: missing required field '{}'"_format(key)};
         auto list = data.consume_list_consumer();
         auto it = signatures.begin();
         for (; !list.is_finished(); ++it) {
             if (it == signatures.end())
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "Invalid blink signature data: {} size > i size"_format(key)};
             std::get<decltype(consume(list))>(*it) = consume(list);
         }
         if (it != signatures.end())
-            throw cpptrace::invalid_argument(
+            throw oxen::invalid_argument(
                     "Invalid blink signature data: {} size < i size"_format(key));
     }
 
     crypto::signature convert_string_view_bytes_to_signature(std::string_view sig_str) {
         if (sig_str.size() != sizeof(crypto::signature))
-            throw cpptrace::invalid_argument{"Invalid signature data size: {}"_format(sig_str.size())};
+            throw oxen::invalid_argument{"Invalid signature data size: {}"_format(sig_str.size())};
 
         crypto::signature result;
         std::memcpy(&result, sig_str.data(), sizeof(crypto::signature));
         if (!result)
-            throw cpptrace::invalid_argument{"Invalid signature data: null signature given"};
+            throw oxen::invalid_argument{"Invalid signature data: null signature given"};
 
         return result;
     }
@@ -1428,7 +1428,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         log::debug(logcat, "Received a blink tx signature from SN {}", to_hex(m.conn.pubkey()));
 
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Rejecting blink signature: expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -1438,30 +1438,30 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
         // # - hash (32 bytes)
         if (!data.skip_until("#"))
-            throw cpptrace::invalid_argument{"Invalid blink signature data: missing required field '#'"};
+            throw oxen::invalid_argument{"Invalid blink signature data: missing required field '#'"};
         auto hash_str = data.consume_string_view();
         if (hash_str.size() != sizeof(crypto::hash))
-            throw cpptrace::invalid_argument{"Invalid blink signature data: invalid tx hash"};
+            throw oxen::invalid_argument{"Invalid blink signature data: invalid tx hash"};
         crypto::hash tx_hash;
         std::memcpy(tx_hash.data(), hash_str.data(), hash_str.size());
 
         // h - height
         if (!data.skip_until("h"))
-            throw cpptrace::invalid_argument{"Invalid blink signature data: missing required field 'h'"};
+            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'h'"};
         uint64_t blink_height = data.consume_integer<uint64_t>();
         if (!blink_height)
-            throw cpptrace::invalid_argument{"Invalid blink signature data: height cannot be 0"};
+            throw oxen::invalid_argument{"Invalid blink signature data: height cannot be 0"};
 
         std::list<pending_signature> signatures;
 
         // i - list of quorum indices
         if (!data.skip_until("i"))
-            throw cpptrace::invalid_argument{"Invalid blink signature data: missing required field 'i'"};
+            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'i'"};
         auto quorum_indices = data.consume_list_consumer();
         while (!quorum_indices.is_finished()) {
             uint8_t q = quorum_indices.consume_integer<uint8_t>();
             if (q >= NUM_BLINK_QUORUMS)
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "Invalid blink signature data: invalid quorum index {}"_format(q)};
             signatures.emplace_back();
             std::get<uint8_t>(signatures.back()) = q;
@@ -1473,14 +1473,14 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (pos < 0 || pos >= BLINK_SUBQUORUM_SIZE)  // This is only input validation: it might
                                                          // actually have to be smaller depending on
                                                          // the actual quorum (we check later)
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "Invalid blink signature data: invalid quorum position {}"_format(pos)};
             return pos;
         });
 
         // q - quorum membership checksum
         if (!data.skip_until("q"))
-            throw cpptrace::invalid_argument{"Invalid blink signature data: missing required field 'q'"};
+            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'q'"};
         // Before 7.1.8 we get a int64_t on the wire, using 2s-complement representation when the
         // value is a uint64_t that exceeds the max of an int64_t so, if negative, pull it off and
         // static cast it back (the static_cast assumes a 2s-complement architecture which isn't
@@ -1911,19 +1911,19 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (auto const& tag = PULSE_TAG_QUORUM_POSITION; data.skip_until(tag))
                 result.quorum_position = data.consume_integer<int>();
             else
-                throw cpptrace::invalid_argument(std::string(error_prefix) + tag + "'");
+                throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
         }
 
         if (auto const& tag = PULSE_TAG_BLOCK_ROUND; data.skip_until(tag))
             result.round = data.consume_integer<uint8_t>();
         else
-            throw cpptrace::invalid_argument(std::string(error_prefix) + tag + "'");
+            throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
 
         if (auto const& tag = PULSE_TAG_SIGNATURE; data.skip_until(tag)) {
             auto sig_str = data.consume_string_view();
             result.signature = convert_string_view_bytes_to_signature(sig_str);
         } else {
-            throw cpptrace::invalid_argument(std::string(error_prefix) + tag + "'");
+            throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
         }
 
         return result;
@@ -1935,7 +1935,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
     // contents of the message is left to the caller.
     void handle_pulse_participation_bit_or_bitset(Message& m, QnetState& qnet, bool bitset) {
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Rejecting pulse participation {}: expected one data entry not {}"_format(
                             bitset ? "bitset" : "handshake", m.data.size())};
 
@@ -1951,7 +1951,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (auto const& tag = PULSE_TAG_VALIDATOR_BITSET; data.skip_until(tag))
                 msg.handshakes.validator_bitset = data.consume_integer<uint16_t>();
             else
-                throw cpptrace::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+                throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -1961,7 +1961,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_block_template(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Rejecting pulse block template expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -1974,7 +1974,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_BLOCK_TEMPLATE; data.skip_until(tag))
             msg.block_template.blob = data.consume_string_view();
         else
-            throw cpptrace::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
 
         qnet.omq.job(
                 [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
@@ -1983,7 +1983,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_random_value_hash(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Rejecting pulse random value hash expected one data entry not "s +
                     std::to_string(m.data.size()));
 
@@ -1997,12 +1997,12 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE_HASH; data.skip_until(tag)) {
             auto str = data.consume_string_view();
             if (str.size() != sizeof(msg.random_value_hash.hash))
-                throw cpptrace::invalid_argument(
+                throw oxen::invalid_argument(
                         "Invalid hash data size: " + std::to_string(str.size()));
 
             std::memcpy(msg.random_value_hash.hash.data(), str.data(), str.size());
         } else {
-            throw cpptrace::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2012,7 +2012,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_random_value(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Rejecting pulse random value expected one data entry not "s +
                     std::to_string(m.data.size()));
 
@@ -2025,10 +2025,10 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE; data.skip_until(tag)) {
             auto str = data.consume_string_view();
             if (str.size() != sizeof(msg.random_value.value.data))
-                throw cpptrace::invalid_argument("Invalid data size: " + std::to_string(str.size()));
+                throw oxen::invalid_argument("Invalid data size: " + std::to_string(str.size()));
             std::memcpy(msg.random_value.value.data, str.data(), str.size());
         } else {
-            throw cpptrace::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2038,7 +2038,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_signed_block(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Rejecting pulse signed block expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -2053,7 +2053,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
             msg.signed_block.signature_of_final_block_hash =
                     convert_string_view_bytes_to_signature(sig_str);
         } else {
-            throw cpptrace::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2086,7 +2086,7 @@ namespace {
 
         if (core.service_node()) {
             if (!obj)
-                throw cpptrace::logic_error{
+                throw oxen::logic_error{
                         "qnet initialization failure: quorumnet_new must be called for service "
                         "node operation"};
             auto& qnet = QnetState::from(obj);

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -151,7 +151,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         E result = static_cast<E>(get_int<std::underlying_type_t<E>>(d.at(key)));
         if (result < E::_count)
             return result;
-        throw oxen::invalid_argument("invalid enum value for field " + key);
+        throw oxen::traced<std::invalid_argument>("invalid enum value for field " + key);
     }
 
     struct prepared_relay_destinations {
@@ -586,16 +586,16 @@ E get_enum(const bt_dict &d, const std::string &key) {
         vote.block_height = get_int<uint64_t>(d.at("h"));
         vote.group = get_enum<quorum_group>(d, "g");
         if (vote.group == quorum_group::invalid)
-            throw oxen::invalid_argument("invalid vote group");
+            throw oxen::traced<std::invalid_argument>("invalid vote group");
         vote.index_in_group = get_int<uint16_t>(d.at("i"));
         auto& sig = var::get<std::string>(d.at("s"));
         if (sig.size() != sizeof(vote.signature))
-            throw oxen::invalid_argument("invalid vote signature size");
+            throw oxen::traced<std::invalid_argument>("invalid vote signature size");
         std::memcpy(&vote.signature, sig.data(), sizeof(vote.signature));
         if (vote.type == quorum_type::checkpointing) {
             auto& bh = var::get<std::string>(d.at("bh"));
             if (bh.size() != vote.checkpoint.block_hash.size())
-                throw oxen::invalid_argument("invalid vote checkpoint block hash");
+                throw oxen::traced<std::invalid_argument>("invalid vote checkpoint block hash");
             std::memcpy(vote.checkpoint.block_hash.data(), bh.data(), bh.size());
         } else {
             vote.state_change.worker_index = get_int<uint16_t>(d.at("wi"));
@@ -727,7 +727,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
     // Obtains the blink quorums, verifies that they are of an acceptable size, and verifies the
     // given input quorum checksum matches the computed checksum for the quorums (if provided),
     // otherwise sets the given output checksum (if provided) to the calculated value.  Throws
-    // oxen::runtime_error on failure.
+    // oxen::traced<std::runtime_error> on failure.
     quorum_array get_blink_quorums(
             uint64_t blink_height,
             const service_node_list& snl,
@@ -743,13 +743,13 @@ E get_enum(const bt_dict &d, const std::string &key) {
             auto height =
                     blink_tx::quorum_height(blink_height, static_cast<blink_tx::subquorum>(qi));
             if (!height)
-                throw oxen::runtime_error("too early in blockchain to create a quorum");
+                throw oxen::traced<std::runtime_error>("too early in blockchain to create a quorum");
             result[qi] = snl.get_quorum(quorum_type::blink, height);
             if (!result[qi])
-                throw oxen::runtime_error("failed to obtain a blink quorum");
+                throw oxen::traced<std::runtime_error>("failed to obtain a blink quorum");
             auto& v = result[qi]->validators;
             if (v.size() < BLINK_MIN_VOTES || v.size() > BLINK_SUBQUORUM_SIZE)
-                throw oxen::runtime_error("not enough blink nodes to form a quorum");
+                throw oxen::traced<std::runtime_error>("not enough blink nodes to form a quorum");
             local_checksum += quorum_checksum(v, qi * BLINK_SUBQUORUM_SIZE);
         }
         log::trace(
@@ -759,7 +759,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
         if (input_checksum) {
             if (*input_checksum != local_checksum)
-                throw oxen::runtime_error{"wrong quorum checksum: expected {}, received {}"_format(
+                throw oxen::traced<std::runtime_error>{"wrong quorum checksum: expected {}, received {}"_format(
                         local_checksum, *input_checksum)};
 
             log::trace(logcat, "Blink quorum checksum matched");
@@ -1188,7 +1188,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         try {
             blink_quorums =
                     get_blink_quorums(blink_height, qnet.core.get_service_node_list(), &checksum);
-        } catch (const oxen::runtime_error& e) {
+        } catch (const oxen::traced<std::runtime_error>& e) {
             log::info(logcat, "Rejecting blink tx: {}", e.what());
             if (tag)
                 m.send_back(
@@ -1375,29 +1375,29 @@ E get_enum(const bt_dict &d, const std::string &key) {
             std::list<pending_signature>& signatures,
             Consume consume) {
         if (!data.skip_until(key))
-            throw oxen::invalid_argument{
+            throw oxen::traced<std::invalid_argument>{
                     "Invalid blink signature data: missing required field '{}'"_format(key)};
         auto list = data.consume_list_consumer();
         auto it = signatures.begin();
         for (; !list.is_finished(); ++it) {
             if (it == signatures.end())
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "Invalid blink signature data: {} size > i size"_format(key)};
             std::get<decltype(consume(list))>(*it) = consume(list);
         }
         if (it != signatures.end())
-            throw oxen::invalid_argument(
+            throw oxen::traced<std::invalid_argument>(
                     "Invalid blink signature data: {} size < i size"_format(key));
     }
 
     crypto::signature convert_string_view_bytes_to_signature(std::string_view sig_str) {
         if (sig_str.size() != sizeof(crypto::signature))
-            throw oxen::invalid_argument{"Invalid signature data size: {}"_format(sig_str.size())};
+            throw oxen::traced<std::invalid_argument>{"Invalid signature data size: {}"_format(sig_str.size())};
 
         crypto::signature result;
         std::memcpy(&result, sig_str.data(), sizeof(crypto::signature));
         if (!result)
-            throw oxen::invalid_argument{"Invalid signature data: null signature given"};
+            throw oxen::traced<std::invalid_argument>{"Invalid signature data: null signature given"};
 
         return result;
     }
@@ -1428,7 +1428,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         log::debug(logcat, "Received a blink tx signature from SN {}", to_hex(m.conn.pubkey()));
 
         if (m.data.size() != 1)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Rejecting blink signature: expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -1438,30 +1438,30 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
         // # - hash (32 bytes)
         if (!data.skip_until("#"))
-            throw oxen::invalid_argument{"Invalid blink signature data: missing required field '#'"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: missing required field '#'"};
         auto hash_str = data.consume_string_view();
         if (hash_str.size() != sizeof(crypto::hash))
-            throw oxen::invalid_argument{"Invalid blink signature data: invalid tx hash"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: invalid tx hash"};
         crypto::hash tx_hash;
         std::memcpy(tx_hash.data(), hash_str.data(), hash_str.size());
 
         // h - height
         if (!data.skip_until("h"))
-            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'h'"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: missing required field 'h'"};
         uint64_t blink_height = data.consume_integer<uint64_t>();
         if (!blink_height)
-            throw oxen::invalid_argument{"Invalid blink signature data: height cannot be 0"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: height cannot be 0"};
 
         std::list<pending_signature> signatures;
 
         // i - list of quorum indices
         if (!data.skip_until("i"))
-            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'i'"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: missing required field 'i'"};
         auto quorum_indices = data.consume_list_consumer();
         while (!quorum_indices.is_finished()) {
             uint8_t q = quorum_indices.consume_integer<uint8_t>();
             if (q >= NUM_BLINK_QUORUMS)
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "Invalid blink signature data: invalid quorum index {}"_format(q)};
             signatures.emplace_back();
             std::get<uint8_t>(signatures.back()) = q;
@@ -1473,14 +1473,14 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (pos < 0 || pos >= BLINK_SUBQUORUM_SIZE)  // This is only input validation: it might
                                                          // actually have to be smaller depending on
                                                          // the actual quorum (we check later)
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "Invalid blink signature data: invalid quorum position {}"_format(pos)};
             return pos;
         });
 
         // q - quorum membership checksum
         if (!data.skip_until("q"))
-            throw oxen::invalid_argument{"Invalid blink signature data: missing required field 'q'"};
+            throw oxen::traced<std::invalid_argument>{"Invalid blink signature data: missing required field 'q'"};
         // Before 7.1.8 we get a int64_t on the wire, using 2s-complement representation when the
         // value is a uint64_t that exceeds the max of an int64_t so, if negative, pull it off and
         // static cast it back (the static_cast assumes a 2s-complement architecture which isn't
@@ -1911,19 +1911,19 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (auto const& tag = PULSE_TAG_QUORUM_POSITION; data.skip_until(tag))
                 result.quorum_position = data.consume_integer<int>();
             else
-                throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
+                throw oxen::traced<std::invalid_argument>(std::string(error_prefix) + tag + "'");
         }
 
         if (auto const& tag = PULSE_TAG_BLOCK_ROUND; data.skip_until(tag))
             result.round = data.consume_integer<uint8_t>();
         else
-            throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
+            throw oxen::traced<std::invalid_argument>(std::string(error_prefix) + tag + "'");
 
         if (auto const& tag = PULSE_TAG_SIGNATURE; data.skip_until(tag)) {
             auto sig_str = data.consume_string_view();
             result.signature = convert_string_view_bytes_to_signature(sig_str);
         } else {
-            throw oxen::invalid_argument(std::string(error_prefix) + tag + "'");
+            throw oxen::traced<std::invalid_argument>(std::string(error_prefix) + tag + "'");
         }
 
         return result;
@@ -1935,7 +1935,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
     // contents of the message is left to the caller.
     void handle_pulse_participation_bit_or_bitset(Message& m, QnetState& qnet, bool bitset) {
         if (m.data.size() != 1)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Rejecting pulse participation {}: expected one data entry not {}"_format(
                             bitset ? "bitset" : "handshake", m.data.size())};
 
@@ -1951,7 +1951,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
             if (auto const& tag = PULSE_TAG_VALIDATOR_BITSET; data.skip_until(tag))
                 msg.handshakes.validator_bitset = data.consume_integer<uint16_t>();
             else
-                throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+                throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -1961,7 +1961,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_block_template(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Rejecting pulse block template expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -1974,7 +1974,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_BLOCK_TEMPLATE; data.skip_until(tag))
             msg.block_template.blob = data.consume_string_view();
         else
-            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
 
         qnet.omq.job(
                 [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
@@ -1983,7 +1983,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_random_value_hash(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Rejecting pulse random value hash expected one data entry not "s +
                     std::to_string(m.data.size()));
 
@@ -1997,12 +1997,12 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE_HASH; data.skip_until(tag)) {
             auto str = data.consume_string_view();
             if (str.size() != sizeof(msg.random_value_hash.hash))
-                throw oxen::invalid_argument(
+                throw oxen::traced<std::invalid_argument>(
                         "Invalid hash data size: " + std::to_string(str.size()));
 
             std::memcpy(msg.random_value_hash.hash.data(), str.data(), str.size());
         } else {
-            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2012,7 +2012,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_random_value(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Rejecting pulse random value expected one data entry not "s +
                     std::to_string(m.data.size()));
 
@@ -2025,10 +2025,10 @@ E get_enum(const bt_dict &d, const std::string &key) {
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE; data.skip_until(tag)) {
             auto str = data.consume_string_view();
             if (str.size() != sizeof(msg.random_value.value.data))
-                throw oxen::invalid_argument("Invalid data size: " + std::to_string(str.size()));
+                throw oxen::traced<std::invalid_argument>("Invalid data size: " + std::to_string(str.size()));
             std::memcpy(msg.random_value.value.data, str.data(), str.size());
         } else {
-            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2038,7 +2038,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
 
     void handle_pulse_signed_block(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Rejecting pulse signed block expected one data entry not {}"_format(
                             m.data.size())};
 
@@ -2053,7 +2053,7 @@ E get_enum(const bt_dict &d, const std::string &key) {
             msg.signed_block.signature_of_final_block_hash =
                     convert_string_view_bytes_to_signature(sig_str);
         } else {
-            throw oxen::invalid_argument{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+            throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
@@ -2086,7 +2086,7 @@ namespace {
 
         if (core.service_node()) {
             if (!obj)
-                throw oxen::logic_error{
+                throw oxen::traced<std::logic_error>{
                         "qnet initialization failure: quorumnet_new must be called for service "
                         "node operation"};
             auto& qnet = QnetState::from(obj);

--- a/src/cryptonote_protocol/quorumnet_conn_matrix.h
+++ b/src/cryptonote_protocol/quorumnet_conn_matrix.h
@@ -32,8 +32,9 @@
 // N-quorum establish connections to each other.  The patterns here were determined by the
 // utils/generate-quorum-matrix.py script.
 
+#include <common/exception.h>
+
 #include <array>
-#include <cpptrace/cpptrace.hpp>
 
 namespace quorumnet {
 
@@ -49,7 +50,7 @@ class quorum_conn_iterator {
     quorum_conn_iterator(const bool* flags_, int N_, bool outgoing_ = true) :
             flags{flags_}, i{0}, N{N_}, step{outgoing_ ? 1 : N} {
         if (flags == nullptr && N != 0)
-            throw cpptrace::domain_error("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
+            throw oxen::domain_error("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
         if (!flags[0] && N > 0)
             ++*this;
     }

--- a/src/cryptonote_protocol/quorumnet_conn_matrix.h
+++ b/src/cryptonote_protocol/quorumnet_conn_matrix.h
@@ -33,7 +33,7 @@
 // utils/generate-quorum-matrix.py script.
 
 #include <array>
-#include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 namespace quorumnet {
 
@@ -49,7 +49,7 @@ class quorum_conn_iterator {
     quorum_conn_iterator(const bool* flags_, int N_, bool outgoing_ = true) :
             flags{flags_}, i{0}, N{N_}, step{outgoing_ ? 1 : N} {
         if (flags == nullptr && N != 0)
-            throw std::domain_error("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
+            throw cpptrace::domain_error("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
         if (!flags[0] && N > 0)
             ++*this;
     }

--- a/src/cryptonote_protocol/quorumnet_conn_matrix.h
+++ b/src/cryptonote_protocol/quorumnet_conn_matrix.h
@@ -50,7 +50,7 @@ class quorum_conn_iterator {
     quorum_conn_iterator(const bool* flags_, int N_, bool outgoing_ = true) :
             flags{flags_}, i{0}, N{N_}, step{outgoing_ ? 1 : N} {
         if (flags == nullptr && N != 0)
-            throw oxen::domain_error("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
+            throw oxen::traced<std::domain_error>("Invalid/unsupported quorum size (" + std::to_string(N) + ")");
         if (!flags[0] && N > 0)
             ++*this;
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <stdexcept>
 #include <utility>
+#include <cpptrace/cpptrace.hpp>
 
 #include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_core.h"
@@ -80,7 +81,7 @@ std::pair<std::string, uint16_t> parse_ip_port(
         colon != std::string::npos && tools::parse_int(ip_port.substr(colon + 1), port))
         ip_port.remove_suffix(ip_port.size() - colon);
     else
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Invalid IP/port value specified to " + argname + ": " + std::string(ip_port)};
 
     if (!ip_port.empty() && ip_port.front() == '[' && ip_port.back() == ']') {
@@ -98,7 +99,7 @@ std::pair<std::string, uint16_t> parse_ip_port(
 #endif
             (ip_str, ec);
     if (ec)
-        throw std::runtime_error{"Invalid IP address specified: " + ip_str};
+        throw cpptrace::runtime_error{"Invalid IP address specified: " + ip_str};
 
     ip = addr.to_string();
 
@@ -116,11 +117,11 @@ daemon::daemon(boost::program_options::variables_map vm_) :
 
     log::info(logcat, "- cryptonote protocol");
     if (!protocol->init(vm))
-        throw std::runtime_error("Failed to initialize cryptonote protocol.");
+        throw cpptrace::runtime_error("Failed to initialize cryptonote protocol.");
 
     log::info(logcat, "- p2p");
     if (!p2p->init(vm))
-        throw std::runtime_error("Failed to initialize p2p server.");
+        throw cpptrace::runtime_error("Failed to initialize p2p server.");
 
     // Handle circular dependencies
     protocol->set_p2p_endpoint(p2p.get());
@@ -142,7 +143,7 @@ daemon::daemon(boost::program_options::variables_map vm_) :
             "--rpc-bind-ip/--rpc-bind-port/--rpc-restricted-bind-port/--restricted-rpc/--public-node/--rpc-use-ipv6"sv;
 
     if (new_rpc_options && deprecated_rpc_options)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Failed to initialize rpc settings: --rpc-public/--rpc-admin cannot be combined "
                 "with deprecated " +
                 std::string{deprecated_option_names} + " options"};
@@ -284,7 +285,7 @@ void daemon::init_options(
         boost::program_options::options_description& hidden) {
     static bool called = false;
     if (called)
-        throw std::logic_error("daemon::init_options must only be called once");
+        throw cpptrace::logic_error("daemon::init_options must only be called once");
     else
         called = true;
     cryptonote::core::init_options(option_spec);
@@ -297,7 +298,7 @@ void daemon::init_options(
 
 bool daemon::run(bool interactive) {
     if (!core)
-        throw std::runtime_error{"Can't run stopped daemon"};
+        throw cpptrace::runtime_error{"Can't run stopped daemon"};
 
     std::atomic<bool> stop_sig(false), shutdown(false);
     std::thread stop_thread{[&stop_sig, &shutdown, this] {
@@ -325,7 +326,7 @@ bool daemon::run(bool interactive) {
 #endif
         log::info(logcat, "Starting core");
         if (!core->init(vm, nullptr, get_checkpoints))
-            throw std::runtime_error("Failed to start core");
+            throw cpptrace::runtime_error("Failed to start core");
 
         log::info(logcat, "Starting OxenMQ");
         omq_rpc = std::make_unique<cryptonote::rpc::omq_rpc>(*core, *rpc, vm);
@@ -350,7 +351,7 @@ bool daemon::run(bool interactive) {
                     [&p](oxenmq::ConnectionID) { p.set_value(); },
                     [&p](oxenmq::ConnectionID, std::string_view err) {
                         try {
-                            throw std::runtime_error{
+                            throw cpptrace::runtime_error{
                                     "Internal oxend RPC connection failed: " + std::string{err}};
                         } catch (...) {
                             p.set_exception(std::current_exception());
@@ -399,7 +400,7 @@ bool daemon::run(bool interactive) {
 
 void daemon::stop() {
     if (!core)
-        throw std::logic_error{"Can't send stop signal to a stopped daemon"};
+        throw cpptrace::logic_error{"Can't send stop signal to a stopped daemon"};
 
     p2p->send_stop_signal();  // Make p2p stop so that `run()` above continues with tear down
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -36,7 +36,7 @@
 #include <memory>
 #include <stdexcept>
 #include <utility>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_core.h"
@@ -81,7 +81,7 @@ std::pair<std::string, uint16_t> parse_ip_port(
         colon != std::string::npos && tools::parse_int(ip_port.substr(colon + 1), port))
         ip_port.remove_suffix(ip_port.size() - colon);
     else
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Invalid IP/port value specified to " + argname + ": " + std::string(ip_port)};
 
     if (!ip_port.empty() && ip_port.front() == '[' && ip_port.back() == ']') {
@@ -99,7 +99,7 @@ std::pair<std::string, uint16_t> parse_ip_port(
 #endif
             (ip_str, ec);
     if (ec)
-        throw cpptrace::runtime_error{"Invalid IP address specified: " + ip_str};
+        throw oxen::runtime_error{"Invalid IP address specified: " + ip_str};
 
     ip = addr.to_string();
 
@@ -117,11 +117,11 @@ daemon::daemon(boost::program_options::variables_map vm_) :
 
     log::info(logcat, "- cryptonote protocol");
     if (!protocol->init(vm))
-        throw cpptrace::runtime_error("Failed to initialize cryptonote protocol.");
+        throw oxen::runtime_error("Failed to initialize cryptonote protocol.");
 
     log::info(logcat, "- p2p");
     if (!p2p->init(vm))
-        throw cpptrace::runtime_error("Failed to initialize p2p server.");
+        throw oxen::runtime_error("Failed to initialize p2p server.");
 
     // Handle circular dependencies
     protocol->set_p2p_endpoint(p2p.get());
@@ -143,7 +143,7 @@ daemon::daemon(boost::program_options::variables_map vm_) :
             "--rpc-bind-ip/--rpc-bind-port/--rpc-restricted-bind-port/--restricted-rpc/--public-node/--rpc-use-ipv6"sv;
 
     if (new_rpc_options && deprecated_rpc_options)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Failed to initialize rpc settings: --rpc-public/--rpc-admin cannot be combined "
                 "with deprecated " +
                 std::string{deprecated_option_names} + " options"};
@@ -285,7 +285,7 @@ void daemon::init_options(
         boost::program_options::options_description& hidden) {
     static bool called = false;
     if (called)
-        throw cpptrace::logic_error("daemon::init_options must only be called once");
+        throw oxen::logic_error("daemon::init_options must only be called once");
     else
         called = true;
     cryptonote::core::init_options(option_spec);
@@ -298,7 +298,7 @@ void daemon::init_options(
 
 bool daemon::run(bool interactive) {
     if (!core)
-        throw cpptrace::runtime_error{"Can't run stopped daemon"};
+        throw oxen::runtime_error{"Can't run stopped daemon"};
 
     std::atomic<bool> stop_sig(false), shutdown(false);
     std::thread stop_thread{[&stop_sig, &shutdown, this] {
@@ -326,7 +326,7 @@ bool daemon::run(bool interactive) {
 #endif
         log::info(logcat, "Starting core");
         if (!core->init(vm, nullptr, get_checkpoints))
-            throw cpptrace::runtime_error("Failed to start core");
+            throw oxen::runtime_error("Failed to start core");
 
         log::info(logcat, "Starting OxenMQ");
         omq_rpc = std::make_unique<cryptonote::rpc::omq_rpc>(*core, *rpc, vm);
@@ -351,7 +351,7 @@ bool daemon::run(bool interactive) {
                     [&p](oxenmq::ConnectionID) { p.set_value(); },
                     [&p](oxenmq::ConnectionID, std::string_view err) {
                         try {
-                            throw cpptrace::runtime_error{
+                            throw oxen::runtime_error{
                                     "Internal oxend RPC connection failed: " + std::string{err}};
                         } catch (...) {
                             p.set_exception(std::current_exception());
@@ -400,7 +400,7 @@ bool daemon::run(bool interactive) {
 
 void daemon::stop() {
     if (!core)
-        throw cpptrace::logic_error{"Can't send stop signal to a stopped daemon"};
+        throw oxen::logic_error{"Can't send stop signal to a stopped daemon"};
 
     p2p->send_stop_signal();  // Make p2p stop so that `run()` above continues with tear down
 }

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char const* argv[]) {
             try {
                 std::ifstream cfg{*load_config};
                 if (!cfg.is_open())
-                    throw oxen::runtime_error{"Unable to open file"};
+                    throw oxen::traced<std::runtime_error>{"Unable to open file"};
                 po::store(
                         po::parse_config_file<char>(
                                 cfg,
@@ -325,7 +325,7 @@ int main(int argc, char const* argv[]) {
         } else {
             std::cerr << "Incorrect log level: "
                       << command_line::get_arg(vm, daemon_args::arg_log_level).c_str() << std::endl;
-            throw oxen::runtime_error{"Incorrect log level"};
+            throw oxen::traced<std::runtime_error>{"Incorrect log level"};
         }
         auto log_file_path = data_dir / cryptonote::LOG_FILENAME;
         if (!command_line::is_arg_defaulted(vm, daemon_args::arg_log_file))
@@ -368,7 +368,7 @@ int main(int argc, char const* argv[]) {
                     rpc_addr = command_line::get_arg(
                             vm, cryptonote::rpc::http_server::arg_rpc_admin)[0];
                     if (rpc_addr == "none")
-                        throw oxen::runtime_error{
+                        throw oxen::traced<std::runtime_error>{
                                 "Cannot invoke oxend command: --rpc-admin is disabled"};
                 }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -30,9 +30,9 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <cstdlib>
-#include <cpptrace/cpptrace.hpp>
 
 #include "command_server.h"
+#include "common/exception.h"
 #include "common/command_line.h"
 #include "common/fs.h"
 #include "common/password.h"
@@ -69,7 +69,7 @@ constexpr auto CYAN = "\033[36;1m";
 }  // namespace
 
 int main(int argc, char const* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     bool logs_initialized = false;
     try {
         // TODO parse the debug options like set log level right here at start
@@ -232,7 +232,7 @@ int main(int argc, char const* argv[]) {
             try {
                 std::ifstream cfg{*load_config};
                 if (!cfg.is_open())
-                    throw cpptrace::runtime_error{"Unable to open file"};
+                    throw oxen::runtime_error{"Unable to open file"};
                 po::store(
                         po::parse_config_file<char>(
                                 cfg,
@@ -323,7 +323,7 @@ int main(int argc, char const* argv[]) {
         } else {
             std::cerr << "Incorrect log level: "
                       << command_line::get_arg(vm, daemon_args::arg_log_level).c_str() << std::endl;
-            throw cpptrace::runtime_error{"Incorrect log level"};
+            throw oxen::runtime_error{"Incorrect log level"};
         }
         auto log_file_path = data_dir / cryptonote::LOG_FILENAME;
         if (!command_line::is_arg_defaulted(vm, daemon_args::arg_log_file))
@@ -366,7 +366,7 @@ int main(int argc, char const* argv[]) {
                     rpc_addr = command_line::get_arg(
                             vm, cryptonote::rpc::http_server::arg_rpc_admin)[0];
                     if (rpc_addr == "none")
-                        throw cpptrace::runtime_error{
+                        throw oxen::runtime_error{
                                 "Cannot invoke oxend command: --rpc-admin is disabled"};
                 }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -68,6 +68,8 @@ constexpr auto YELLOW = "\033[33;1m";
 constexpr auto CYAN = "\033[36;1m";
 }  // namespace
 
+#include <crypto/crypto.h>
+
 int main(int argc, char const* argv[]) {
     std::set_terminate(oxen::on_terminate_handler);
     bool logs_initialized = false;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -30,6 +30,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <cstdlib>
+#include <cpptrace/cpptrace.hpp>
 
 #include "command_server.h"
 #include "common/command_line.h"
@@ -49,6 +50,7 @@
 #include "rpc/core_rpc_server.h"
 #include "version.h"
 
+
 namespace po = boost::program_options;
 
 namespace Log = oxen::log;  // capital Log to avoid conflict with math.h log()
@@ -67,6 +69,7 @@ constexpr auto CYAN = "\033[36;1m";
 }  // namespace
 
 int main(int argc, char const* argv[]) {
+    cpptrace::register_terminate_handler();
     bool logs_initialized = false;
     try {
         // TODO parse the debug options like set log level right here at start
@@ -229,7 +232,7 @@ int main(int argc, char const* argv[]) {
             try {
                 std::ifstream cfg{*load_config};
                 if (!cfg.is_open())
-                    throw std::runtime_error{"Unable to open file"};
+                    throw cpptrace::runtime_error{"Unable to open file"};
                 po::store(
                         po::parse_config_file<char>(
                                 cfg,
@@ -320,7 +323,7 @@ int main(int argc, char const* argv[]) {
         } else {
             std::cerr << "Incorrect log level: "
                       << command_line::get_arg(vm, daemon_args::arg_log_level).c_str() << std::endl;
-            throw std::runtime_error{"Incorrect log level"};
+            throw cpptrace::runtime_error{"Incorrect log level"};
         }
         auto log_file_path = data_dir / cryptonote::LOG_FILENAME;
         if (!command_line::is_arg_defaulted(vm, daemon_args::arg_log_file))
@@ -363,7 +366,7 @@ int main(int argc, char const* argv[]) {
                     rpc_addr = command_line::get_arg(
                             vm, cryptonote::rpc::http_server::arg_rpc_admin)[0];
                     if (rpc_addr == "none")
-                        throw std::runtime_error{
+                        throw cpptrace::runtime_error{
                                 "Cannot invoke oxend command: --rpc-admin is disabled"};
                 }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -46,6 +46,7 @@
 #include <stack>
 #include <string>
 #include <type_traits>
+#include <cpptrace/cpptrace.hpp>
 
 #include "checkpoints/checkpoints.h"
 #include "common/median.h"
@@ -265,11 +266,11 @@ json rpc_command_executor::invoke(
                 [&result_p](bool success, auto data) {
                     try {
                         if (!success)
-                            throw std::runtime_error{"Request timed out"};
+                            throw cpptrace::runtime_error{"Request timed out"};
                         if (data.size() >= 2 && data[0] == "200")
                             result_p.set_value(json::parse(data[1]));
                         else
-                            throw std::runtime_error{
+                            throw cpptrace::runtime_error{
                                     "RPC method failed: " +
                                     (data.empty() ? "empty response" : tools::join(" ", data))};
                     } catch (...) {
@@ -284,7 +285,7 @@ json rpc_command_executor::invoke(
     if (check_status_ok) {
         if (auto it = result.find("status");
             it == result.end() || it->get<std::string_view>() != cryptonote::rpc::STATUS_OK)
-            throw std::runtime_error{
+            throw cpptrace::runtime_error{
                     "Received status " +
                     (it == result.end() ? "(empty)" : it->get_ref<const std::string&>()) +
                     " != OK"};

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -266,11 +266,11 @@ json rpc_command_executor::invoke(
                 [&result_p](bool success, auto data) {
                     try {
                         if (!success)
-                            throw oxen::runtime_error{"Request timed out"};
+                            throw oxen::traced<std::runtime_error>{"Request timed out"};
                         if (data.size() >= 2 && data[0] == "200")
                             result_p.set_value(json::parse(data[1]));
                         else
-                            throw oxen::runtime_error{
+                            throw oxen::traced<std::runtime_error>{
                                     "RPC method failed: " +
                                     (data.empty() ? "empty response" : tools::join(" ", data))};
                     } catch (...) {
@@ -285,7 +285,7 @@ json rpc_command_executor::invoke(
     if (check_status_ok) {
         if (auto it = result.find("status");
             it == result.end() || it->get<std::string_view>() != cryptonote::rpc::STATUS_OK)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "Received status " +
                     (it == result.end() ? "(empty)" : it->get_ref<const std::string&>()) +
                     " != OK"};

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -46,9 +46,9 @@
 #include <stack>
 #include <string>
 #include <type_traits>
-#include <cpptrace/cpptrace.hpp>
 
 #include "checkpoints/checkpoints.h"
+#include "common/exception.h"
 #include "common/median.h"
 #include "common/password.h"
 #include "common/pruning.h"
@@ -266,11 +266,11 @@ json rpc_command_executor::invoke(
                 [&result_p](bool success, auto data) {
                     try {
                         if (!success)
-                            throw cpptrace::runtime_error{"Request timed out"};
+                            throw oxen::runtime_error{"Request timed out"};
                         if (data.size() >= 2 && data[0] == "200")
                             result_p.set_value(json::parse(data[1]));
                         else
-                            throw cpptrace::runtime_error{
+                            throw oxen::runtime_error{
                                     "RPC method failed: " +
                                     (data.empty() ? "empty response" : tools::join(" ", data))};
                     } catch (...) {
@@ -285,7 +285,7 @@ json rpc_command_executor::invoke(
     if (check_status_ok) {
         if (auto it = result.find("status");
             it == result.end() || it->get<std::string_view>() != cryptonote::rpc::STATUS_OK)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Received status " +
                     (it == result.end() ? "(empty)" : it->get_ref<const std::string&>()) +
                     " != OK"};

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -34,8 +34,8 @@
 #include <concepts>
 #include <exception>
 #include <optional>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/common_fwd.h"
 #include "common/scoped_message_writer.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -81,7 +81,7 @@ class rpc_command_executor final {
             if (auto* rpc_client = std::get_if<cryptonote::rpc::http_client>(&m_rpc)) {
                 res = rpc_client->json_rpc<RPC>(RPC::names()[0], req);
             } else {
-                throw cpptrace::runtime_error{"fixme"};
+                throw oxen::runtime_error{"fixme"};
             }
             if (!check_status_ok || res.status == cryptonote::rpc::STATUS_OK)
                 return true;

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -34,6 +34,7 @@
 #include <concepts>
 #include <exception>
 #include <optional>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/common_fwd.h"
 #include "common/scoped_message_writer.h"
@@ -80,7 +81,7 @@ class rpc_command_executor final {
             if (auto* rpc_client = std::get_if<cryptonote::rpc::http_client>(&m_rpc)) {
                 res = rpc_client->json_rpc<RPC>(RPC::names()[0], req);
             } else {
-                throw std::runtime_error{"fixme"};
+                throw cpptrace::runtime_error{"fixme"};
             }
             if (!check_status_ok || res.status == cryptonote::rpc::STATUS_OK)
                 return true;

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -81,7 +81,7 @@ class rpc_command_executor final {
             if (auto* rpc_client = std::get_if<cryptonote::rpc::http_client>(&m_rpc)) {
                 res = rpc_client->json_rpc<RPC>(RPC::names()[0], req);
             } else {
-                throw oxen::runtime_error{"fixme"};
+                throw oxen::traced<std::runtime_error>{"fixme"};
             }
             if (!check_status_ok || res.status == cryptonote::rpc::STATUS_OK)
                 return true;

--- a/src/daemonizer/windows_service_runner.h
+++ b/src/daemonizer/windows_service_runner.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "daemonizer/windows_service.h"
 
@@ -64,7 +65,7 @@ class service_runner final {
         // This limitation is crappy, but imposed on us by Windows
         auto& instance = get_instance();
         if (instance)
-            throw std::runtime_error("Only one service_runner<T> may exist at a time");
+            throw cpptrace::runtime_error("Only one service_runner<T> may exist at a time");
         instance = this;
 
         m_status.dwServiceType = SERVICE_WIN32;

--- a/src/daemonizer/windows_service_runner.h
+++ b/src/daemonizer/windows_service_runner.h
@@ -66,7 +66,7 @@ class service_runner final {
         // This limitation is crappy, but imposed on us by Windows
         auto& instance = get_instance();
         if (instance)
-            throw oxen::runtime_error("Only one service_runner<T> may exist at a time");
+            throw oxen::traced<std::runtime_error>("Only one service_runner<T> may exist at a time");
         instance = this;
 
         m_status.dwServiceType = SERVICE_WIN32;

--- a/src/daemonizer/windows_service_runner.h
+++ b/src/daemonizer/windows_service_runner.h
@@ -33,12 +33,13 @@
 #undef UNICODE
 #undef _UNICODE
 
+#include <common/exception.h>
+
 #include <windows.h>
 
 #include <memory>
 #include <string>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
 
 #include "daemonizer/windows_service.h"
 
@@ -65,7 +66,7 @@ class service_runner final {
         // This limitation is crappy, but imposed on us by Windows
         auto& instance = get_instance();
         if (instance)
-            throw cpptrace::runtime_error("Only one service_runner<T> may exist at a time");
+            throw oxen::runtime_error("Only one service_runner<T> may exist at a time");
         instance = this;
 
         m_status.dwServiceType = SERVICE_WIN32;

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -29,6 +29,8 @@
 
 #include <oxenc/hex.h>
 
+#include <cpptrace/cpptrace.hpp>
+
 #include "common/command_line.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/tx_extra.h"
@@ -176,6 +178,7 @@ constexpr static std::string_view network_type_str(network_type nettype) {
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     uint32_t default_log_level = 0;
     std::string input;
 
@@ -229,7 +232,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level)
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -32,6 +32,7 @@
 #include <cpptrace/cpptrace.hpp>
 
 #include "common/command_line.h"
+#include "common/exception.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/tx_extra.h"
 #include "cryptonote_core/blockchain.h"
@@ -178,7 +179,7 @@ constexpr static std::string_view network_type_str(network_type nettype) {
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     uint32_t default_log_level = 0;
     std::string input;
 
@@ -232,7 +233,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level)
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[]) {
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level)
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
     oxen::logging::init(log_file_path, log_level);
     log::warning(logcat, "Starting...");

--- a/src/debug_utilities/object_sizes.cpp
+++ b/src/debug_utilities/object_sizes.cpp
@@ -28,6 +28,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
+#include <cpptrace/cpptrace.hpp>
 
 #include "blockchain_db/lmdb/db_lmdb.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -60,6 +61,7 @@ class size_logger {
 #define SL(type) sl.add(#type, sizeof(type))
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     size_logger sl;
 
     tools::on_startup();

--- a/src/debug_utilities/object_sizes.cpp
+++ b/src/debug_utilities/object_sizes.cpp
@@ -61,7 +61,7 @@ class size_logger {
 #define SL(type) sl.add(#type, sizeof(type))
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     size_logger sl;
 
     tools::on_startup();

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -90,7 +90,7 @@ device& device_registry::get_device(const std::string& device_descriptor) {
                 logcat, "Device not found in registry: '{}'. Known devices: ", device_descriptor);
         for (const auto& sm_pair : registry)
             log::error(logcat, " - {}", sm_pair.first);
-        throw oxen::runtime_error("device not found: " + device_descriptor);
+        throw oxen::traced<std::runtime_error>("device not found: " + device_descriptor);
     }
     return *device->second;
 }

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -29,6 +29,8 @@
 
 #include "device.hpp"
 
+#include <cpptrace/cpptrace.hpp>
+
 #include "device_default.hpp"
 #include "logging/oxen_logger.h"
 #ifdef WITH_DEVICE_LEDGER
@@ -89,7 +91,7 @@ device& device_registry::get_device(const std::string& device_descriptor) {
                 logcat, "Device not found in registry: '{}'. Known devices: ", device_descriptor);
         for (const auto& sm_pair : registry)
             log::error(logcat, " - {}", sm_pair.first);
-        throw std::runtime_error("device not found: " + device_descriptor);
+        throw cpptrace::runtime_error("device not found: " + device_descriptor);
     }
     return *device->second;
 }

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -29,8 +29,7 @@
 
 #include "device.hpp"
 
-#include <cpptrace/cpptrace.hpp>
-
+#include "common/exception.h"
 #include "device_default.hpp"
 #include "logging/oxen_logger.h"
 #ifdef WITH_DEVICE_LEDGER
@@ -91,7 +90,7 @@ device& device_registry::get_device(const std::string& device_descriptor) {
                 logcat, "Device not found in registry: '{}'. Known devices: ", device_descriptor);
         for (const auto& sm_pair : registry)
             log::error(logcat, " - {}", sm_pair.first);
-        throw cpptrace::runtime_error("device not found: " + device_descriptor);
+        throw oxen::runtime_error("device not found: " + device_descriptor);
     }
     return *device->second;
 }

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -30,8 +30,8 @@
 #include "device_default.hpp"
 
 #include <sodium/crypto_generichash.h>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "crypto/crypto.h"
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/subaddress_index.h"
@@ -97,10 +97,10 @@ bool device_default::generate_chacha_key(
     return true;
 }
 bool device_default::get_public_address(cryptonote::account_public_address& pubkey) {
-    throw cpptrace::runtime_error{"device function not supported: get_public_address"};
+    throw oxen::runtime_error{"device function not supported: get_public_address"};
 }
 bool device_default::get_secret_keys(crypto::secret_key& viewkey, crypto::secret_key& spendkey) {
-    throw cpptrace::runtime_error{"device function not supported: get_secret_keys"};
+    throw oxen::runtime_error{"device function not supported: get_secret_keys"};
 }
 /* ======================================================================= */
 /*                               SUB ADDRESS                               */

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -97,10 +97,10 @@ bool device_default::generate_chacha_key(
     return true;
 }
 bool device_default::get_public_address(cryptonote::account_public_address& pubkey) {
-    throw oxen::runtime_error{"device function not supported: get_public_address"};
+    throw oxen::traced<std::runtime_error>{"device function not supported: get_public_address"};
 }
 bool device_default::get_secret_keys(crypto::secret_key& viewkey, crypto::secret_key& spendkey) {
-    throw oxen::runtime_error{"device function not supported: get_secret_keys"};
+    throw oxen::traced<std::runtime_error>{"device function not supported: get_secret_keys"};
 }
 /* ======================================================================= */
 /*                               SUB ADDRESS                               */

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -30,6 +30,7 @@
 #include "device_default.hpp"
 
 #include <sodium/crypto_generichash.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "crypto/crypto.h"
 #include "cryptonote_basic/account.h"
@@ -96,10 +97,10 @@ bool device_default::generate_chacha_key(
     return true;
 }
 bool device_default::get_public_address(cryptonote::account_public_address& pubkey) {
-    throw std::runtime_error{"device function not supported: get_public_address"};
+    throw cpptrace::runtime_error{"device function not supported: get_public_address"};
 }
 bool device_default::get_secret_keys(crypto::secret_key& viewkey, crypto::secret_key& spendkey) {
-    throw std::runtime_error{"device function not supported: get_secret_keys"};
+    throw cpptrace::runtime_error{"device function not supported: get_secret_keys"};
 }
 /* ======================================================================= */
 /*                               SUB ADDRESS                               */

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -31,7 +31,7 @@
 #include "device_ledger.hpp"
 
 #include <oxenc/endian.h>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include <chrono>
 
@@ -138,7 +138,7 @@ void HMACmap::find_mac(const uint8_t sec[32], uint8_t hmac[32]) {
             return;
         }
     }
-    throw cpptrace::runtime_error("Protocol error: try to send untrusted secret");
+    throw oxen::runtime_error("Protocol error: try to send untrusted secret");
 }
 
 void HMACmap::add_mac(const uint8_t sec[32], const uint8_t hmac[32]) {
@@ -717,7 +717,7 @@ bool device_ledger::connect() {
     else if (auto* tcp = dynamic_cast<io::ledger_tcp*>(hw_device.get()))
         tcp->connect();
     else
-        throw cpptrace::logic_error{"Invalid ledger hardware configure"};
+        throw oxen::logic_error{"Invalid ledger hardware configure"};
     reset();
 
     check_network_type();
@@ -767,10 +767,10 @@ void device_ledger::check_network_type() {
     auto device_nettype = static_cast<cryptonote::network_type>(buffer_recv[4]);
     log::debug(logcat, "Ledger wallet is set to {} {}", coin, nettype_string(device_nettype));
     if (coin != COIN_NETWORK)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Invalid wallet app: expected " + std::string{COIN_NETWORK} + ", got " + coin};
     if (device_nettype != nettype)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Ledger wallet is set to the wrong network type: expected " +
                 nettype_string(nettype) + " but the device is set to " +
                 nettype_string(device_nettype)};
@@ -1209,7 +1209,7 @@ crypto::secret_key device_ledger::generate_keys(
     auto locks = tools::unique_locks(device_locker, command_locker);
     int offset;
     if (recover) {
-        throw cpptrace::runtime_error("device generate key does not support recover");
+        throw oxen::runtime_error("device generate key does not support recover");
     }
 
 #ifdef DEBUG_HWDEVICE
@@ -1721,7 +1721,7 @@ void device_ledger::get_transaction_prefix_hash(
     } catch (const std::exception& e) {
         auto err = "unable to serialize transaction prefix: {}"_format(e.what());
         log::error(logcat, "{}", err);
-        throw cpptrace::runtime_error{e.what()};
+        throw oxen::runtime_error{e.what()};
     }
 
     unsigned char* send = buffer_send + set_command_header_noopt(INS_PREFIX_HASH, 1);

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -138,7 +138,7 @@ void HMACmap::find_mac(const uint8_t sec[32], uint8_t hmac[32]) {
             return;
         }
     }
-    throw oxen::runtime_error("Protocol error: try to send untrusted secret");
+    throw oxen::traced<std::runtime_error>("Protocol error: try to send untrusted secret");
 }
 
 void HMACmap::add_mac(const uint8_t sec[32], const uint8_t hmac[32]) {
@@ -717,7 +717,7 @@ bool device_ledger::connect() {
     else if (auto* tcp = dynamic_cast<io::ledger_tcp*>(hw_device.get()))
         tcp->connect();
     else
-        throw oxen::logic_error{"Invalid ledger hardware configure"};
+        throw oxen::traced<std::logic_error>{"Invalid ledger hardware configure"};
     reset();
 
     check_network_type();
@@ -767,10 +767,10 @@ void device_ledger::check_network_type() {
     auto device_nettype = static_cast<cryptonote::network_type>(buffer_recv[4]);
     log::debug(logcat, "Ledger wallet is set to {} {}", coin, nettype_string(device_nettype));
     if (coin != COIN_NETWORK)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Invalid wallet app: expected " + std::string{COIN_NETWORK} + ", got " + coin};
     if (device_nettype != nettype)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Ledger wallet is set to the wrong network type: expected " +
                 nettype_string(nettype) + " but the device is set to " +
                 nettype_string(device_nettype)};
@@ -1209,7 +1209,7 @@ crypto::secret_key device_ledger::generate_keys(
     auto locks = tools::unique_locks(device_locker, command_locker);
     int offset;
     if (recover) {
-        throw oxen::runtime_error("device generate key does not support recover");
+        throw oxen::traced<std::runtime_error>("device generate key does not support recover");
     }
 
 #ifdef DEBUG_HWDEVICE
@@ -1721,7 +1721,7 @@ void device_ledger::get_transaction_prefix_hash(
     } catch (const std::exception& e) {
         auto err = "unable to serialize transaction prefix: {}"_format(e.what());
         log::error(logcat, "{}", err);
-        throw oxen::runtime_error{e.what()};
+        throw oxen::traced<std::runtime_error>{e.what()};
     }
 
     unsigned char* send = buffer_send + set_command_header_noopt(INS_PREFIX_HASH, 1);

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -31,6 +31,7 @@
 #include "device_ledger.hpp"
 
 #include <oxenc/endian.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <chrono>
 
@@ -137,7 +138,7 @@ void HMACmap::find_mac(const uint8_t sec[32], uint8_t hmac[32]) {
             return;
         }
     }
-    throw std::runtime_error("Protocol error: try to send untrusted secret");
+    throw cpptrace::runtime_error("Protocol error: try to send untrusted secret");
 }
 
 void HMACmap::add_mac(const uint8_t sec[32], const uint8_t hmac[32]) {
@@ -716,7 +717,7 @@ bool device_ledger::connect() {
     else if (auto* tcp = dynamic_cast<io::ledger_tcp*>(hw_device.get()))
         tcp->connect();
     else
-        throw std::logic_error{"Invalid ledger hardware configure"};
+        throw cpptrace::logic_error{"Invalid ledger hardware configure"};
     reset();
 
     check_network_type();
@@ -766,10 +767,10 @@ void device_ledger::check_network_type() {
     auto device_nettype = static_cast<cryptonote::network_type>(buffer_recv[4]);
     log::debug(logcat, "Ledger wallet is set to {} {}", coin, nettype_string(device_nettype));
     if (coin != COIN_NETWORK)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Invalid wallet app: expected " + std::string{COIN_NETWORK} + ", got " + coin};
     if (device_nettype != nettype)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Ledger wallet is set to the wrong network type: expected " +
                 nettype_string(nettype) + " but the device is set to " +
                 nettype_string(device_nettype)};
@@ -1208,7 +1209,7 @@ crypto::secret_key device_ledger::generate_keys(
     auto locks = tools::unique_locks(device_locker, command_locker);
     int offset;
     if (recover) {
-        throw std::runtime_error("device generate key does not support recover");
+        throw cpptrace::runtime_error("device generate key does not support recover");
     }
 
 #ifdef DEBUG_HWDEVICE
@@ -1720,7 +1721,7 @@ void device_ledger::get_transaction_prefix_hash(
     } catch (const std::exception& e) {
         auto err = "unable to serialize transaction prefix: {}"_format(e.what());
         log::error(logcat, "{}", err);
-        throw std::runtime_error{err};
+        throw cpptrace::runtime_error{e.what()};
     }
 
     unsigned char* send = buffer_send + set_command_header_noopt(INS_PREFIX_HASH, 1);

--- a/src/device/io_ledger_tcp.cpp
+++ b/src/device/io_ledger_tcp.cpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <cstring>
 #include <stdexcept>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/oxen.h"
 #include "epee/misc_log_ex.h"
@@ -59,21 +59,21 @@ void ledger_tcp::connect() {
 
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0)
-        throw cpptrace::runtime_error{"Failed to open socket: "s + strerror(errno)};
+        throw oxen::runtime_error{"Failed to open socket: "s + strerror(errno)};
     auto closer = oxen::defer([&] { close(fd); });
 
 #ifdef _WIN32
     unsigned long blocking_param = 1;  // 1 = make non-blocking, 0 = blocking
     if (auto result = ioctlsocket(fd, FIONBIO, &blocking_param); result != NO_ERROR)
-        throw cpptrace::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
+        throw oxen::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
 #else
     if (-1 == fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK))
-        throw cpptrace::runtime_error{"Failed to set socket non-blocking: "s + strerror(errno)};
+        throw oxen::runtime_error{"Failed to set socket non-blocking: "s + strerror(errno)};
 #endif
 
     addrinfo* addr;
     if (int rc = getaddrinfo(host.data(), port.data(), nullptr, &addr); rc != 0)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Failed to resolve " + host + ":" + port + ": " + gai_strerror(rc)};
     auto addr_free = oxen::defer([&] { freeaddrinfo(addr); });
 
@@ -106,17 +106,17 @@ void ledger_tcp::connect() {
         }
     }
     if (!connected)
-        throw cpptrace::runtime_error{"Failed to connect to " + host + ":" + port + ": " + err};
+        throw oxen::runtime_error{"Failed to connect to " + host + ":" + port + ": " + err};
 
     log::debug(logcat, "Connected to {}", to_string(a));
 
 #ifdef _WIN32
     blocking_param = 0;
     if (auto result = ioctlsocket(fd, FIONBIO, &blocking_param); result != NO_ERROR)
-        throw cpptrace::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
+        throw oxen::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
 #else
     if (-1 == fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK))
-        throw cpptrace::runtime_error{"Failed to set socket back to blocking: "s + strerror(errno)};
+        throw oxen::runtime_error{"Failed to set socket back to blocking: "s + strerror(errno)};
 #endif
 
     timeval timeo;
@@ -151,7 +151,7 @@ void full_read(int fd, unsigned char* to, int size) {
     while (size > 0) {
         auto read_size = read(fd, to, size);
         if (read_size == -1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Failed to read from hardware wallet socket: "s + strerror(errno)};
         size -= read_size;
         to += read_size;
@@ -162,7 +162,7 @@ void full_write(int fd, const unsigned char* from, int size) {
     while (size > 0) {
         auto wrote = write(fd, from, size);
         if (wrote == -1)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "Failed to write to hardware wallet socket: "s + strerror(errno)};
         size -= wrote;
         from += wrote;
@@ -176,7 +176,7 @@ int ledger_tcp::exchange(
         unsigned int max_resp_len,
         bool user_input) {
     if (!sockfd)
-        throw cpptrace::runtime_error{"Unable to exchange data with hardware wallet: not connected"};
+        throw oxen::runtime_error{"Unable to exchange data with hardware wallet: not connected"};
 
     // Sending: [SIZE][DATA], where SIZE is a uint32_t in network order
     uint32_t size = oxenc::host_to_big(cmd_len);
@@ -191,7 +191,7 @@ int ledger_tcp::exchange(
     auto data_size = oxenc::big_to_host(size) + 2;
 
     if (data_size > max_resp_len)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Hardware wallet returned unexpectedly large response: got " +
                 std::to_string(data_size) + " bytes, expected <= " + std::to_string(max_resp_len)};
 

--- a/src/device/io_ledger_tcp.cpp
+++ b/src/device/io_ledger_tcp.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstring>
 #include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/oxen.h"
 #include "epee/misc_log_ex.h"
@@ -58,21 +59,21 @@ void ledger_tcp::connect() {
 
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0)
-        throw std::runtime_error{"Failed to open socket: "s + strerror(errno)};
+        throw cpptrace::runtime_error{"Failed to open socket: "s + strerror(errno)};
     auto closer = oxen::defer([&] { close(fd); });
 
 #ifdef _WIN32
     unsigned long blocking_param = 1;  // 1 = make non-blocking, 0 = blocking
     if (auto result = ioctlsocket(fd, FIONBIO, &blocking_param); result != NO_ERROR)
-        throw std::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
+        throw cpptrace::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
 #else
     if (-1 == fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK))
-        throw std::runtime_error{"Failed to set socket non-blocking: "s + strerror(errno)};
+        throw cpptrace::runtime_error{"Failed to set socket non-blocking: "s + strerror(errno)};
 #endif
 
     addrinfo* addr;
     if (int rc = getaddrinfo(host.data(), port.data(), nullptr, &addr); rc != 0)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Failed to resolve " + host + ":" + port + ": " + gai_strerror(rc)};
     auto addr_free = oxen::defer([&] { freeaddrinfo(addr); });
 
@@ -105,17 +106,17 @@ void ledger_tcp::connect() {
         }
     }
     if (!connected)
-        throw std::runtime_error{"Failed to connect to " + host + ":" + port + ": " + err};
+        throw cpptrace::runtime_error{"Failed to connect to " + host + ":" + port + ": " + err};
 
     log::debug(logcat, "Connected to {}", to_string(a));
 
 #ifdef _WIN32
     blocking_param = 0;
     if (auto result = ioctlsocket(fd, FIONBIO, &blocking_param); result != NO_ERROR)
-        throw std::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
+        throw cpptrace::runtime_error{"ioctlsocket failed with error: " + std::to_string(result)};
 #else
     if (-1 == fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK))
-        throw std::runtime_error{"Failed to set socket back to blocking: "s + strerror(errno)};
+        throw cpptrace::runtime_error{"Failed to set socket back to blocking: "s + strerror(errno)};
 #endif
 
     timeval timeo;
@@ -150,7 +151,7 @@ void full_read(int fd, unsigned char* to, int size) {
     while (size > 0) {
         auto read_size = read(fd, to, size);
         if (read_size == -1)
-            throw std::runtime_error{
+            throw cpptrace::runtime_error{
                     "Failed to read from hardware wallet socket: "s + strerror(errno)};
         size -= read_size;
         to += read_size;
@@ -161,7 +162,7 @@ void full_write(int fd, const unsigned char* from, int size) {
     while (size > 0) {
         auto wrote = write(fd, from, size);
         if (wrote == -1)
-            throw std::runtime_error{
+            throw cpptrace::runtime_error{
                     "Failed to write to hardware wallet socket: "s + strerror(errno)};
         size -= wrote;
         from += wrote;
@@ -175,7 +176,7 @@ int ledger_tcp::exchange(
         unsigned int max_resp_len,
         bool user_input) {
     if (!sockfd)
-        throw std::runtime_error{"Unable to exchange data with hardware wallet: not connected"};
+        throw cpptrace::runtime_error{"Unable to exchange data with hardware wallet: not connected"};
 
     // Sending: [SIZE][DATA], where SIZE is a uint32_t in network order
     uint32_t size = oxenc::host_to_big(cmd_len);
@@ -190,7 +191,7 @@ int ledger_tcp::exchange(
     auto data_size = oxenc::big_to_host(size) + 2;
 
     if (data_size > max_resp_len)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Hardware wallet returned unexpectedly large response: got " +
                 std::to_string(data_size) + " bytes, expected <= " + std::to_string(max_resp_len)};
 

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -31,6 +31,8 @@
 
 #include "common/lock.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace hw::trezor {
 
 #ifdef WITH_DEVICE_TREZOR
@@ -539,7 +541,7 @@ void device_trezor::tx_sign(
                     return true;
                 });
         if (!all_are_txin_to_key) {
-            throw std::invalid_argument("Not all are txin_to_key");
+            throw cpptrace::invalid_argument("Not all are txin_to_key");
         }
         cpend.key_images = key_images.str();
 

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -30,8 +30,7 @@
 #include "device_trezor.hpp"
 
 #include "common/lock.h"
-
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 namespace hw::trezor {
 
@@ -541,7 +540,7 @@ void device_trezor::tx_sign(
                     return true;
                 });
         if (!all_are_txin_to_key) {
-            throw cpptrace::invalid_argument("Not all are txin_to_key");
+            throw oxen::invalid_argument("Not all are txin_to_key");
         }
         cpend.key_images = key_images.str();
 

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -540,7 +540,7 @@ void device_trezor::tx_sign(
                     return true;
                 });
         if (!all_are_txin_to_key) {
-            throw oxen::invalid_argument("Not all are txin_to_key");
+            throw oxen::traced<std::invalid_argument>("Not all are txin_to_key");
         }
         cpend.key_images = key_images.str();
 

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -578,7 +578,7 @@ void device_trezor_base::load_device(
         bool skip_checksum,
         bool expand) {
     if (m_features && m_features->initialized()) {
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Device is initialized already. Call device.wipe() and try again.");
     }
 

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -33,6 +33,8 @@
 #include "common/string_util.h"
 #include "epee/memwipe.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace hw::trezor {
 
 #ifdef WITH_DEVICE_TREZOR
@@ -577,7 +579,7 @@ void device_trezor_base::load_device(
         bool skip_checksum,
         bool expand) {
     if (m_features && m_features->initialized()) {
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Device is initialized already. Call device.wipe() and try again.");
     }
 

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -31,9 +31,8 @@
 
 #include "common/lock.h"
 #include "common/string_util.h"
+#include "common/exception.h"
 #include "epee/memwipe.h"
-
-#include <cpptrace/cpptrace.hpp>
 
 namespace hw::trezor {
 
@@ -579,7 +578,7 @@ void device_trezor_base::load_device(
         bool skip_checksum,
         bool expand) {
     if (m_features && m_features->initialized()) {
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Device is initialized already. Call device.wipe() and try again.");
     }
 

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <mutex>
 #include <string>
+#include <cpptrace/cpptrace.hpp>
 
 #include "cryptonote_config.h"
 #include "device/device.hpp"
@@ -134,7 +135,7 @@ class device_trezor_base : public hw::core::device_default {
         static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
         const bool accepting_base = boost::is_same<google::protobuf::Message, t_message>::value;
         if (resp_types && !accepting_base) {
-            throw std::invalid_argument(
+            throw cpptrace::invalid_argument(
                     "Cannot specify list of accepted types and not using generic response");
         }
 

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -33,8 +33,8 @@
 #include <cstddef>
 #include <mutex>
 #include <string>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "cryptonote_config.h"
 #include "device/device.hpp"
 #include "device/device_cold.hpp"
@@ -135,7 +135,7 @@ class device_trezor_base : public hw::core::device_default {
         static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
         const bool accepting_base = boost::is_same<google::protobuf::Message, t_message>::value;
         if (resp_types && !accepting_base) {
-            throw cpptrace::invalid_argument(
+            throw oxen::invalid_argument(
                     "Cannot specify list of accepted types and not using generic response");
         }
 

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -135,7 +135,7 @@ class device_trezor_base : public hw::core::device_default {
         static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
         const bool accepting_base = boost::is_same<google::protobuf::Message, t_message>::value;
         if (resp_types && !accepting_base) {
-            throw oxen::invalid_argument(
+            throw oxen::traced<std::invalid_argument>(
                     "Cannot specify list of accepted types and not using generic response");
         }
 

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -31,13 +31,13 @@
 
 #include <common/apply_permutation.h>
 #include <common/json_util.h>
+#include <common/exception.h>
 #include <crypto/hmac-keccak.h>
 #include <ringct/bulletproofs.h>
 #include <ringct/rctSigs.h>
 #include <sodium.h>
 #include <sodium/crypto_aead_chacha20poly1305.h>
 #include <sodium/crypto_verify_32.h>
-#include <cpptrace/cpptrace.hpp>
 
 #include <set>
 #include <unordered_map>
@@ -68,10 +68,10 @@
                 VAL(name, type, jtype);                                                        \
                 field_##name##_found = true;                                                   \
             } else {                                                                           \
-                throw cpptrace::invalid_argument("Field " #name " found in JSON, but not " #jtype); \
+                throw oxen::invalid_argument("Field " #name " found in JSON, but not " #jtype); \
             }                                                                                  \
         } else if (mandatory) {                                                                \
-            throw cpptrace::invalid_argument("Field " #name " not found in JSON");                  \
+            throw oxen::invalid_argument("Field " #name " not found in JSON");                  \
         }                                                                                      \
     while (0)
 
@@ -95,7 +95,7 @@ std::string key_to_string(const ::rct::key& key) {
 
 void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw cpptrace::invalid_argument(
+        throw oxen::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -103,7 +103,7 @@ void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
 
 void string_to_key(::crypto::ec_point& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw cpptrace::invalid_argument(
+        throw oxen::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -111,7 +111,7 @@ void string_to_key(::crypto::ec_point& key, const std::string& str) {
 
 void string_to_key(::rct::key& key, const std::string& str) {
     if (str.size() != sizeof(key.bytes)) {
-        throw cpptrace::invalid_argument(
+        throw oxen::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.bytes)) + " B");
     }
     memcpy(key.bytes, str.data(), sizeof(key.bytes));
@@ -350,7 +350,7 @@ namespace tx {
             std::optional<bool> is_subaddr) {
         ::crypto::public_key spend{}, view{};
         if (spend_key.size() != 32 || view_key.size() != 32) {
-            throw cpptrace::invalid_argument("Public keys have invalid sizes");
+            throw oxen::invalid_argument("Public keys have invalid sizes");
         }
 
         memcpy(spend.data, spend_key.data(), 32);
@@ -414,7 +414,7 @@ namespace tx {
         std::string sep = is_iv ? "sig-iv" : "sig-key";
         std::string idx_data = tools::get_varint_data(idx);
         if (idx_data.size() > 4) {
-            throw cpptrace::invalid_argument("index is too big");
+            throw oxen::invalid_argument("index is too big");
         }
 
         keccak_init(&ctx);
@@ -497,7 +497,7 @@ namespace tx {
 
             } else if (rsig_type == rct::RangeProofType::PaddedBulletproof) {
                 if (num_outputs > BULLETPROOF_MAX_OUTPUTS) {
-                    throw cpptrace::invalid_argument(
+                    throw oxen::invalid_argument(
                             "BP padded can support only BULLETPROOF_MAX_OUTPUTS "
                             "statements");
                 }
@@ -515,7 +515,7 @@ namespace tx {
                 amount_batched += batch_size;
 
             } else {
-                throw cpptrace::invalid_argument("Unknown rsig type");
+                throw oxen::invalid_argument("Unknown rsig type");
             }
         }
     }
@@ -662,7 +662,7 @@ namespace tx {
             fee -= cur_out.amount;
         }
         if (fee < 0) {
-            throw cpptrace::invalid_argument("Fee cannot be negative");
+            throw oxen::invalid_argument("Fee cannot be negative");
         }
 
         tsx_data.set_fee(static_cast<google::protobuf::uint64>(fee));
@@ -1078,7 +1078,7 @@ namespace tx {
             auto& cout_key = ack->cout_key();
             for (auto& cur : m_ct.couts) {
                 if (cur.size() != crypto::chacha::IV_SIZE + 32) {
-                    throw cpptrace::invalid_argument("Encrypted cout has invalid length");
+                    throw oxen::invalid_argument("Encrypted cout has invalid length");
                 }
 
                 char buff[32];
@@ -1182,9 +1182,9 @@ namespace tx {
 
         // The contents should be JSON if the wallet follows the new format.
         if (json.Parse(data.c_str()).HasParseError()) {
-            throw cpptrace::invalid_argument("Data parsing error");
+            throw oxen::invalid_argument("Data parsing error");
         } else if (!json.IsObject()) {
-            throw cpptrace::invalid_argument("Data parsing error - not an object");
+            throw oxen::invalid_argument("Data parsing error - not an object");
         }
 
         GET_FIELD_FROM_JSON(json, version, int, Int, true, -1);
@@ -1194,7 +1194,7 @@ namespace tx {
         GET_STRING_FROM_JSON(json, tx_prefix_hash, std::string, false, std::string());
 
         if (field_version != 1) {
-            throw cpptrace::invalid_argument("Unknown version");
+            throw oxen::invalid_argument("Unknown version");
         }
 
         res.salt1 = field_salt1;

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -37,6 +37,7 @@
 #include <sodium.h>
 #include <sodium/crypto_aead_chacha20poly1305.h>
 #include <sodium/crypto_verify_32.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <set>
 #include <unordered_map>
@@ -67,10 +68,10 @@
                 VAL(name, type, jtype);                                                        \
                 field_##name##_found = true;                                                   \
             } else {                                                                           \
-                throw std::invalid_argument("Field " #name " found in JSON, but not " #jtype); \
+                throw cpptrace::invalid_argument("Field " #name " found in JSON, but not " #jtype); \
             }                                                                                  \
         } else if (mandatory) {                                                                \
-            throw std::invalid_argument("Field " #name " not found in JSON");                  \
+            throw cpptrace::invalid_argument("Field " #name " not found in JSON");                  \
         }                                                                                      \
     while (0)
 
@@ -94,7 +95,7 @@ std::string key_to_string(const ::rct::key& key) {
 
 void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw std::invalid_argument(
+        throw cpptrace::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -102,7 +103,7 @@ void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
 
 void string_to_key(::crypto::ec_point& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw std::invalid_argument(
+        throw cpptrace::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -110,7 +111,7 @@ void string_to_key(::crypto::ec_point& key, const std::string& str) {
 
 void string_to_key(::rct::key& key, const std::string& str) {
     if (str.size() != sizeof(key.bytes)) {
-        throw std::invalid_argument(
+        throw cpptrace::invalid_argument(
                 std::string("Key has to have ") + std::to_string(sizeof(key.bytes)) + " B");
     }
     memcpy(key.bytes, str.data(), sizeof(key.bytes));
@@ -349,7 +350,7 @@ namespace tx {
             std::optional<bool> is_subaddr) {
         ::crypto::public_key spend{}, view{};
         if (spend_key.size() != 32 || view_key.size() != 32) {
-            throw std::invalid_argument("Public keys have invalid sizes");
+            throw cpptrace::invalid_argument("Public keys have invalid sizes");
         }
 
         memcpy(spend.data, spend_key.data(), 32);
@@ -413,7 +414,7 @@ namespace tx {
         std::string sep = is_iv ? "sig-iv" : "sig-key";
         std::string idx_data = tools::get_varint_data(idx);
         if (idx_data.size() > 4) {
-            throw std::invalid_argument("index is too big");
+            throw cpptrace::invalid_argument("index is too big");
         }
 
         keccak_init(&ctx);
@@ -496,7 +497,7 @@ namespace tx {
 
             } else if (rsig_type == rct::RangeProofType::PaddedBulletproof) {
                 if (num_outputs > BULLETPROOF_MAX_OUTPUTS) {
-                    throw std::invalid_argument(
+                    throw cpptrace::invalid_argument(
                             "BP padded can support only BULLETPROOF_MAX_OUTPUTS "
                             "statements");
                 }
@@ -514,7 +515,7 @@ namespace tx {
                 amount_batched += batch_size;
 
             } else {
-                throw std::invalid_argument("Unknown rsig type");
+                throw cpptrace::invalid_argument("Unknown rsig type");
             }
         }
     }
@@ -661,7 +662,7 @@ namespace tx {
             fee -= cur_out.amount;
         }
         if (fee < 0) {
-            throw std::invalid_argument("Fee cannot be negative");
+            throw cpptrace::invalid_argument("Fee cannot be negative");
         }
 
         tsx_data.set_fee(static_cast<google::protobuf::uint64>(fee));
@@ -1077,7 +1078,7 @@ namespace tx {
             auto& cout_key = ack->cout_key();
             for (auto& cur : m_ct.couts) {
                 if (cur.size() != crypto::chacha::IV_SIZE + 32) {
-                    throw std::invalid_argument("Encrypted cout has invalid length");
+                    throw cpptrace::invalid_argument("Encrypted cout has invalid length");
                 }
 
                 char buff[32];
@@ -1181,9 +1182,9 @@ namespace tx {
 
         // The contents should be JSON if the wallet follows the new format.
         if (json.Parse(data.c_str()).HasParseError()) {
-            throw std::invalid_argument("Data parsing error");
+            throw cpptrace::invalid_argument("Data parsing error");
         } else if (!json.IsObject()) {
-            throw std::invalid_argument("Data parsing error - not an object");
+            throw cpptrace::invalid_argument("Data parsing error - not an object");
         }
 
         GET_FIELD_FROM_JSON(json, version, int, Int, true, -1);
@@ -1193,7 +1194,7 @@ namespace tx {
         GET_STRING_FROM_JSON(json, tx_prefix_hash, std::string, false, std::string());
 
         if (field_version != 1) {
-            throw std::invalid_argument("Unknown version");
+            throw cpptrace::invalid_argument("Unknown version");
         }
 
         res.salt1 = field_salt1;

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -68,10 +68,10 @@
                 VAL(name, type, jtype);                                                        \
                 field_##name##_found = true;                                                   \
             } else {                                                                           \
-                throw oxen::invalid_argument("Field " #name " found in JSON, but not " #jtype); \
+                throw oxen::traced<std::invalid_argument>("Field " #name " found in JSON, but not " #jtype); \
             }                                                                                  \
         } else if (mandatory) {                                                                \
-            throw oxen::invalid_argument("Field " #name " not found in JSON");                  \
+            throw oxen::traced<std::invalid_argument>("Field " #name " not found in JSON");                  \
         }                                                                                      \
     while (0)
 
@@ -95,7 +95,7 @@ std::string key_to_string(const ::rct::key& key) {
 
 void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw oxen::invalid_argument(
+        throw oxen::traced<std::invalid_argument>(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -103,7 +103,7 @@ void string_to_key(::crypto::ec_scalar& key, const std::string& str) {
 
 void string_to_key(::crypto::ec_point& key, const std::string& str) {
     if (str.size() != sizeof(key.data)) {
-        throw oxen::invalid_argument(
+        throw oxen::traced<std::invalid_argument>(
                 std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
     }
     memcpy(key.data, str.data(), sizeof(key.data));
@@ -111,7 +111,7 @@ void string_to_key(::crypto::ec_point& key, const std::string& str) {
 
 void string_to_key(::rct::key& key, const std::string& str) {
     if (str.size() != sizeof(key.bytes)) {
-        throw oxen::invalid_argument(
+        throw oxen::traced<std::invalid_argument>(
                 std::string("Key has to have ") + std::to_string(sizeof(key.bytes)) + " B");
     }
     memcpy(key.bytes, str.data(), sizeof(key.bytes));
@@ -350,7 +350,7 @@ namespace tx {
             std::optional<bool> is_subaddr) {
         ::crypto::public_key spend{}, view{};
         if (spend_key.size() != 32 || view_key.size() != 32) {
-            throw oxen::invalid_argument("Public keys have invalid sizes");
+            throw oxen::traced<std::invalid_argument>("Public keys have invalid sizes");
         }
 
         memcpy(spend.data, spend_key.data(), 32);
@@ -414,7 +414,7 @@ namespace tx {
         std::string sep = is_iv ? "sig-iv" : "sig-key";
         std::string idx_data = tools::get_varint_data(idx);
         if (idx_data.size() > 4) {
-            throw oxen::invalid_argument("index is too big");
+            throw oxen::traced<std::invalid_argument>("index is too big");
         }
 
         keccak_init(&ctx);
@@ -497,7 +497,7 @@ namespace tx {
 
             } else if (rsig_type == rct::RangeProofType::PaddedBulletproof) {
                 if (num_outputs > BULLETPROOF_MAX_OUTPUTS) {
-                    throw oxen::invalid_argument(
+                    throw oxen::traced<std::invalid_argument>(
                             "BP padded can support only BULLETPROOF_MAX_OUTPUTS "
                             "statements");
                 }
@@ -515,7 +515,7 @@ namespace tx {
                 amount_batched += batch_size;
 
             } else {
-                throw oxen::invalid_argument("Unknown rsig type");
+                throw oxen::traced<std::invalid_argument>("Unknown rsig type");
             }
         }
     }
@@ -662,7 +662,7 @@ namespace tx {
             fee -= cur_out.amount;
         }
         if (fee < 0) {
-            throw oxen::invalid_argument("Fee cannot be negative");
+            throw oxen::traced<std::invalid_argument>("Fee cannot be negative");
         }
 
         tsx_data.set_fee(static_cast<google::protobuf::uint64>(fee));
@@ -1078,7 +1078,7 @@ namespace tx {
             auto& cout_key = ack->cout_key();
             for (auto& cur : m_ct.couts) {
                 if (cur.size() != crypto::chacha::IV_SIZE + 32) {
-                    throw oxen::invalid_argument("Encrypted cout has invalid length");
+                    throw oxen::traced<std::invalid_argument>("Encrypted cout has invalid length");
                 }
 
                 char buff[32];
@@ -1182,9 +1182,9 @@ namespace tx {
 
         // The contents should be JSON if the wallet follows the new format.
         if (json.Parse(data.c_str()).HasParseError()) {
-            throw oxen::invalid_argument("Data parsing error");
+            throw oxen::traced<std::invalid_argument>("Data parsing error");
         } else if (!json.IsObject()) {
-            throw oxen::invalid_argument("Data parsing error - not an object");
+            throw oxen::traced<std::invalid_argument>("Data parsing error - not an object");
         }
 
         GET_FIELD_FROM_JSON(json, version, int, Int, true, -1);
@@ -1194,7 +1194,7 @@ namespace tx {
         GET_STRING_FROM_JSON(json, tx_prefix_hash, std::string, false, std::string());
 
         if (field_version != 1) {
-            throw oxen::invalid_argument("Unknown version");
+            throw oxen::traced<std::invalid_argument>("Unknown version");
         }
 
         res.salt1 = field_salt1;

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -38,6 +38,8 @@
 #include "wallet/tx_construction_data.h"
 #include "wallet/tx_sets.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace hw::trezor::protocol {
 
 std::string key_to_string(const ::crypto::ec_point& key);
@@ -340,7 +342,7 @@ namespace tx {
 
         bool is_simple() const {
             if (!m_ct.rv) {
-                throw std::invalid_argument("RV not initialized");
+                throw cpptrace::invalid_argument("RV not initialized");
             }
             auto tp = m_ct.rv->type;
             return tp == rct::RCTType::Simple;
@@ -352,7 +354,7 @@ namespace tx {
 
         bool is_bulletproof() const {
             if (!m_ct.rv) {
-                throw std::invalid_argument("RV not initialized");
+                throw cpptrace::invalid_argument("RV not initialized");
             }
             return rct::is_rct_bulletproof(m_ct.rv->type);
         }

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -31,14 +31,13 @@
 #define MONERO_PROTOCOL_H
 
 #include "device/device_cold.hpp"
+#include "common/exception.h"
 #include "messages_map.hpp"
 #include "ringct/rctTypes.h"
 #include "transport.hpp"
 #include "trezor_defs.hpp"
 #include "wallet/tx_construction_data.h"
 #include "wallet/tx_sets.h"
-
-#include <cpptrace/cpptrace.hpp>
 
 namespace hw::trezor::protocol {
 
@@ -342,7 +341,7 @@ namespace tx {
 
         bool is_simple() const {
             if (!m_ct.rv) {
-                throw cpptrace::invalid_argument("RV not initialized");
+                throw oxen::invalid_argument("RV not initialized");
             }
             auto tp = m_ct.rv->type;
             return tp == rct::RCTType::Simple;
@@ -354,7 +353,7 @@ namespace tx {
 
         bool is_bulletproof() const {
             if (!m_ct.rv) {
-                throw cpptrace::invalid_argument("RV not initialized");
+                throw oxen::invalid_argument("RV not initialized");
             }
             return rct::is_rct_bulletproof(m_ct.rv->type);
         }

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -341,7 +341,7 @@ namespace tx {
 
         bool is_simple() const {
             if (!m_ct.rv) {
-                throw oxen::invalid_argument("RV not initialized");
+                throw oxen::traced<std::invalid_argument>("RV not initialized");
             }
             auto tp = m_ct.rv->type;
             return tp == rct::RCTType::Simple;
@@ -353,7 +353,7 @@ namespace tx {
 
         bool is_bulletproof() const {
             if (!m_ct.rv) {
-                throw oxen::invalid_argument("RV not initialized");
+                throw oxen::traced<std::invalid_argument>("RV not initialized");
             }
             return rct::is_rct_bulletproof(m_ct.rv->type);
         }

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -39,8 +39,8 @@
 #include <boost/asio/ip/udp.hpp>
 #include <chrono>
 #include <iomanip>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/apply_permutation.h"
 #include "common/string_util.h"
 #include "messages/messages-common.pb.h"
@@ -191,7 +191,7 @@ static void serialize_message(
     auto msg_wire_num = MessageMapper::get_message_wire_number(req);
     const auto req_buffer_size = serialize_message_buffer_size(msg_size);
     if (req_buffer_size > buff_size) {
-        throw cpptrace::invalid_argument("Buffer too small");
+        throw oxen::invalid_argument("Buffer too small");
     }
 
     serialize_message_header(buff, msg_wire_num, msg_size);
@@ -533,10 +533,10 @@ std::string BridgeTransport::post_json(std::string_view uri, std::string json) {
     res = m_http_session.Post();
 
     if (res.error)
-        throw cpptrace::runtime_error{"Trezor bridge request failed: " + res.error.message};
+        throw oxen::runtime_error{"Trezor bridge request failed: " + res.error.message};
 
     if (res.status_code != 200)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Trezor bridge request failed: received bad HTTP status " + res.status_line};
 
     return std::move(res.text);
@@ -589,7 +589,7 @@ UdpTransport::UdpTransport(
 
     assert_port_number((uint32_t)m_device_port);
     if (m_device_host != "localhost" && m_device_host != DEFAULT_HOST) {
-        throw cpptrace::invalid_argument("Local endpoint allowed only");
+        throw oxen::invalid_argument("Local endpoint allowed only");
     }
 
     m_proto = proto ? *proto : std::make_shared<ProtocolV1>();
@@ -704,7 +704,7 @@ void UdpTransport::write_chunk(const void* buff, size_t size) {
 size_t UdpTransport::read_chunk(void* buff, size_t size) {
     require_socket();
     if (size < 64) {
-        throw cpptrace::invalid_argument("Buffer too small");
+        throw oxen::invalid_argument("Buffer too small");
     }
 
     ssize_t len;
@@ -928,14 +928,14 @@ WebUsbTransport::~WebUsbTransport() {
 
 void WebUsbTransport::require_device() const {
     if (!m_usb_device_desc) {
-        throw cpptrace::runtime_error("No USB device specified");
+        throw oxen::runtime_error("No USB device specified");
     }
 }
 
 void WebUsbTransport::require_connected() const {
     require_device();
     if (!m_usb_device_handle) {
-        throw cpptrace::runtime_error("USB Device not opened");
+        throw oxen::runtime_error("USB Device not opened");
     }
 }
 
@@ -952,7 +952,7 @@ void WebUsbTransport::enumerate(t_transport_vect& res) {
     ssize_t cnt = libusb_get_device_list(ctx, &devs);
     if (cnt < 0) {
         libusb_exit(ctx);
-        throw cpptrace::runtime_error("Unable to enumerate libusb devices");
+        throw oxen::runtime_error("Unable to enumerate libusb devices");
     }
 
     log::trace(logcat, "Libusb devices: {}", cnt);
@@ -1028,7 +1028,7 @@ void WebUsbTransport::open() {
     ssize_t cnt = libusb_get_device_list(m_usb_session, &devs);
     if (cnt < 0) {
         TREZOR_DESTROY_SESSION();
-        throw cpptrace::runtime_error("Unable to enumerate libusb devices");
+        throw oxen::runtime_error("Unable to enumerate libusb devices");
     }
 
     for (ssize_t i = 0; i < cnt; i++) {
@@ -1288,13 +1288,13 @@ std::shared_ptr<Transport> transport(const std::string& path) {
         return std::make_shared<UdpTransport>(path.substr(strlen(UdpTransport::PATH_PREFIX)));
 
     } else {
-        throw cpptrace::invalid_argument("Unknown Trezor device path: " + path);
+        throw oxen::invalid_argument("Unknown Trezor device path: " + path);
     }
 }
 
 void throw_failure_exception(const messages::common::Failure* failure) {
     if (failure == nullptr) {
-        throw cpptrace::invalid_argument("Failure message cannot be null");
+        throw oxen::invalid_argument("Failure message cannot be null");
     }
 
     std::optional<std::string> message =

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -39,6 +39,7 @@
 #include <boost/asio/ip/udp.hpp>
 #include <chrono>
 #include <iomanip>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/apply_permutation.h"
 #include "common/string_util.h"
@@ -190,7 +191,7 @@ static void serialize_message(
     auto msg_wire_num = MessageMapper::get_message_wire_number(req);
     const auto req_buffer_size = serialize_message_buffer_size(msg_size);
     if (req_buffer_size > buff_size) {
-        throw std::invalid_argument("Buffer too small");
+        throw cpptrace::invalid_argument("Buffer too small");
     }
 
     serialize_message_header(buff, msg_wire_num, msg_size);
@@ -532,10 +533,10 @@ std::string BridgeTransport::post_json(std::string_view uri, std::string json) {
     res = m_http_session.Post();
 
     if (res.error)
-        throw std::runtime_error{"Trezor bridge request failed: " + res.error.message};
+        throw cpptrace::runtime_error{"Trezor bridge request failed: " + res.error.message};
 
     if (res.status_code != 200)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Trezor bridge request failed: received bad HTTP status " + res.status_line};
 
     return std::move(res.text);
@@ -588,7 +589,7 @@ UdpTransport::UdpTransport(
 
     assert_port_number((uint32_t)m_device_port);
     if (m_device_host != "localhost" && m_device_host != DEFAULT_HOST) {
-        throw std::invalid_argument("Local endpoint allowed only");
+        throw cpptrace::invalid_argument("Local endpoint allowed only");
     }
 
     m_proto = proto ? *proto : std::make_shared<ProtocolV1>();
@@ -703,7 +704,7 @@ void UdpTransport::write_chunk(const void* buff, size_t size) {
 size_t UdpTransport::read_chunk(void* buff, size_t size) {
     require_socket();
     if (size < 64) {
-        throw std::invalid_argument("Buffer too small");
+        throw cpptrace::invalid_argument("Buffer too small");
     }
 
     ssize_t len;
@@ -927,14 +928,14 @@ WebUsbTransport::~WebUsbTransport() {
 
 void WebUsbTransport::require_device() const {
     if (!m_usb_device_desc) {
-        throw std::runtime_error("No USB device specified");
+        throw cpptrace::runtime_error("No USB device specified");
     }
 }
 
 void WebUsbTransport::require_connected() const {
     require_device();
     if (!m_usb_device_handle) {
-        throw std::runtime_error("USB Device not opened");
+        throw cpptrace::runtime_error("USB Device not opened");
     }
 }
 
@@ -951,7 +952,7 @@ void WebUsbTransport::enumerate(t_transport_vect& res) {
     ssize_t cnt = libusb_get_device_list(ctx, &devs);
     if (cnt < 0) {
         libusb_exit(ctx);
-        throw std::runtime_error("Unable to enumerate libusb devices");
+        throw cpptrace::runtime_error("Unable to enumerate libusb devices");
     }
 
     log::trace(logcat, "Libusb devices: {}", cnt);
@@ -1027,7 +1028,7 @@ void WebUsbTransport::open() {
     ssize_t cnt = libusb_get_device_list(m_usb_session, &devs);
     if (cnt < 0) {
         TREZOR_DESTROY_SESSION();
-        throw std::runtime_error("Unable to enumerate libusb devices");
+        throw cpptrace::runtime_error("Unable to enumerate libusb devices");
     }
 
     for (ssize_t i = 0; i < cnt; i++) {
@@ -1287,13 +1288,13 @@ std::shared_ptr<Transport> transport(const std::string& path) {
         return std::make_shared<UdpTransport>(path.substr(strlen(UdpTransport::PATH_PREFIX)));
 
     } else {
-        throw std::invalid_argument("Unknown Trezor device path: " + path);
+        throw cpptrace::invalid_argument("Unknown Trezor device path: " + path);
     }
 }
 
 void throw_failure_exception(const messages::common::Failure* failure) {
     if (failure == nullptr) {
-        throw std::invalid_argument("Failure message cannot be null");
+        throw cpptrace::invalid_argument("Failure message cannot be null");
     }
 
     std::optional<std::string> message =

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -37,6 +37,7 @@
 #include <fmt/core.h>
 #include <fmt/std.h>
 
+#include <cpptrace/cpptrace.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
@@ -176,6 +177,7 @@ static bool generate_multisig(
 }
 
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     po::options_description desc_params(wallet_args::tr("Wallet options"));

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -177,7 +177,7 @@ static bool generate_multisig(
 }
 
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     po::options_description desc_params(wallet_args::tr("Wallet options"));

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -95,13 +95,13 @@ static constexpr inline std::string_view NO_PROVIDER_CLIENTS_ERROR = "L2 tracker
 std::pair<uint64_t, crypto::hash> L2Tracker::latest_state() {
     if (provider.clients.empty()) {
         oxen::log::error(logcat, NO_PROVIDER_CLIENTS_ERROR);
-        throw oxen::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw oxen::traced<std::runtime_error>(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
 
     if (state_history.empty()) {
         oxen::log::error(logcat, "L2 tracker doesnt have any state history to query");
-        throw oxen::runtime_error("Internal error getting latest state from l2 tracker");
+        throw oxen::traced<std::runtime_error>("Internal error getting latest state from l2 tracker");
     }
     auto& latest_state = state_history.front();
     return std::make_pair(latest_state.height, latest_state.block_hash);
@@ -181,7 +181,7 @@ void L2Tracker::populate_review_transactions(std::shared_ptr<TransactionReviewSe
 
 std::vector<TransactionStateChangeVariant> L2Tracker::get_block_transactions() {
     if (provider.clients.empty()) {
-        throw oxen::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw oxen::traced<std::runtime_error>(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
     std::vector<TransactionStateChangeVariant> all_transactions;

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -2,6 +2,7 @@
 
 #include <thread>
 #include <utility>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/guts.h"
 #include "crypto/crypto.h"
@@ -93,13 +94,13 @@ static constexpr inline std::string_view NO_PROVIDER_CLIENTS_ERROR = "L2 tracker
 std::pair<uint64_t, crypto::hash> L2Tracker::latest_state() {
     if (provider.clients.empty()) {
         oxen::log::error(logcat, NO_PROVIDER_CLIENTS_ERROR);
-        throw std::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw cpptrace::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
 
     if (state_history.empty()) {
         oxen::log::error(logcat, "L2 tracker doesnt have any state history to query");
-        throw std::runtime_error("Internal error getting latest state from l2 tracker");
+        throw cpptrace::runtime_error("Internal error getting latest state from l2 tracker");
     }
     auto& latest_state = state_history.front();
     return std::make_pair(latest_state.height, latest_state.block_hash);
@@ -179,7 +180,7 @@ void L2Tracker::populate_review_transactions(std::shared_ptr<TransactionReviewSe
 
 std::vector<TransactionStateChangeVariant> L2Tracker::get_block_transactions() {
     if (provider.clients.empty()) {
-        throw std::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw cpptrace::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
     std::vector<TransactionStateChangeVariant> all_transactions;

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -243,8 +243,7 @@ bool TransactionReviewSession::processNewServiceNodeTx(
                 it->bls_pubkey,
                 it->eth_address,
                 it->sn_pubkey);
-        if (it->bls_pubkey == bls_pubkey && it->eth_address == eth_address &&
-            it->sn_pubkey == service_node_pubkey) {
+        if (it->bls_pubkey == bls_pubkey && it->eth_address == eth_address && it->sn_pubkey == service_node_pubkey) {
             new_service_nodes.erase(it);
             return true;
         }

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -2,9 +2,10 @@
 
 #include <thread>
 #include <utility>
-#include <cpptrace/cpptrace.hpp>
 
-#include "common/guts.h"
+#include <common/guts.h>
+#include <common/exception.h>
+
 #include "crypto/crypto.h"
 #include "logging/oxen_logger.h"
 
@@ -94,13 +95,13 @@ static constexpr inline std::string_view NO_PROVIDER_CLIENTS_ERROR = "L2 tracker
 std::pair<uint64_t, crypto::hash> L2Tracker::latest_state() {
     if (provider.clients.empty()) {
         oxen::log::error(logcat, NO_PROVIDER_CLIENTS_ERROR);
-        throw cpptrace::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw oxen::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
 
     if (state_history.empty()) {
         oxen::log::error(logcat, "L2 tracker doesnt have any state history to query");
-        throw cpptrace::runtime_error("Internal error getting latest state from l2 tracker");
+        throw oxen::runtime_error("Internal error getting latest state from l2 tracker");
     }
     auto& latest_state = state_history.front();
     return std::make_pair(latest_state.height, latest_state.block_hash);
@@ -180,7 +181,7 @@ void L2Tracker::populate_review_transactions(std::shared_ptr<TransactionReviewSe
 
 std::vector<TransactionStateChangeVariant> L2Tracker::get_block_transactions() {
     if (provider.clients.empty()) {
-        throw cpptrace::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
+        throw oxen::runtime_error(std::string(NO_PROVIDER_CLIENTS_ERROR));
     }
     std::lock_guard lock{mutex};
     std::vector<TransactionStateChangeVariant> all_transactions;

--- a/src/l2_tracker/pool_contract.cpp
+++ b/src/l2_tracker/pool_contract.cpp
@@ -1,7 +1,5 @@
 #include "pool_contract.h"
-
 #include <ethyl/utils.hpp>
-
 #include "logging/oxen_logger.h"
 
 static auto logcat = oxen::log::Cat("l2_tracker");
@@ -10,13 +8,37 @@ PoolContract::PoolContract(std::string _contractAddress, ethyl::Provider& _provi
         contractAddress(std::move(_contractAddress)), provider(_provider) {}
 
 RewardRateResponse PoolContract::RewardRate(uint64_t timestamp, uint64_t ethereum_block_height) {
+    oxen::log::trace(
+            logcat,
+            "Querying reward rate from pool contract {} at ts {}, Ethereum height {}",
+            contractAddress,
+            timestamp,
+            ethereum_block_height);
+
     ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
-    std::string timestampStr =
-            ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(timestamp), ethyl::utils::PaddingDirection::LEFT);
+    std::string timestampStr = ethyl::utils::padTo32Bytes(
+            ethyl::utils::decimalToHex(timestamp), ethyl::utils::PaddingDirection::LEFT);
+
     // keccak256("rewardRate(uint256)")
     std::string functionABI = "0xcea01962";
     callData.data = functionABI + timestampStr;
-    std::string result = provider.callReadFunction(callData, ethereum_block_height);
-    return RewardRateResponse{timestamp, ethyl::utils::hexStringToU64(result)};
+
+    // NOTE: Parse the reward value (returned in a hex string, e.g. "0x")
+    std::string reward_rate_str     = provider.callReadFunction(callData, ethereum_block_height);
+    std::string_view reward_rate_sv = reward_rate_str;
+    if (reward_rate_sv.starts_with("0x") || reward_rate_sv.starts_with("0X"))
+        reward_rate_sv.remove_prefix(2);
+
+    RewardRateResponse result = {
+        .timestamp = timestamp,
+        .reward = reward_rate_sv.size() ? ethyl::utils::hexStringToU64(reward_rate_sv) : 0,
+    };
+
+    oxen::log::trace(
+            logcat,
+            "Retrieved pool reward {} (reward string was {})",
+            result.reward,
+            reward_rate_str);
+    return result;
 }

--- a/src/l2_tracker/pool_contract.h
+++ b/src/l2_tracker/pool_contract.h
@@ -5,12 +5,9 @@
 #include <string>
 #include <vector>
 
-class RewardRateResponse {
-  public:
+struct RewardRateResponse {
     uint64_t timestamp;
     uint64_t reward;
-    RewardRateResponse(uint64_t _timestamp, uint64_t _reward) :
-            timestamp(_timestamp), reward(_reward) {}
 };
 
 class PoolContract {

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -344,12 +344,16 @@ ContractServiceNode RewardsContract::serviceNodes(
     std::string blockNumArg = blockNumber ? "0x{:x}"_format(*blockNumber) : "latest";
     nlohmann::json callResult = provider.callReadFunctionJSON(callData, blockNumArg);
     auto callResultHex = callResult.get<std::string_view>();
+    if (callResultHex.starts_with("0x") || callResultHex.starts_with("0X"))
+        callResultHex.remove_prefix(2);
 
     // NOTE: The ServiceNode struct is a dynamic type (because its child `Contributor` field is
     // dynamic) hence the offset to the struct is encoded in the first 32 byte element.
-    auto [sn_data_offset] = tools::split_hex_into<u256, tools::ignore>(callResultHex);
-    auto sn_data = callResultHex.substr(tools::decode_integer_be(sn_data_offset));
-    auto [next, prev, op_addr, pubkey, leaveRequestTimestamp, deposit, contr_offset] = tools::split_hex_into<
+    std::string_view sn_data_offset_hex =
+            tools::string_safe_substr(callResultHex, /*pos*/ 0, /*size*/ 64);
+    auto sn_data_offset_bytes = tools::make_from_hex_guts<u256>(sn_data_offset_hex);
+    auto sn_data = callResultHex.substr(tools::decode_integer_be(sn_data_offset_bytes) * 2);
+    auto [next, prev, op_addr, pubkey, leaveRequestTimestamp, deposit, contr_offset, remainder] = tools::split_hex_into<
             u256,
             u256,
             skip<12>,
@@ -358,7 +362,7 @@ ContractServiceNode RewardsContract::serviceNodes(
             u256,
             u256,
             u256,
-            tools::ignore>(sn_data);
+            std::string_view>(sn_data);
 
     ContractServiceNode result{};
     result.good = false; // until proven otherwise
@@ -369,8 +373,8 @@ ContractServiceNode RewardsContract::serviceNodes(
     result.leaveRequestTimestamp = tools::decode_integer_be(leaveRequestTimestamp);
     result.deposit = tools::decode_integer_be(deposit);
 
-    auto contrib_data = sn_data.substr(tools::decode_integer_be(contr_offset));
-    auto [contrib_len] = tools::split_hex_into<u256, tools::ignore>(contrib_data);
+    auto contrib_data = sn_data.substr(tools::decode_integer_be(contr_offset) * 2);
+    auto [contrib_len, remainder2] = tools::split_hex_into<u256, std::string_view>(contrib_data);
 
     // NOTE: Start parsing the contributors blobs
     if (auto contributorSize = tools::decode_integer_be(contrib_len);contributorSize <= result.contributors.max_size())

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -92,7 +92,7 @@ static std::string log_new_service_node_tx(const NewServiceNodeTx& item, std::st
         fmt::format_to(std::back_inserter(buffer), "  - {:02} [address: {}, amount: {}]\n", index, contributor.addr, contributor.amount);
     }
 
-    fmt::format_to(std::back_inserter(buffer), "\nThe raw blob was (32 byte chunks/line):\n\n", hex);
+    fmt::format_to(std::back_inserter(buffer), "\nThe raw blob was (32 byte chunks/line):\n\n");
     std::string_view it = hex;
     if (it.starts_with("0x") || it.starts_with("0X"))
         it.remove_prefix(2);
@@ -107,8 +107,9 @@ static std::string log_new_service_node_tx(const NewServiceNodeTx& item, std::st
     return result;
 }
 
-static std::string log_service_node_blob(const ContractServiceNode& result, std::string_view hex) {
-    return "Service node blob components were:\n"
+static std::string log_service_node_blob(const ContractServiceNode& blob, std::string_view hex) {
+    fmt::memory_buffer buffer{};
+    fmt::format_to(std::back_inserter(buffer), "Service node blob components were:\n"
                 "\n"
                 "  - next:                   {}\n"
                 "  - prev:                   {}\n"
@@ -118,15 +119,27 @@ static std::string log_service_node_blob(const ContractServiceNode& result, std:
                 "  - deposit:                {}\n"
                 "  - num contributors:       {}\n"
                 "\n"
-                "The raw blob was:\n\n{}"_format(
-                result.next,
-                result.prev,
-                result.operatorAddr,
-                result.pubkey,
-                result.leaveRequestTimestamp,
-                result.deposit,
-                result.contributorsSize,
-                hex);
+                "The raw blob was (32 byte chunks/line):\n\n",
+                blob.next,
+                blob.prev,
+                blob.operatorAddr,
+                blob.pubkey,
+                blob.leaveRequestTimestamp,
+                blob.deposit,
+                blob.contributorsSize);
+
+    std::string_view it = hex;
+    if (it.starts_with("0x") || it.starts_with("0X"))
+        it.remove_prefix(2);
+
+    while (it.size()) {
+        std::string_view chunk = tools::string_safe_substr(it, 0, 64);  // Grab 32 byte chunk
+        fmt::format_to(std::back_inserter(buffer), "  {}\n", chunk);    // Output the chunk
+        it = tools::string_safe_substr(it, 64, it.size());              // Advance the it
+    }
+
+    std::string result = fmt::to_string(buffer);
+    return result;
 }
 
 TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
@@ -376,8 +389,12 @@ ContractServiceNode RewardsContract::serviceNodes(
     auto contrib_data = sn_data.substr(tools::decode_integer_be(contr_offset) * 2);
     auto [contrib_len, remainder2] = tools::split_hex_into<u256, std::string_view>(contrib_data);
 
+    // NOTE: Set the contrib_data to point to directly after the 32 byte
+    // contrib_len field (e.g. the payload of the contrib_data).
+    contrib_data = remainder2;
+
     // NOTE: Start parsing the contributors blobs
-    if (auto contributorSize = tools::decode_integer_be(contrib_len);contributorSize <= result.contributors.max_size())
+    if (auto contributorSize = tools::decode_integer_be(contrib_len); contributorSize <= result.contributors.max_size())
         result.contributorsSize = contributorSize;
     else {
         oxen::log::error(

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -85,9 +85,9 @@ static std::string log_new_service_node_tx(const NewServiceNodeTx& item, std::st
             item.sn_pubkey,
             item.ed_signature,
             item.fee,
-            item.contributors_size);
+            item.contributors.size());
 
-    for (size_t index = 0; index < item.contributors_size; index++) {
+    for (size_t index = 0; index < item.contributors.size(); index++) {
         const Contributor& contributor = item.contributors[index];
         fmt::format_to(std::back_inserter(buffer), "  - {:02} [address: {}, amount: {}]\n", index, contributor.addr, contributor.amount);
     }
@@ -182,11 +182,11 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             // NOTE: Verify that the number of contributors in the blob is
             // within maximum range
             uint64_t num_contributors = tools::decode_integer_be(c_len);
-            if (num_contributors > item.contributors.max_size()) {
+            if (num_contributors > oxen::MAX_CONTRIBUTORS_HF19) {
                 throw oxen::invalid_argument("Invalid NewServiceNode data: {}\n{}"_format(
                         log_more_contributors_than_allowed(
                                 num_contributors,
-                                item.contributors.max_size(),
+                                oxen::MAX_CONTRIBUTORS_HF19,
                                 item.bls_pubkey,
                                 log.blockNumber,
                                 /*index*/ std::optional<uint64_t>()),
@@ -200,6 +200,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
                         "received 0\n{}"
                         ""_format(log_new_service_node_tx(item, log.data)));
             }
+            item.contributors.reserve(num_contributors);
 
             // NOTE: Verify that the offset to the dynamic part of the
             // contributors array is correct.
@@ -232,7 +233,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             // TODO: Validate the amount, can't be 0, should be min contribution. Is this done in
             // the SNL? Maybe.
             for (size_t index = 0; index < num_contributors; index++) {
-                auto& [addr, amt] = item.contributors[item.contributors_size++];
+                auto& [addr, amt] = item.contributors.emplace_back();
                 u256 amt256;
                 std::tie(addr, amt256, contrib_hex) = tools::
                         split_hex_into<skip<12>, crypto::eth_address, u256, std::string_view>(

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -74,16 +74,16 @@ static std::string log_new_service_node_tx(const NewServiceNodeTx& item, std::st
     fmt::format_to(
             std::back_inserter(buffer),
             "New service node TX components were:\n"
-            "- BLS Public Key: {}\n"
-            "- ETH Address:    {}\n"
-            "- SN Public Key:  {}\n"
-            "- SN Signature:   {}\n"
-            "- Fee:            {}\n"
-            "- Contributor(s): {}\n",
-            item.eth_address,
+            "- BLS Public Key:    {}\n"
+            "- ETH Address:       {}\n"
+            "- SN Public Key:     {}\n"
+            "- ED25519 Signature: {}\n"
+            "- Fee:               {}\n"
+            "- Contributor(s):    {}\n",
             item.bls_pubkey,
+            item.eth_address,
             item.sn_pubkey,
-            item.sn_signature,
+            item.ed_signature,
             item.fee,
             item.contributors_size);
 
@@ -157,7 +157,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
                     item.eth_address,
                     item.bls_pubkey,
                     item.sn_pubkey,
-                    item.sn_signature,
+                    item.ed_signature,
                     fee256,
                     c_offset,
                     c_len,

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -3,7 +3,7 @@
 #include <ethyl/utils.hpp>
 #include <common/oxen.h>
 #include <common/string_util.h>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
@@ -21,7 +21,7 @@ static auto logcat = oxen::log::Cat("l2_tracker");
 
 TransactionType getLogType(const ethyl::LogEntry& log) {
     if (log.topics.empty()) {
-        throw cpptrace::runtime_error("No topics in log entry");
+        throw oxen::runtime_error("No topics in log entry");
     }
     // keccak256('NewServiceNode(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),(address,uint256)[])')
     if (log.topics[0] == "0xe82ed1bfc15e6602fba1a19273171c8a63c1d40b0e0117be4598167b8655498f") {
@@ -81,12 +81,12 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
 
             fee = tools::decode_integer_be(fee256);
             if (fee > cryptonote::STAKING_FEE_BASIS)
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                     "Invalid NewServiceNode data: fee must be in [0, {}]"_format(cryptonote::STAKING_FEE_BASIS)};
             auto num_contributors = tools::decode_integer_be(c_len);
             if (tools::decode_integer_be(c_size) != 64 ||
                 contrib_hex.size() != 2 * num_contributors * (32 + 32))
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "Invalid NewServiceNode data: invalid contributor data"};
 
             contributors.resize(num_contributors);

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -21,7 +21,7 @@ static auto logcat = oxen::log::Cat("l2_tracker");
 
 TransactionType getLogType(const ethyl::LogEntry& log) {
     if (log.topics.empty()) {
-        throw oxen::runtime_error("No topics in log entry");
+        throw oxen::traced<std::runtime_error>("No topics in log entry");
     }
     // keccak256('NewServiceNode(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),(address,uint256)[])')
     if (log.topics[0] == "0xe82ed1bfc15e6602fba1a19273171c8a63c1d40b0e0117be4598167b8655498f") {
@@ -189,14 +189,14 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             // NOTE: Decode fee and that it is within acceptable range
             item.fee = tools::decode_integer_be(fee256);
             if (item.fee > cryptonote::STAKING_FEE_BASIS)
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                     "Invalid NewServiceNode data: fee must be in [0, {}]"_format(cryptonote::STAKING_FEE_BASIS)};
 
             // NOTE: Verify that the number of contributors in the blob is
             // within maximum range
             uint64_t num_contributors = tools::decode_integer_be(c_len);
             if (num_contributors > oxen::MAX_CONTRIBUTORS_HF19) {
-                throw oxen::invalid_argument("Invalid NewServiceNode data: {}\n{}"_format(
+                throw oxen::traced<std::invalid_argument>("Invalid NewServiceNode data: {}\n{}"_format(
                         log_more_contributors_than_allowed(
                                 num_contributors,
                                 oxen::MAX_CONTRIBUTORS_HF19,
@@ -208,7 +208,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
 
             // NOTE: Verify that there's atleast one contributor
             if (num_contributors <= 0) {
-                throw oxen::invalid_argument(
+                throw oxen::traced<std::invalid_argument>(
                         "Invalid NewServiceNode data: There must be atleast one contributor, "
                         "received 0\n{}"
                         ""_format(log_new_service_node_tx(item, log.data)));
@@ -221,7 +221,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             const uint64_t expected_c_offset_value = 32 /*ID*/ + 32 /*recipient*/ + 64 /*BLS Key*/ +
                                                      32 /*SN Key*/ + 64 /*SN Sig*/ + 32 /*Fee*/;
             if (c_offset_value != expected_c_offset_value) {
-                throw oxen::invalid_argument(
+                throw oxen::traced<std::invalid_argument>(
                         "Invalid NewServiceNode data: The offset to the contributor payload ({} "
                         "bytes) did not match the offset we derived {}\n{}"
                         ""_format(
@@ -234,7 +234,7 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             const size_t expected_contrib_hex_size =
                     2 /*hex*/ * num_contributors * (/*address*/ 32 + /*amount*/ 32);
             if (contrib_hex.size() != expected_contrib_hex_size) {
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "Invalid NewServiceNode data: The hex payload length ({}) derived for "
                         "{} contributors did not match the size we derived of {} hex characters\n{}"_format(
                                 contrib_hex.size(),

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -3,6 +3,7 @@
 #include <ethyl/utils.hpp>
 #include <common/oxen.h>
 #include <common/string_util.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
@@ -20,7 +21,7 @@ static auto logcat = oxen::log::Cat("l2_tracker");
 
 TransactionType getLogType(const ethyl::LogEntry& log) {
     if (log.topics.empty()) {
-        throw std::runtime_error("No topics in log entry");
+        throw cpptrace::runtime_error("No topics in log entry");
     }
     // keccak256('NewServiceNode(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),(address,uint256)[])')
     if (log.topics[0] == "0xe82ed1bfc15e6602fba1a19273171c8a63c1d40b0e0117be4598167b8655498f") {
@@ -80,12 +81,12 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
 
             fee = tools::decode_integer_be(fee256);
             if (fee > cryptonote::STAKING_FEE_BASIS)
-                throw std::invalid_argument{
+                throw cpptrace::invalid_argument{
                     "Invalid NewServiceNode data: fee must be in [0, {}]"_format(cryptonote::STAKING_FEE_BASIS)};
             auto num_contributors = tools::decode_integer_be(c_len);
             if (tools::decode_integer_be(c_size) != 64 ||
                 contrib_hex.size() != 2 * num_contributors * (32 + 32))
-                throw std::invalid_argument{
+                throw cpptrace::invalid_argument{
                         "Invalid NewServiceNode data: invalid contributor data"};
 
             contributors.resize(num_contributors);

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -360,6 +360,18 @@ ContractServiceNode RewardsContract::serviceNodes(
     if (callResultHex.starts_with("0x") || callResultHex.starts_with("0X"))
         callResultHex.remove_prefix(2);
 
+    ContractServiceNode result{};
+    result.good = false; // until proven otherwise
+    if (callResultHex.empty()) {
+        oxen::log::warning(
+                logcat,
+                "Provider returned an empty string when querying contract service node {} at block "
+                "'{}'",
+                index,
+                blockNumArg);
+        return result;
+    }
+
     // NOTE: The ServiceNode struct is a dynamic type (because its child `Contributor` field is
     // dynamic) hence the offset to the struct is encoded in the first 32 byte element.
     std::string_view sn_data_offset_hex =
@@ -377,8 +389,6 @@ ContractServiceNode RewardsContract::serviceNodes(
             u256,
             std::string_view>(sn_data);
 
-    ContractServiceNode result{};
-    result.good = false; // until proven otherwise
     result.next = tools::decode_integer_be(next);
     result.prev = tools::decode_integer_be(prev);
     result.operatorAddr = op_addr;

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -42,6 +42,93 @@ using u256 = std::array<std::byte, 32>;
 using tools::skip;
 using tools::skip_t;
 
+static std::string log_more_contributors_than_allowed(
+        size_t num_contributors,
+        size_t max_contributors,
+        const crypto::bls_public_key& bls_pk,
+        std::optional<uint64_t> block_number,
+        std::optional<uint64_t> sn_index) {
+    std::string result;
+
+    if (sn_index) {
+        result = "The number of contributors ({}) in the service node blob exceeded the available "
+                 "storage ({}) for service node ({}) w/ BLS public key {} at height {}"_format(
+                         num_contributors,
+                         max_contributors,
+                         *sn_index,
+                         bls_pk,
+                         block_number ? "{}"_format(*block_number) : "(latest)");
+    } else {
+        result = "The number of contributors ({}) in the service node blob exceeded the available "
+                 "storage ({}) for service node w/ BLS public key {} at height {}"_format(
+                         num_contributors,
+                         max_contributors,
+                         bls_pk,
+                         block_number ? "{}"_format(*block_number) : "(latest)");
+    }
+    return result;
+}
+
+static std::string log_new_service_node_tx(const NewServiceNodeTx& item, std::string_view hex) {
+    fmt::memory_buffer buffer{};
+    fmt::format_to(
+            std::back_inserter(buffer),
+            "New service node TX components were:\n"
+            "- BLS Public Key: {}\n"
+            "- ETH Address:    {}\n"
+            "- SN Public Key:  {}\n"
+            "- SN Signature:   {}\n"
+            "- Fee:            {}\n"
+            "- Contributor(s): {}\n",
+            item.eth_address,
+            item.bls_pubkey,
+            item.sn_pubkey,
+            item.sn_signature,
+            item.fee,
+            item.contributors_size);
+
+    for (size_t index = 0; index < item.contributors_size; index++) {
+        const Contributor& contributor = item.contributors[index];
+        fmt::format_to(std::back_inserter(buffer), "  - {:02} [address: {}, amount: {}]\n", index, contributor.addr, contributor.amount);
+    }
+
+    fmt::format_to(std::back_inserter(buffer), "\nThe raw blob was (32 byte chunks/line):\n\n", hex);
+    std::string_view it = hex;
+    if (it.starts_with("0x") || it.starts_with("0X"))
+        it.remove_prefix(2);
+
+    while (it.size()) {
+        std::string_view chunk = tools::string_safe_substr(it, 0, 64);  // Grab 32 byte chunk
+        fmt::format_to(std::back_inserter(buffer), "  {}\n", chunk);    // Output the chunk
+        it = tools::string_safe_substr(it, 64, it.size());              // Advance the it
+    }
+
+    std::string result = fmt::to_string(buffer);
+    return result;
+}
+
+static std::string log_service_node_blob(const ContractServiceNode& result, std::string_view hex) {
+    return "Service node blob components were:\n"
+                "\n"
+                "  - next:                   {}\n"
+                "  - prev:                   {}\n"
+                "  - operator:               {}\n"
+                "  - pubkey:                 {}\n"
+                "  - leaveRequestTimestamp:  {}\n"
+                "  - deposit:                {}\n"
+                "  - num contributors:       {}\n"
+                "\n"
+                "The raw blob was:\n\n{}"_format(
+                result.next,
+                result.prev,
+                result.operatorAddr,
+                result.pubkey,
+                result.leaveRequestTimestamp,
+                result.deposit,
+                result.contributorsSize,
+                hex);
+}
+
 TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
     TransactionStateChangeVariant result;
     TransactionType type = getLogType(log);
@@ -62,12 +149,19 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             // - address is 32 bytes, the first 12 of which are padding
             // - fee is between 0 and 10000, despite being packed into a gigantic 256-bit int.
 
-            auto& [bls_pk, eth_addr, sn_pubkey, sn_sig, fee, contributors] =
-                    result.emplace<NewServiceNodeTx>();
+            NewServiceNodeTx& item = result.emplace<NewServiceNodeTx>();
 
-            u256 fee256, c_size, c_len;
+            u256 fee256, c_offset, c_len;
             std::string_view contrib_hex;
-            std::tie(eth_addr, bls_pk, sn_pubkey, sn_sig, fee256, c_size, c_len, contrib_hex) =
+            std::tie(
+                    item.eth_address,
+                    item.bls_pubkey,
+                    item.sn_pubkey,
+                    item.sn_signature,
+                    fee256,
+                    c_offset,
+                    c_len,
+                    contrib_hex) =
                     tools::split_hex_into<
                             skip<12>,
                             crypto::eth_address,
@@ -79,24 +173,74 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
                             u256,
                             std::string_view>(log.data);
 
-            fee = tools::decode_integer_be(fee256);
-            if (fee > cryptonote::STAKING_FEE_BASIS)
+            // NOTE: Decode fee and that it is within acceptable range
+            item.fee = tools::decode_integer_be(fee256);
+            if (item.fee > cryptonote::STAKING_FEE_BASIS)
                 throw oxen::invalid_argument{
                     "Invalid NewServiceNode data: fee must be in [0, {}]"_format(cryptonote::STAKING_FEE_BASIS)};
-            auto num_contributors = tools::decode_integer_be(c_len);
-            if (tools::decode_integer_be(c_size) != 64 ||
-                contrib_hex.size() != 2 * num_contributors * (32 + 32))
-                throw oxen::invalid_argument{
-                        "Invalid NewServiceNode data: invalid contributor data"};
 
-            contributors.resize(num_contributors);
-            for (auto& [addr, amt] : contributors) {
+            // NOTE: Verify that the number of contributors in the blob is
+            // within maximum range
+            uint64_t num_contributors = tools::decode_integer_be(c_len);
+            if (num_contributors > item.contributors.max_size()) {
+                throw oxen::invalid_argument("Invalid NewServiceNode data: {}\n{}"_format(
+                        log_more_contributors_than_allowed(
+                                num_contributors,
+                                item.contributors.max_size(),
+                                item.bls_pubkey,
+                                log.blockNumber,
+                                /*index*/ std::optional<uint64_t>()),
+                        log_new_service_node_tx(item, log.data)));
+            }
+
+            // NOTE: Verify that there's atleast one contributor
+            if (num_contributors <= 0) {
+                throw oxen::invalid_argument(
+                        "Invalid NewServiceNode data: There must be atleast one contributor, "
+                        "received 0\n{}"
+                        ""_format(log_new_service_node_tx(item, log.data)));
+            }
+
+            // NOTE: Verify that the offset to the dynamic part of the
+            // contributors array is correct.
+            const uint64_t c_offset_value = tools::decode_integer_be(c_offset);
+            const uint64_t expected_c_offset_value = 32 /*ID*/ + 32 /*recipient*/ + 64 /*BLS Key*/ +
+                                                     32 /*SN Key*/ + 64 /*SN Sig*/ + 32 /*Fee*/;
+            if (c_offset_value != expected_c_offset_value) {
+                throw oxen::invalid_argument(
+                        "Invalid NewServiceNode data: The offset to the contributor payload ({} "
+                        "bytes) did not match the offset we derived {}\n{}"
+                        ""_format(
+                                c_offset_value,
+                                expected_c_offset_value,
+                                log_new_service_node_tx(item, log.data)));
+            }
+
+            // NOTE: Verify the length of the contributor blob
+            const size_t expected_contrib_hex_size =
+                    2 /*hex*/ * num_contributors * (/*address*/ 32 + /*amount*/ 32);
+            if (contrib_hex.size() != expected_contrib_hex_size) {
+                throw oxen::invalid_argument{
+                        "Invalid NewServiceNode data: The hex payload length ({}) derived for "
+                        "{} contributors did not match the size we derived of {} hex characters\n{}"_format(
+                                contrib_hex.size(),
+                                num_contributors,
+                                expected_contrib_hex_size,
+                                log_new_service_node_tx(item, log.data))};
+            }
+
+            // TODO: Validate the amount, can't be 0, should be min contribution. Is this done in
+            // the SNL? Maybe.
+            for (size_t index = 0; index < num_contributors; index++) {
+                auto& [addr, amt] = item.contributors[item.contributors_size++];
                 u256 amt256;
                 std::tie(addr, amt256, contrib_hex) = tools::
                         split_hex_into<skip<12>, crypto::eth_address, u256, std::string_view>(
                                 contrib_hex);
                 amt = tools::decode_integer_be(amt256);
             }
+
+            oxen::log::debug(logcat, "{}", log_new_service_node_tx(item, log.data));
             break;
         }
         case TransactionType::ServiceNodeLeaveRequest: {
@@ -183,29 +327,6 @@ std::vector<crypto::bls_public_key> RewardsContract::getAllBLSPubkeys(uint64_t b
     return blsPublicKeys;
 }
 
-static std::string service_node_blob_debug(
-    const ContractServiceNode& result, std::string_view full_hex) {
-    return "Service node blob components were:\n"
-                "\n"
-                "  - next:                   {}\n"
-                "  - prev:                   {}\n"
-                "  - operator:               {}\n"
-                "  - pubkey:                 {}\n"
-                "  - leaveRequestTimestamp:  {}\n"
-                "  - deposit:                {}\n"
-                "  - num contributors:       {}\n"
-                "\n"
-                "The raw blob was:\n\n{}"_format(
-                result.next,
-                result.prev,
-                result.operatorAddr,
-                result.pubkey,
-                result.leaveRequestTimestamp,
-                result.deposit,
-                result.contributorsSize,
-                full_hex);
-}
-
 ContractServiceNode RewardsContract::serviceNodes(
         uint64_t index, std::optional<uint64_t> blockNumber) {
     ethyl::ReadCallData callData = {};
@@ -224,7 +345,7 @@ ContractServiceNode RewardsContract::serviceNodes(
     auto callResultHex = callResult.get<std::string_view>();
 
     // NOTE: The ServiceNode struct is a dynamic type (because its child `Contributor` field is
-    // dynamic) hence the offset struct is encoded in the first 32 byte element.
+    // dynamic) hence the offset to the struct is encoded in the first 32 byte element.
     auto [sn_data_offset] = tools::split_hex_into<u256, tools::ignore>(callResultHex);
     auto sn_data = callResultHex.substr(tools::decode_integer_be(sn_data_offset));
     auto [next, prev, op_addr, pubkey, leaveRequestTimestamp, deposit, contr_offset] = tools::split_hex_into<
@@ -256,16 +377,14 @@ ContractServiceNode RewardsContract::serviceNodes(
     else {
         oxen::log::error(
                 logcat,
-                "The number of contributors ({}) in the service node blob exceeded the available "
-                "storage ({}) for service node {} with BLS public key {} at height {}",
-                contributorSize,
-                result.contributors.max_size(),
-                index,
-                result.pubkey,
-                blockNumber ? "{}"_format(*blockNumber) : "(latest)");
-        oxen::log::debug(
-                logcat,
-                "{}", service_node_blob_debug(result, callResultHex));
+                "{}",
+                log_more_contributors_than_allowed(
+                        contributorSize,
+                        result.contributors.max_size(),
+                        result.pubkey,
+                        blockNumber,
+                        index));
+        oxen::log::debug(logcat, "{}", log_service_node_blob(result, callResultHex));
         return result;
     }
 
@@ -281,14 +400,13 @@ ContractServiceNode RewardsContract::serviceNodes(
                     "Failed to parse contributor/contribution [{}] for service node {} with BLS pubkey {} at height {}: {}",
                     i, index, result.pubkey,
                     blockNumber ? "{}"_format(*blockNumber) : "(latest)", e.what());
-            oxen::log::debug(logcat, "{}", service_node_blob_debug(result, callResultHex));
+            oxen::log::debug(logcat, "{}", log_service_node_blob(result, callResultHex));
             return result;
         }
     }
 
     oxen::log::trace(
-                logcat,
-                "Successfully parsed new SN. {}", service_node_blob_debug(result, callResultHex));
+            logcat, "Successfully parsed new SN. {}", log_service_node_blob(result, callResultHex));
 
     result.good = true;
     return result;

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -27,8 +27,7 @@ struct NewServiceNodeTx {
     crypto::public_key sn_pubkey;
     crypto::ed25519_signature ed_signature;
     uint64_t fee;
-    std::array<Contributor, oxen::MAX_CONTRIBUTORS_HF19> contributors;
-    size_t contributors_size;
+    std::vector<Contributor> contributors;
 };
 
 struct ServiceNodeLeaveRequestTx {

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -25,7 +25,7 @@ struct NewServiceNodeTx {
     crypto::bls_public_key bls_pubkey;
     crypto::eth_address eth_address;
     crypto::public_key sn_pubkey;
-    crypto::ed25519_signature sn_signature;
+    crypto::ed25519_signature ed_signature;
     uint64_t fee;
     std::array<Contributor, oxen::MAX_CONTRIBUTORS_HF19> contributors;
     size_t contributors_size;

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <crypto/crypto.h>
+#include <oxen_economy.h>
 
 #include <ethyl/logs.hpp>
 #include <ethyl/provider.hpp>
@@ -26,7 +27,8 @@ struct NewServiceNodeTx {
     crypto::public_key sn_pubkey;
     crypto::ed25519_signature sn_signature;
     uint64_t fee;
-    std::vector<Contributor> contributors;
+    std::array<Contributor, oxen::MAX_CONTRIBUTORS_HF19> contributors;
+    size_t contributors_size;
 };
 
 struct ServiceNodeLeaveRequestTx {
@@ -66,7 +68,7 @@ struct ContractServiceNode {
     crypto::bls_public_key pubkey;
     uint64_t leaveRequestTimestamp;
     uint64_t deposit;
-    std::array<Contributor, 10> contributors;
+    std::array<Contributor, oxen::MAX_CONTRIBUTORS_HF19> contributors;
     size_t contributorsSize;
 };
 

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(mnemonics
 
 target_link_libraries(mnemonics
   PRIVATE
+    cpptrace::cpptrace
     cncrypto
     epee
     logging

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(mnemonics
 
 target_link_libraries(mnemonics
   PRIVATE
-    cpptrace::cpptrace
+    $<$<CONFIG:Debug>:cpptrace::cpptrace>
     cncrypto
     epee
     logging

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -43,7 +43,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 #include "chinese_simplified.h"
 #include "common/oxen.h"
@@ -205,7 +205,7 @@ namespace {
             word = Language::utf8prefix(*it, unique_prefix_length);
             auto it2 = trimmed_word_map.find(word);
             if (it2 == trimmed_word_map.end())
-                throw cpptrace::runtime_error(
+                throw oxen::runtime_error(
                         "Word \"" + std::string(word.data(), word.size()) +
                         "\" not found in trimmed word map in " +
                         language->get_english_language_name());
@@ -439,7 +439,7 @@ namespace ElectrumWords {
     std::string bytes_to_words(const crypto::secret_key& src, const std::string& language_name) {
         epee::wipeable_string epee_words;
         if (!bytes_to_words(src.data(), src.size(), epee_words, language_name))
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Failed to create seed from key for language: " + language_name);
         return std::string(epee_words.view());
     }

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -205,7 +205,7 @@ namespace {
             word = Language::utf8prefix(*it, unique_prefix_length);
             auto it2 = trimmed_word_map.find(word);
             if (it2 == trimmed_word_map.end())
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Word \"" + std::string(word.data(), word.size()) +
                         "\" not found in trimmed word map in " +
                         language->get_english_language_name());
@@ -439,7 +439,7 @@ namespace ElectrumWords {
     std::string bytes_to_words(const crypto::secret_key& src, const std::string& language_name) {
         epee::wipeable_string epee_words;
         if (!bytes_to_words(src.data(), src.size(), epee_words, language_name))
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Failed to create seed from key for language: " + language_name);
         return std::string(epee_words.view());
     }

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "chinese_simplified.h"
 #include "common/oxen.h"
@@ -204,7 +205,7 @@ namespace {
             word = Language::utf8prefix(*it, unique_prefix_length);
             auto it2 = trimmed_word_map.find(word);
             if (it2 == trimmed_word_map.end())
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Word \"" + std::string(word.data(), word.size()) +
                         "\" not found in trimmed word map in " +
                         language->get_english_language_name());
@@ -438,7 +439,7 @@ namespace ElectrumWords {
     std::string bytes_to_words(const crypto::secret_key& src, const std::string& language_name) {
         epee::wipeable_string epee_words;
         if (!bytes_to_words(src.data(), src.size(), epee_words, language_name))
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Failed to create seed from key for language: " + language_name);
         return std::string(epee_words.view());
     }

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -38,9 +38,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <cpptrace/cpptrace.hpp>
-
 #include "epee/wipeable_string.h"
+#include "common/exception.h"
 #include "logging/oxen_logger.h"
 
 /*!
@@ -87,14 +86,14 @@ inline T utf8canonical(const T& s) {
             bytes = 1;
         } else if ((*ptr & 0xe0) == 0xc0) {
             if (avail < 1)
-                throw cpptrace::runtime_error("Invalid UTF-8");
+                throw oxen::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0x1f) << 6;
             cp |= *ptr++ & 0x3f;
             --avail;
             bytes = 2;
         } else if ((*ptr & 0xf0) == 0xe0) {
             if (avail < 2)
-                throw cpptrace::runtime_error("Invalid UTF-8");
+                throw oxen::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0xf) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
             cp |= *ptr++ & 0x3f;
@@ -102,7 +101,7 @@ inline T utf8canonical(const T& s) {
             bytes = 3;
         } else if ((*ptr & 0xf8) == 0xf0) {
             if (avail < 3)
-                throw cpptrace::runtime_error("Invalid UTF-8");
+                throw oxen::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0x7) << 18;
             cp |= (*ptr++ & 0x3f) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
@@ -110,7 +109,7 @@ inline T utf8canonical(const T& s) {
             avail -= 3;
             bytes = 4;
         } else
-            throw cpptrace::runtime_error("Invalid UTF-8");
+            throw oxen::runtime_error("Invalid UTF-8");
 
         cp = std::towlower(cp);
         wptr = wbuf;
@@ -131,7 +130,7 @@ inline T utf8canonical(const T& s) {
                 *wptr++ = 0x80 | ((cp >> 6) & 0x3f);
                 *wptr++ = 0x80 | (cp & 0x3f);
                 break;
-            default: throw cpptrace::runtime_error("Invalid UTF-8");
+            default: throw oxen::runtime_error("Invalid UTF-8");
         }
         *wptr = 0;
         sc += T(wbuf, bytes);
@@ -183,7 +182,7 @@ class Base {
         int ii;
         std::vector<std::string>::const_iterator it;
         if (word_list.size() != NWORDS)
-            throw cpptrace::runtime_error("Wrong word list length for " + language_name);
+            throw oxen::runtime_error("Wrong word list length for " + language_name);
         for (it = word_list.begin(), ii = 0; it != word_list.end(); it++, ii++) {
             word_map[*it] = ii;
             if ((*it).size() < unique_prefix_length) {
@@ -195,7 +194,7 @@ class Base {
                             *it,
                             unique_prefix_length);
                 else
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "Too short word in " + language_name + " word list: " + *it);
             }
             epee::wipeable_string trimmed;
@@ -212,7 +211,7 @@ class Base {
                             language_name,
                             std::string(trimmed.data(), trimmed.size()));
                 else
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "Duplicate prefix in " + language_name +
                             " word list: " + std::string(trimmed.data(), trimmed.size()));
             }

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "epee/wipeable_string.h"
 #include "logging/oxen_logger.h"
@@ -86,14 +87,14 @@ inline T utf8canonical(const T& s) {
             bytes = 1;
         } else if ((*ptr & 0xe0) == 0xc0) {
             if (avail < 1)
-                throw std::runtime_error("Invalid UTF-8");
+                throw cpptrace::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0x1f) << 6;
             cp |= *ptr++ & 0x3f;
             --avail;
             bytes = 2;
         } else if ((*ptr & 0xf0) == 0xe0) {
             if (avail < 2)
-                throw std::runtime_error("Invalid UTF-8");
+                throw cpptrace::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0xf) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
             cp |= *ptr++ & 0x3f;
@@ -101,7 +102,7 @@ inline T utf8canonical(const T& s) {
             bytes = 3;
         } else if ((*ptr & 0xf8) == 0xf0) {
             if (avail < 3)
-                throw std::runtime_error("Invalid UTF-8");
+                throw cpptrace::runtime_error("Invalid UTF-8");
             cp = (*ptr++ & 0x7) << 18;
             cp |= (*ptr++ & 0x3f) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
@@ -109,7 +110,7 @@ inline T utf8canonical(const T& s) {
             avail -= 3;
             bytes = 4;
         } else
-            throw std::runtime_error("Invalid UTF-8");
+            throw cpptrace::runtime_error("Invalid UTF-8");
 
         cp = std::towlower(cp);
         wptr = wbuf;
@@ -130,7 +131,7 @@ inline T utf8canonical(const T& s) {
                 *wptr++ = 0x80 | ((cp >> 6) & 0x3f);
                 *wptr++ = 0x80 | (cp & 0x3f);
                 break;
-            default: throw std::runtime_error("Invalid UTF-8");
+            default: throw cpptrace::runtime_error("Invalid UTF-8");
         }
         *wptr = 0;
         sc += T(wbuf, bytes);
@@ -182,7 +183,7 @@ class Base {
         int ii;
         std::vector<std::string>::const_iterator it;
         if (word_list.size() != NWORDS)
-            throw std::runtime_error("Wrong word list length for " + language_name);
+            throw cpptrace::runtime_error("Wrong word list length for " + language_name);
         for (it = word_list.begin(), ii = 0; it != word_list.end(); it++, ii++) {
             word_map[*it] = ii;
             if ((*it).size() < unique_prefix_length) {
@@ -194,7 +195,7 @@ class Base {
                             *it,
                             unique_prefix_length);
                 else
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "Too short word in " + language_name + " word list: " + *it);
             }
             epee::wipeable_string trimmed;
@@ -211,7 +212,7 @@ class Base {
                             language_name,
                             std::string(trimmed.data(), trimmed.size()));
                 else
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "Duplicate prefix in " + language_name +
                             " word list: " + std::string(trimmed.data(), trimmed.size()));
             }

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -86,14 +86,14 @@ inline T utf8canonical(const T& s) {
             bytes = 1;
         } else if ((*ptr & 0xe0) == 0xc0) {
             if (avail < 1)
-                throw oxen::runtime_error("Invalid UTF-8");
+                throw oxen::traced<std::runtime_error>("Invalid UTF-8");
             cp = (*ptr++ & 0x1f) << 6;
             cp |= *ptr++ & 0x3f;
             --avail;
             bytes = 2;
         } else if ((*ptr & 0xf0) == 0xe0) {
             if (avail < 2)
-                throw oxen::runtime_error("Invalid UTF-8");
+                throw oxen::traced<std::runtime_error>("Invalid UTF-8");
             cp = (*ptr++ & 0xf) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
             cp |= *ptr++ & 0x3f;
@@ -101,7 +101,7 @@ inline T utf8canonical(const T& s) {
             bytes = 3;
         } else if ((*ptr & 0xf8) == 0xf0) {
             if (avail < 3)
-                throw oxen::runtime_error("Invalid UTF-8");
+                throw oxen::traced<std::runtime_error>("Invalid UTF-8");
             cp = (*ptr++ & 0x7) << 18;
             cp |= (*ptr++ & 0x3f) << 12;
             cp |= (*ptr++ & 0x3f) << 6;
@@ -109,7 +109,7 @@ inline T utf8canonical(const T& s) {
             avail -= 3;
             bytes = 4;
         } else
-            throw oxen::runtime_error("Invalid UTF-8");
+            throw oxen::traced<std::runtime_error>("Invalid UTF-8");
 
         cp = std::towlower(cp);
         wptr = wbuf;
@@ -130,7 +130,7 @@ inline T utf8canonical(const T& s) {
                 *wptr++ = 0x80 | ((cp >> 6) & 0x3f);
                 *wptr++ = 0x80 | (cp & 0x3f);
                 break;
-            default: throw oxen::runtime_error("Invalid UTF-8");
+            default: throw oxen::traced<std::runtime_error>("Invalid UTF-8");
         }
         *wptr = 0;
         sc += T(wbuf, bytes);
@@ -182,7 +182,7 @@ class Base {
         int ii;
         std::vector<std::string>::const_iterator it;
         if (word_list.size() != NWORDS)
-            throw oxen::runtime_error("Wrong word list length for " + language_name);
+            throw oxen::traced<std::runtime_error>("Wrong word list length for " + language_name);
         for (it = word_list.begin(), ii = 0; it != word_list.end(); it++, ii++) {
             word_map[*it] = ii;
             if ((*it).size() < unique_prefix_length) {
@@ -194,7 +194,7 @@ class Base {
                             *it,
                             unique_prefix_length);
                 else
-                    throw oxen::runtime_error(
+                    throw oxen::traced<std::runtime_error>(
                             "Too short word in " + language_name + " word list: " + *it);
             }
             epee::wipeable_string trimmed;
@@ -211,7 +211,7 @@ class Base {
                             language_name,
                             std::string(trimmed.data(), trimmed.size()));
                 else
-                    throw oxen::runtime_error(
+                    throw oxen::traced<std::runtime_error>(
                             "Duplicate prefix in " + language_name +
                             " word list: " + std::string(trimmed.data(), trimmed.size()));
             }

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -79,7 +79,7 @@ inline void serialize(Archive& a, epee::net_utils::network_address& na, const ve
             do_serialize<net::i2p_address>(is_saving, a, na);
             break;
         case epee::net_utils::address_type::invalid:
-        default: throw oxen::runtime_error("Unsupported network address type");
+        default: throw oxen::traced<std::runtime_error>("Unsupported network address type");
     }
 }
 template <class Archive, class ver_type>

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -31,10 +31,11 @@
 #pragma once
 
 #include <cstring>
-#include <cpptrace/cpptrace.hpp>
 
-#include "common/expect.h"
-#include "common/pruning.h"
+#include <common/expect.h>
+#include <common/pruning.h>
+#include <common/exception.h>
+
 #include "epee/net/net_utils_base.h"
 #include "net/i2p_address.h"
 #include "net/tor_address.h"
@@ -78,7 +79,7 @@ inline void serialize(Archive& a, epee::net_utils::network_address& na, const ve
             do_serialize<net::i2p_address>(is_saving, a, na);
             break;
         case epee::net_utils::address_type::invalid:
-        default: throw cpptrace::runtime_error("Unsupported network address type");
+        default: throw oxen::runtime_error("Unsupported network address type");
     }
 }
 template <class Archive, class ver_type>

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <cstring>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/expect.h"
 #include "common/pruning.h"
@@ -77,7 +78,7 @@ inline void serialize(Archive& a, epee::net_utils::network_address& na, const ve
             do_serialize<net::i2p_address>(is_saving, a, na);
             break;
         case epee::net_utils::address_type::invalid:
-        default: throw std::runtime_error("Unsupported network address type");
+        default: throw cpptrace::runtime_error("Unsupported network address type");
     }
 }
 template <class Archive, class ver_type>

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -41,7 +41,7 @@ auto logcat = oxen::log::Cat("ringct");
     {                                                                 \
         if (!(expr)) {                                                \
             oxen::log::warning(logcat, frmt, __VA_ARGS__);            \
-            throw std::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw cpptrace::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -30,9 +30,12 @@
 
 #include "rctOps.h"
 
+#include <common/exception.h>
+
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "epee/misc_log_ex.h"
 #include "logging/oxen_logger.h"
+
 using namespace crypto;
 
 auto logcat = oxen::log::Cat("ringct");
@@ -41,7 +44,7 @@ auto logcat = oxen::log::Cat("ringct");
     {                                                                 \
         if (!(expr)) {                                                \
             oxen::log::warning(logcat, frmt, __VA_ARGS__);            \
-            throw cpptrace::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw oxen::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -44,7 +44,7 @@ auto logcat = oxen::log::Cat("ringct");
     {                                                                 \
         if (!(expr)) {                                                \
             oxen::log::warning(logcat, frmt, __VA_ARGS__);            \
-            throw oxen::runtime_error(fmt::format(frmt, __VA_ARGS__)); \
+            throw oxen::traced<std::runtime_error>(fmt::format(frmt, __VA_ARGS__)); \
         }                                                             \
     }
 

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -35,7 +35,7 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 
 #include <sodium/crypto_verify_32.h>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -118,7 +118,7 @@ struct multisig_out {
     FIELD(c)
     FIELD(mu_p)
     if (!mu_p.empty() && mu_p.size() != c.size())
-        throw cpptrace::runtime_error{"Invalid multisig output serialization"};
+        throw oxen::runtime_error{"Invalid multisig output serialization"};
     END_SERIALIZE()
 };
 
@@ -258,7 +258,7 @@ struct Bulletproof {
     FIELD(t)
 
     if (L.empty() || L.size() != R.size())
-        throw cpptrace::runtime_error("Bad bulletproof serialization");
+        throw oxen::runtime_error("Bad bulletproof serialization");
     END_SERIALIZE()
 };
 
@@ -273,7 +273,7 @@ auto start_array(Archive& ar, std::string_view tag, std::vector<T>& v, size_t si
     if (Archive::is_deserializer)
         v.resize(size);
     else if (v.size() != size)
-        throw cpptrace::invalid_argument{
+        throw oxen::invalid_argument{
                 "invalid " + std::string{tag} + " size: " + std::to_string(size) +
                 " (given size) != " + std::to_string(v.size()) + " (# elements)"};
     return ar.begin_array();
@@ -338,7 +338,7 @@ struct rctSigBase {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw cpptrace::invalid_argument{"invalid ringct type"};
+            throw oxen::invalid_argument{"invalid ringct type"};
 
         field_varint(ar, "txnFee", txnFee);
 
@@ -394,7 +394,7 @@ struct rctSigPrunable {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw cpptrace::invalid_argument{"invalid ringct type"};
+            throw oxen::invalid_argument{"invalid ringct type"};
         if (rct::is_rct_bulletproof(type)) {
             uint32_t nbp = bulletproofs.size();
             if (tools::equals_any(type, RCTType::Bulletproof2, RCTType::CLSAG))
@@ -402,14 +402,14 @@ struct rctSigPrunable {
             else
                 field(ar, "nbp", nbp);
             if (nbp > outputs)
-                throw cpptrace::invalid_argument{"too many bulletproofs"};
+                throw oxen::invalid_argument{"too many bulletproofs"};
 
             auto arr = start_array(ar, "bp", bulletproofs, nbp);
             for (auto& b : bulletproofs)
                 value(ar, b);
 
             if (auto n_max = n_bulletproof_max_amounts(bulletproofs); n_max < outputs)
-                throw cpptrace::invalid_argument{
+                throw oxen::invalid_argument{
                         "invalid bulletproofs: n_max (" + std::to_string(n_max) + ") < outputs (" +
                         std::to_string(outputs) + ")"};
         } else {
@@ -460,7 +460,7 @@ struct rctSigPrunable {
                             if constexpr (Archive::is_deserializer)
                                 ss.resize(mg_ss2_elements);
                             else if (ss.size() != mg_ss2_elements)
-                                throw cpptrace::invalid_argument{
+                                throw oxen::invalid_argument{
                                         "invalid mg_ss2 size: have " + std::to_string(ss.size()) +
                                         ", expected " + std::to_string(mg_ss2_elements)};
 

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -35,6 +35,7 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 
 #include <sodium/crypto_verify_32.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -117,7 +118,7 @@ struct multisig_out {
     FIELD(c)
     FIELD(mu_p)
     if (!mu_p.empty() && mu_p.size() != c.size())
-        throw std::runtime_error{"Invalid multisig output serialization"};
+        throw cpptrace::runtime_error{"Invalid multisig output serialization"};
     END_SERIALIZE()
 };
 
@@ -257,7 +258,7 @@ struct Bulletproof {
     FIELD(t)
 
     if (L.empty() || L.size() != R.size())
-        throw std::runtime_error("Bad bulletproof serialization");
+        throw cpptrace::runtime_error("Bad bulletproof serialization");
     END_SERIALIZE()
 };
 
@@ -272,7 +273,7 @@ auto start_array(Archive& ar, std::string_view tag, std::vector<T>& v, size_t si
     if (Archive::is_deserializer)
         v.resize(size);
     else if (v.size() != size)
-        throw std::invalid_argument{
+        throw cpptrace::invalid_argument{
                 "invalid " + std::string{tag} + " size: " + std::to_string(size) +
                 " (given size) != " + std::to_string(v.size()) + " (# elements)"};
     return ar.begin_array();
@@ -337,7 +338,7 @@ struct rctSigBase {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw std::invalid_argument{"invalid ringct type"};
+            throw cpptrace::invalid_argument{"invalid ringct type"};
 
         field_varint(ar, "txnFee", txnFee);
 
@@ -393,7 +394,7 @@ struct rctSigPrunable {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw std::invalid_argument{"invalid ringct type"};
+            throw cpptrace::invalid_argument{"invalid ringct type"};
         if (rct::is_rct_bulletproof(type)) {
             uint32_t nbp = bulletproofs.size();
             if (tools::equals_any(type, RCTType::Bulletproof2, RCTType::CLSAG))
@@ -401,14 +402,14 @@ struct rctSigPrunable {
             else
                 field(ar, "nbp", nbp);
             if (nbp > outputs)
-                throw std::invalid_argument{"too many bulletproofs"};
+                throw cpptrace::invalid_argument{"too many bulletproofs"};
 
             auto arr = start_array(ar, "bp", bulletproofs, nbp);
             for (auto& b : bulletproofs)
                 value(ar, b);
 
             if (auto n_max = n_bulletproof_max_amounts(bulletproofs); n_max < outputs)
-                throw std::invalid_argument{
+                throw cpptrace::invalid_argument{
                         "invalid bulletproofs: n_max (" + std::to_string(n_max) + ") < outputs (" +
                         std::to_string(outputs) + ")"};
         } else {
@@ -459,7 +460,7 @@ struct rctSigPrunable {
                             if constexpr (Archive::is_deserializer)
                                 ss.resize(mg_ss2_elements);
                             else if (ss.size() != mg_ss2_elements)
-                                throw std::invalid_argument{
+                                throw cpptrace::invalid_argument{
                                         "invalid mg_ss2 size: have " + std::to_string(ss.size()) +
                                         ", expected " + std::to_string(mg_ss2_elements)};
 

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -118,7 +118,7 @@ struct multisig_out {
     FIELD(c)
     FIELD(mu_p)
     if (!mu_p.empty() && mu_p.size() != c.size())
-        throw oxen::runtime_error{"Invalid multisig output serialization"};
+        throw oxen::traced<std::runtime_error>{"Invalid multisig output serialization"};
     END_SERIALIZE()
 };
 
@@ -258,7 +258,7 @@ struct Bulletproof {
     FIELD(t)
 
     if (L.empty() || L.size() != R.size())
-        throw oxen::runtime_error("Bad bulletproof serialization");
+        throw oxen::traced<std::runtime_error>("Bad bulletproof serialization");
     END_SERIALIZE()
 };
 
@@ -273,7 +273,7 @@ auto start_array(Archive& ar, std::string_view tag, std::vector<T>& v, size_t si
     if (Archive::is_deserializer)
         v.resize(size);
     else if (v.size() != size)
-        throw oxen::invalid_argument{
+        throw oxen::traced<std::invalid_argument>{
                 "invalid " + std::string{tag} + " size: " + std::to_string(size) +
                 " (given size) != " + std::to_string(v.size()) + " (# elements)"};
     return ar.begin_array();
@@ -338,7 +338,7 @@ struct rctSigBase {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw oxen::invalid_argument{"invalid ringct type"};
+            throw oxen::traced<std::invalid_argument>{"invalid ringct type"};
 
         field_varint(ar, "txnFee", txnFee);
 
@@ -394,7 +394,7 @@ struct rctSigPrunable {
                     RCTType::Bulletproof,
                     RCTType::Bulletproof2,
                     RCTType::CLSAG))
-            throw oxen::invalid_argument{"invalid ringct type"};
+            throw oxen::traced<std::invalid_argument>{"invalid ringct type"};
         if (rct::is_rct_bulletproof(type)) {
             uint32_t nbp = bulletproofs.size();
             if (tools::equals_any(type, RCTType::Bulletproof2, RCTType::CLSAG))
@@ -402,14 +402,14 @@ struct rctSigPrunable {
             else
                 field(ar, "nbp", nbp);
             if (nbp > outputs)
-                throw oxen::invalid_argument{"too many bulletproofs"};
+                throw oxen::traced<std::invalid_argument>{"too many bulletproofs"};
 
             auto arr = start_array(ar, "bp", bulletproofs, nbp);
             for (auto& b : bulletproofs)
                 value(ar, b);
 
             if (auto n_max = n_bulletproof_max_amounts(bulletproofs); n_max < outputs)
-                throw oxen::invalid_argument{
+                throw oxen::traced<std::invalid_argument>{
                         "invalid bulletproofs: n_max (" + std::to_string(n_max) + ") < outputs (" +
                         std::to_string(outputs) + ")"};
         } else {
@@ -460,7 +460,7 @@ struct rctSigPrunable {
                             if constexpr (Archive::is_deserializer)
                                 ss.resize(mg_ss2_elements);
                             else if (ss.size() != mg_ss2_elements)
-                                throw oxen::invalid_argument{
+                                throw oxen::traced<std::invalid_argument>{
                                         "invalid mg_ss2 size: have " + std::to_string(ss.size()) +
                                         ", expected " + std::to_string(mg_ss2_elements)};
 

--- a/src/rpc/common/json_bt.cpp
+++ b/src/rpc/common/json_bt.cpp
@@ -1,6 +1,6 @@
 #include "json_bt.h"
 
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 namespace oxen {
 
@@ -29,7 +29,7 @@ oxenc::bt_value json_to_bt(json&& j) {
         return j.get<uint64_t>();
     if (j.is_number_integer())
         return j.get<int64_t>();
-    throw cpptrace::domain_error{
+    throw oxen::domain_error{
             "internal error: encountered some unhandled/invalid type in json-to-bt translation"};
 }
 

--- a/src/rpc/common/json_bt.cpp
+++ b/src/rpc/common/json_bt.cpp
@@ -1,5 +1,7 @@
 #include "json_bt.h"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace oxen {
 
 oxenc::bt_value json_to_bt(json&& j) {
@@ -27,7 +29,7 @@ oxenc::bt_value json_to_bt(json&& j) {
         return j.get<uint64_t>();
     if (j.is_number_integer())
         return j.get<int64_t>();
-    throw std::domain_error{
+    throw cpptrace::domain_error{
             "internal error: encountered some unhandled/invalid type in json-to-bt translation"};
 }
 

--- a/src/rpc/common/json_bt.cpp
+++ b/src/rpc/common/json_bt.cpp
@@ -29,7 +29,7 @@ oxenc::bt_value json_to_bt(json&& j) {
         return j.get<uint64_t>();
     if (j.is_number_integer())
         return j.get<int64_t>();
-    throw oxen::domain_error{
+    throw oxen::traced<std::domain_error>{
             "internal error: encountered some unhandled/invalid type in json-to-bt translation"};
 }
 

--- a/src/rpc/common/param_parser.hpp
+++ b/src/rpc/common/param_parser.hpp
@@ -21,7 +21,7 @@ using json_range = std::pair<json::const_iterator, json::const_iterator>;
 template <typename... Ignore>
 void check_ascending_names(std::string_view name1, std::string_view name2, const Ignore&...) {
     if (!(name2 > name1))
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Internal error: request values must be retrieved in ascending order"};
 }
 
@@ -162,27 +162,27 @@ void load_value(json_range& r, T& val) {
             if (b <= 1)
                 val = b;
             else
-                throw oxen::domain_error{"Invalid value for '" + key + "': expected boolean"};
+                throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': expected boolean"};
         } else {
-            throw oxen::domain_error{"Invalid value for '" + key + "': expected boolean"};
+            throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': expected boolean"};
         }
     } else if constexpr (std::is_unsigned_v<T>) {
         if (!e.is_number_unsigned())
-            throw oxen::domain_error{"Invalid value for '" + key + "': non-negative value required"};
+            throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': non-negative value required"};
         auto i = e.get<uint64_t>();
         if (sizeof(T) < sizeof(uint64_t) && i > std::numeric_limits<T>::max())
-            throw oxen::domain_error{"Invalid value for '" + key + "': value too large"};
+            throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': value too large"};
         val = i;
     } else if constexpr (std::is_integral_v<T>) {
         if (!e.is_number_integer())
-            throw oxen::domain_error{"Invalid value for '" + key + "': value is not an integer"};
+            throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': value is not an integer"};
         auto i = e.get<int64_t>();
         if (sizeof(T) < sizeof(int64_t)) {
             if (i < std::numeric_limits<T>::lowest())
-                throw oxen::domain_error{
+                throw oxen::traced<std::domain_error>{
                         "Invalid value for '" + key + "': negative value magnitude is too large"};
             else if (i > std::numeric_limits<T>::max())
-                throw oxen::domain_error{"Invalid value for '" + key + "': value is too large"};
+                throw oxen::traced<std::domain_error>{"Invalid value for '" + key + "': value is too large"};
         }
         val = i;
     } else if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>) {
@@ -191,7 +191,7 @@ void load_value(json_range& r, T& val) {
         try {
             e.get_to(val);
         } catch (const std::exception& e) {
-            throw oxen::domain_error{"Invalid values in '" + key + "'"};
+            throw oxen::traced<std::domain_error>{"Invalid values in '" + key + "'"};
         }
     } else {
         static_assert(std::is_same_v<T, void>, "Unsupported load type");
@@ -232,7 +232,7 @@ void get_next_value(In& in, [[maybe_unused]] std::string_view name, T& val) {
     else if (skip_until(in, name))
         load_curr_value(in, val);
     else if constexpr (is_required_wrapper<T>)
-        throw oxen::runtime_error{"Required key '" + std::string{name} + "' not found"};
+        throw oxen::traced<std::runtime_error>{"Required key '" + std::string{name} + "' not found"};
 }
 
 /// Accessor for simple, flat value retrieval from a json or bt_dict_consumer.  In the later

--- a/src/rpc/common/param_parser.hpp
+++ b/src/rpc/common/param_parser.hpp
@@ -6,7 +6,7 @@
 #include <nlohmann/json.hpp>
 #include <type_traits>
 #include <utility>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/json_binary_proxy.h"
 
@@ -21,7 +21,7 @@ using json_range = std::pair<json::const_iterator, json::const_iterator>;
 template <typename... Ignore>
 void check_ascending_names(std::string_view name1, std::string_view name2, const Ignore&...) {
     if (!(name2 > name1))
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Internal error: request values must be retrieved in ascending order"};
 }
 
@@ -162,27 +162,27 @@ void load_value(json_range& r, T& val) {
             if (b <= 1)
                 val = b;
             else
-                throw cpptrace::domain_error{"Invalid value for '" + key + "': expected boolean"};
+                throw oxen::domain_error{"Invalid value for '" + key + "': expected boolean"};
         } else {
-            throw cpptrace::domain_error{"Invalid value for '" + key + "': expected boolean"};
+            throw oxen::domain_error{"Invalid value for '" + key + "': expected boolean"};
         }
     } else if constexpr (std::is_unsigned_v<T>) {
         if (!e.is_number_unsigned())
-            throw cpptrace::domain_error{"Invalid value for '" + key + "': non-negative value required"};
+            throw oxen::domain_error{"Invalid value for '" + key + "': non-negative value required"};
         auto i = e.get<uint64_t>();
         if (sizeof(T) < sizeof(uint64_t) && i > std::numeric_limits<T>::max())
-            throw cpptrace::domain_error{"Invalid value for '" + key + "': value too large"};
+            throw oxen::domain_error{"Invalid value for '" + key + "': value too large"};
         val = i;
     } else if constexpr (std::is_integral_v<T>) {
         if (!e.is_number_integer())
-            throw cpptrace::domain_error{"Invalid value for '" + key + "': value is not an integer"};
+            throw oxen::domain_error{"Invalid value for '" + key + "': value is not an integer"};
         auto i = e.get<int64_t>();
         if (sizeof(T) < sizeof(int64_t)) {
             if (i < std::numeric_limits<T>::lowest())
-                throw cpptrace::domain_error{
+                throw oxen::domain_error{
                         "Invalid value for '" + key + "': negative value magnitude is too large"};
             else if (i > std::numeric_limits<T>::max())
-                throw cpptrace::domain_error{"Invalid value for '" + key + "': value is too large"};
+                throw oxen::domain_error{"Invalid value for '" + key + "': value is too large"};
         }
         val = i;
     } else if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>) {
@@ -191,7 +191,7 @@ void load_value(json_range& r, T& val) {
         try {
             e.get_to(val);
         } catch (const std::exception& e) {
-            throw cpptrace::domain_error{"Invalid values in '" + key + "'"};
+            throw oxen::domain_error{"Invalid values in '" + key + "'"};
         }
     } else {
         static_assert(std::is_same_v<T, void>, "Unsupported load type");
@@ -232,7 +232,7 @@ void get_next_value(In& in, [[maybe_unused]] std::string_view name, T& val) {
     else if (skip_until(in, name))
         load_curr_value(in, val);
     else if constexpr (is_required_wrapper<T>)
-        throw cpptrace::runtime_error{"Required key '" + std::string{name} + "' not found"};
+        throw oxen::runtime_error{"Required key '" + std::string{name} + "' not found"};
 }
 
 /// Accessor for simple, flat value retrieval from a json or bt_dict_consumer.  In the later

--- a/src/rpc/common/rpc_args.cpp
+++ b/src/rpc/common/rpc_args.cpp
@@ -30,7 +30,7 @@
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/version.hpp>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/command_line.h"
 #include "common/i18n.h"
@@ -94,10 +94,10 @@ static void check_ip(const std::string& ip, bool allow_external, const std::stri
             boost::asio::ip::address::from_string(ip, ec);
 #endif
     if (ec)
-        throw cpptrace::runtime_error{tr("Invalid IP address given for --") + option_name};
+        throw oxen::runtime_error{tr("Invalid IP address given for --") + option_name};
 
     if (!parsed_ip.is_loopback() && !allow_external)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "--" + option_name +
                 tr(" permits inbound unencrypted external connections. Consider SSH tunnel or SSL "
                    "proxy instead. Override with --confirm-external-bind")};
@@ -139,7 +139,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
         config.login = tools::login::parse(env_rpc_login, true, verify);
 
     if (config.login && config.login->username.empty())
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 tr("Username specified with --") + std::string{arg.rpc_login.name} +
                 " cannot be empty"};
 
@@ -147,7 +147,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
     if (!access_control_origins_input.empty()) {
         // FIXME: this requirement makes no sense.
         if (!config.login)
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     "--"s + arg.rpc_access_control_origins.name +
                     tr(" requires RPC server password --") + arg.rpc_login.name +
                     tr(" cannot be empty")};

--- a/src/rpc/common/rpc_args.cpp
+++ b/src/rpc/common/rpc_args.cpp
@@ -30,6 +30,7 @@
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/version.hpp>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/command_line.h"
 #include "common/i18n.h"
@@ -93,10 +94,10 @@ static void check_ip(const std::string& ip, bool allow_external, const std::stri
             boost::asio::ip::address::from_string(ip, ec);
 #endif
     if (ec)
-        throw std::runtime_error{tr("Invalid IP address given for --") + option_name};
+        throw cpptrace::runtime_error{tr("Invalid IP address given for --") + option_name};
 
     if (!parsed_ip.is_loopback() && !allow_external)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "--" + option_name +
                 tr(" permits inbound unencrypted external connections. Consider SSH tunnel or SSL "
                    "proxy instead. Override with --confirm-external-bind")};
@@ -138,7 +139,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
         config.login = tools::login::parse(env_rpc_login, true, verify);
 
     if (config.login && config.login->username.empty())
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 tr("Username specified with --") + std::string{arg.rpc_login.name} +
                 " cannot be empty"};
 
@@ -146,7 +147,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
     if (!access_control_origins_input.empty()) {
         // FIXME: this requirement makes no sense.
         if (!config.login)
-            throw std::runtime_error{
+            throw cpptrace::runtime_error{
                     "--"s + arg.rpc_access_control_origins.name +
                     tr(" requires RPC server password --") + arg.rpc_login.name +
                     tr(" cannot be empty")};

--- a/src/rpc/common/rpc_args.cpp
+++ b/src/rpc/common/rpc_args.cpp
@@ -94,10 +94,10 @@ static void check_ip(const std::string& ip, bool allow_external, const std::stri
             boost::asio::ip::address::from_string(ip, ec);
 #endif
     if (ec)
-        throw oxen::runtime_error{tr("Invalid IP address given for --") + option_name};
+        throw oxen::traced<std::runtime_error>{tr("Invalid IP address given for --") + option_name};
 
     if (!parsed_ip.is_loopback() && !allow_external)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "--" + option_name +
                 tr(" permits inbound unencrypted external connections. Consider SSH tunnel or SSL "
                    "proxy instead. Override with --confirm-external-bind")};
@@ -139,7 +139,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
         config.login = tools::login::parse(env_rpc_login, true, verify);
 
     if (config.login && config.login->username.empty())
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 tr("Username specified with --") + std::string{arg.rpc_login.name} +
                 " cannot be empty"};
 
@@ -147,7 +147,7 @@ rpc_args rpc_args::process(const boost::program_options::variables_map& vm) {
     if (!access_control_origins_input.empty()) {
         // FIXME: this requirement makes no sense.
         if (!config.login)
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     "--"s + arg.rpc_access_control_origins.name +
                     tr(" requires RPC server password --") + arg.rpc_login.name +
                     tr(" cannot be empty")};

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2524,60 +2524,59 @@ void core_rpc_server::invoke(
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
         GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES& get_service_node_blacklisted_key_images,
-        rpc_context context) {
+        rpc_context) {
     auto& blacklist = m_core.get_service_node_blacklisted_key_images();
 
     get_service_node_blacklisted_key_images.response["status"] = STATUS_OK;
     get_service_node_blacklisted_key_images.response["blacklist"] = blacklist;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_REWARDS_REQUEST& bls_rewards_request, rpc_context) {
-    const auto bls_withdrawal_signature_response =
-            m_core.bls_rewards_request(bls_rewards_request.request.address);
-    bls_rewards_request.response["status"] = STATUS_OK;
-    bls_rewards_request.response_hex["address"] = bls_withdrawal_signature_response.address;
-    bls_rewards_request.response["amount"] = bls_withdrawal_signature_response.amount;
-    bls_rewards_request.response["height"] = bls_withdrawal_signature_response.height;
-    bls_rewards_request.response_hex["signed_hash"] = bls_withdrawal_signature_response.signed_hash;
-    bls_rewards_request.response_hex["signature"] = bls_withdrawal_signature_response.signature;
-    bls_rewards_request.response["non_signer_indices"] =
+void core_rpc_server::invoke(BLS_REWARDS_REQUEST& rpc, rpc_context) {
+    const auto response = m_core.bls_rewards_request(rpc.request.address);
+    rpc.response["status"] = STATUS_OK;
+    rpc.response_hex["address"] = response.address;
+    rpc.response["amount"] = response.amount;
+    rpc.response["height"] = response.height;
+    rpc.response_hex["msg_to_sign"] =
+            oxenc::to_hex(response.msg_to_sign.begin(), response.msg_to_sign.end());
+    rpc.response_hex["signature"] = response.signature;
+    rpc.response["non_signer_indices"] =
             m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(
-                    bls_withdrawal_signature_response.signers_bls_pubkeys.begin(),
-                    bls_withdrawal_signature_response.signers_bls_pubkeys.end());
+                    response.signers_bls_pubkeys.begin(), response.signers_bls_pubkeys.end());
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_EXIT_REQUEST& exit, rpc_context) {
-    const auto exit_sig = m_core.aggregate_exit_request(exit.request.bls_pubkey);
-    exit.response["status"] = STATUS_OK;
-    exit.response_hex["bls_pubkey"] = exit_sig.exit_pubkey;
-    exit.response_hex["signed_hash"] = exit_sig.signed_hash;
-    exit.response_hex["signature"] = exit_sig.signature;
-    exit.response["non_signer_indices"] =
+void core_rpc_server::invoke(BLS_EXIT_REQUEST& rpc, rpc_context) {
+    const auto response = m_core.aggregate_exit_request(rpc.request.bls_pubkey);
+    rpc.response["status"] = STATUS_OK;
+    rpc.response_hex["bls_pubkey"] = response.exit_pubkey;
+    rpc.response_hex["msg_to_sign"] =
+            oxenc::to_hex(response.msg_to_sign.begin(), response.msg_to_sign.end());
+    rpc.response_hex["signature"] = response.signature;
+    rpc.response["non_signer_indices"] =
             m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(
-                    exit_sig.signers_bls_pubkeys.begin(), exit_sig.signers_bls_pubkeys.end());
+                    response.signers_bls_pubkeys.begin(), response.signers_bls_pubkeys.end());
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& liquidate, rpc_context) {
-    const auto liquidate_sig = m_core.aggregate_liquidation_request(liquidate.request.bls_pubkey);
-    liquidate.response["status"] = STATUS_OK;
-    liquidate.response_hex["bls_pubkey"] = liquidate_sig.exit_pubkey;
-    liquidate.response_hex["signed_hash"] = liquidate_sig.signed_hash;
-    liquidate.response_hex["signature"] = liquidate_sig.signature;
-    liquidate.response["non_signer_indices"] =
+void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& rpc, rpc_context) {
+    const auto response = m_core.aggregate_liquidation_request(rpc.request.bls_pubkey);
+    rpc.response["status"] = STATUS_OK;
+    rpc.response_hex["bls_pubkey"] = response.exit_pubkey;
+    rpc.response_hex["msg_to_sign"] =
+            oxenc::to_hex(response.msg_to_sign.begin(), response.msg_to_sign.end());
+    rpc.response_hex["signature"] = response.signature;
+    rpc.response["non_signer_indices"] =
             m_core.get_blockchain_storage().m_l2_tracker->get_non_signers(
-                    liquidate_sig.signers_bls_pubkeys.begin(),
-                    liquidate_sig.signers_bls_pubkeys.end());
+                    response.signers_bls_pubkeys.begin(), response.signers_bls_pubkeys.end());
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_REGISTRATION& bls_registration_request, rpc_context) {
-    const auto bls_registration = m_core.bls_registration(bls_registration_request.request.address);
-    bls_registration_request.response["status"] = STATUS_OK;
-    bls_registration_request.response_hex["address"] = bls_registration.address;
-    bls_registration_request.response_hex["bls_pubkey"] = bls_registration.bls_pubkey;
-    bls_registration_request.response_hex["proof_of_possession"] =
-            bls_registration.proof_of_possession;
-    bls_registration_request.response_hex["service_node_pubkey"] = bls_registration.sn_pubkey;
-    bls_registration_request.response_hex["service_node_signature"] = bls_registration.ed_signature;
+void core_rpc_server::invoke(BLS_REGISTRATION& rpc, rpc_context) {
+    const auto response = m_core.bls_registration(rpc.request.address);
+    rpc.response["status"] = STATUS_OK;
+    rpc.response_hex["address"] = response.address;
+    rpc.response_hex["bls_pubkey"] = response.bls_pubkey;
+    rpc.response_hex["proof_of_possession"] = response.proof_of_possession;
+    rpc.response_hex["service_node_pubkey"] = response.sn_pubkey;
+    rpc.response_hex["service_node_signature"] = response.ed_signature;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -2761,8 +2760,7 @@ void core_rpc_server::fill_sn_response_entry(
                     m_core.get_service_keys().pub_ed25519,
                     "pubkey_x25519",
                     m_core.get_service_keys().pub_x25519);
-            if (!info.bls_public_key)
-                set_if_requested(reqed, binary, "pubkey_bls", m_core.get_service_keys().pub_bls);
+            set_if_requested(reqed, binary, "pubkey_bls", m_core.get_service_keys().pub_bls);
         } else {
             if (proof.proof->public_ip != 0)
                 set_if_requested(
@@ -2791,8 +2789,11 @@ void core_rpc_server::fill_sn_response_entry(
                         "pubkey_x25519",
                         proof.pubkey_x25519);
             // During HF20 the BLS pubkey isn't in info, but is in the proof:
-            if (!info.bls_public_key && proof.proof->pubkey_bls)
+            if (info.bls_public_key) {
+                set_if_requested(reqed, binary, "pubkey_bls", info.bls_public_key);
+            } else if (proof.proof->pubkey_bls) {
                 set_if_requested(reqed, binary, "pubkey_bls", proof.proof->pubkey_bls);
+            }
         }
 
         auto system_now = std::chrono::system_clock::now();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -34,6 +34,7 @@
 #include <fmt/color.h>
 #include <fmt/core.h>
 #include <oxenc/base64.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <algorithm>
 #include <boost/program_options/options_description.hpp>
@@ -121,7 +122,7 @@ namespace {
             if (auto body = request.body_view())
                 data = *body;
             else
-                throw std::runtime_error{
+                throw cpptrace::runtime_error{
                         "Internal error: can't load binary a RPC command with non-string body"};
             if (!epee::serialization::load_t_from_binary(req, data))
                 throw parse_error{"Failed to parse binary data parameters"};
@@ -870,12 +871,12 @@ void core_rpc_server::invoke(GET_TRANSACTIONS& get, [[maybe_unused]] rpc_context
             auto split_mempool_tx = [](std::pair<const crypto::hash, tx_info>& info) {
                 cryptonote::transaction tx;
                 if (!cryptonote::parse_and_validate_tx_from_blob(info.second.tx_blob, tx))
-                    throw std::runtime_error{"Unable to parse and validate tx from blob"};
+                    throw cpptrace::runtime_error{"Unable to parse and validate tx from blob"};
                 serialization::binary_string_archiver ba;
                 try {
                     tx.serialize_base(ba);
                 } catch (const std::exception& e) {
-                    throw std::runtime_error{"Failed to serialize transaction base: "s + e.what()};
+                    throw cpptrace::runtime_error{"Failed to serialize transaction base: "s + e.what()};
                 }
                 std::string pruned = ba.str();
                 std::string pruned2{info.second.tx_blob, pruned.size()};
@@ -2498,7 +2499,7 @@ void core_rpc_server::invoke(
     auto& amounts = get_service_node_registration_cmd.request.contributor_amounts;
 
     if (addresses.size() != amounts.size()) {
-        throw std::runtime_error("Mismatch in sizes of addresses and amounts");
+        throw cpptrace::runtime_error("Mismatch in sizes of addresses and amounts");
     }
 
     for (size_t i = 0; i < addresses.size(); ++i) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -122,7 +122,7 @@ namespace {
             if (auto body = request.body_view())
                 data = *body;
             else
-                throw oxen::runtime_error{
+                throw oxen::traced<std::runtime_error>{
                         "Internal error: can't load binary a RPC command with non-string body"};
             if (!epee::serialization::load_t_from_binary(req, data))
                 throw parse_error{"Failed to parse binary data parameters"};
@@ -871,12 +871,12 @@ void core_rpc_server::invoke(GET_TRANSACTIONS& get, [[maybe_unused]] rpc_context
             auto split_mempool_tx = [](std::pair<const crypto::hash, tx_info>& info) {
                 cryptonote::transaction tx;
                 if (!cryptonote::parse_and_validate_tx_from_blob(info.second.tx_blob, tx))
-                    throw oxen::runtime_error{"Unable to parse and validate tx from blob"};
+                    throw oxen::traced<std::runtime_error>{"Unable to parse and validate tx from blob"};
                 serialization::binary_string_archiver ba;
                 try {
                     tx.serialize_base(ba);
                 } catch (const std::exception& e) {
-                    throw oxen::runtime_error{"Failed to serialize transaction base: "s + e.what()};
+                    throw oxen::traced<std::runtime_error>{"Failed to serialize transaction base: "s + e.what()};
                 }
                 std::string pruned = ba.str();
                 std::string pruned2{info.second.tx_blob, pruned.size()};
@@ -2499,7 +2499,7 @@ void core_rpc_server::invoke(
     auto& amounts = get_service_node_registration_cmd.request.contributor_amounts;
 
     if (addresses.size() != amounts.size()) {
-        throw oxen::runtime_error("Mismatch in sizes of addresses and amounts");
+        throw oxen::traced<std::runtime_error>("Mismatch in sizes of addresses and amounts");
     }
 
     for (size_t i = 0; i < addresses.size(); ++i) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2586,6 +2586,7 @@ void core_rpc_server::invoke(
         get_service_keys.response_hex["service_node_pubkey"] = keys.pub;
     get_service_keys.response_hex["service_node_ed25519_pubkey"] = keys.pub_ed25519;
     get_service_keys.response_hex["service_node_x25519_pubkey"] = keys.pub_x25519;
+    get_service_keys.response_hex["service_node_bls_pubkey"] = keys.pub_bls;
     get_service_keys.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -34,7 +34,6 @@
 #include <fmt/color.h>
 #include <fmt/core.h>
 #include <oxenc/base64.h>
-#include <cpptrace/cpptrace.hpp>
 
 #include <algorithm>
 #include <boost/program_options/options_description.hpp>
@@ -44,6 +43,7 @@
 #include <type_traits>
 #include <variant>
 
+#include "common/exception.h"
 #include "common/command_line.h"
 #include "common/guts.h"
 #include "common/json_binary_proxy.h"
@@ -122,7 +122,7 @@ namespace {
             if (auto body = request.body_view())
                 data = *body;
             else
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Internal error: can't load binary a RPC command with non-string body"};
             if (!epee::serialization::load_t_from_binary(req, data))
                 throw parse_error{"Failed to parse binary data parameters"};
@@ -871,12 +871,12 @@ void core_rpc_server::invoke(GET_TRANSACTIONS& get, [[maybe_unused]] rpc_context
             auto split_mempool_tx = [](std::pair<const crypto::hash, tx_info>& info) {
                 cryptonote::transaction tx;
                 if (!cryptonote::parse_and_validate_tx_from_blob(info.second.tx_blob, tx))
-                    throw cpptrace::runtime_error{"Unable to parse and validate tx from blob"};
+                    throw oxen::runtime_error{"Unable to parse and validate tx from blob"};
                 serialization::binary_string_archiver ba;
                 try {
                     tx.serialize_base(ba);
                 } catch (const std::exception& e) {
-                    throw cpptrace::runtime_error{"Failed to serialize transaction base: "s + e.what()};
+                    throw oxen::runtime_error{"Failed to serialize transaction base: "s + e.what()};
                 }
                 std::string pruned = ba.str();
                 std::string pruned2{info.second.tx_blob, pruned.size()};
@@ -2499,7 +2499,7 @@ void core_rpc_server::invoke(
     auto& amounts = get_service_node_registration_cmd.request.contributor_amounts;
 
     if (addresses.size() != amounts.size()) {
-        throw cpptrace::runtime_error("Mismatch in sizes of addresses and amounts");
+        throw oxen::runtime_error("Mismatch in sizes of addresses and amounts");
     }
 
     for (size_t i = 0; i < addresses.size(); ++i) {

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <type_traits>
 #include <utility>
+#include <cpptrace/cpptrace.hpp>
 
 #include "rpc/common/param_parser.hpp"
 
@@ -103,7 +104,7 @@ void parse_request(GET_TRANSACTION_POOL_STATS& pstats, rpc_input in) {
 void parse_request(HARD_FORK_INFO& hfinfo, rpc_input in) {
     get_values(in, "height", hfinfo.request.height, "version", hfinfo.request.version);
     if (hfinfo.request.height && hfinfo.request.version)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Error: at most one of 'height'" + std::to_string(hfinfo.request.height) + "/" +
                 std::to_string(hfinfo.request.version) + " and 'version' may be specified"};
 }
@@ -132,14 +133,14 @@ void parse_request(GET_TRANSACTIONS& get, rpc_input in) {
             get.request.tx_hashes);
 
     if (get.request.memory_pool && !get.request.tx_hashes.empty())
-        throw std::runtime_error{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
+        throw cpptrace::runtime_error{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
 }
 void parse_request(GET_TRANSACTION_POOL& get, rpc_input in) {
     // Deprecated wrapper; GET_TRANSACTION_POOL is a no-member subclass of GET_TRANSACTIONS; it
     // works identically, except that we force `memory_pool` to true.
     parse_request(static_cast<GET_TRANSACTIONS&>(get), std::move(in));
     if (!get.request.tx_hashes.empty())
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Error: 'get_transaction_pool' does not support specifying 'tx_hashes'"};
     get.request.memory_pool = true;
 }
@@ -148,9 +149,9 @@ void parse_request(SET_LIMIT& limit, rpc_input in) {
     get_values(in, "limit_down", limit.request.limit_down, "limit_up", limit.request.limit_up);
 
     if (limit.request.limit_down < -1)
-        throw std::domain_error{"limit_down must be >= -1"};
+        throw cpptrace::domain_error{"limit_down must be >= -1"};
     if (limit.request.limit_down < -1)
-        throw std::domain_error{"limit_up must be >= -1"};
+        throw cpptrace::domain_error{"limit_up must be >= -1"};
 }
 
 void parse_request(IS_KEY_IMAGE_SPENT& spent, rpc_input in) {
@@ -167,7 +168,7 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
 
     if (tx_data.empty())  // required above will make sure it's specified, but doesn't guarantee
                           // against an empty value
-        throw std::domain_error{"Invalid 'tx' value: cannot be empty"};
+        throw cpptrace::domain_error{"Invalid 'tx' value: cannot be empty"};
 
     // tx can be specified as base64, hex, or binary, so try to figure out which one we have by
     // looking at the beginning.
@@ -209,14 +210,14 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
     }
 
     if (!good)
-        throw std::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
+        throw cpptrace::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
 }
 
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in) {
     get_values(in, "heights", bh.request.heights);
 
     if (bh.request.heights.size() > bh.MAX_HEIGHTS)
-        throw std::domain_error{"Error: too many block heights requested at once"};
+        throw cpptrace::domain_error{"Error: too many block heights requested at once"};
 }
 
 void parse_request(GET_PEER_LIST& pl, rpc_input in) {
@@ -449,7 +450,7 @@ void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {
         if (*qs.request.quorum_type == 255)  // backwards-compat magic value
             qs.request.quorum_type = std::nullopt;
         else if (*qs.request.quorum_type > tools::enum_count<service_nodes::quorum_type>)
-            throw std::domain_error{
+            throw cpptrace::domain_error{
                     "Quorum type specifies an invalid value: "_format(*qs.request.quorum_type)};
     }
 }

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -104,7 +104,7 @@ void parse_request(GET_TRANSACTION_POOL_STATS& pstats, rpc_input in) {
 void parse_request(HARD_FORK_INFO& hfinfo, rpc_input in) {
     get_values(in, "height", hfinfo.request.height, "version", hfinfo.request.version);
     if (hfinfo.request.height && hfinfo.request.version)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Error: at most one of 'height'" + std::to_string(hfinfo.request.height) + "/" +
                 std::to_string(hfinfo.request.version) + " and 'version' may be specified"};
 }
@@ -133,14 +133,14 @@ void parse_request(GET_TRANSACTIONS& get, rpc_input in) {
             get.request.tx_hashes);
 
     if (get.request.memory_pool && !get.request.tx_hashes.empty())
-        throw oxen::runtime_error{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
+        throw oxen::traced<std::runtime_error>{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
 }
 void parse_request(GET_TRANSACTION_POOL& get, rpc_input in) {
     // Deprecated wrapper; GET_TRANSACTION_POOL is a no-member subclass of GET_TRANSACTIONS; it
     // works identically, except that we force `memory_pool` to true.
     parse_request(static_cast<GET_TRANSACTIONS&>(get), std::move(in));
     if (!get.request.tx_hashes.empty())
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Error: 'get_transaction_pool' does not support specifying 'tx_hashes'"};
     get.request.memory_pool = true;
 }
@@ -149,9 +149,9 @@ void parse_request(SET_LIMIT& limit, rpc_input in) {
     get_values(in, "limit_down", limit.request.limit_down, "limit_up", limit.request.limit_up);
 
     if (limit.request.limit_down < -1)
-        throw oxen::domain_error{"limit_down must be >= -1"};
+        throw oxen::traced<std::domain_error>{"limit_down must be >= -1"};
     if (limit.request.limit_down < -1)
-        throw oxen::domain_error{"limit_up must be >= -1"};
+        throw oxen::traced<std::domain_error>{"limit_up must be >= -1"};
 }
 
 void parse_request(IS_KEY_IMAGE_SPENT& spent, rpc_input in) {
@@ -168,7 +168,7 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
 
     if (tx_data.empty())  // required above will make sure it's specified, but doesn't guarantee
                           // against an empty value
-        throw oxen::domain_error{"Invalid 'tx' value: cannot be empty"};
+        throw oxen::traced<std::domain_error>{"Invalid 'tx' value: cannot be empty"};
 
     // tx can be specified as base64, hex, or binary, so try to figure out which one we have by
     // looking at the beginning.
@@ -210,14 +210,14 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
     }
 
     if (!good)
-        throw oxen::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
+        throw oxen::traced<std::domain_error>{"Invalid 'tx' value: expected hex, base64, or bytes"};
 }
 
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in) {
     get_values(in, "heights", bh.request.heights);
 
     if (bh.request.heights.size() > bh.MAX_HEIGHTS)
-        throw oxen::domain_error{"Error: too many block heights requested at once"};
+        throw oxen::traced<std::domain_error>{"Error: too many block heights requested at once"};
 }
 
 void parse_request(GET_PEER_LIST& pl, rpc_input in) {
@@ -450,7 +450,7 @@ void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {
         if (*qs.request.quorum_type == 255)  // backwards-compat magic value
             qs.request.quorum_type = std::nullopt;
         else if (*qs.request.quorum_type > tools::enum_count<service_nodes::quorum_type>)
-            throw oxen::domain_error{
+            throw oxen::traced<std::domain_error>{
                     "Quorum type specifies an invalid value: "_format(*qs.request.quorum_type)};
     }
 }

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -7,8 +7,8 @@
 #include <chrono>
 #include <type_traits>
 #include <utility>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "rpc/common/param_parser.hpp"
 
 namespace cryptonote::rpc {
@@ -104,7 +104,7 @@ void parse_request(GET_TRANSACTION_POOL_STATS& pstats, rpc_input in) {
 void parse_request(HARD_FORK_INFO& hfinfo, rpc_input in) {
     get_values(in, "height", hfinfo.request.height, "version", hfinfo.request.version);
     if (hfinfo.request.height && hfinfo.request.version)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Error: at most one of 'height'" + std::to_string(hfinfo.request.height) + "/" +
                 std::to_string(hfinfo.request.version) + " and 'version' may be specified"};
 }
@@ -133,14 +133,14 @@ void parse_request(GET_TRANSACTIONS& get, rpc_input in) {
             get.request.tx_hashes);
 
     if (get.request.memory_pool && !get.request.tx_hashes.empty())
-        throw cpptrace::runtime_error{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
+        throw oxen::runtime_error{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
 }
 void parse_request(GET_TRANSACTION_POOL& get, rpc_input in) {
     // Deprecated wrapper; GET_TRANSACTION_POOL is a no-member subclass of GET_TRANSACTIONS; it
     // works identically, except that we force `memory_pool` to true.
     parse_request(static_cast<GET_TRANSACTIONS&>(get), std::move(in));
     if (!get.request.tx_hashes.empty())
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Error: 'get_transaction_pool' does not support specifying 'tx_hashes'"};
     get.request.memory_pool = true;
 }
@@ -149,9 +149,9 @@ void parse_request(SET_LIMIT& limit, rpc_input in) {
     get_values(in, "limit_down", limit.request.limit_down, "limit_up", limit.request.limit_up);
 
     if (limit.request.limit_down < -1)
-        throw cpptrace::domain_error{"limit_down must be >= -1"};
+        throw oxen::domain_error{"limit_down must be >= -1"};
     if (limit.request.limit_down < -1)
-        throw cpptrace::domain_error{"limit_up must be >= -1"};
+        throw oxen::domain_error{"limit_up must be >= -1"};
 }
 
 void parse_request(IS_KEY_IMAGE_SPENT& spent, rpc_input in) {
@@ -168,7 +168,7 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
 
     if (tx_data.empty())  // required above will make sure it's specified, but doesn't guarantee
                           // against an empty value
-        throw cpptrace::domain_error{"Invalid 'tx' value: cannot be empty"};
+        throw oxen::domain_error{"Invalid 'tx' value: cannot be empty"};
 
     // tx can be specified as base64, hex, or binary, so try to figure out which one we have by
     // looking at the beginning.
@@ -210,14 +210,14 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
     }
 
     if (!good)
-        throw cpptrace::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
+        throw oxen::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
 }
 
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in) {
     get_values(in, "heights", bh.request.heights);
 
     if (bh.request.heights.size() > bh.MAX_HEIGHTS)
-        throw cpptrace::domain_error{"Error: too many block heights requested at once"};
+        throw oxen::domain_error{"Error: too many block heights requested at once"};
 }
 
 void parse_request(GET_PEER_LIST& pl, rpc_input in) {
@@ -450,7 +450,7 @@ void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {
         if (*qs.request.quorum_type == 255)  // backwards-compat magic value
             qs.request.quorum_type = std::nullopt;
         else if (*qs.request.quorum_type > tools::enum_count<service_nodes::quorum_type>)
-            throw cpptrace::domain_error{
+            throw oxen::domain_error{
                     "Quorum type specifies an invalid value: "_format(*qs.request.quorum_type)};
     }
 }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1865,6 +1865,7 @@ struct GET_SERVICE_NODE_REGISTRATION_CMD : RPC_COMMAND {
 ///   running as a service node.
 /// - `service_node_ed25519_pubkey` -- The daemon's ed25519 auxiliary public key.
 /// - `service_node_x25519_pubkey` -- The daemon's x25519 auxiliary public key.
+/// - `service_node_bls_pubkey` -- The daemon's BLS auxiliary public key.
 struct GET_SERVICE_KEYS : NO_ARGS {
     static constexpr auto names() { return NAMES("get_service_keys", "get_service_node_key"); }
 };

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -163,7 +163,7 @@ http_server::http_server(
                         error << "tried to bind to:";
                         for (const auto& [addr, port, required] : bind)
                             error << ' ' << addr << ':' << port;
-                        throw oxen::runtime_error(error.str());
+                        throw oxen::traced<std::runtime_error>(error.str());
                     }
                 } catch (...) {
                     startup_success.set_exception(std::current_exception());
@@ -676,7 +676,7 @@ static std::unordered_set<oxenmq::OxenMQ*> timer_started;
 
 void http_server::start() {
     if (m_sent_startup)
-        throw oxen::logic_error{"Cannot call http_server::start() more than once"};
+        throw oxen::traced<std::logic_error>{"Cannot call http_server::start() more than once"};
 
     auto net = m_server.nettype();
     m_server_header =

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <exception>
 #include <variant>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/command_line.h"
 #include "common/string_util.h"
@@ -161,7 +162,7 @@ http_server::http_server(
                         error << "tried to bind to:";
                         for (const auto& [addr, port, required] : bind)
                             error << ' ' << addr << ':' << port;
-                        throw std::runtime_error(error.str());
+                        throw cpptrace::runtime_error(error.str());
                     }
                 } catch (...) {
                     startup_success.set_exception(std::current_exception());
@@ -674,7 +675,7 @@ static std::unordered_set<oxenmq::OxenMQ*> timer_started;
 
 void http_server::start() {
     if (m_sent_startup)
-        throw std::logic_error{"Cannot call http_server::start() more than once"};
+        throw cpptrace::logic_error{"Cannot call http_server::start() more than once"};
 
     auto net = m_server.nettype();
     m_server_header =

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/command_line.h"
 #include "common/string_util.h"
 #include "cryptonote_config.h"
@@ -162,7 +163,7 @@ http_server::http_server(
                         error << "tried to bind to:";
                         for (const auto& [addr, port, required] : bind)
                             error << ' ' << addr << ':' << port;
-                        throw cpptrace::runtime_error(error.str());
+                        throw oxen::runtime_error(error.str());
                     }
                 } catch (...) {
                     startup_success.set_exception(std::current_exception());
@@ -675,7 +676,7 @@ static std::unordered_set<oxenmq::OxenMQ*> timer_started;
 
 void http_server::start() {
     if (m_sent_startup)
-        throw cpptrace::logic_error{"Cannot call http_server::start() more than once"};
+        throw oxen::logic_error{"Cannot call http_server::start() more than once"};
 
     auto net = m_server.nettype();
     m_server_header =

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -76,7 +76,7 @@ namespace {
         // Crude check for basic validity; you can specify all sorts of invalid things, but at
         // least we can check the prefix for something that looks zmq-y.
         if (addr.size() < 7 || (addr.substr(0, 6) != "tcp://" && addr.substr(0, 6) != "ipc://"))
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Error: omq listen address '" + std::string(addr) +
                     "' is invalid: expected tcp://IP:PORT, tcp://[IPv6]:PORT or "
                     "ipc:///path/to/socket");
@@ -87,7 +87,7 @@ namespace {
         pks.reserve(pk_strings.size());
         for (const auto& pkstr : pk_strings) {
             if (pkstr.size() != 64 || !oxenc::is_hex(pkstr))
-                throw oxen::runtime_error(
+                throw oxen::traced<std::runtime_error>(
                         "Invalid OMQ login pubkey: '" + pkstr + "'; expected 64-char hex pubkey");
             pks.emplace_back();
             oxenc::to_hex(pkstr.begin(), pkstr.end(), reinterpret_cast<char*>(&pks.back()));
@@ -181,12 +181,12 @@ omq_rpc::omq_rpc(
         size_t len = 0;
         umask = std::stoi(umask_str, &len, 8);
         if (len != umask_str.size())
-            throw oxen::invalid_argument("not an octal value");
+            throw oxen::traced<std::invalid_argument>("not an octal value");
         if (umask < 0 || umask > 0777)
-            throw oxen::invalid_argument("invalid umask value");
+            throw oxen::traced<std::invalid_argument>("invalid umask value");
         omq.STARTUP_UMASK = umask;
     } catch (const std::exception& e) {
-        throw oxen::invalid_argument(
+        throw oxen::traced<std::invalid_argument>(
                 "Invalid --lmq-umask value '" + umask_str +
                 "': value must be an octal value between 0 and 0777");
     }

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -6,6 +6,7 @@
 #include <oxenc/bt.h>
 #include <oxenmq/fmt.h>
 #include <oxenmq/oxenmq.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "cryptonote_config.h"
 #include "rpc/common/param_parser.hpp"
@@ -75,7 +76,7 @@ namespace {
         // Crude check for basic validity; you can specify all sorts of invalid things, but at
         // least we can check the prefix for something that looks zmq-y.
         if (addr.size() < 7 || (addr.substr(0, 6) != "tcp://" && addr.substr(0, 6) != "ipc://"))
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Error: omq listen address '" + std::string(addr) +
                     "' is invalid: expected tcp://IP:PORT, tcp://[IPv6]:PORT or "
                     "ipc:///path/to/socket");
@@ -86,7 +87,7 @@ namespace {
         pks.reserve(pk_strings.size());
         for (const auto& pkstr : pk_strings) {
             if (pkstr.size() != 64 || !oxenc::is_hex(pkstr))
-                throw std::runtime_error(
+                throw cpptrace::runtime_error(
                         "Invalid OMQ login pubkey: '" + pkstr + "'; expected 64-char hex pubkey");
             pks.emplace_back();
             oxenc::to_hex(pkstr.begin(), pkstr.end(), reinterpret_cast<char*>(&pks.back()));
@@ -180,12 +181,12 @@ omq_rpc::omq_rpc(
         size_t len = 0;
         umask = std::stoi(umask_str, &len, 8);
         if (len != umask_str.size())
-            throw std::invalid_argument("not an octal value");
+            throw cpptrace::invalid_argument("not an octal value");
         if (umask < 0 || umask > 0777)
-            throw std::invalid_argument("invalid umask value");
+            throw cpptrace::invalid_argument("invalid umask value");
         omq.STARTUP_UMASK = umask;
     } catch (const std::exception& e) {
-        throw std::invalid_argument(
+        throw cpptrace::invalid_argument(
                 "Invalid --lmq-umask value '" + umask_str +
                 "': value must be an octal value between 0 and 0777");
     }

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -6,7 +6,7 @@
 #include <oxenc/bt.h>
 #include <oxenmq/fmt.h>
 #include <oxenmq/oxenmq.h>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "cryptonote_config.h"
 #include "rpc/common/param_parser.hpp"
@@ -76,7 +76,7 @@ namespace {
         // Crude check for basic validity; you can specify all sorts of invalid things, but at
         // least we can check the prefix for something that looks zmq-y.
         if (addr.size() < 7 || (addr.substr(0, 6) != "tcp://" && addr.substr(0, 6) != "ipc://"))
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Error: omq listen address '" + std::string(addr) +
                     "' is invalid: expected tcp://IP:PORT, tcp://[IPv6]:PORT or "
                     "ipc:///path/to/socket");
@@ -87,7 +87,7 @@ namespace {
         pks.reserve(pk_strings.size());
         for (const auto& pkstr : pk_strings) {
             if (pkstr.size() != 64 || !oxenc::is_hex(pkstr))
-                throw cpptrace::runtime_error(
+                throw oxen::runtime_error(
                         "Invalid OMQ login pubkey: '" + pkstr + "'; expected 64-char hex pubkey");
             pks.emplace_back();
             oxenc::to_hex(pkstr.begin(), pkstr.end(), reinterpret_cast<char*>(&pks.back()));
@@ -181,12 +181,12 @@ omq_rpc::omq_rpc(
         size_t len = 0;
         umask = std::stoi(umask_str, &len, 8);
         if (len != umask_str.size())
-            throw cpptrace::invalid_argument("not an octal value");
+            throw oxen::invalid_argument("not an octal value");
         if (umask < 0 || umask > 0777)
-            throw cpptrace::invalid_argument("invalid umask value");
+            throw oxen::invalid_argument("invalid umask value");
         omq.STARTUP_UMASK = umask;
     } catch (const std::exception& e) {
-        throw cpptrace::invalid_argument(
+        throw oxen::invalid_argument(
                 "Invalid --lmq-umask value '" + umask_str +
                 "': value must be an octal value between 0 and 0777");
     }

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -34,6 +34,10 @@
  * Portable, little-endian binary archive */
 #pragma once
 
+#include "base.h"
+
+#include <common/exception.h>
+#include <common/varint.h>
 #include <oxenc/endian.h>
 
 #include <cassert>
@@ -44,10 +48,6 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <cpptrace/cpptrace.hpp>
-
-#include "base.h"
-#include "common/varint.h"
 
 namespace serialization {
 
@@ -104,7 +104,7 @@ class binary_unarchiver : public deserializer {
     void serialize_uvarint(T& v) {
         using It = std::istreambuf_iterator<char>;
         if (tools::read_varint(It{stream_}, It{}, v) < 0)
-            throw cpptrace::runtime_error{"deserialization of varint failed"};
+            throw oxen::runtime_error{"deserialization of varint failed"};
     }
 
     // RAII class for `begin_array()`/`begin_object()`.  This particular implementation is a no-op.

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -104,7 +104,7 @@ class binary_unarchiver : public deserializer {
     void serialize_uvarint(T& v) {
         using It = std::istreambuf_iterator<char>;
         if (tools::read_varint(It{stream_}, It{}, v) < 0)
-            throw oxen::runtime_error{"deserialization of varint failed"};
+            throw oxen::traced<std::runtime_error>{"deserialization of varint failed"};
     }
 
     // RAII class for `begin_array()`/`begin_object()`.  This particular implementation is a no-op.

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -44,6 +44,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <cpptrace/cpptrace.hpp>
 
 #include "base.h"
 #include "common/varint.h"
@@ -103,7 +104,7 @@ class binary_unarchiver : public deserializer {
     void serialize_uvarint(T& v) {
         using It = std::istreambuf_iterator<char>;
         if (tools::read_varint(It{stream_}, It{}, v) < 0)
-            throw std::runtime_error{"deserialization of varint failed"};
+            throw cpptrace::runtime_error{"deserialization of varint failed"};
     }
 
     // RAII class for `begin_array()`/`begin_object()`.  This particular implementation is a no-op.

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -31,7 +31,7 @@
 
 #pragma once
 #include <utility>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "serialization.h"
 
@@ -53,7 +53,7 @@ void serialize_value(Archive& ar, std::pair<F, S>& p) {
     size_t cnt;
     auto arr = ar.begin_array(cnt);
     if (!Archive::is_serializer && cnt != 2)
-        throw cpptrace::runtime_error(
+        throw oxen::runtime_error(
                 "Serialization failed: expected pair, found " + std::to_string(cnt) + " values");
 
     detail::serialize_pair_element(ar, p.first);

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -53,7 +53,7 @@ void serialize_value(Archive& ar, std::pair<F, S>& p) {
     size_t cnt;
     auto arr = ar.begin_array(cnt);
     if (!Archive::is_serializer && cnt != 2)
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "Serialization failed: expected pair, found " + std::to_string(cnt) + " values");
 
     detail::serialize_pair_element(ar, p.first);

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -31,6 +31,7 @@
 
 #pragma once
 #include <utility>
+#include <cpptrace/cpptrace.hpp>
 
 #include "serialization.h"
 
@@ -52,7 +53,7 @@ void serialize_value(Archive& ar, std::pair<F, S>& p) {
     size_t cnt;
     auto arr = ar.begin_array(cnt);
     if (!Archive::is_serializer && cnt != 2)
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "Serialization failed: expected pair, found " + std::to_string(cnt) + " values");
 
     detail::serialize_pair_element(ar, p.first);

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -242,7 +242,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void value(Archive& ar, T& v, Predicate test) {
     value(ar, v);
     if (Archive::is_deserializer && !test(v))
-        throw oxen::out_of_range{"Invalid value during deserialization"};
+        throw oxen::traced<std::out_of_range>{"Invalid value during deserialization"};
 }
 
 /// Serializes an integer value using varint encoding.
@@ -272,7 +272,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void varint(Archive& ar, T& val, Predicate test) {
     varint(ar, val);
     if (Archive::is_deserializer && !test(val))
-        throw oxen::out_of_range{"Invalid integer or enum value during deserialization"};
+        throw oxen::traced<std::out_of_range>{"Invalid integer or enum value during deserialization"};
 }
 
 /// Adds a key-value pair
@@ -322,7 +322,7 @@ template <class Archive>
 void done(Archive& ar) {
     if constexpr (Archive::is_deserializer)
         if (auto remaining = ar.remaining_bytes(); remaining > 0)
-            throw oxen::runtime_error(
+            throw oxen::traced<std::runtime_error>(
                     "Expected end of serialization data but not all data was consumed (" +
                     std::to_string(remaining) + ")");
 }

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -154,8 +154,8 @@
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "base.h"
 #include "epee/span.h"  // for detecting epee-wrapped byte spannable objects
 
@@ -242,7 +242,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void value(Archive& ar, T& v, Predicate test) {
     value(ar, v);
     if (Archive::is_deserializer && !test(v))
-        throw cpptrace::out_of_range{"Invalid value during deserialization"};
+        throw oxen::out_of_range{"Invalid value during deserialization"};
 }
 
 /// Serializes an integer value using varint encoding.
@@ -272,7 +272,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void varint(Archive& ar, T& val, Predicate test) {
     varint(ar, val);
     if (Archive::is_deserializer && !test(val))
-        throw cpptrace::out_of_range{"Invalid integer or enum value during deserialization"};
+        throw oxen::out_of_range{"Invalid integer or enum value during deserialization"};
 }
 
 /// Adds a key-value pair
@@ -322,7 +322,7 @@ template <class Archive>
 void done(Archive& ar) {
     if constexpr (Archive::is_deserializer)
         if (auto remaining = ar.remaining_bytes(); remaining > 0)
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "Expected end of serialization data but not all data was consumed (" +
                     std::to_string(remaining) + ")");
 }

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -154,6 +154,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
+#include <cpptrace/cpptrace.hpp>
 
 #include "base.h"
 #include "epee/span.h"  // for detecting epee-wrapped byte spannable objects
@@ -241,7 +242,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void value(Archive& ar, T& v, Predicate test) {
     value(ar, v);
     if (Archive::is_deserializer && !test(v))
-        throw std::out_of_range{"Invalid value during deserialization"};
+        throw cpptrace::out_of_range{"Invalid value during deserialization"};
 }
 
 /// Serializes an integer value using varint encoding.
@@ -271,7 +272,7 @@ template <class Archive, typename T, std::predicate<const T&> Predicate>
 void varint(Archive& ar, T& val, Predicate test) {
     varint(ar, val);
     if (Archive::is_deserializer && !test(val))
-        throw std::out_of_range{"Invalid integer or enum value during deserialization"};
+        throw cpptrace::out_of_range{"Invalid integer or enum value during deserialization"};
 }
 
 /// Adds a key-value pair
@@ -321,7 +322,7 @@ template <class Archive>
 void done(Archive& ar) {
     if constexpr (Archive::is_deserializer)
         if (auto remaining = ar.remaining_bytes(); remaining > 0)
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "Expected end of serialization data but not all data was consumed (" +
                     std::to_string(remaining) + ")");
 }

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <oxenc/variant.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/meta.h"
 #include "serialization.h"
@@ -111,7 +112,7 @@ namespace detail {
         auto obj = ar.begin_object();
         ar.read_variant_tag(tag);
         if (!(... || read_variant_impl_one<I>(ar, v, tag)))
-            throw std::runtime_error("failed to read variant");
+            throw cpptrace::runtime_error("failed to read variant");
     }
 
     template <

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -112,7 +112,7 @@ namespace detail {
         auto obj = ar.begin_object();
         ar.read_variant_tag(tag);
         if (!(... || read_variant_impl_one<I>(ar, v, tag)))
-            throw oxen::runtime_error("failed to read variant");
+            throw oxen::traced<std::runtime_error>("failed to read variant");
     }
 
     template <

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -36,11 +36,11 @@
  */
 #pragma once
 
-#include <oxenc/variant.h>
-#include <cpptrace/cpptrace.hpp>
-
-#include "common/meta.h"
 #include "serialization.h"
+
+#include <oxenc/variant.h>
+#include <common/exception.h>
+#include <common/meta.h>
 
 namespace serialization {
 
@@ -112,7 +112,7 @@ namespace detail {
         auto obj = ar.begin_object();
         ar.read_variant_tag(tag);
         if (!(... || read_variant_impl_one<I>(ar, v, tag)))
-            throw cpptrace::runtime_error("failed to read variant");
+            throw oxen::runtime_error("failed to read variant");
     }
 
     template <

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -10128,7 +10128,7 @@ void simple_wallet::commit_or_save(
 
 //----------------------------------------------------------------------------------------------------
 int main(int argc, char* argv[]) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     setlocale(LC_CTYPE, "");

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -64,6 +64,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <thread>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/base58.h"
 #include "common/command_line.h"
@@ -10127,6 +10128,7 @@ void simple_wallet::commit_or_save(
 
 //----------------------------------------------------------------------------------------------------
 int main(int argc, char* argv[]) {
+    cpptrace::register_terminate_handler();
     TRY_ENTRY();
 
     setlocale(LC_CTYPE, "");

--- a/src/sqlitedb/database.cpp
+++ b/src/sqlitedb/database.cpp
@@ -55,7 +55,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign keys constraints: {}",
                 sqlite3_errstr(rc));
-        throw oxen::runtime_error{"Foreign key constrains required"};
+        throw oxen::traced<std::runtime_error>{"Foreign key constrains required"};
     }
     int fk_enabled = db.execAndGet("PRAGMA foreign_keys").getInt();
     if (fk_enabled != 1) {
@@ -63,7 +63,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign key constraints; perhaps this sqlite3 is compiled "
                 "without it?");
-        throw oxen::runtime_error{"Foreign key support is required"};
+        throw oxen::traced<std::runtime_error>{"Foreign key support is required"};
     }
 
     // FIXME: SQLite / SQLiteCPP may not have encryption available

--- a/src/sqlitedb/database.cpp
+++ b/src/sqlitedb/database.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/core.h>
 #include <sqlite3.h>
+#include <cpptrace/cpptrace.hpp>
 
 namespace db {
 std::string multi_in_query(std::string_view prefix, size_t count, std::string_view suffix) {
@@ -53,7 +54,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign keys constraints: {}",
                 sqlite3_errstr(rc));
-        throw std::runtime_error{"Foreign key constrains required"};
+        throw cpptrace::runtime_error{"Foreign key constrains required"};
     }
     int fk_enabled = db.execAndGet("PRAGMA foreign_keys").getInt();
     if (fk_enabled != 1) {
@@ -61,7 +62,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign key constraints; perhaps this sqlite3 is compiled "
                 "without it?");
-        throw std::runtime_error{"Foreign key support is required"};
+        throw cpptrace::runtime_error{"Foreign key support is required"};
     }
 
     // FIXME: SQLite / SQLiteCPP may not have encryption available

--- a/src/sqlitedb/database.cpp
+++ b/src/sqlitedb/database.cpp
@@ -1,8 +1,9 @@
 #include "database.hpp"
 
+#include <common/exception.h>
+
 #include <fmt/core.h>
 #include <sqlite3.h>
-#include <cpptrace/cpptrace.hpp>
 
 namespace db {
 std::string multi_in_query(std::string_view prefix, size_t count, std::string_view suffix) {
@@ -54,7 +55,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign keys constraints: {}",
                 sqlite3_errstr(rc));
-        throw cpptrace::runtime_error{"Foreign key constrains required"};
+        throw oxen::runtime_error{"Foreign key constrains required"};
     }
     int fk_enabled = db.execAndGet("PRAGMA foreign_keys").getInt();
     if (fk_enabled != 1) {
@@ -62,7 +63,7 @@ Database::Database(const fs::path& db_path, const std::string_view db_password) 
                 sqlitedb_logcat,
                 "Failed to enable foreign key constraints; perhaps this sqlite3 is compiled "
                 "without it?");
-        throw cpptrace::runtime_error{"Foreign key support is required"};
+        throw oxen::runtime_error{"Foreign key support is required"};
     }
 
     // FIXME: SQLite / SQLiteCPP may not have encryption available

--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -11,10 +11,10 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
-#include <cpptrace/cpptrace.hpp>
 
 #include "common/fs.h"
 #include "common/guts.h"
+#include "common/exception.h"
 #include "logging/oxen_logger.h"
 
 namespace db {
@@ -151,7 +151,7 @@ std::optional<type_or_tuple<T...>> exec_and_maybe_get(SQLite::Statement& st, con
                     sqlitedb_logcat,
                     "Expected single-row result, got multiple rows from {}",
                     st.getQuery());
-            throw cpptrace::runtime_error{"DB error: expected single-row result, got multiple rows"};
+            throw oxen::runtime_error{"DB error: expected single-row result, got multiple rows"};
         }
         result = get<T...>(st);
     }
@@ -168,7 +168,7 @@ type_or_tuple<T...> exec_and_get(SQLite::Statement& st, const Args&... bind) {
     if (!maybe_result) {
         log::error(
                 sqlitedb_logcat, "Expected single-row result, got no rows from {}", st.getQuery());
-        throw cpptrace::runtime_error{"DB error: expected single-row result, got no rows"};
+        throw oxen::runtime_error{"DB error: expected single-row result, got no rows"};
     }
     return *std::move(maybe_result);
 }

--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -151,7 +151,7 @@ std::optional<type_or_tuple<T...>> exec_and_maybe_get(SQLite::Statement& st, con
                     sqlitedb_logcat,
                     "Expected single-row result, got multiple rows from {}",
                     st.getQuery());
-            throw oxen::runtime_error{"DB error: expected single-row result, got multiple rows"};
+            throw oxen::traced<std::runtime_error>{"DB error: expected single-row result, got multiple rows"};
         }
         result = get<T...>(st);
     }
@@ -168,7 +168,7 @@ type_or_tuple<T...> exec_and_get(SQLite::Statement& st, const Args&... bind) {
     if (!maybe_result) {
         log::error(
                 sqlitedb_logcat, "Expected single-row result, got no rows from {}", st.getQuery());
-        throw oxen::runtime_error{"DB error: expected single-row result, got no rows"};
+        throw oxen::traced<std::runtime_error>{"DB error: expected single-row result, got no rows"};
     }
     return *std::move(maybe_result);
 }

--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -5,13 +5,13 @@
 #include <epee/misc_log_ex.h>
 
 #include <cstdlib>
-#include <exception>
 #include <optional>
 #include <shared_mutex>
 #include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/fs.h"
 #include "common/guts.h"
@@ -151,7 +151,7 @@ std::optional<type_or_tuple<T...>> exec_and_maybe_get(SQLite::Statement& st, con
                     sqlitedb_logcat,
                     "Expected single-row result, got multiple rows from {}",
                     st.getQuery());
-            throw std::runtime_error{"DB error: expected single-row result, got multiple rows"};
+            throw cpptrace::runtime_error{"DB error: expected single-row result, got multiple rows"};
         }
         result = get<T...>(st);
     }
@@ -168,7 +168,7 @@ type_or_tuple<T...> exec_and_get(SQLite::Statement& st, const Args&... bind) {
     if (!maybe_result) {
         log::error(
                 sqlitedb_logcat, "Expected single-row result, got no rows from {}", st.getQuery());
-        throw std::runtime_error{"DB error: expected single-row result, got no rows"};
+        throw cpptrace::runtime_error{"DB error: expected single-row result, got no rows"};
     }
     return *std::move(maybe_result);
 }

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -89,7 +89,7 @@ class NodeRPCProxy {
                                 (result.status == cryptonote::rpc::STATUS_BUSY ? "daemon is busy"
                                                                                : result.status);
             log::error(globallogcat, error);
-            throw oxen::runtime_error{error};
+            throw oxen::traced<std::runtime_error>{error};
         }
 
         return result;

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -32,6 +32,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <type_traits>
+#include <cpptrace/cpptrace.hpp>
 
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "rpc/http_client.h"
@@ -88,7 +89,7 @@ class NodeRPCProxy {
                                 (result.status == cryptonote::rpc::STATUS_BUSY ? "daemon is busy"
                                                                                : result.status);
             log::error(globallogcat, error);
-            throw std::runtime_error{error};
+            throw cpptrace::runtime_error{error};
         }
 
         return result;

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -32,7 +32,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <type_traits>
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "rpc/http_client.h"
@@ -89,7 +89,7 @@ class NodeRPCProxy {
                                 (result.status == cryptonote::rpc::STATUS_BUSY ? "daemon is busy"
                                                                                : result.status);
             log::error(globallogcat, error);
-            throw cpptrace::runtime_error{error};
+            throw oxen::runtime_error{error};
         }
 
         return result;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -43,6 +43,7 @@
 #include <optional>
 #include <tuple>
 #include <type_traits>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/apply_permutation.h"
 #include "common/base58.h"
@@ -4297,7 +4298,7 @@ void wallet2::refresh(
                     short_chain_history.clear();
                     get_short_chain_history(short_chain_history);
                     start_height = stop_height;
-                    throw std::runtime_error("");  // loop again
+                    throw cpptrace::runtime_error("");  // loop again
                 } catch (const std::exception& e) {
                     log::error(logcat, "Error parsing blocks: {}", e.what());
                     error = true;
@@ -4314,7 +4315,7 @@ void wallet2::refresh(
 
             // handle error from async fetching thread
             if (error) {
-                throw std::runtime_error("proxy exception in refresh thread");
+                throw cpptrace::runtime_error("proxy exception in refresh thread");
             }
 
             // if we've got at least 10 blocks to refresh, assume we're starting
@@ -13694,7 +13695,7 @@ void wallet2::cold_sign_tx(
         std::vector<std::string>& tx_device_aux) {
     auto& hwdev = get_account().get_device();
     if (!hwdev.has_tx_cold_sign()) {
-        throw std::invalid_argument("Device does not support cold sign protocol");
+        throw cpptrace::invalid_argument("Device does not support cold sign protocol");
     }
 
     unsigned_tx_set txs;
@@ -15431,7 +15432,7 @@ void wallet2::set_account_tag_description(const std::string& tag, const std::str
 
 std::string wallet2::sign(std::string_view data, cryptonote::subaddress_index index) const {
     if (m_watch_only)
-        throw std::logic_error{"Unable to sign with a watch-only wallet"};
+        throw cpptrace::logic_error{"Unable to sign with a watch-only wallet"};
 
     crypto::hash hash;
     crypto::cn_fast_hash(data.data(), data.size(), hash);
@@ -16908,24 +16909,24 @@ bool wallet2::parse_uri(
 uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day) {
     rpc::version_t version;
     if (!check_connection(&version)) {
-        throw std::runtime_error("failed to connect to daemon: " + get_daemon_address());
+        throw cpptrace::runtime_error("failed to connect to daemon: " + get_daemon_address());
     }
     if (version < rpc::version_t{1, 6}) {
-        throw std::runtime_error("this function requires RPC version 1.6 or higher");
+        throw cpptrace::runtime_error("this function requires RPC version 1.6 or higher");
     }
     std::tm date = {0, 0, 0, 0, 0, 0, 0, 0};
     date.tm_year = year - 1900;
     date.tm_mon = month - 1;
     date.tm_mday = day;
     if (date.tm_mon < 0 || 11 < date.tm_mon || date.tm_mday < 1 || 31 < date.tm_mday) {
-        throw std::runtime_error("month or day out of range");
+        throw cpptrace::runtime_error("month or day out of range");
     }
     uint64_t timestamp_target = std::mktime(&date);
     std::string err;
     uint64_t height_min = 0;
     uint64_t height_max = get_daemon_blockchain_height(err) - 1;
     if (!err.empty()) {
-        throw std::runtime_error("failed to get blockchain height");
+        throw cpptrace::runtime_error("failed to get blockchain height");
     }
     while (true) {
         rpc::GET_BLOCKS_BY_HEIGHT_BIN::request req{};
@@ -16945,19 +16946,19 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
                 oss << "daemon is busy";
             else
                 oss << get_rpc_status(res.status);
-            throw std::runtime_error(oss.str());
+            throw cpptrace::runtime_error(oss.str());
         }
         cryptonote::block blk_min, blk_mid, blk_max;
         if (res.blocks.size() < 3)
-            throw std::runtime_error("Not enough blocks returned from daemon");
+            throw cpptrace::runtime_error("Not enough blocks returned from daemon");
         if (!parse_and_validate_block_from_blob(res.blocks[0].block, blk_min))
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_min));
         if (!parse_and_validate_block_from_blob(res.blocks[1].block, blk_mid))
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_mid));
         if (!parse_and_validate_block_from_blob(res.blocks[2].block, blk_max))
-            throw std::runtime_error(
+            throw cpptrace::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_max));
         uint64_t timestamp_min = blk_min.timestamp;
         uint64_t timestamp_mid = blk_mid.timestamp;
@@ -16968,7 +16969,7 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
             return std::min({height_min, height_mid, height_max});
         }
         if (timestamp_target > timestamp_max) {
-            throw std::runtime_error("specified date is in the future");
+            throw cpptrace::runtime_error("specified date is in the future");
         }
         if (timestamp_target <= timestamp_min + 2 * 24 * 60 * 60)  // two days of "buffer" period
         {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -43,7 +43,7 @@
 #include <optional>
 #include <tuple>
 #include <type_traits>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/apply_permutation.h"
 #include "common/base58.h"
@@ -4298,7 +4298,7 @@ void wallet2::refresh(
                     short_chain_history.clear();
                     get_short_chain_history(short_chain_history);
                     start_height = stop_height;
-                    throw cpptrace::runtime_error("");  // loop again
+                    throw oxen::runtime_error("");  // loop again
                 } catch (const std::exception& e) {
                     log::error(logcat, "Error parsing blocks: {}", e.what());
                     error = true;
@@ -4315,7 +4315,7 @@ void wallet2::refresh(
 
             // handle error from async fetching thread
             if (error) {
-                throw cpptrace::runtime_error("proxy exception in refresh thread");
+                throw oxen::runtime_error("proxy exception in refresh thread");
             }
 
             // if we've got at least 10 blocks to refresh, assume we're starting
@@ -13695,7 +13695,7 @@ void wallet2::cold_sign_tx(
         std::vector<std::string>& tx_device_aux) {
     auto& hwdev = get_account().get_device();
     if (!hwdev.has_tx_cold_sign()) {
-        throw cpptrace::invalid_argument("Device does not support cold sign protocol");
+        throw oxen::invalid_argument("Device does not support cold sign protocol");
     }
 
     unsigned_tx_set txs;
@@ -15432,7 +15432,7 @@ void wallet2::set_account_tag_description(const std::string& tag, const std::str
 
 std::string wallet2::sign(std::string_view data, cryptonote::subaddress_index index) const {
     if (m_watch_only)
-        throw cpptrace::logic_error{"Unable to sign with a watch-only wallet"};
+        throw oxen::logic_error{"Unable to sign with a watch-only wallet"};
 
     crypto::hash hash;
     crypto::cn_fast_hash(data.data(), data.size(), hash);
@@ -16909,24 +16909,24 @@ bool wallet2::parse_uri(
 uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day) {
     rpc::version_t version;
     if (!check_connection(&version)) {
-        throw cpptrace::runtime_error("failed to connect to daemon: " + get_daemon_address());
+        throw oxen::runtime_error("failed to connect to daemon: " + get_daemon_address());
     }
     if (version < rpc::version_t{1, 6}) {
-        throw cpptrace::runtime_error("this function requires RPC version 1.6 or higher");
+        throw oxen::runtime_error("this function requires RPC version 1.6 or higher");
     }
     std::tm date = {0, 0, 0, 0, 0, 0, 0, 0};
     date.tm_year = year - 1900;
     date.tm_mon = month - 1;
     date.tm_mday = day;
     if (date.tm_mon < 0 || 11 < date.tm_mon || date.tm_mday < 1 || 31 < date.tm_mday) {
-        throw cpptrace::runtime_error("month or day out of range");
+        throw oxen::runtime_error("month or day out of range");
     }
     uint64_t timestamp_target = std::mktime(&date);
     std::string err;
     uint64_t height_min = 0;
     uint64_t height_max = get_daemon_blockchain_height(err) - 1;
     if (!err.empty()) {
-        throw cpptrace::runtime_error("failed to get blockchain height");
+        throw oxen::runtime_error("failed to get blockchain height");
     }
     while (true) {
         rpc::GET_BLOCKS_BY_HEIGHT_BIN::request req{};
@@ -16946,19 +16946,19 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
                 oss << "daemon is busy";
             else
                 oss << get_rpc_status(res.status);
-            throw cpptrace::runtime_error(oss.str());
+            throw oxen::runtime_error(oss.str());
         }
         cryptonote::block blk_min, blk_mid, blk_max;
         if (res.blocks.size() < 3)
-            throw cpptrace::runtime_error("Not enough blocks returned from daemon");
+            throw oxen::runtime_error("Not enough blocks returned from daemon");
         if (!parse_and_validate_block_from_blob(res.blocks[0].block, blk_min))
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_min));
         if (!parse_and_validate_block_from_blob(res.blocks[1].block, blk_mid))
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_mid));
         if (!parse_and_validate_block_from_blob(res.blocks[2].block, blk_max))
-            throw cpptrace::runtime_error(
+            throw oxen::runtime_error(
                     "failed to parse blob at height " + std::to_string(height_max));
         uint64_t timestamp_min = blk_min.timestamp;
         uint64_t timestamp_mid = blk_mid.timestamp;
@@ -16969,7 +16969,7 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
             return std::min({height_min, height_mid, height_max});
         }
         if (timestamp_target > timestamp_max) {
-            throw cpptrace::runtime_error("specified date is in the future");
+            throw oxen::runtime_error("specified date is in the future");
         }
         if (timestamp_target <= timestamp_min + 2 * 24 * 60 * 60)  // two days of "buffer" period
         {

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -167,7 +167,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
             if (std::error_code ec; fs::exists(config, ec)) {
                 std::ifstream cfg{config};
                 if (!cfg.is_open())
-                    throw oxen::runtime_error{"Unable to open config file: {}"_format(config)};
+                    throw oxen::traced<std::runtime_error>{"Unable to open config file: {}"_format(config)};
                 po::store(po::parse_config_file<char>(cfg, desc_params), vm);
             } else {
                 log::error(logcat, "{}{}", wallet_args::tr("Can't find config file "), config);
@@ -195,7 +195,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw oxen::runtime_error{"Incorrect log level"};
+        throw oxen::traced<std::runtime_error>{"Incorrect log level"};
     }
 
     oxen::logging::init(log_path, log_level, false /*do not log to stdout.*/);

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -37,6 +37,7 @@
 #include "common/file.h"
 #include "common/i18n.h"
 #include "common/util.h"
+#include "common/exception.h"
 #include "epee/misc_log_ex.h"
 #include "epee/string_tools.h"
 #include "logging/oxen_logger.h"
@@ -166,7 +167,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
             if (std::error_code ec; fs::exists(config, ec)) {
                 std::ifstream cfg{config};
                 if (!cfg.is_open())
-                    throw cpptrace::runtime_error{"Unable to open config file: {}"_format(config)};
+                    throw oxen::runtime_error{"Unable to open config file: {}"_format(config)};
                 po::store(po::parse_config_file<char>(cfg, desc_params), vm);
             } else {
                 log::error(logcat, "{}{}", wallet_args::tr("Can't find config file "), config);
@@ -194,7 +195,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw cpptrace::runtime_error{"Incorrect log level"};
+        throw oxen::runtime_error{"Incorrect log level"};
     }
 
     oxen::logging::init(log_path, log_level, false /*do not log to stdout.*/);

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -32,6 +32,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/file.h"
 #include "common/i18n.h"
@@ -165,7 +166,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
             if (std::error_code ec; fs::exists(config, ec)) {
                 std::ifstream cfg{config};
                 if (!cfg.is_open())
-                    throw std::runtime_error{"Unable to open config file: {}"_format(config)};
+                    throw cpptrace::runtime_error{"Unable to open config file: {}"_format(config)};
                 po::store(po::parse_config_file<char>(cfg, desc_params), vm);
             } else {
                 log::error(logcat, "{}{}", wallet_args::tr("Can't find config file "), config);
@@ -193,7 +194,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
     } else {
         std::cerr << "Incorrect log level: " << command_line::get_arg(vm, arg_log_level).c_str()
                   << std::endl;
-        throw std::runtime_error{"Incorrect log level"};
+        throw cpptrace::runtime_error{"Incorrect log level"};
     }
 
     oxen::logging::init(log_path, log_level, false /*do not log to stdout.*/);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -40,8 +40,8 @@
 #include <concepts>
 #include <cstdint>
 #include <exception>
-#include <cpptrace/cpptrace.hpp>
 
+#include "common/exception.h"
 #include "common/command_line.h"
 #include "common/guts.h"
 #include "common/i18n.h"
@@ -130,7 +130,7 @@ namespace {
                                 throw tools::wallet_rpc_server::parse_error{
                                         "Failed to parse JSON parameters"};
                         } else
-                            throw cpptrace::runtime_error{
+                            throw oxen::runtime_error{
                                     "only top-level JSON object values are currently supported"};
                     }
                     epee::json_rpc::response<Response> r{
@@ -158,7 +158,7 @@ namespace {
     const auto rpc_commands = register_rpc_commands(wallet_rpc_types{});
 
     // Thrown with a code and message to return a json_rpc error.
-    class wallet_rpc_error : public cpptrace::runtime_error {
+    class wallet_rpc_error : public oxen::runtime_error {
       public:
         int16_t code;
         std::string message;
@@ -389,7 +389,7 @@ void wallet_rpc_server::run_loop() {
                     for (const auto& [addr, port, required] : m_bind)
                         error << ' ' << addr << ':' << port;
                 }
-                throw cpptrace::runtime_error{error.str()};
+                throw oxen::runtime_error{error.str()};
             }
         } catch (...) {
             loop_promise.set_exception(std::current_exception());
@@ -3653,7 +3653,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
         const bool testnet = tools::wallet2::has_testnet_option(m_vm);
         const bool devnet = tools::wallet2::has_devnet_option(m_vm);
         if (testnet && devnet)
-            throw cpptrace::logic_error{tr("Can't specify more than one of --testnet and --devnet")};
+            throw oxen::logic_error{tr("Can't specify more than one of --testnet and --devnet")};
 
         const auto arg_wallet_file = wallet_args::arg_wallet_file();
         const auto arg_from_json = wallet_args::arg_generate_from_json();
@@ -3665,14 +3665,14 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
         const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
 
         if (!wallet_file.empty() && !from_json.empty())
-            throw cpptrace::logic_error{
+            throw oxen::logic_error{
                     tr("Can't specify more than one of --wallet-file and --generate-from-json")};
 
         if (!wallet_dir.empty())
             return nullptr;
 
         if (wallet_file.empty() && from_json.empty())
-            throw cpptrace::logic_error{
+            throw oxen::logic_error{
                     tr("Must specify --wallet-file or --generate-from-json or --wallet-dir")};
 
         log::warning(logcat, "{}", tools::wallet_rpc_server::tr("Loading wallet..."));
@@ -3682,7 +3682,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
             wal = tools::wallet2::make_from_json(m_vm, true, from_json, password_prompt).first;
 
         if (!wal)  // safety check (the above should throw on error)
-            throw cpptrace::runtime_error{"Failed to create wallet: (unknown reason)"};
+            throw oxen::runtime_error{"Failed to create wallet: (unknown reason)"};
 
         bool quit = false;
         tools::signal_handler::install([&wal, &quit](int) {
@@ -3697,7 +3697,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
             log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Saving wallet..."));
             wal->store();
             log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Successfully saved"));
-            throw cpptrace::runtime_error{
+            throw oxen::runtime_error{
                     tr("Wallet loading cancelled before initial refresh completed")};
         }
         log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Successfully loaded"));
@@ -3751,7 +3751,7 @@ void wallet_rpc_server::stop() {
 }  // namespace tools
 
 int main(int argc, char** argv) {
-    cpptrace::register_terminate_handler();
+    std::set_terminate(oxen::on_terminate_handler);
     TRY_ENTRY();
 
     namespace po = boost::program_options;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -130,7 +130,7 @@ namespace {
                                 throw tools::wallet_rpc_server::parse_error{
                                         "Failed to parse JSON parameters"};
                         } else
-                            throw oxen::runtime_error{
+                            throw oxen::traced<std::runtime_error>{
                                     "only top-level JSON object values are currently supported"};
                     }
                     epee::json_rpc::response<Response> r{
@@ -158,7 +158,7 @@ namespace {
     const auto rpc_commands = register_rpc_commands(wallet_rpc_types{});
 
     // Thrown with a code and message to return a json_rpc error.
-    class wallet_rpc_error : public oxen::runtime_error {
+    class wallet_rpc_error : public std::runtime_error {
       public:
         int16_t code;
         std::string message;
@@ -389,7 +389,7 @@ void wallet_rpc_server::run_loop() {
                     for (const auto& [addr, port, required] : m_bind)
                         error << ' ' << addr << ':' << port;
                 }
-                throw oxen::runtime_error{error.str()};
+                throw oxen::traced<std::runtime_error>{error.str()};
             }
         } catch (...) {
             loop_promise.set_exception(std::current_exception());
@@ -3653,7 +3653,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
         const bool testnet = tools::wallet2::has_testnet_option(m_vm);
         const bool devnet = tools::wallet2::has_devnet_option(m_vm);
         if (testnet && devnet)
-            throw oxen::logic_error{tr("Can't specify more than one of --testnet and --devnet")};
+            throw oxen::traced<std::logic_error>{tr("Can't specify more than one of --testnet and --devnet")};
 
         const auto arg_wallet_file = wallet_args::arg_wallet_file();
         const auto arg_from_json = wallet_args::arg_generate_from_json();
@@ -3665,14 +3665,14 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
         const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
 
         if (!wallet_file.empty() && !from_json.empty())
-            throw oxen::logic_error{
+            throw oxen::traced<std::logic_error>{
                     tr("Can't specify more than one of --wallet-file and --generate-from-json")};
 
         if (!wallet_dir.empty())
             return nullptr;
 
         if (wallet_file.empty() && from_json.empty())
-            throw oxen::logic_error{
+            throw oxen::traced<std::logic_error>{
                     tr("Must specify --wallet-file or --generate-from-json or --wallet-dir")};
 
         log::warning(logcat, "{}", tools::wallet_rpc_server::tr("Loading wallet..."));
@@ -3682,7 +3682,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
             wal = tools::wallet2::make_from_json(m_vm, true, from_json, password_prompt).first;
 
         if (!wal)  // safety check (the above should throw on error)
-            throw oxen::runtime_error{"Failed to create wallet: (unknown reason)"};
+            throw oxen::traced<std::runtime_error>{"Failed to create wallet: (unknown reason)"};
 
         bool quit = false;
         tools::signal_handler::install([&wal, &quit](int) {
@@ -3697,7 +3697,7 @@ std::unique_ptr<tools::wallet2> wallet_rpc_server::load_wallet() {
             log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Saving wallet..."));
             wal->store();
             log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Successfully saved"));
-            throw oxen::runtime_error{
+            throw oxen::traced<std::runtime_error>{
                     tr("Wallet loading cancelled before initial refresh completed")};
         }
         log::info(globallogcat, "{}", tools::wallet_rpc_server::tr("Successfully loaded"));

--- a/src/wallet3/db/walletdb.cpp
+++ b/src/wallet3/db/walletdb.cpp
@@ -6,7 +6,7 @@
 #include <fmt/core.h>
 
 #include <iostream>
-#include <cpptrace/cpptrace.hpp>
+#include <common/exception.h>
 
 #include "common/guts.h"
 #include "wallet3/block.hpp"
@@ -24,7 +24,7 @@ void WalletDB::create_schema(cryptonote::network_type nettype) {
                             cryptonote::network_type_to_string(nettype),
                             cryptonote::network_type_to_string(stored_nettype));
             // TODO: log error as well
-            throw cpptrace::invalid_argument(err);
+            throw oxen::invalid_argument(err);
         }
         return;
     }
@@ -248,7 +248,7 @@ void WalletDB::add_address(int32_t major_index, int32_t minor_index, const std::
 
         // FIXME: better error type
         if (existing_addr != address)
-            throw cpptrace::invalid_argument(
+            throw oxen::invalid_argument(
                     "WalletDB address insertion, new address mismatch with existing address.");
     } else {
         prepared_exec(
@@ -269,7 +269,7 @@ std::string WalletDB::get_address(int32_t major_index, int32_t minor_index) {
     if (addr)
         return *addr;
 
-    throw cpptrace::invalid_argument(
+    throw oxen::invalid_argument(
             "WalletDB address fetch, address for subaddress indices not found in database.");
     return "";  // compilers can be dumb
 }
@@ -462,7 +462,7 @@ void WalletDB::save_keys(const std::shared_ptr<WalletKeys> keys) {
              tools::view_guts(keys->view_privkey())) ||
             (tools::view_guts(maybe_db_keys->view_pubkey()) !=
              tools::view_guts(keys->view_pubkey())))
-            throw cpptrace::runtime_error("provided keys do not match database file");
+            throw oxen::runtime_error("provided keys do not match database file");
     }
 
     set_metadata_blob_guts("spend_priv", keys->spend_privkey());

--- a/src/wallet3/db/walletdb.cpp
+++ b/src/wallet3/db/walletdb.cpp
@@ -6,6 +6,7 @@
 #include <fmt/core.h>
 
 #include <iostream>
+#include <cpptrace/cpptrace.hpp>
 
 #include "common/guts.h"
 #include "wallet3/block.hpp"
@@ -23,7 +24,7 @@ void WalletDB::create_schema(cryptonote::network_type nettype) {
                             cryptonote::network_type_to_string(nettype),
                             cryptonote::network_type_to_string(stored_nettype));
             // TODO: log error as well
-            throw std::invalid_argument(err);
+            throw cpptrace::invalid_argument(err);
         }
         return;
     }
@@ -247,7 +248,7 @@ void WalletDB::add_address(int32_t major_index, int32_t minor_index, const std::
 
         // FIXME: better error type
         if (existing_addr != address)
-            throw std::invalid_argument(
+            throw cpptrace::invalid_argument(
                     "WalletDB address insertion, new address mismatch with existing address.");
     } else {
         prepared_exec(
@@ -268,7 +269,7 @@ std::string WalletDB::get_address(int32_t major_index, int32_t minor_index) {
     if (addr)
         return *addr;
 
-    throw std::invalid_argument(
+    throw cpptrace::invalid_argument(
             "WalletDB address fetch, address for subaddress indices not found in database.");
     return "";  // compilers can be dumb
 }
@@ -461,7 +462,7 @@ void WalletDB::save_keys(const std::shared_ptr<WalletKeys> keys) {
              tools::view_guts(keys->view_privkey())) ||
             (tools::view_guts(maybe_db_keys->view_pubkey()) !=
              tools::view_guts(keys->view_pubkey())))
-            throw std::runtime_error("provided keys do not match database file");
+            throw cpptrace::runtime_error("provided keys do not match database file");
     }
 
     set_metadata_blob_guts("spend_priv", keys->spend_privkey());

--- a/src/wallet3/db/walletdb.cpp
+++ b/src/wallet3/db/walletdb.cpp
@@ -24,7 +24,7 @@ void WalletDB::create_schema(cryptonote::network_type nettype) {
                             cryptonote::network_type_to_string(nettype),
                             cryptonote::network_type_to_string(stored_nettype));
             // TODO: log error as well
-            throw oxen::invalid_argument(err);
+            throw oxen::traced<std::invalid_argument>(err);
         }
         return;
     }
@@ -248,7 +248,7 @@ void WalletDB::add_address(int32_t major_index, int32_t minor_index, const std::
 
         // FIXME: better error type
         if (existing_addr != address)
-            throw oxen::invalid_argument(
+            throw oxen::traced<std::invalid_argument>(
                     "WalletDB address insertion, new address mismatch with existing address.");
     } else {
         prepared_exec(
@@ -269,7 +269,7 @@ std::string WalletDB::get_address(int32_t major_index, int32_t minor_index) {
     if (addr)
         return *addr;
 
-    throw oxen::invalid_argument(
+    throw oxen::traced<std::invalid_argument>(
             "WalletDB address fetch, address for subaddress indices not found in database.");
     return "";  // compilers can be dumb
 }
@@ -462,7 +462,7 @@ void WalletDB::save_keys(const std::shared_ptr<WalletKeys> keys) {
              tools::view_guts(keys->view_privkey())) ||
             (tools::view_guts(maybe_db_keys->view_pubkey()) !=
              tools::view_guts(keys->view_pubkey())))
-            throw oxen::runtime_error("provided keys do not match database file");
+            throw oxen::traced<std::runtime_error>("provided keys do not match database file");
     }
 
     set_metadata_blob_guts("spend_priv", keys->spend_privkey());

--- a/src/wallet3/default_daemon_comms.cpp
+++ b/src/wallet3/default_daemon_comms.cpp
@@ -4,10 +4,10 @@
 #include <cryptonote_basic/cryptonote_format_utils.h>
 
 #include <iostream>
-#include <cpptrace/cpptrace.hpp>
 
 #include "block.hpp"
 #include "block_tx.hpp"
+#include "common/exception.h"
 #include "common/guts.h"
 #include "wallet.hpp"
 #include "wallet2½.hpp"
@@ -159,7 +159,7 @@ void DefaultDaemonComms::request_top_block_info() {
                 if (not dc.skip_until("hash")) {
                     oxen::log::warning(
                             logcat, "bad response from rpc.get_height, key 'hash' missing");
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "bad response from rpc.get_height, key 'hash' missing");
                 }
                 new_hash = tools::make_from_guts<crypto::hash>(dc.consume_string_view());
@@ -167,7 +167,7 @@ void DefaultDaemonComms::request_top_block_info() {
                 if (not dc.skip_until("height")) {
                     oxen::log::warning(
                             logcat, "bad response from rpc.get_height, key 'height' missing");
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "bad response from rpc.get_height, key 'height' missing");
                 }
                 new_height = dc.consume_integer<int64_t>();
@@ -214,7 +214,7 @@ void DefaultDaemonComms::request_top_block_info() {
                     oxen::log::warning(
                             logcat,
                             "bad response from rpc.get_fee_estimate, key 'fee_per_byte' missing");
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "bad response from rpc.get_fee_estimate, key 'fee_per_byte' missing");
                 }
                 new_fee_per_byte = dc.consume_integer<int64_t>();
@@ -223,7 +223,7 @@ void DefaultDaemonComms::request_top_block_info() {
                     oxen::log::warning(
                             logcat,
                             "bad response from rpc.get_fee_estimate, key 'fee_per_output' missing");
-                    throw cpptrace::runtime_error(
+                    throw oxen::runtime_error(
                             "bad response from rpc.get_fee_estimate, key 'fee_per_output' missing");
                 }
                 new_fee_per_output = dc.consume_integer<int64_t>();
@@ -401,20 +401,20 @@ std::future<std::string> DefaultDaemonComms::submit_transaction(
     auto req_cb = [p = std::move(p)](bool ok, std::vector<std::string> response) {
         try {
             if (not ok or response.size() != 2 or response[0] != "200")
-                throw cpptrace::runtime_error{"Unknown Error"};
+                throw oxen::runtime_error{"Unknown Error"};
 
             oxenc::bt_dict_consumer dc{response[1]};
             if (dc.skip_until("reason"))
-                throw cpptrace::runtime_error{
+                throw oxen::runtime_error{
                         "Submit Transaction rejected, reason: " + dc.consume_string()};
 
             if (not dc.skip_until("status"))
-                throw cpptrace::runtime_error{"Invalid response from daemon"};
+                throw oxen::runtime_error{"Invalid response from daemon"};
 
             auto status = dc.consume_string();
 
             if (status != "OK")
-                throw cpptrace::runtime_error{"Submit Transaction rejected, reason: " + status};
+                throw oxen::runtime_error{"Submit Transaction rejected, reason: " + status};
 
             p->set_value("OK");
 
@@ -425,7 +425,7 @@ std::future<std::string> DefaultDaemonComms::submit_transaction(
 
     std::string tx_str;
     if (not cryptonote::tx_to_blob(tx, tx_str))
-        throw cpptrace::runtime_error{"wallet daemon comms, failed to serialize transaction"};
+        throw oxen::runtime_error{"wallet daemon comms, failed to serialize transaction"};
 
     oxenc::bt_dict req_params_dict;
 
@@ -446,7 +446,7 @@ std::future<std::pair<std::string, crypto::hash>> DefaultDaemonComms::ons_names_
             oxenc::bt_dict_consumer dc{response[1]};
 
             if (not dc.skip_until("result"))
-                throw cpptrace::runtime_error{"Invalid response from daemon"};
+                throw oxen::runtime_error{"Invalid response from daemon"};
 
             auto result_list = dc.consume_list_consumer();
             auto result = result_list.consume_dict_consumer();
@@ -455,12 +455,12 @@ std::future<std::pair<std::string, crypto::hash>> DefaultDaemonComms::ons_names_
             std::string curr_owner;
 
             if (not result.skip_until("owner"))
-                throw cpptrace::runtime_error{"Invalid response from daemon"};
+                throw oxen::runtime_error{"Invalid response from daemon"};
 
             curr_owner = dc.consume_string();
 
             if (not result.skip_until("txid"))
-                throw cpptrace::runtime_error{"Invalid response from daemon"};
+                throw oxen::runtime_error{"Invalid response from daemon"};
 
             tools::load_from_hex_guts(dc.consume_string(), prev_txid);
 

--- a/src/wallet3/default_daemon_comms.cpp
+++ b/src/wallet3/default_daemon_comms.cpp
@@ -4,6 +4,7 @@
 #include <cryptonote_basic/cryptonote_format_utils.h>
 
 #include <iostream>
+#include <cpptrace/cpptrace.hpp>
 
 #include "block.hpp"
 #include "block_tx.hpp"
@@ -158,7 +159,7 @@ void DefaultDaemonComms::request_top_block_info() {
                 if (not dc.skip_until("hash")) {
                     oxen::log::warning(
                             logcat, "bad response from rpc.get_height, key 'hash' missing");
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "bad response from rpc.get_height, key 'hash' missing");
                 }
                 new_hash = tools::make_from_guts<crypto::hash>(dc.consume_string_view());
@@ -166,7 +167,7 @@ void DefaultDaemonComms::request_top_block_info() {
                 if (not dc.skip_until("height")) {
                     oxen::log::warning(
                             logcat, "bad response from rpc.get_height, key 'height' missing");
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "bad response from rpc.get_height, key 'height' missing");
                 }
                 new_height = dc.consume_integer<int64_t>();
@@ -213,7 +214,7 @@ void DefaultDaemonComms::request_top_block_info() {
                     oxen::log::warning(
                             logcat,
                             "bad response from rpc.get_fee_estimate, key 'fee_per_byte' missing");
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "bad response from rpc.get_fee_estimate, key 'fee_per_byte' missing");
                 }
                 new_fee_per_byte = dc.consume_integer<int64_t>();
@@ -222,7 +223,7 @@ void DefaultDaemonComms::request_top_block_info() {
                     oxen::log::warning(
                             logcat,
                             "bad response from rpc.get_fee_estimate, key 'fee_per_output' missing");
-                    throw std::runtime_error(
+                    throw cpptrace::runtime_error(
                             "bad response from rpc.get_fee_estimate, key 'fee_per_output' missing");
                 }
                 new_fee_per_output = dc.consume_integer<int64_t>();
@@ -400,20 +401,20 @@ std::future<std::string> DefaultDaemonComms::submit_transaction(
     auto req_cb = [p = std::move(p)](bool ok, std::vector<std::string> response) {
         try {
             if (not ok or response.size() != 2 or response[0] != "200")
-                throw std::runtime_error{"Unknown Error"};
+                throw cpptrace::runtime_error{"Unknown Error"};
 
             oxenc::bt_dict_consumer dc{response[1]};
             if (dc.skip_until("reason"))
-                throw std::runtime_error{
+                throw cpptrace::runtime_error{
                         "Submit Transaction rejected, reason: " + dc.consume_string()};
 
             if (not dc.skip_until("status"))
-                throw std::runtime_error{"Invalid response from daemon"};
+                throw cpptrace::runtime_error{"Invalid response from daemon"};
 
             auto status = dc.consume_string();
 
             if (status != "OK")
-                throw std::runtime_error{"Submit Transaction rejected, reason: " + status};
+                throw cpptrace::runtime_error{"Submit Transaction rejected, reason: " + status};
 
             p->set_value("OK");
 
@@ -424,7 +425,7 @@ std::future<std::string> DefaultDaemonComms::submit_transaction(
 
     std::string tx_str;
     if (not cryptonote::tx_to_blob(tx, tx_str))
-        throw std::runtime_error{"wallet daemon comms, failed to serialize transaction"};
+        throw cpptrace::runtime_error{"wallet daemon comms, failed to serialize transaction"};
 
     oxenc::bt_dict req_params_dict;
 
@@ -445,7 +446,7 @@ std::future<std::pair<std::string, crypto::hash>> DefaultDaemonComms::ons_names_
             oxenc::bt_dict_consumer dc{response[1]};
 
             if (not dc.skip_until("result"))
-                throw std::runtime_error{"Invalid response from daemon"};
+                throw cpptrace::runtime_error{"Invalid response from daemon"};
 
             auto result_list = dc.consume_list_consumer();
             auto result = result_list.consume_dict_consumer();
@@ -454,12 +455,12 @@ std::future<std::pair<std::string, crypto::hash>> DefaultDaemonComms::ons_names_
             std::string curr_owner;
 
             if (not result.skip_until("owner"))
-                throw std::runtime_error{"Invalid response from daemon"};
+                throw cpptrace::runtime_error{"Invalid response from daemon"};
 
             curr_owner = dc.consume_string();
 
             if (not result.skip_until("txid"))
-                throw std::runtime_error{"Invalid response from daemon"};
+                throw cpptrace::runtime_error{"Invalid response from daemon"};
 
             tools::load_from_hex_guts(dc.consume_string(), prev_txid);
 

--- a/src/wallet3/keyring.cpp
+++ b/src/wallet3/keyring.cpp
@@ -9,6 +9,7 @@
 
 #include <device/device.hpp>
 #include <stdexcept>
+#include <cpptrace/cpptrace.hpp>
 
 #include "wallet2½.hpp"
 
@@ -27,7 +28,7 @@ crypto::secret_key Keyring::generate_tx_key(cryptonote::hf hf_version) {
                 tx_key,
                 cryptonote::transaction::get_max_version_for_hf(hf_version),
                 cryptonote::txtype::standard))
-        throw std::runtime_error("Could not generate transaction secret key");
+        throw cpptrace::runtime_error("Could not generate transaction secret key");
 
     return tx_key;
 }
@@ -35,7 +36,7 @@ crypto::secret_key Keyring::generate_tx_key(cryptonote::hf hf_version) {
 crypto::public_key Keyring::secret_tx_key_to_public_tx_key(const crypto::secret_key a) {
     rct::key aG{};
     if (!key_device.scalarmultBase(aG, rct::sk2rct(a)))
-        throw std::runtime_error("Could not convert secret tx key to public tx key");
+        throw cpptrace::runtime_error("Could not convert secret tx key to public tx key");
     return rct::rct2pk(aG);
 }
 
@@ -256,7 +257,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
         crypto::public_key computed_output_pubkey{};
         if (!key_device.secret_key_to_public_key(output_secret_key, computed_output_pubkey) or
             (computed_output_pubkey != src_entr.key))
-            throw std::runtime_error("computed output secret key wrong, pubkey mismatch");
+            throw cpptrace::runtime_error("computed output secret key wrong, pubkey mismatch");
 
         // There is a input secret keys structure (inSk) that gets passed to the ringct
         // library/module and it is essentially an array of our output secret keys. It also needs to
@@ -283,7 +284,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
                 src_entr.output_index,
                 src_entr.subaddress_index);
         if (input_to_key.k_image != src_entr.key_image)
-            throw std::runtime_error("computed key_image wrong");
+            throw cpptrace::runtime_error("computed key_image wrong");
 
         // The outputs array in the VIN structure lists all the global indexs of the ring decoys,
         // it uses offsets relative to the first output to save space on chain, so they need
@@ -396,7 +397,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
             key_device);  // hw::device& hwdev
 
     if (not rct::verRctNonSemanticsSimple(ptx.tx.rct_signatures))
-        throw std::runtime_error(
+        throw cpptrace::runtime_error(
                 "RCT signing went wrong -- verRctNonSemanticsSimple returned false");
 }
 
@@ -405,7 +406,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
 std::vector<crypto::public_key> Keyring::get_subaddress_spend_public_keys(
         uint32_t account, uint32_t begin, uint32_t end) {
     if (begin > end)
-        throw std::runtime_error("begin > end");
+        throw cpptrace::runtime_error("begin > end");
 
     std::vector<crypto::public_key> pkeys;
     pkeys.reserve(end - begin + 1);
@@ -414,7 +415,7 @@ std::vector<crypto::public_key> Keyring::get_subaddress_spend_public_keys(
     ge_p3 p3;
     ge_cached cached;
     if (ge_frombytes_vartime(&p3, spend_public_key.data()) != 0)
-        throw std::runtime_error("ge_frombytes_vartime failed to convert spend public key");
+        throw cpptrace::runtime_error("ge_frombytes_vartime failed to convert spend public key");
     ge_p3_to_cached(&cached, &p3);
 
     for (uint32_t idx = begin; idx <= end; ++idx) {
@@ -469,7 +470,7 @@ ons::generic_signature Keyring::generate_ons_signature(
     ons::generic_signature result;
     cryptonote::address_parse_info curr_owner_parsed = {};
     if (!cryptonote::get_account_address_from_str(curr_owner_parsed, nettype, curr_owner))
-        throw std::runtime_error("Could not parse address");
+        throw cpptrace::runtime_error("Could not parse address");
 
     // TODO sean this should actually get it from the db
     cryptonote::subaddress_index index = {0, 0};
@@ -480,7 +481,7 @@ ons::generic_signature Keyring::generate_ons_signature(
     auto sig_data = ons::tx_extra_signature(
             encrypted_value.to_view(), new_owner, new_backup_owner, prev_txid);
     if (sig_data.empty())
-        throw std::runtime_error("Could not generate signature");
+        throw cpptrace::runtime_error("Could not generate signature");
 
     cryptonote::account_base account;
     account.create_from_keys(

--- a/src/wallet3/keyring.cpp
+++ b/src/wallet3/keyring.cpp
@@ -28,7 +28,7 @@ crypto::secret_key Keyring::generate_tx_key(cryptonote::hf hf_version) {
                 tx_key,
                 cryptonote::transaction::get_max_version_for_hf(hf_version),
                 cryptonote::txtype::standard))
-        throw oxen::runtime_error("Could not generate transaction secret key");
+        throw oxen::traced<std::runtime_error>("Could not generate transaction secret key");
 
     return tx_key;
 }
@@ -36,7 +36,7 @@ crypto::secret_key Keyring::generate_tx_key(cryptonote::hf hf_version) {
 crypto::public_key Keyring::secret_tx_key_to_public_tx_key(const crypto::secret_key a) {
     rct::key aG{};
     if (!key_device.scalarmultBase(aG, rct::sk2rct(a)))
-        throw oxen::runtime_error("Could not convert secret tx key to public tx key");
+        throw oxen::traced<std::runtime_error>("Could not convert secret tx key to public tx key");
     return rct::rct2pk(aG);
 }
 
@@ -257,7 +257,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
         crypto::public_key computed_output_pubkey{};
         if (!key_device.secret_key_to_public_key(output_secret_key, computed_output_pubkey) or
             (computed_output_pubkey != src_entr.key))
-            throw oxen::runtime_error("computed output secret key wrong, pubkey mismatch");
+            throw oxen::traced<std::runtime_error>("computed output secret key wrong, pubkey mismatch");
 
         // There is a input secret keys structure (inSk) that gets passed to the ringct
         // library/module and it is essentially an array of our output secret keys. It also needs to
@@ -284,7 +284,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
                 src_entr.output_index,
                 src_entr.subaddress_index);
         if (input_to_key.k_image != src_entr.key_image)
-            throw oxen::runtime_error("computed key_image wrong");
+            throw oxen::traced<std::runtime_error>("computed key_image wrong");
 
         // The outputs array in the VIN structure lists all the global indexs of the ring decoys,
         // it uses offsets relative to the first output to save space on chain, so they need
@@ -397,7 +397,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
             key_device);  // hw::device& hwdev
 
     if (not rct::verRctNonSemanticsSimple(ptx.tx.rct_signatures))
-        throw oxen::runtime_error(
+        throw oxen::traced<std::runtime_error>(
                 "RCT signing went wrong -- verRctNonSemanticsSimple returned false");
 }
 
@@ -406,7 +406,7 @@ void Keyring::sign_transaction(PendingTransaction& ptx) {
 std::vector<crypto::public_key> Keyring::get_subaddress_spend_public_keys(
         uint32_t account, uint32_t begin, uint32_t end) {
     if (begin > end)
-        throw oxen::runtime_error("begin > end");
+        throw oxen::traced<std::runtime_error>("begin > end");
 
     std::vector<crypto::public_key> pkeys;
     pkeys.reserve(end - begin + 1);
@@ -415,7 +415,7 @@ std::vector<crypto::public_key> Keyring::get_subaddress_spend_public_keys(
     ge_p3 p3;
     ge_cached cached;
     if (ge_frombytes_vartime(&p3, spend_public_key.data()) != 0)
-        throw oxen::runtime_error("ge_frombytes_vartime failed to convert spend public key");
+        throw oxen::traced<std::runtime_error>("ge_frombytes_vartime failed to convert spend public key");
     ge_p3_to_cached(&cached, &p3);
 
     for (uint32_t idx = begin; idx <= end; ++idx) {
@@ -470,7 +470,7 @@ ons::generic_signature Keyring::generate_ons_signature(
     ons::generic_signature result;
     cryptonote::address_parse_info curr_owner_parsed = {};
     if (!cryptonote::get_account_address_from_str(curr_owner_parsed, nettype, curr_owner))
-        throw oxen::runtime_error("Could not parse address");
+        throw oxen::traced<std::runtime_error>("Could not parse address");
 
     // TODO sean this should actually get it from the db
     cryptonote::subaddress_index index = {0, 0};
@@ -481,7 +481,7 @@ ons::generic_signature Keyring::generate_ons_signature(
     auto sig_data = ons::tx_extra_signature(
             encrypted_value.to_view(), new_owner, new_backup_owner, prev_txid);
     if (sig_data.empty())
-        throw oxen::runtime_error("Could not generate signature");
+        throw oxen::traced<std::runtime_error>("Could not generate signature");
 
     cryptonote::account_base account;
     account.create_from_keys(

--- a/src/wallet3/pending_transaction.cpp
+++ b/src/wallet3/pending_transaction.cpp
@@ -3,6 +3,8 @@
 #include "oxen_economy.h"
 #include "transaction_constructor.hpp"
 
+#include <cpptrace/cpptrace.hpp>
+
 namespace wallet {
 PendingTransaction::PendingTransaction(
         const std::vector<cryptonote::tx_destination_entry>& new_recipients) :
@@ -69,7 +71,7 @@ size_t PendingTransaction::get_tx_weight(int64_t n_inputs) const {
 
     size_t n_outputs = recipients.size() + 1;  // Recipients plus change
     if (n_outputs == 0)
-        throw std::runtime_error{
+        throw cpptrace::runtime_error{
                 "Get Transaction Weight called on a transaction with no recipients"};
 
     size += 1 + 6;                                            // tx prefix, first few bytes

--- a/src/wallet3/pending_transaction.cpp
+++ b/src/wallet3/pending_transaction.cpp
@@ -3,7 +3,7 @@
 #include "oxen_economy.h"
 #include "transaction_constructor.hpp"
 
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 namespace wallet {
 PendingTransaction::PendingTransaction(
@@ -71,7 +71,7 @@ size_t PendingTransaction::get_tx_weight(int64_t n_inputs) const {
 
     size_t n_outputs = recipients.size() + 1;  // Recipients plus change
     if (n_outputs == 0)
-        throw cpptrace::runtime_error{
+        throw oxen::runtime_error{
                 "Get Transaction Weight called on a transaction with no recipients"};
 
     size += 1 + 6;                                            // tx prefix, first few bytes

--- a/src/wallet3/pending_transaction.cpp
+++ b/src/wallet3/pending_transaction.cpp
@@ -71,7 +71,7 @@ size_t PendingTransaction::get_tx_weight(int64_t n_inputs) const {
 
     size_t n_outputs = recipients.size() + 1;  // Recipients plus change
     if (n_outputs == 0)
-        throw oxen::runtime_error{
+        throw oxen::traced<std::runtime_error>{
                 "Get Transaction Weight called on a transaction with no recipients"};
 
     size += 1 + 6;                                            // tx prefix, first few bytes

--- a/src/wallet3/transaction_scanner.cpp
+++ b/src/wallet3/transaction_scanner.cpp
@@ -27,7 +27,7 @@ std::vector<Output> TransactionScanner::scan_received(
         return {};
     }
     if (tx.tx.vout.size() != tx.global_indices.size()) {
-        throw oxen::invalid_argument(
+        throw oxen::traced<std::invalid_argument>(
                 "Invalid wallet::BlockTX, created outputs count != global indices count.");
     }
 
@@ -95,7 +95,7 @@ std::vector<Output> TransactionScanner::scan_received(
 
             received_outputs.push_back(std::move(o));
         } else {
-            throw oxen::invalid_argument(
+            throw oxen::traced<std::invalid_argument>(
                     "Invalid output target variant, only txout_to_key is valid.");
         }
     }

--- a/src/wallet3/transaction_scanner.cpp
+++ b/src/wallet3/transaction_scanner.cpp
@@ -1,6 +1,7 @@
 #include "transaction_scanner.hpp"
 
 #include <common/string_util.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include <sqlitedb/database.hpp>
 #include <vector>
@@ -26,7 +27,7 @@ std::vector<Output> TransactionScanner::scan_received(
         return {};
     }
     if (tx.tx.vout.size() != tx.global_indices.size()) {
-        throw std::invalid_argument(
+        throw cpptrace::invalid_argument(
                 "Invalid wallet::BlockTX, created outputs count != global indices count.");
     }
 
@@ -94,7 +95,7 @@ std::vector<Output> TransactionScanner::scan_received(
 
             received_outputs.push_back(std::move(o));
         } else {
-            throw std::invalid_argument(
+            throw cpptrace::invalid_argument(
                     "Invalid output target variant, only txout_to_key is valid.");
         }
     }

--- a/src/wallet3/transaction_scanner.cpp
+++ b/src/wallet3/transaction_scanner.cpp
@@ -1,7 +1,7 @@
 #include "transaction_scanner.hpp"
 
 #include <common/string_util.h>
-#include <cpptrace/cpptrace.hpp>
+#include "common/exception.h"
 
 #include <sqlitedb/database.hpp>
 #include <vector>
@@ -27,7 +27,7 @@ std::vector<Output> TransactionScanner::scan_received(
         return {};
     }
     if (tx.tx.vout.size() != tx.global_indices.size()) {
-        throw cpptrace::invalid_argument(
+        throw oxen::invalid_argument(
                 "Invalid wallet::BlockTX, created outputs count != global indices count.");
     }
 
@@ -95,7 +95,7 @@ std::vector<Output> TransactionScanner::scan_received(
 
             received_outputs.push_back(std::move(o));
         } else {
-            throw cpptrace::invalid_argument(
+            throw oxen::invalid_argument(
                     "Invalid output target variant, only txout_to_key is valid.");
         }
     }

--- a/tests/unit_tests/bls.cpp
+++ b/tests/unit_tests/bls.cpp
@@ -83,7 +83,7 @@ TEST(BLS, to_from_crypto) {
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex);
     BLSSigner signer{cryptonote::network_type::MAINNET, &sk};
     EXPECT_EQ(
-            oxenc::to_hex(signer.getPublicKey().getStr(bls_utils::BLS_MODE_BINARY)),
+            oxenc::to_hex(signer.getPubkey().getStr(bls_utils::BLS_MODE_BINARY)),
             "2c325c9d9c9593096528b2aa9d0d2cce042915e87a19c2a2a4cfbe4f5c61c694");
     auto pk3 = signer.getCryptoPubkey();
     EXPECT_EQ(
@@ -120,7 +120,7 @@ TEST(BLS, signatures) {
     auto sig1b = bls_utils::to_crypto_signature(bls_utils::from_crypto_signature(sig1));
     EXPECT_EQ("{}"_format(sig1), "{}"_format(sig1b));
     EXPECT_EQ(sig1a.getStr(), bls_utils::from_crypto_signature(sig1b).getStr());
-    EXPECT_TRUE(sig1a.verifyHash(signer.getPublicKey(), hash1.data(), hash1.size()));
+    EXPECT_TRUE(sig1a.verifyHash(signer.getPubkey(), hash1.data(), hash1.size()));
     EXPECT_TRUE(sig1a.verifyHash(bls_utils::from_crypto_pubkey(pk), hash1.data(), hash1.size()));
 
     EXPECT_TRUE(bls_utils::from_crypto_signature(sig1).verifyHash(

--- a/tests/unit_tests/bls.cpp
+++ b/tests/unit_tests/bls.cpp
@@ -115,8 +115,8 @@ TEST(BLS, signatures) {
     ASSERT_EQ(
             "{}"_format(hash2), "dc85a6bbfd4658040ef305c9333cf0d5a82ede2854f112549f3925df6b2c0e71");
 
-    auto sig1 = signer.signHash(hash1);
-    auto sig1a = signer.signHashSig(hash1);
+    auto sig1 = signer.signMsg(hash1);
+    auto sig1a = bls_utils::from_crypto_signature(sig1);
     auto sig1b = bls_utils::to_crypto_signature(bls_utils::from_crypto_signature(sig1));
     EXPECT_EQ("{}"_format(sig1), "{}"_format(sig1b));
     EXPECT_EQ(sig1a.getStr(), bls_utils::from_crypto_signature(sig1b).getStr());
@@ -132,14 +132,14 @@ TEST(BLS, signatures) {
             "0900de2368d7bdf4a83233d96cb8ab81461ebfe87ea6e73b56864e03e693a2be"
             "29fcf509fa071fa7d8c569a2f8003ffc386ac07ad787815a5f906c4fd2405bef"
             "2a84e7afd7fcb6d3299312906d0f56b3ea80603ee8688f05f68cb03a7c0db4f6");
-    EXPECT_TRUE(bls_utils::verify(sig1, hash1, pk));
+    EXPECT_TRUE(signer.verifyMsg(sig1, pk, hash1));
 
-    auto sig2 = signer.signHash(hash2);
+    auto sig2 = signer.signMsg(hash2);
     EXPECT_EQ(
             "{}"_format(sig2),
             "3025a58f31717081510467944556989cfb0676e0f135f2cd7151442dd404385e"
             "2671e7a21c2bee7840c54b839718dd2c665cc0376c6d78cd6d5ab62f3036ea14"
             "1d86c93f8884a2ca97b893fbea2d1629c237231668fd86ce43b00abf6d8d68fa"
             "2bc306182916f2d1633c82cd2b78794a049554da9ff68e72fefeb9680590e9fb");
-    EXPECT_TRUE(bls_utils::verify(sig2, hash2, pk));
+    EXPECT_TRUE(signer.verifyMsg(sig2, pk, hash2));
 }

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -68,7 +68,7 @@ class RPCDaemon:
         if self.proc and self.proc.poll() is None:
             raise RuntimeError("Cannot start process that is already running!")
         self.proc = subprocess.Popen(self.arguments(),
-                stdin=subprocess.DEVNULL, stdout=sout, stderr=subprocess.DEVNULL)
+                stdin=subprocess.DEVNULL, stdout=sout, stderr=sys.stderr)
         self.terminated = False
 
 

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -241,7 +241,7 @@ class Daemon(RPCDaemon):
     def ping(self, *, storage=True, lokinet=True):
         """Sends fake storage server and lokinet pings to the running oxend"""
         if storage:
-            self.json_rpc("storage_server_ping", { "version_major": 2, "version_minor": 1, "version_patch": 0 })
+            self.json_rpc("storage_server_ping", { "version": [2, 1, 0], "https_port": 1111, "omq_port": 1112, "pubkey_ed25519": self.get_service_keys().ed25519_pubkey})
         if lokinet:
             self.json_rpc("lokinet_ping", { "version": [9,9,9] })
 

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -241,7 +241,7 @@ class Daemon(RPCDaemon):
     def ping(self, *, storage=True, lokinet=True):
         """Sends fake storage server and lokinet pings to the running oxend"""
         if storage:
-            self.json_rpc("storage_server_ping", { "version": [2, 1, 0], "https_port": 1111, "omq_port": 1112, "pubkey_ed25519": self.get_service_keys().ed25519_pubkey})
+            self.json_rpc("storage_server_ping", { "version": [2, 5, 0], "https_port": 0, "omq_port": 0, "pubkey_ed25519": self.get_service_keys().ed25519_pubkey})
         if lokinet:
             self.json_rpc("lokinet_ping", { "version": [9,9,9] })
 

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -274,15 +274,13 @@ class Daemon(RPCDaemon):
         return self.json_rpc("bls_rewards_request", {"address": address}, timeout=1000).json()
 
     def get_exit_request(self, bls_key):
-        return self.json_rpc("bls_exit_request", {"bls_key": bls_key}).json()
+        return self.json_rpc("bls_exit_request", {"bls_pubkey": bls_key}).json()
 
     def get_liquidation_request(self, bls_key):
-        return self.json_rpc("bls_liquidation_request", {"bls_key": bls_key}).json()
+        return self.json_rpc("bls_liquidation_request", {"bls_pubkey": bls_key}).json()
 
     def get_service_nodes(self):
         return self.json_rpc("get_service_nodes").json()
-
-
 
 class Wallet(RPCDaemon):
     base_args = ('--disable-rpc-login', '--non-interactive', '--password','', '--devnet', '--disable-rpc-long-poll',

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -279,6 +279,9 @@ class Daemon(RPCDaemon):
     def get_liquidation_request(self, bls_key):
         return self.json_rpc("bls_liquidation_request", {"bls_key": bls_key}).json()
 
+    def get_service_nodes(self):
+        return self.json_rpc("get_service_nodes").json()
+
 
 
 class Wallet(RPCDaemon):

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -31,10 +31,10 @@ class ServiceNodeRewardContract:
         self.web3         = Web3(Web3.HTTPProvider(self.provider_url))
 
         self.contract_address = self.getContractDeployedInLatestBlock()
-        self.contract = self.web3.eth.contract(address=self.contract_address, abi=contract_abi)
-        self.acc = self.web3.eth.account.from_key(self.private_key)
+        self.contract         = self.web3.eth.contract(address=self.contract_address, abi=contract_abi)
+        self.acc              = self.web3.eth.account.from_key(self.private_key)
 
-        self.foundation_pool_address = self.contract.functions.foundationPool().call();
+        self.foundation_pool_address  = self.contract.functions.foundationPool().call();
         self.foundation_pool_contract = self.web3.eth.contract(address=self.foundation_pool_address, abi=foundation_pool_abi)
 
         # NOTE: Start the rewards contract
@@ -42,9 +42,9 @@ class ServiceNodeRewardContract:
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
 
-        self.erc20_address = self.contract.functions.designatedToken().call()
+        self.erc20_address  = self.contract.functions.designatedToken().call()
         self.erc20_contract = self.web3.eth.contract(address=self.erc20_address, abi=erc20_contract_abi)
 
         # NOTE: Approve an amount to be sent from the hardhat account to the contract
@@ -52,7 +52,18 @@ class ServiceNodeRewardContract:
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+
+        # SENT Contract Address deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+
+        address_check_err_msg = ("If this assert triggers, the rewards contract ABI has been "
+        "changed OR we're reusing a wallet and creating the contract with a different nonce. The "
+        "ABI in this script is hardcoded to the instance of the contract with that hash. Verify "
+        "and re-update the ABI if necessary and any auxiliary contracts if the ABI has changed or "
+        "that the wallets are _not_ being reused.")
+
+        assert self.contract_address.lower()        == "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707".lower(), (f"{address_check_err_msg}\n\nAddress was: {self.contract_address}")
+        assert self.foundation_pool_address.lower() == "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0".lower(), (f"{address_check_err_msg}\n\nAddress was: {self.foundation_pool_address}")
 
     def call_function(self, function_name, *args, **kwargs):
         contract_function = self.contract.functions[function_name](*args)

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -1,11 +1,34 @@
 from web3 import Web3
+import urllib.request
 import json
+
+PROVIDER_URL = "http://127.0.0.1:8545"
+
+def eth_chainId():
+    method = "eth_chainId"
+    data = json.dumps({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": [],
+        "id": 1
+    }).encode('utf-8')
+
+    try:
+        req = urllib.request.Request(PROVIDER_URL, data=data, headers={'content-type': 'application/json'}, )
+        with urllib.request.urlopen(req, timeout=2) as response:
+            response      = response.read()
+            response_json = json.loads(response)
+            result        = int(response_json["result"], 16) # Parse chain ID from hex
+    except Exception as e:
+        raise RuntimeError("Failed to query {} from {}: {}".format(method, PROVIDER_URL, e))
+
+    return result
 
 class ServiceNodeRewardContract:
     def __init__(self):
-        self.provider_url = "http://127.0.0.1:8545"
-        self.private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Hardhat account #0
-        self.web3 = Web3(Web3.HTTPProvider(self.provider_url))
+        self.provider_url = PROVIDER_URL
+        self.private_key  = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Hardhat account #0
+        self.web3         = Web3(Web3.HTTPProvider(self.provider_url))
 
         self.contract_address = self.getContractDeployedInLatestBlock()
         self.contract = self.web3.eth.contract(address=self.contract_address, abi=contract_abi)

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -24,6 +24,28 @@ def eth_chainId():
 
     return result
 
+def evm_increaseTime(web3, seconds):
+    web3.provider.make_request('evm_increaseTime', [seconds])
+
+def evm_mine(web3):
+    web3.provider.make_request('mine', [])
+
+class ContractServiceNodeContributor:
+    def __init__(self):
+        self.addr         = None
+        self.stakedAmount = None
+
+class ContractServiceNode:
+    def __init__(self):
+        self.next                  = None
+        self.prev                  = None
+        self.operator              = None
+        self.pubkey_x              = None
+        self.pubkey_y              = None
+        self.leaveRequestTimestamp = None
+        self.deposit               = None
+        self.contributors          = None
+
 class ServiceNodeRewardContract:
     def __init__(self):
         self.provider_url = PROVIDER_URL
@@ -140,8 +162,7 @@ class ServiceNodeRewardContract:
         return tx_hash
 
     def initiateRemoveBLSPublicKey(self, service_node_id):
-        # function initiateRemoveBLSPublicKey(uint64 serviceNodeID) public {
-
+        # function initiateRemoveBLSPublicKey(uint64 serviceNodeID) public
         unsent_tx = self.contract.functions.initiateRemoveBLSPublicKey(service_node_id
                     ).build_transaction({
                         "from": self.acc.address,
@@ -268,7 +289,38 @@ class ServiceNodeRewardContract:
             if bls_key not in bls_public_keys:
                 non_signers.append(service_node_id)
             service_node_id = service_node[0]
-        return non_signers;
+        return non_signers
+
+    def serviceNodes(self, u64_id):
+        call_result                  = self.contract.functions.serviceNodes(u64_id).call()
+        result                       = ContractServiceNode()
+        index                        = 0;
+
+        result.next                  = call_result[index]
+        index += 1;
+
+        result.prev                  = call_result[index]
+        index += 1;
+
+        result.operator              = call_result[index]
+        index += 1;
+
+        result.pubkey_x              = call_result[index][0]
+        result.pubkey_y              = call_result[index][1]
+        index += 1;
+
+        result.leaveRequestTimestamp = call_result[index]
+        index += 1;
+
+        result.deposit               = call_result[index]
+        index += 1;
+
+        result.contributors          = call_result[index]
+        index += 1;
+
+        return result
+
+
 
 contract_abi = json.loads("""
 [

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -37,13 +37,7 @@ class ServiceNodeRewardContract:
         self.foundation_pool_address  = self.contract.functions.foundationPool().call();
         self.foundation_pool_contract = self.web3.eth.contract(address=self.foundation_pool_address, abi=foundation_pool_abi)
 
-        # NOTE: Start the rewards contract
-        unsent_tx = self.contract.functions.start().build_transaction({
-            "from": self.acc.address,
-            'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
-        signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-
+        # NOTE: Setup ERC20 contract
         self.erc20_address  = self.contract.functions.designatedToken().call()
         self.erc20_contract = self.web3.eth.contract(address=self.erc20_address, abi=erc20_contract_abi)
 
@@ -55,7 +49,6 @@ class ServiceNodeRewardContract:
         tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
 
         # SENT Contract Address deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-
         address_check_err_msg = ("If this assert triggers, the rewards contract ABI has been "
         "changed OR we're reusing a wallet and creating the contract with a different nonce. The "
         "ABI in this script is hardcoded to the instance of the contract with that hash. Verify "
@@ -68,6 +61,13 @@ class ServiceNodeRewardContract:
     def call_function(self, function_name, *args, **kwargs):
         contract_function = self.contract.functions[function_name](*args)
         return contract_function.call(**kwargs)
+
+    def start(self):
+        unsent_tx = self.contract.functions.start().build_transaction({
+            "from": self.acc.address,
+            'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
+        signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
+        self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
 
     # Add more methods as needed to interact with the smart contract
     def getContractDeployedInLatestBlock(self):
@@ -269,10 +269,6 @@ class ServiceNodeRewardContract:
                 non_signers.append(service_node_id)
             service_node_id = service_node[0]
         return non_signers;
-
-
-
-
 
 contract_abi = json.loads("""
 [

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -178,22 +178,22 @@ class ServiceNodeRewardContract:
         tx_hash = self.submitSignedTX("Liquidate BLS public key w/ signature", signed_tx)
         return tx_hash
 
-    def seedPublicKeyList(self, args):
+    def seedPublicKeyList(self, bls_pubkey_list):
         pkX = []
         pkY = []
         amounts = []
-        for item in args:
-            pkX.append(int(item[0][:64], 16))  # First 32 bytes as pkX
-            pkY.append(int(item[0][64:], 16))  # Last 32 bytes as pkY
-            amounts.append(item[1])  # Corresponding amount
+        for seed in bls_pubkey_list:
+            pkX.append(int(seed.bls_pubkey_hex[:64], 16)) # First 32 bytes as pkX
+            pkY.append(int(seed.bls_pubkey_hex[64:], 16)) # Last 32 bytes as pkY
+            amounts.append(seed.deposit)                     # Corresponding amount
 
         unsent_tx = self.contract.functions.seedPublicKeyList(pkX, pkY, amounts).build_transaction({
-            "from": self.acc.address,
-            'gas': 3000000,  # Adjust gas limit as necessary
+            "from":  self.acc.address,
+            'gas':   3000000,  # Adjust gas limit as necessary
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)
         })
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash = self.submitSignedTX("Seed public key list", signed_tx)
+        tx_hash   = self.submitSignedTX("Seed public key list", signed_tx)
         return tx_hash
 
     def numberServiceNodes(self):

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -211,7 +211,6 @@ class SNNetwork:
             self.mike.transfer(wallet, coins(11))
         self.sync_nodes(self.mine(1), timeout=120)
 
-
         self.print_wallet_balances()
 
         vprint("Sending fake lokinet/ss pings")
@@ -220,7 +219,6 @@ class SNNetwork:
 
         all_service_nodes_proofed = lambda sn: all(x['quorumnet_port'] > 0 for x in
                 sn.json_rpc("get_n_service_nodes", {"fields":{"quorumnet_port":True}}).json()['result']['service_node_states'])
-
 
         vprint("Waiting for proofs to propagate: ", end="", flush=True)
         for sn in self.sns:
@@ -238,7 +236,7 @@ class SNNetwork:
         # This commented out code will register the last SN through Bobs wallet (Has not done any others)
         # and also get 9 other wallets to contribute the rest of the node with a 10% operator fee
         self.bob.register_sn_for_contributions(sn=self.sns[-1], cut=10, amount=coins(28), staking_requirement=self.sns[0].get_staking_requirement())
-        self.sync_nodes(self.mine(10), timeout=120)
+        self.sync_nodes(self.mine(40), timeout=120)
         self.print_wallet_balances()
         for wallet in self.extrawallets:
             wallet.contribute_to_sn(self.sns[-1], coins(8))
@@ -247,7 +245,7 @@ class SNNetwork:
         for sn in self.sns:
             sn.send_uptime_proof()
 
-        # Collect all BLS public-keys, note all SNs up to this point (HF <= feature::ETH_BLS) had a 100 OXEN staking requirement
+        # Collect all BLS public-keys, note all SNs up to this point (HF < feature::ETH_BLS) had a 100 OXEN staking requirement
         bls_pubkey_list = []
         for sn in self.sns:
             bls_pubkey = sn.get_service_keys().bls_pubkey
@@ -299,7 +297,7 @@ class SNNetwork:
         vprint(f"Waking up after sleeping for {sleep_time}s, blockchain height is {self.ethsns[0].height()}");
 
         # Claim rewards for Address
-        rewards = self.ethsns[0].get_bls_rewards(hardhat_account)
+        rewards = self.ethsns[0].get_bls_rewards(hardhat_account_no_0x)
         vprint(rewards)
         rewardsAccount = rewards["result"]["address"]
         assert rewardsAccount.lower() == hardhat_account.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhat_account.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
@@ -444,6 +442,8 @@ class SNNetwork:
             n.terminate()
         for w in self.wallets:
             w.terminate()
+        if self.anvil is not None:
+            self.anvil.terminate()
 
 snn = None
 

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -310,12 +310,12 @@ class SNNetwork:
         rewards = self.ethsns[0].get_bls_rewards(hardhat_account_no_0x)
         vprint(rewards)
         rewardsAccount = rewards["result"]["address"]
-        assert rewardsAccount.lower() == hardhat_account.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhat_account.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
+        assert rewardsAccount.lower() == hardhat_account_no_0x.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhat_account_no_0x.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
 
         vprint("Contract rewards before updating has ['available', 'claimed'] respectively: ",
                self.servicenodecontract.recipients(hardhat_account),
                " for ",
-               hardhat_account)
+               hardhat_account_no_0x)
 
         # TODO: We send the required balance from the hardhat account to the
         # contract to guarantee that claiming will succeed. We should hook up
@@ -324,23 +324,23 @@ class SNNetwork:
             "from": self.servicenodecontract.acc.address,
             'nonce': self.servicenodecontract.web3.eth.get_transaction_count(self.servicenodecontract.acc.address)})
         signed_tx = self.servicenodecontract.web3.eth.account.sign_transaction(unsent_tx, private_key=self.servicenodecontract.acc.key)
-        tx_hash = self.servicenodecontract.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        self.servicenodecontract.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
         self.servicenodecontract.foundation_pool_contract.functions.payoutReleased().call()
 
         vprint("Foundation pool balance: {}".format(self.servicenodecontract.erc20balance(self.servicenodecontract.foundation_pool_address)))
         vprint("Rewards contract balance: {}".format(self.servicenodecontract.erc20balance(self.servicenodecontract.contract_address)))
 
         # NOTE: Then update the rewards blaance
-        result = self.servicenodecontract.updateRewardsBalance(
+        self.servicenodecontract.updateRewardsBalance(
                 hardhat_account,
                 rewards["result"]["amount"],
                 rewards["result"]["signature"],
-                rewards["result"]["non_signers_bls_pubkeys"])
+                rewards["result"]["non_signer_indices"])
 
         vprint("Contract rewards update executed, has ['available', 'claimed'] now respectively: ",
                self.servicenodecontract.recipients(hardhat_account),
                " for ",
-               hardhat_account)
+               hardhat_account_no_0x)
 
         vprint("Balance for '{}' before claim {}".format(hardhat_account, self.servicenodecontract.erc20balance(hardhat_account)))
 

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -228,14 +228,17 @@ class SNNetwork:
         for sn in self.sns:
             sn.send_uptime_proof()
 
-        all_service_nodes_proofed = lambda sn: all(x['quorumnet_port'] > 0 for x in
-                sn.json_rpc("get_n_service_nodes", {"fields":{"quorumnet_port":True}}).json()['result']['service_node_states'])
+        vprint(self.sns[0].json_rpc("get_n_service_nodes", {"fields":{"quorumnet_port":True, "pubkey_bls":True,}}).json()['result']['service_node_states'])
+
+        all_service_nodes_proofed = lambda sn: all(x['quorumnet_port'] > 0 and x['pubkey_bls'] is not None for x in
+                                                   sn.json_rpc("get_n_service_nodes", {"fields":{"quorumnet_port":True, "pubkey_bls":True,}}).json()['result']['service_node_states'])
 
         vprint("Waiting for proofs to propagate: ", end="", flush=True)
         for sn in self.sns:
             wait_for(lambda: all_service_nodes_proofed(sn), timeout=120)
             vprint(".", end="", flush=True, timestamp=False)
         vprint(timestamp=False)
+
         # This commented out code will register the last SN through Mikes wallet (Has done every other SN)
         # for sn in self.sns[-1:]:
             # self.mike.register_sn(sn)

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -49,16 +49,16 @@ def vprint(*args, timestamp=True, **kwargs):
 
 
 class SNNetwork:
-    def __init__(self, datadir, *, binpath, sns=12, nodes=3):
+    def __init__(self, datadir, *, oxen_bin_dir, sns=12, nodes=3):
         self.datadir = datadir
         if not os.path.exists(self.datadir):
             os.makedirs(self.datadir)
-        self.binpath = binpath
+        self.oxen_bin_dir = oxen_bin_dir
         self.servicenodecontract = ServiceNodeRewardContract()
 
         vprint("Using '{}' for data files and logs".format(datadir))
 
-        nodeopts = dict(oxend=str(self.binpath / 'oxend'), datadir=datadir)
+        nodeopts = dict(oxend=str(self.oxen_bin_dir / 'oxend'), datadir=datadir)
 
         self.ethsns = [Daemon(service_node=True, **nodeopts) for _ in range(1)]
         self.sns = [Daemon(service_node=True, **nodeopts) for _ in range(sns)]
@@ -71,7 +71,7 @@ class SNNetwork:
             self.wallets.append(Wallet(
                 node=self.nodes[len(self.wallets) % len(self.nodes)],
                 name=name,
-                rpc_wallet=str(self.binpath/'oxen-wallet-rpc'),
+                rpc_wallet=str(self.oxen_bin_dir/'oxen-wallet-rpc'),
                 datadir=datadir))
 
         self.alice, self.bob, self.mike = self.wallets
@@ -81,7 +81,7 @@ class SNNetwork:
             self.extrawallets.append(Wallet(
                 node=self.nodes[len(self.extrawallets) % len(self.nodes)],
                 name="extrawallet-"+str(name),
-                rpc_wallet=str(self.binpath/'oxen-wallet-rpc'),
+                rpc_wallet=str(self.oxen_bin_dir/'oxen-wallet-rpc'),
                 datadir=datadir))
 
         # Interconnections
@@ -401,8 +401,8 @@ snn = None
 
 def run():
     arg_parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('--bin-path',
-                            help=f'Set the directory where `oxend` is located',
+    arg_parser.add_argument('--oxen-bin-dir',
+                            help=f'Set the directory where Oxen binaries (oxend, wallet rpc, ...) are located',
                             default="../../build/bin",
                             type=pathlib.Path)
     args = arg_parser.parse_args();
@@ -412,7 +412,7 @@ def run():
         if path.isdir(datadirectory+'/'):
             shutil.rmtree(datadirectory+'/', ignore_errors=False, onerror=None)
         vprint("new SNN")
-        snn = SNNetwork(binpath=args.bin_path, datadir=datadirectory+'/')
+        snn = SNNetwork(oxen_bin_dir=args.oxen_bin_dir, datadir=datadirectory+'/')
     else:
         vprint("reusing SNN")
         snn.alice.new_wallet()

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -6,16 +6,14 @@ from ethereum import ServiceNodeRewardContract
 
 import pathlib
 import argparse
-import random
 import time
 import shutil
 import os
 from   os import path
 import asyncio
-import glob
 from   datetime import datetime
-import uuid
 import subprocess
+import atexit
 
 datadirectory="testdata"
 
@@ -481,6 +479,7 @@ def run():
         if args.eth_sn_contracts_dir is None:
             raise RuntimeError('--eth-sn-contracts-dir must be specified when --anvil-path is set')
 
+    atexit.register(cleanup)
     global snn, verbose
     if not snn:
         if path.isdir(datadirectory+'/'):
@@ -513,9 +512,10 @@ def run():
         print(f'!!! AsyncApplication.run: got KeyboardInterrupt during start')
     finally:
         loop.close()
-        if snn is not None and snn.anvil is not None:
-            snn.anvil.terminate()
 
+def cleanup():
+    if snn is not None and snn.anvil is not None:
+        snn.anvil.terminate()
 
 # Shortcuts for accessing the named wallets
 def alice(net):

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -262,6 +262,9 @@ class SNNetwork:
         self.servicenodecontract.seedPublicKeyList(bls_pubkey_list)
         vprint("Seeded BLS public keys into contract. Contract has {} SNs".format(self.servicenodecontract.numberServiceNodes()))
 
+        # Start the rewards contract after seeding the BLS public keys
+        self.servicenodecontract.start()
+
         # Pull out some useful keys to local variables
         sn0_pubkey            = self.ethsns[0].get_service_keys().pubkey
         hardhat_account       = self.servicenodecontract.hardhatAccountAddress()


### PR DESCRIPTION
- Fixes various issues preventing a BLS rewards claim not working
  - Various parsing issues with the binary streams and new parsing methods had some bugs in them that have mostly been solved
- I've added cpptrace, a stack trace library to dump on exception which was very helpful in identifying the changes needed to get this to work
- Setup the python script to run the suite of programs required for testing. It needs some prior setup, I currently have it configure to run like this:

```
python3 service_node_network.py --oxen-bin-dir ../../Build/gcc-debug-host/bin --anvil-path ~/Downloads/2024-06-11/anvil --eth-sn-contracts-dir ~/Code/eth-sn-contracts
```
  - Anvil for running a local blockchain
  - Contracts to script the deploy of the contracts at startup
  - Setting up the binary directory the script looks into to find binaries for launching daemons

This will run the suite, setup the network and correctly seed the network (with contributor information) and successfully claim rewards from the contract. 

- I'm currently working through the exit and liquidation user flow which is broken because the contract interface has changed. Contracts now take a timestamp to prevent replay attacks which need to be incorporated into the RPC end points and BLS aggregator. This is around 75% done in another fork of this branch.

- Incorporates the review from Zellic's audit regarding updated cryptographic methodologies to be utilised in the C++ layer (the updated map to g2, hash to field changes). This is working as signatures produced on the C++ side are successfully being verified in the smart contracts via the python testing suite.

- Fixed a bug in uptime proofs w/ BLS keys at the eth transition hard fork and onwards. There were some branches that were not using the `bls_public_key` field in the service node state after the hardfork which would cause signatures to fail.
  - I added an additional change to write the BLS key from the proof into the service node state, this makes sure that the public key is available for use after the transition. This might be handled in the new migration code already, but this was necessary to get the python test suite to work.

This branch depends on https://github.com/oxen-io/eth-sn-contracts/pull/48 for the python script to work