### PR TITLE
10.5.0 release with storage server 2.7.0 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 10.4.1
+    VERSION 10.5.0
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Wistful Wagyu")
 # Version update notes:

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -53,6 +53,7 @@ static constexpr std::array mainnet_hard_forks =
   hard_fork{hf::hf19_reward_batching,     2,   1146479, 1663113600 /*Wednesday, September 14, 2022 0:00 UTC */}, // Oxen 10.2: Unlock fixes, mandatory SS 2.4.0 update
   hard_fork{hf::hf19_reward_batching,     3,   1253039, 1675900800 /*Thursday, February 9, 2023 0:00 UTC */}, // Oxen 10.3: Mandatory SS 2.5.0 update
   hard_fork{hf::hf19_reward_batching,     4,   1523759, 1708387200 /*Tuesday, February 20, 2024 0:00 UTC */}, // Oxen 10.4: Mandatory SS 2.6.0 update
+  hard_fork{hf::hf19_reward_batching,     5,   1634624, 1721691000 /*Monday, July 22, 23:30 UTC */}, // Oxen 10.5: Mandatory SS 2.7.0 update
 };
 
 static constexpr std::array testnet_hard_forks =

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -207,8 +207,8 @@ namespace service_nodes {
 
   // The minimum that we accept in proofs from other Service Nodes:
   inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS = {
+    proof_version{{cryptonote::hf::hf19_reward_batching, 5}, {10,5,0}, {0,9,11}, {2,7,0}},
     proof_version{{cryptonote::hf::hf19_reward_batching, 4}, {10,4,0}, {0,9,11}, {2,6,1}},
-    proof_version{{cryptonote::hf::hf19_reward_batching, 3}, {10,3,0}, {0,9,11}, {2,5,0}},
   };
 
   using swarm_id_t = uint64_t;


### PR DESCRIPTION
This adds a 10.5.0 mandatory service node upgrade, which updates the required storage server version to 2.7.0 to resolve a storage server crash that is destablising the Session network.

The mandatory SN upgrade is scheduled for block 1634624, which should arrive at:

Mon Jul 22 23:30:00 2024 UTC
Tue Jul 23 09:30:00 2024 Australia/Melbourne
Mon Jul 22 19:30:00 2024 US/Eastern