### PR TITLE
Fix ETH reward calculation

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -498,7 +498,7 @@ void BlockchainSQLite::calculate_rewards(
                 contributor.amount, distribution_amount - operator_fee, total_contributed_to_sn);
         if (c_reward > 0) {
             if (contributor.ethereum_address)
-                payments.emplace_back(contributor.ethereum_address, operator_fee);
+                payments.emplace_back(contributor.ethereum_address, c_reward);
             else
                 payments.emplace_back(contributor.address, c_reward);
         }
@@ -516,8 +516,8 @@ bool BlockchainSQLite::reward_handler(
     bool (BlockchainSQLite::*add_or_subtract)(const std::vector<cryptonote::batch_sn_payment>&) =
             add ? &BlockchainSQLite::add_sn_rewards : &BlockchainSQLite::subtract_sn_rewards;
 
-    // From here on we calculate everything in milli-atomic OXEN (i.e. thousanths of an atomic
-    // OXEN) so that our integer math has minimal loss from integer division.
+    // From here on we calculate everything in milli-atomic OXEN/SENT (i.e. thousanths of an atomic
+    // unit) so that our integer math has reduced loss from integer division.
     if (block.reward > std::numeric_limits<uint64_t>::max() / BATCH_REWARD_FACTOR)
         throw oxen::traced<std::logic_error>{"Reward distribution amount is too large"};
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -145,8 +145,8 @@ using MAXIMUM_ACCEPTABLE_STAKE = std::ratio<101, 100>;
 // precision of HF19+ registrations (i.e. to a percentage with two decimal places of precision).
 inline constexpr uint64_t STAKING_FEE_BASIS = 10'000;
 
-// We calculate and store batch rewards in thousanths of atomic OXEN, to reduce the size of errors
-// from integer division of rewards.
+// We calculate and store batch rewards in thousanths of atomic OXEN/SENT, to reduce the size of
+// errors from integer division of rewards.
 constexpr uint64_t BATCH_REWARD_FACTOR = 1000;
 
 // If we don't hear any SS ping/lokinet session test failures for more than this long then we

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1559,9 +1559,12 @@ validate_and_get_ethereum_registration(
     info.staking_requirement = staking_requirement;
     info.operator_ethereum_address = reg.eth_contributions[0].first;
     info.bls_public_key = reg.bls_pubkey;
-    info.portions_for_operator = staking_requirement;
+    assert(!reg.uses_portions);
+    info.portions_for_operator =
+            mul128_div64(reg.fee, cryptonote::old::STAKING_PORTIONS, cryptonote::STAKING_FEE_BASIS);
     info.registration_height = block_height;
     info.registration_hf_version = hf_version;
+    info.active_since_height = block_height;
     info.last_reward_block_height = block_height;
     info.last_reward_transaction_index = index;
     info.swarm_id = UNASSIGNED_SWARM_ID;


### PR DESCRIPTION
Batched earnings were considerably wrong on stagenet: e.g. after 70 blocks of rewards the `batched_payments_accrued` table contained:

    sqlite> select * from batched_payments_accrued;
    ┌────────────────────────────────────────────┬────────┬───────────────┐
    │                  address                   │ amount │ payout_offset │
    ├────────────────────────────────────────────┼────────┼───────────────┤
    │ 0xb0cefd61ddb88176fb972955341adc6c1d05230e │ 73888  │ 0             │
    │ 0x00979f83287a7ed917faa37bb1da51f9f7aeb767 │ 16436  │ 0             │
    │ 0xb7649b5a5dfabaa0713acfb3040945035b0bbd9e │ 35560  │ 0             │
    └────────────────────────────────────────────┴────────┴───────────────┘

which are miniscule (since amount is in thousandths of an atomic unit, i.e. that first one is 73 atomic SENT).

I tracked this down to some bugs in the registration handling and reward calculation code:

- the registration operator fee was being set to the staking_requirement rather than the fee.  (Since this is a portions amount, that works out to a 120*1000000000 / ((1<<64) - 4) * 100% ≈ 0.00000065% fee.

- The contributor payout amount was assigning the operator fee instead of the contributor reward value.

- active_since_height was not being set for ETH registrations, and so service nodes were earning rewards immediately after registration instead of waiting until after SERVICE_NODE_PAYABLE_AFTER_BLOCKS blocks.

Putting them together, for a solo node, each operator in a 12-node network with the block reward around 0.1435 SENT per block, each operator earning just over 15 atomic SENT per block.  (and so with 12 SNs and ~70 blocks of rewards that comes out to approximately the sum of the amounts in the table above).

This fixes these issues, but requires stopping oxend, removing the DATADIR/sqlite.db, and restarting oxend again to recompute the reward amounts from the chain.

Post rewards-db rebuild and restart, the rewards look reasonable:

    sqlite> select * from batched_payments_accrued;
    ┌────────────────────────────────────────────┬────────────────┬───────────────┐
    │                  address                   │     amount     │ payout_offset │
    ├────────────────────────────────────────────┼────────────────┼───────────────┤
    │ 0xb0cefd61ddb88176fb972955341adc6c1d05230e │ 12754513865548 │ 0             │
    │ 0x00979f83287a7ed917faa37bb1da51f9f7aeb767 │ 3620616586612  │ 0             │
    │ 0xb7649b5a5dfabaa0713acfb3040945035b0bbd9e │ 7450017715032  │ 0             │
    └────────────────────────────────────────────┴────────────────┴───────────────┘

which sums to the appropriate amount for 166 rewardable blocks with L2 per-block reward of 0.1436-0.1435 over the block range in question:

    Total actually paid: 23.825148167192 SENT
    166 rewardable blocks × 0.14355 reward = 23.8293 SENT

(There's slight imprecision here because of the changing per-block reward -- the 0.14355 amount is approximate).