### PR TITLE
Improve x25519 lookup at eth HF

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -270,6 +270,7 @@ namespace feature {
     constexpr auto PROOF_BTENC = hf::hf18;
     constexpr auto ETH_TRANSITION = hf::hf20_eth_transition;
     constexpr auto ETH_BLS = hf::hf21_eth;
+    constexpr auto SN_PK_IS_ED25519 = hf::hf21_eth;
 }  // namespace feature
 
 enum class network_type : uint8_t { MAINNET = 0, TESTNET, DEVNET, STAGENET, LOCALDEV, FAKECHAIN, UNDEFINED = 255 };

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1065,7 +1065,10 @@ bool core::init_service_keys() {
 
     auto style = fg(fmt::terminal_color::yellow) | fmt::emphasis::bold;
     if (m_service_node) {
-        log::info(globallogcat, fg(fmt::terminal_color::cyan) | fmt::emphasis::bold, "Service node public keys:");
+        log::info(
+                globallogcat,
+                fg(fmt::terminal_color::cyan) | fmt::emphasis::bold,
+                "Service node public keys:");
         log::info(globallogcat, style, "- primary: {:x}", keys.pub);
         log::info(globallogcat, style, "- ed25519: {:x}", keys.pub_ed25519);
         // .snode address is the ed25519 pubkey, encoded with base32z and with .snode appended:
@@ -1105,8 +1108,7 @@ oxenmq::AuthLevel core::omq_allow(
     using namespace oxenmq;
     AuthLevel auth = default_auth;
     if (x25519_pubkey_str.size() == sizeof(crypto::x25519_public_key)) {
-        crypto::x25519_public_key x25519_pubkey;
-        std::memcpy(x25519_pubkey.data(), x25519_pubkey_str.data(), x25519_pubkey_str.size());
+        auto x25519_pubkey = tools::make_from_guts<crypto::x25519_public_key>(x25519_pubkey_str);
         auto user_auth = omq_check_access(x25519_pubkey);
         if (user_auth >= AuthLevel::basic) {
             if (user_auth > auth)
@@ -2488,7 +2490,7 @@ bool core::check_incoming_block_size(const std::string& block_blob) const {
 void core::update_omq_sns() {
     // TODO: let callers (e.g. lokinet, ss) subscribe to callbacks when this fires
     oxenmq::pubkey_set active_sns;
-    m_service_node_list.copy_active_x25519_pubkeys(std::inserter(active_sns, active_sns.end()));
+    m_service_node_list.copy_x25519_pubkeys(std::inserter(active_sns, active_sns.end()), m_nettype);
     m_omq->set_active_sns(std::move(active_sns));
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2854,7 +2854,7 @@ void service_node_list::state_t::update_from_block(
             continue;
         if (my_keys && my_keys->pub == pubkey)
             log::info(
-                    logcat,
+                    globallogcat,
                     fg(fmt::terminal_color::green),
                     "Service node expired (yours): {} at block height: {}",
                     pubkey,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -966,7 +966,7 @@ bool service_node_list::state_t::process_state_change_tx(
                 }
             }
 
-            service_nodes_infos.erase(iter);
+            erase_info(iter);
             return true;
 
         case new_state::decommission:
@@ -1145,7 +1145,7 @@ bool service_node_list::state_t::process_ethereum_deregister_tx(
     else
         log::info(logcat, "Deregistration for service node: {}", snode_key);
 
-    service_nodes_infos.erase(iter);
+    erase_info(iter);
     return true;
 }
 
@@ -1674,7 +1674,7 @@ bool service_node_list::state_t::process_registration_tx(
         }
     }
 
-    service_nodes_infos[key] = std::move(info_ptr);
+    insert_info(key, std::move(info_ptr));
     return true;
 }
 
@@ -1688,7 +1688,7 @@ bool service_node_list::state_t::process_ethereum_registration_tx(
     uint64_t const block_height = cryptonote::get_block_height(block);
 
     try {
-        const auto [key, service_node_info] = validate_and_get_ethereum_registration(
+        auto [key, service_node_info] = validate_and_get_ethereum_registration(
                 nettype, hf_version, tx, block.timestamp, block_height, index);
         // TODO sean -> explore what happens if registration contains duplicate service node pubkey?
         if (sn_list && !sn_list->m_rescanning) {
@@ -1709,7 +1709,7 @@ bool service_node_list::state_t::process_ethereum_registration_tx(
                     "New service node registered from ethereum: {} on height: {}",
                     key,
                     block_height);
-        service_nodes_infos[key] = std::move(service_node_info);
+        insert_info(key, std::move(service_node_info));
         return true;
     } catch (const std::exception& e) {
         log::error(logcat, "Failed to register node from ethereum transaction: {}", e.what());
@@ -2765,6 +2765,18 @@ static void generate_other_quorums(
     }
 }
 
+// Converts an Ed25519 public key to an x25519 pubkey.  Only intended for use with hf >=
+// feature::SN_PK_IS_ED25519 (because before that we don't have a guarantee that a
+// crypto::public_key is actually the correct Ed25519 pubkeys that we want to convert to get the
+// X25519 pubkey).
+static crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk) {
+    crypto::x25519_public_key xpk;
+    if (0 != crypto_sign_ed25519_pk_to_curve25519(xpk.data(), snpk.data()))
+        throw oxen::traced<std::runtime_error>{
+                "Unable to convert SN Ed25519 pubkey {} to X25519 pubkey"_format(snpk)};
+    return xpk;
+}
+
 void service_node_list::state_t::update_from_block(
         cryptonote::BlockchainDB const& db,
         cryptonote::network_type nettype,
@@ -2775,6 +2787,11 @@ void service_node_list::state_t::update_from_block(
         const std::vector<cryptonote::transaction>& txs,
         const service_node_keys* my_keys) {
     ++height;
+    log::debug(
+            logcat,
+            "Updating state_t{} from block for height {}",
+            sn_list ? "" : " (without sn_list yet)",
+            height);
     bool need_swarm_update = false;
     uint64_t block_height = cryptonote::get_block_height(block);
     assert(height == block_height);
@@ -2806,8 +2823,7 @@ void service_node_list::state_t::update_from_block(
             for (size_t quorum_index = 0; quorum_index < pulse_quorum.validators.size();
                  quorum_index++) {
                 crypto::public_key const& key = pulse_quorum.validators[quorum_index];
-                auto& info_ptr = service_nodes_infos[key];
-                service_node_info& new_info = duplicate_info(info_ptr);
+                service_node_info& new_info = duplicate_info(service_nodes_infos[key]);
                 new_info.pulse_sorter.last_height_validating_in_quorum = height;
                 new_info.pulse_sorter.quorum_index = quorum_index;
             }
@@ -2834,28 +2850,28 @@ void service_node_list::state_t::update_from_block(
     for (const crypto::public_key& pubkey :
          get_expired_nodes(db, nettype, block.major_version, block_height)) {
         auto i = service_nodes_infos.find(pubkey);
-        if (i != service_nodes_infos.end()) {
-            if (my_keys && my_keys->pub == pubkey)
-                log::info(
-                        logcat,
-                        fg(fmt::terminal_color::green),
-                        "Service node expired (yours): {} at block height: {}",
-                        pubkey,
-                        block_height);
-            else
-                log::info(
-                        logcat,
-                        "Service node expired: {} at block height: {}",
-                        pubkey,
-                        block_height);
+        if (i == service_nodes_infos.end())
+            continue;
+        if (my_keys && my_keys->pub == pubkey)
+            log::info(
+                    logcat,
+                    fg(fmt::terminal_color::green),
+                    "Service node expired (yours): {} at block height: {}",
+                    pubkey,
+                    block_height);
+        else
+            log::info(
+                    logcat,
+                    "Service node expired: {} at block height: {}",
+                    pubkey,
+                    block_height);
 
-            need_swarm_update = need_swarm_update || i->second->is_active();
-            // NOTE: sn_list is not set in tests when we construct events to replay
-            if (sn_list)
-                sn_list->recently_expired_nodes.emplace(
-                        i->second->bls_public_key, block_height + netconf.ETH_EXIT_BUFFER);
-            service_nodes_infos.erase(i);
-        }
+        need_swarm_update = need_swarm_update || i->second->is_active();
+        // NOTE: sn_list is not set in tests when we construct events to replay
+        if (sn_list)
+            sn_list->recently_expired_nodes.emplace(
+                    i->second->bls_public_key, block_height + netconf.ETH_EXIT_BUFFER);
+        erase_info(i);
     }
 
     //
@@ -2882,20 +2898,27 @@ void service_node_list::state_t::update_from_block(
     for (uint32_t index = 0; index < txs.size(); ++index) {
         const cryptonote::transaction& tx = txs[index];
         if (tx.type == staking_tx_type) {
+            log::debug(logcat, "Processing registration tx");
             process_registration_tx(nettype, block, tx, index, my_keys);
             need_swarm_update += process_contribution_tx(nettype, block, tx, index);
         } else if (tx.type == cryptonote::txtype::state_change) {
+            log::debug(logcat, "Processing state change tx");
             need_swarm_update += process_state_change_tx(
                     state_history, state_archive, alt_states, nettype, block, tx, my_keys);
         } else if (tx.type == cryptonote::txtype::key_image_unlock) {
+            log::debug(logcat, "Processing key image unlock tx");
             process_key_image_unlock_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_new_service_node) {
+            log::debug(logcat, "Processing eth registration tx");
             process_ethereum_registration_tx(nettype, block, tx, index, my_keys);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_leave_request) {
+            log::debug(logcat, "Processing eth unlock tx");
             process_ethereum_unlock_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_exit) {
+            log::debug(logcat, "Processing eth exit tx");
             process_ethereum_exit_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_deregister) {
+            log::debug(logcat, "Processing eth deregister tx");
             process_ethereum_deregister_tx(nettype, hf_version, block_height, tx, my_keys);
         }
     }
@@ -2927,6 +2950,12 @@ void service_node_list::state_t::update_from_block(
         }
     }
     generate_other_quorums(*this, active_snode_list, nettype, hf_version);
+
+    // If our x25519 map is empty then try populating it (which only does something if we're into
+    // the unified-pubkey-and-ed-pubkey hardfork).  In normal operation, this only happens once (for
+    // the first post-unified-keys hard fork state block).
+    if (x25519_map.empty())
+        initialize_xpk_map();
 }
 
 void service_node_list::process_block(
@@ -2956,8 +2985,9 @@ void service_node_list::process_block(
                 m_transient.state_added_to_archive = true;
                 if (need_quorum_for_future_states)  // Preserve just quorum
                 {
-                    state_t& state = const_cast<state_t&>(
-                            *it);  // safe: set order only depends on state_t.height
+                    // This const cast is a little ugly, but is safe because we don't touch
+                    // state_t.height (which is all the set order depends on).
+                    state_t& state = const_cast<state_t&>(*it);
                     state.service_nodes_infos = {};
                     state.key_image_blacklist = {};
                     state.only_loaded_quorums = true;
@@ -3843,7 +3873,7 @@ bool service_node_list::handle_uptime_proof(
         return false;
     }
 
-    if (vers.first >= feature::ETH_BLS) {
+    if (vers.first >= feature::SN_PK_IS_ED25519) {
         // Starting at the ETH_BLS hard fork we prohibit proofs with differing pubkey/ed25519
         // pubkey; any mixed node registrations get updated as part of the HF transition.
         if (tools::view_guts(proof->pubkey) != tools::view_guts(proof->pubkey_ed25519)) {
@@ -3852,7 +3882,7 @@ bool service_node_list::handle_uptime_proof(
                     "Rejecting uptime proof from {}: pubkey != pubkey_ed25519 is not allowed since "
                     "HF{}",
                     proof->pubkey,
-                    static_cast<uint8_t>(feature::ETH_BLS));
+                    static_cast<uint8_t>(feature::SN_PK_IS_ED25519));
             return false;
         }
     }
@@ -3885,7 +3915,7 @@ bool service_node_list::handle_uptime_proof(
     assert(proof->proof_hash);  // This gets set during parsing of an incoming proof
     const auto& hash = proof->proof_hash;
 
-    if (vers.first < feature::ETH_BLS) {
+    if (vers.first < feature::SN_PK_IS_ED25519) {
         // pre-ETH_BLS includes a Monero-style (i.e. wrongly computed, though cryptographically
         // equivalent) Ed25519 signature signed by `pubkey`.  (Post-ETH_BLS sends and uses only the
         // proper Ed25519 signature, and requires the pubkeys be the same).
@@ -4030,23 +4060,25 @@ bool service_node_list::handle_uptime_proof(
         iproof.store(iproof.proof->pubkey, m_blockchain);
     }
 
-    if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
-        time_t cutoff = std::chrono::system_clock::to_time_t(now - X25519_MAP_PRUNING_LAG);
-        std::erase_if(x25519_to_pub, [&cutoff](const decltype(x25519_to_pub)::value_type& x) {
-            return x.second.second < cutoff;
-        });
-        x25519_map_last_pruned = now;
+    if (vers.first < feature::SN_PK_IS_ED25519) {
+        if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
+            time_t cutoff = std::chrono::system_clock::to_time_t(now - X25519_MAP_PRUNING_LAG);
+            std::erase_if(x25519_to_pub, [&cutoff](const auto& x) {
+                return x.second.second < cutoff;
+            });
+            x25519_map_last_pruned = now;
+        }
+
+        if (old_x25519 && old_x25519 != derived_x25519_pubkey)
+            x25519_to_pub.erase(old_x25519);
+
+        if (derived_x25519_pubkey)
+            x25519_to_pub[derived_x25519_pubkey] = {
+                    iproof.proof->pubkey, std::chrono::system_clock::to_time_t(now)};
+
+        if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
+            x25519_pkey = derived_x25519_pubkey;
     }
-
-    if (old_x25519 && old_x25519 != derived_x25519_pubkey)
-        x25519_to_pub.erase(old_x25519);
-
-    if (derived_x25519_pubkey)
-        x25519_to_pub[derived_x25519_pubkey] = {
-                iproof.proof->pubkey, std::chrono::system_clock::to_time_t(now)};
-
-    if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
-        x25519_pkey = derived_x25519_pubkey;
 
     return true;
 }
@@ -4073,24 +4105,34 @@ void service_node_list::cleanup_proofs() {
 
 crypto::public_key service_node_list::get_pubkey_from_x25519(
         const crypto::x25519_public_key& x25519) const {
-    std::shared_lock lock{m_x25519_map_mutex};
-    auto it = x25519_to_pub.find(x25519);
-    if (it != x25519_to_pub.end())
-        return it->second.first;
+    if (cryptonote::is_hard_fork_at_least(
+                m_blockchain.nettype(),
+                feature::SN_PK_IS_ED25519,
+                m_blockchain.get_current_blockchain_height())) {
+        std::lock_guard lock{m_sn_mutex};
+        auto it = m_state.x25519_map.find(x25519);
+        if (it != m_state.x25519_map.end())
+            return it->second;
+    } else {
+        std::shared_lock lock{m_x25519_map_mutex};
+        auto it = x25519_to_pub.find(x25519);
+        if (it != x25519_to_pub.end())
+            return it->second.first;
+    }
     return crypto::null<crypto::public_key>;
 }
 
 crypto::public_key service_node_list::get_random_pubkey() {
     std::lock_guard lock{m_sn_mutex};
-    auto it = tools::select_randomly(
-            m_state.service_nodes_infos.begin(), m_state.service_nodes_infos.end());
-    if (it != m_state.service_nodes_infos.end()) {
+    if (auto it = tools::select_randomly(
+                m_state.service_nodes_infos.begin(), m_state.service_nodes_infos.end());
+        it != m_state.service_nodes_infos.end()) {
         return it->first;
-    } else {
-        return m_state.service_nodes_infos.begin()->first;
     }
+    return crypto::null<crypto::public_key>;
 }
 
+// Deprecated: can be remove after HF21
 void service_node_list::initialize_x25519_map() {
     auto locks = tools::unique_locks(m_sn_mutex, m_x25519_map_mutex);
 
@@ -4107,8 +4149,7 @@ void service_node_list::initialize_x25519_map() {
 std::string service_node_list::remote_lookup(std::string_view xpk) {
     if (xpk.size() != sizeof(crypto::x25519_public_key))
         return "";
-    crypto::x25519_public_key x25519_pub;
-    std::memcpy(x25519_pub.data(), xpk.data(), xpk.size());
+    auto x25519_pub = tools::make_from_guts<crypto::x25519_public_key>(xpk);
 
     auto pubkey = get_pubkey_from_x25519(x25519_pub);
     if (!pubkey) {
@@ -4313,7 +4354,6 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
             // only two valid values here: initial for a node that has never been recommissioned, or
             // 0 for a recommission.
 
-            auto was = info.recommission_credit;
             if (info.decommission_count <= info.is_decommissioned())
                 // Has never been decommissioned (or is currently in the first decommission), so add
                 // initial starting credit
@@ -4337,7 +4377,40 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
         assert(info.version == tools::enum_top<decltype(info.version)>);
         service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));
     }
+
+    initialize_xpk_map();
+
     quorums = quorum_for_serialization_to_quorum_manager(state.quorums);
+}
+
+void service_node_list::state_t::initialize_xpk_map() {
+    // Compute the x25519 -> pubkey mappings for this state for post-merged-pubkey hardforks.
+    // (Before that the primary and Ed keys might differ, and we need the Ed key to get the correct
+    // X key, which only happens once we get a proof).
+    assert(x25519_map.empty());
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        for (const auto& [snpk, _ignore] : service_nodes_infos)
+            x25519_map[snpk_to_xpk(snpk)] = snpk;
+}
+
+void service_node_list::state_t::insert_info(
+        const crypto::public_key& pubkey, std::shared_ptr<service_node_info>&& info_ptr) {
+    service_nodes_infos[pubkey] = std::move(info_ptr);
+
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                           sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        x25519_map[snpk_to_xpk(pubkey)] = pubkey;
+}
+
+service_nodes_infos_t::iterator service_node_list::state_t::erase_info(
+        const service_nodes_infos_t::iterator& it) {
+    const auto& snpk = it->first;
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                           sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        x25519_map.erase(snpk_to_xpk(snpk));
+
+    return service_nodes_infos.erase(it);
 }
 
 bool service_node_list::load(const uint64_t current_height) {
@@ -4516,7 +4589,10 @@ bool service_node_list::load(const uint64_t current_height) {
         mine.timestamp = mine.effective_timestamp = 0;
     }
 
-    initialize_x25519_map();
+    if (!cryptonote::is_hard_fork_at_least(
+            m_blockchain.nettype(), feature::SN_PK_IS_ED25519, current_height))
+        initialize_x25519_map();
+    // else the x25519 map is part of state_t
 
     log::info(globallogcat, "Service node data loaded successfully, height: {}", m_state.height);
     log::info(

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -54,7 +54,7 @@ Proof::Proof(
     serialized_proof = bt_encode_uptime_proof(hardfork);
     proof_hash = crypto::keccak(serialized_proof);
 
-    if (hardfork < feature::ETH_BLS)
+    if (hardfork < feature::SN_PK_IS_ED25519)
         // Starting from HF21 we have guaranteed unified pubkey/ed25519 pubkey, so don't need to
         // send the old primary SN signature anymore: the single ed25519 signature does it all.
         crypto::generate_signature(proof_hash, keys.pub, keys.key, sig);
@@ -146,7 +146,7 @@ cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request Proof::generate_request(hf ha
     cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request request;
     assert(!serialized_proof.empty());
     request.proof = serialized_proof;
-    if (hardfork < feature::ETH_BLS) {
+    if (hardfork < feature::SN_PK_IS_ED25519) {
         // Starting at the full ETH hardfork we only send the ed25519 sig (because ed and primary
         // pubkeys are guaranteed unified starting at HF21).
         request.sig = tools::view_guts(sig);

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -332,25 +332,12 @@ bool command_parser_executor::print_sn_status(const std::vector<std::string>& ar
 }
 
 bool command_parser_executor::set_log_level(const std::vector<std::string>& args) {
-    if (args.size() > 1) {
-        std::cout << "use: set_log [<log_level_number_0-4> | <categories>]" << std::endl;
+    if (args.empty()) {
+        std::cout << "use: set_log [critical|error|warning|info|debug|trace] [category=LEVEL ...]" << std::endl;
         return true;
     }
 
-    if (args.empty()) {
-        return m_executor.set_log_categories("+");
-    }
-
-    uint16_t l = 0;
-    if (epee::string_tools::get_xtype_from_string(l, args[0])) {
-        if (4 < l) {
-            std::cout << "wrong number range, use: set_log <log_level_number_0-4>" << std::endl;
-            return true;
-        }
-        return m_executor.set_log_level(l);
-    } else {
-        return m_executor.set_log_categories(args.front());
-    }
+    return m_executor.set_log_level("{}"_format(fmt::join(args, ", ")));
 }
 
 bool command_parser_executor::print_height(const std::vector<std::string>& args) {

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -111,10 +111,12 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
     m_command_lookup.set_handler(
             "prepare_eth_registration",
             [this](const auto& x) { return m_parser.prepare_eth_registration(x); },
-            "prepare_eth_registration <operator address> [multi-contributor contract address] [\"print_only\"]",
-            "Interactive prompt to prepare a service node registration for submission to eth.  By default"
-            " this information is submitted to INSERT_URL_HERE to make it easy to submit your registration."
-            "  If you would prefer to just print the information, put print_only as the final argument.");
+            "prepare_eth_registration <operator address> [multi-contributor contract address] "
+            "[\"print_only\"]",
+            "Interactive prompt to prepare a service node registration for submission to eth.  By "
+            "default this information is submitted to INSERT_URL_HERE to make it easy to submit "
+            "your registration.  If you would prefer to just print the information, append "
+            "print_only as the final argument.");
 
     m_command_lookup.set_handler(
             "print_sn",
@@ -166,8 +168,9 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
     m_command_lookup.set_handler(
             "set_log",
             [this](const auto& x) { return m_parser.set_log_level(x); },
-            "set_log <level>|<{+,-,}categories>",
-            "Change the current log level/categories where <level> is a number 0-4.");
+            "set_log [LEVEL] [CATEGORY=LEVEL ...]",
+            "Change the current global log level and/or category-specific log levels.  LEVEL is "
+            "one of critical/error/warning/info/debug/trace.");
     m_command_lookup.set_handler(
             "diff",
             [this](const auto& x) { return m_parser.show_difficulty(x); },

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2287,18 +2287,11 @@ bool rpc_command_executor::prepare_registration(bool force_registration) {
     auto& snode_keys = *maybe_keys;
 
     if (hf_version >= cryptonote::feature::ETH_BLS) {
-        // TODO FIXME XXX
-        tools::fail_msg_writer("FIXME: REPLACE THIS FOR feature::ETH_BLS");
-        assert(false);
-
-        tools::success_msg_writer(
-                "Service Node Pubkey: {}\n"
-                "Service Node Signature: {}\n",
-                snode_keys.value<std::string>("service_node_pubkey", ""),
-                snode_keys.value<std::string>(
-                        "service_node_signature",
-                        ""));  // Assuming 'service_node_signature' is the key for signature
-        return true;
+        tools::fail_msg_writer(
+                "prepare_registration is no longer usable as of HF {}; you should use the "
+                "`prepare_eth_registration` command instead",
+                static_cast<int>(cryptonote::feature::ETH_BLS));
+        return false;
     }
 
     auto nettype = cryptonote::network_type_from_string(info["nettype"].get<std::string_view>());

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -867,28 +867,20 @@ bool rpc_command_executor::print_quorum_state(
     return true;
 }
 
-bool rpc_command_executor::set_log_level(int8_t level) {
-    try {
-        invoke<SET_LOG_LEVEL>(json{{"level", level}});
-    } catch (const std::exception& e) {
-        tools::fail_msg_writer("Failed to set log level: {}", e.what());
+bool rpc_command_executor::set_log_level(std::string categories) {
+    auto maybe_categories = try_running(
+            [this, &categories] {
+                return invoke<SET_LOG_LEVEL>(json{{"categories", std::move(categories)}});
+            },
+            "Failed to set log level");
+    if (!maybe_categories)
         return false;
-    }
 
-    tools::success_msg_writer("Log level set to {:d}", level);
-    return true;
-}
-
-bool rpc_command_executor::set_log_categories(std::string categories) {
-    // auto maybe_categories = try_running([this, &categories] { return
-    // invoke<SET_LOG_CATEGORIES>(json{{"categories", std::move(categories)}}); }, "Failed to set
-    // log categories"); if (!maybe_categories) return false;
-    // auto& categories_response = *maybe_categories;
-    auto categories_response =
-            make_request<SET_LOG_CATEGORIES>(json{{"categories", std::move(categories)}});
+    auto& cats = *maybe_categories;
 
     tools::success_msg_writer(
-            "Log categories are now {}", categories_response["categories"].get<std::string_view>());
+            "Applied log categories {}",
+            fmt::join(cats["applied"].get<std::vector<std::string_view>>(), ", "));
 
     return true;
 }

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -178,9 +178,7 @@ class rpc_command_executor final {
     bool print_quorum_state(
             std::optional<uint64_t> start_height, std::optional<uint64_t> end_height);
 
-    bool set_log_level(int8_t level);
-
-    bool set_log_categories(std::string categories);
+    bool set_log_level(std::string categories);
 
     bool print_height();
 

--- a/src/logging/oxen_logger.cpp
+++ b/src/logging/oxen_logger.cpp
@@ -83,7 +83,7 @@ void apply_categories_string(std::string_view categories) {
     extract_categories(categories).apply();
 }
 
-void LogCats::apply() {
+std::list<std::string> LogCats::apply() {
     std::list<std::string> applied;
     if (default_level) {
         log::reset_level(*default_level);
@@ -98,11 +98,13 @@ void LogCats::apply() {
 
     if (!applied.empty())
         log::info(logcat, "Applied log categories: {}", fmt::join(applied, ", "));
+
+    return applied;
 }
 
 void init(const std::string& log_location, std::string_view log_levels, bool log_to_stdout) {
     auto cats = extract_categories(log_levels);
-    if (!cats.default_level && cats.cat_levels.empty() && !log_levels.empty()) {
+    if (cats.empty() && !log_levels.empty()) {
         std::cerr << "Incorrect log level string: " << log_levels << std::endl;
         throw std::runtime_error{"Invalid log level or log categories"};
     }

--- a/src/logging/oxen_logger.h
+++ b/src/logging/oxen_logger.h
@@ -54,8 +54,13 @@ void apply_categories_string(std::string_view categories);
 struct LogCats {
     std::optional<log::Level> default_level;
     std::unordered_map<std::string, log::Level> cat_levels;
-    // Applies the settings in the object to the global logger.
-    void apply();
+
+    // True if this object contains no parsed levels (either neither a default nor any category levels)
+    bool empty() const { return !default_level && cat_levels.empty(); }
+
+    // Applies the settings in the object to the global logger.  Returns the actual setting applied
+    // (i.e. not including redundant or unparseable settings).
+    std::list<std::string> apply();
 };
 
 /// Given a log level string this extracts the default and individual category levels applied by the

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -155,7 +155,6 @@ class core_rpc_server {
     void invoke(GET_BLOCK_HASH& req, rpc_context context);
     void invoke(GET_PEER_LIST& pl, rpc_context context);
     void invoke(SET_LOG_LEVEL& set_log_level, rpc_context context);
-    void invoke(SET_LOG_CATEGORIES& set_log_categories, rpc_context context);
     void invoke(BANNED& banned, rpc_context context);
     void invoke(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_context context);
     void invoke(GET_VERSION& version, rpc_context context);

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -50,7 +50,6 @@ void parse_request(PRUNE_BLOCKCHAIN& prune_blockchain, rpc_input in);
 void parse_request(REPORT_PEER_STATUS& report_peer_status, rpc_input in);
 void parse_request(SET_BANS& set_bans, rpc_input in);
 void parse_request(SET_LIMIT& limit, rpc_input in);
-void parse_request(SET_LOG_CATEGORIES& set_log_categories, rpc_input in);
 void parse_request(SET_LOG_LEVEL& set_log_level, rpc_input in);
 void parse_request(START_MINING& start_mining, rpc_input in);
 void parse_request(STORAGE_SERVER_PING& storage_server_ping, rpc_input in);


### PR DESCRIPTION
Previously we couldn't have the x25519 map in the state_t because the X25519 pubkey is derived from the service node's Ed25519, which we didn't learn about until we got an uptime proof with it.  Thus our X25519 pubkey list was never quite perfect in the case of missing or delayed proofs, and could sometimes lead to some nodes (temporarily) being unable to communicate with each other until a proof goes out to communicate the Ed25519 (and thus implicitly the X25519) pubkey.

In HF21 we now require unified pubkeys, which means the main SN is always the Ed25519 pubkey, and so we can can always compute the X25519 pubkeys perfectly.

This implements it by adding a x25519 pubkey map in the state_t and updating it on initialization, and when service nodes are added/removed so that we always know the full set of x25519 pubkeys without having to wait for proofs.  (We don't need to serialize this -- it can be constructed on the fly from the main SN pubkey, as long as we're on HF21+).

Doing this resolves some quorumnet communication failures (such as in pulse participation) that can happen when service nodes try working with other service nodes but the proof of the connecting SN hasn't propagated yet (or was missed).

This also changes the OMQ SN list code to include all SNs instead of only active SNs with proofs: decommed SNs can still sometimes try to communicate over oxenmq with other nodes and there's no reason they need to be excluded from such comms.  (Pre-HF21 we still can only include nodes with proofs, of course, because without a proof we don't know the X25519 pubkey that will be used).

Also included here is a fix to the `set_log` command (which was broken) and related RPC methods, which annoyed me in trying to diagnose this; and another SN state change log statement that should be in the global category.