### PR TITLE
Unify ETH event naming references in oxen, plus other fixes

### DIFF
--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -1,19 +1,19 @@
 #include "bls_aggregator.h"
 
+#include <blockchain_db/sqlite/db_sqlite.h>
 #include <bls/bls_signer.h>
 #include <bls/bls_utils.h>
-#include <common/exception.h>
 #include <common/bigint.h>
+#include <common/exception.h>
 #include <common/guts.h>
 #include <common/string_util.h>
 #include <crypto/crypto.h>
 #include <cryptonote_core/cryptonote_core.h>
-#include <blockchain_db/sqlite/db_sqlite.h>
-
-#include <ethyl/utils.hpp>
 #include <logging/oxen_logger.h>
 #include <oxenc/bt_producer.h>
 #include <oxenmq/oxenmq.h>
+
+#include <ethyl/utils.hpp>
 
 #define BLS_ETH
 #define MCLBN_FP_UNIT_SIZE 4
@@ -31,7 +31,147 @@
 
 namespace eth {
 
-static auto logcat = oxen::log::Cat("bls_aggregator");
+namespace {
+    auto logcat = oxen::log::Cat("bls_aggregator");
+
+    // Takes a oxenmq::Message expected to contain a single argument extractable to a `T` that must
+    // be encoded as raw bytes, hex, or 0x-prefixed hex.  Sends an appropriate reply and returns
+    // false on error, otherwise sets `val` and returns true.
+    template <tools::safe_to_memcpy T>
+    bool extract_1part_msg(
+            oxenmq::Message& m, T& val, std::string_view cmd_name, std::string_view value_name) {
+        if (m.data.size() != 1) {
+            m.send_reply(
+                    "400",
+                    "Bad request: {} command should have one {} data part; received {}"_format(
+                            cmd_name, value_name, m.data.size()));
+            return false;
+        }
+        if (m.data[0].size() == sizeof(T)) {
+            val = tools::make_from_guts<T>(m.data[0]);
+            return true;
+        }
+        if (tools::try_load_from_hex_guts(m.data[0], val))
+            return true;
+
+        m.send_reply(
+                "400",
+                "Bad request: {} command data should be a {}-byte {}; got {} bytes"_format(
+                        cmd_name, sizeof(T), value_name, m.data[0].size()));
+        return false;
+    }
+
+    std::vector<uint8_t> get_reward_balance_msg_to_sign(
+            cryptonote::network_type nettype,
+            const address& eth_addr,
+            std::array<std::byte, 32> amount_be) {
+        // TODO(doyle): See BLSSigner::proofOfPossession
+        const auto tag = BLSSigner::buildTagHash(BLSSigner::rewardTag, nettype);
+        std::vector<uint8_t> result;
+        result.reserve(tag.size() + eth_addr.size() + amount_be.size());
+        result.insert(result.end(), tag.begin(), tag.end());
+        result.insert(result.end(), eth_addr.begin(), eth_addr.end());
+        result.insert(
+                result.end(),
+                reinterpret_cast<uint8_t*>(amount_be.begin()),
+                reinterpret_cast<uint8_t*>(amount_be.end()));
+        return result;
+    }
+
+    std::string dump_bls_rewards_response(const BLSRewardsResponse& item) {
+        std::string result =
+                "BLS rewards response was:\n"
+                "\n"
+                "  - address:     {}\n"
+                "  - amount:      {}\n"
+                "  - height:      {}\n"
+                "  - signature:   {}\n"
+                "  - msg_to_sign: {}\n"_format(
+                        item.address,
+                        item.amount,
+                        item.height,
+                        item.signature,
+                        oxenc::to_hex(item.msg_to_sign.begin(), item.msg_to_sign.end()));
+        return result;
+    }
+
+    std::vector<uint8_t> get_removal_msg_to_sign(
+            cryptonote::network_type nettype,
+            BLSAggregator::RemovalType type,
+            const bls_public_key& remove_pk,
+            uint64_t unix_timestamp) {
+        // TODO(doyle): See BLSSigner::proofOfPossession
+        crypto::hash tag{};
+        std::vector<uint8_t> result;
+        if (type == BLSAggregator::RemovalType::Normal) {
+            tag = BLSSigner::buildTagHash(BLSSigner::removalTag, nettype);
+            result.reserve(tag.size() + remove_pk.size() + sizeof(unix_timestamp));
+            result.insert(result.end(), tag.begin(), tag.end());
+            result.insert(result.end(), remove_pk.begin(), remove_pk.end());
+            auto unix_timestamp_it = reinterpret_cast<uint8_t*>(&unix_timestamp);
+            result.insert(
+                    result.end(), unix_timestamp_it, unix_timestamp_it + sizeof(unix_timestamp));
+        } else {
+            assert(type == BLSAggregator::RemovalType::Liquidate);
+            tag = BLSSigner::buildTagHash(BLSSigner::liquidateTag, nettype);
+            result.reserve(tag.size() + remove_pk.size());
+            result.insert(result.end(), tag.begin(), tag.end());
+            result.insert(result.end(), remove_pk.begin(), remove_pk.end());
+        }
+        return result;
+    }
+
+    struct BLSRemovalRequest {
+        bool good;
+        bls_public_key remove_pk;
+        std::chrono::seconds timestamp;
+    };
+
+    BLSRemovalRequest extract_removal_request(oxenmq::Message& m) {
+        BLSRemovalRequest result{};
+        if (m.data.size() != 1) {
+            m.send_reply(
+                    "400",
+                    "Bad request: BLS removal command should have one data part; received {}"_format(
+                            m.data.size()));
+            return result;
+        }
+
+        try {
+            oxenc::bt_dict_consumer d{m.data[0]};
+            result.remove_pk =
+                    tools::make_from_guts<bls_public_key>(d.require<std::string_view>("bls_"
+                                                                                      "pubke"
+                                                                                      "y"));
+            result.timestamp = std::chrono::seconds(
+                    tools::make_from_guts<uint64_t>(d.require<std::string_view>("timestamp")));
+        } catch (const std::exception& e) {
+            m.send_reply(
+                    "400",
+                    "Bad request: BLS removal command specified bad bls pubkey or timestamp: {}"_format(
+                            e.what()));
+            return result;
+        }
+
+        // NOTE: Check if the request is too old. If it's too old we will reject it
+        std::chrono::duration unix_now =
+                std::chrono::high_resolution_clock::now().time_since_epoch();
+        std::chrono::duration time_since_initial_request = result.timestamp > unix_now
+                                                                 ? result.timestamp - unix_now
+                                                                 : unix_now - result.timestamp;
+        if (time_since_initial_request > service_nodes::BLS_MAX_TIME_ALLOWED_FOR_REMOVAL_REQUEST) {
+            m.send_reply(
+                    "400",
+                    "Bad request: BLS removal was too old ({}) to sign"_format(
+                            tools::friendly_duration(time_since_initial_request)));
+            return result;
+        }
+
+        result.good = true;
+        return result;
+    }
+
+}  // namespace
 
 BLSAggregator::BLSAggregator(cryptonote::core& _core) : core{_core} {
 
@@ -40,7 +180,7 @@ BLSAggregator::BLSAggregator(cryptonote::core& _core) : core{_core} {
         omq.add_category("bls", oxenmq::Access{oxenmq::AuthLevel::none})
                 .add_request_command(
                         "get_reward_balance", [this](auto& m) { get_reward_balance(m); })
-                .add_request_command("get_exit", [this](auto& m) { get_exit(m); })
+                .add_request_command("get_removal", [this](auto& m) { get_removal(m); })
                 .add_request_command("get_liquidation", [this](auto& m) { get_liquidation(m); });
     }
 }
@@ -103,45 +243,6 @@ void BLSAggregator::nodesRequest(
     cv.wait(connection_lock, [&active_connections] { return active_connections == 0; });
 }
 
-// Takes a oxenmq::Message expected to contain a single argument extractable to a `T` that must be
-// encoded as raw bytes, hex, or 0x-prefixed hex.  Sends an appropriate reply and returns false on
-// error, otherwise sets `val` and returns true.
-template <tools::safe_to_memcpy T>
-static bool extract_1part_msg(
-        oxenmq::Message& m, T& val, std::string_view cmd_name, std::string_view value_name) {
-    if (m.data.size() != 1) {
-        m.send_reply(
-                "400",
-                "Bad request: {} command should have one {} data part; received {}"_format(
-                        cmd_name, value_name, m.data.size()));
-        return false;
-    }
-    if (m.data[0].size() == sizeof(T)) {
-        val = tools::make_from_guts<T>(m.data[0]);
-        return true;
-    }
-    if (tools::try_load_from_hex_guts(m.data[0], val))
-        return true;
-
-    m.send_reply(
-            "400",
-            "Bad request: {} command data should be a {}-byte {}; got {} bytes"_format(
-                    cmd_name, sizeof(T), value_name, m.data[0].size()));
-    return false;
-}
-
-static std::vector<uint8_t> get_reward_balance_msg_to_sign(cryptonote::network_type nettype, const address& eth_addr, std::array<std::byte, 32> amount_be)
-{
-    // TODO(doyle): See BLSSigner::proofOfPossession
-    const auto tag = BLSSigner::buildTagHash(BLSSigner::rewardTag, nettype);
-    std::vector<uint8_t> result;
-    result.reserve(tag.size() + eth_addr.size() + amount_be.size());
-    result.insert(result.end(), tag.begin(), tag.end());
-    result.insert(result.end(), eth_addr.begin(), eth_addr.end());
-    result.insert(result.end(), reinterpret_cast<uint8_t *>(amount_be.begin()), reinterpret_cast<uint8_t *>(amount_be.end()));
-    return result;
-}
-
 void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq rewards signature request");
 
@@ -163,7 +264,8 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     auto& signer = core.get_bls_signer();
     std::array<std::byte, 32> amount_be = tools::encode_integer_be<32>(amount);
 
-    std::vector<uint8_t> msg = get_reward_balance_msg_to_sign(core.get_nettype(), eth_addr, amount_be);
+    std::vector<uint8_t> msg =
+            get_reward_balance_msg_to_sign(core.get_nettype(), eth_addr, amount_be);
     bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
@@ -179,29 +281,9 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
     m.send_reply("200", std::move(d).str());
 }
 
-static std::string dump_bls_rewards_response(const BLSRewardsResponse &item)
-{
-    std::string result =
-            "BLS rewards response was:\n"
-            "\n"
-            "  - address:     {}\n"
-            "  - amount:      {}\n"
-            "  - height:      {}\n"
-            "  - signature:   {}\n"
-            "  - msg_to_sign: {}\n"_format(
-                    item.address,
-                    item.amount,
-                    item.height,
-                    item.signature,
-                    oxenc::to_hex(item.msg_to_sign.begin(), item.msg_to_sign.end()));
-    return result;
-}
+BLSRewardsResponse BLSAggregator::rewards_request(const eth::address& address) {
 
-BLSRewardsResponse BLSAggregator::rewards_request(
-        const eth::address& address) {
-
-    auto [height, amount] =
-            core.get_blockchain_storage().sqlite_db().get_accrued_earnings(address);
+    auto [height, amount] = core.get_blockchain_storage().sqlite_db().get_accrued_earnings(address);
 
     // FIXME: make this async
 
@@ -247,7 +329,8 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     result.address = address;
     result.amount = amount;
     result.height = height;
-    result.msg_to_sign = get_reward_balance_msg_to_sign(core.get_nettype(), result.address, tools::encode_integer_be<32>(amount));
+    result.msg_to_sign = get_reward_balance_msg_to_sign(
+            core.get_nettype(), result.address, tools::encode_integer_be<32>(amount));
 
     // `nodesRequest` dispatches to a threadpool hence we require synchronisation:
     std::mutex sig_mutex;
@@ -261,7 +344,6 @@ BLSRewardsResponse BLSAggregator::rewards_request(
             tools::view_guts(address),
             [&aggSig, &result, &sig_mutex, nettype = core.get_nettype()](
                     const BLSRequestResult& request_result, const std::vector<std::string>& data) {
-
                 BLSRewardsResponse response = {};
                 bool partially_parsed = true;
                 try {
@@ -271,32 +353,40 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                     oxenc::bt_dict_consumer d{data[1]};
 
-                    response.address = tools::make_from_guts<eth::address>(
-                            d.require<std::string_view>("address"));
+                    response.address =
+                            tools::make_from_guts<eth::address>(d.require<std::string_view>("addres"
+                                                                                            "s"));
                     response.amount = d.require<uint64_t>("amount");
                     response.height = d.require<uint64_t>("height");
                     response.signature = tools::make_from_guts<eth::bls_signature>(
                             d.require<std::string_view>("signature"));
 
                     if (response.address != result.address)
-                        throw oxen::traced<std::runtime_error>{"Response ETH address {} does not match the request address {}"_format(response.address, result.address)};
+                        throw oxen::traced<std::runtime_error>{
+                                "Response ETH address {} does not match the request address {}"_format(
+                                        response.address, result.address)};
                     if (response.amount != result.amount || response.height != result.height)
                         throw oxen::traced<std::runtime_error>{
-                                    "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
-                                            result.amount, result.height, response.amount, response.height)};
+                                "Balance/height mismatch: expected {}/{}, got {}/{}"_format(
+                                        result.amount,
+                                        result.height,
+                                        response.amount,
+                                        response.height)};
 
                     if (!BLSSigner::verifyMsg(
                                 nettype,
                                 response.signature,
                                 request_result.sn.bls_pubkey,
                                 result.msg_to_sign)) {
-                        throw oxen::traced<std::runtime_error>{"Invalid BLS signature for BLS pubkey {}."_format(
-                                request_result.sn.bls_pubkey)};
+                        throw oxen::traced<std::runtime_error>{
+                                "Invalid BLS signature for BLS pubkey {}."_format(
+                                        request_result.sn.bls_pubkey)};
                     }
 
                     {
                         std::lock_guard lock{sig_mutex};
-                        bls::Signature bls_sig = bls_utils::from_crypto_signature(response.signature);
+                        bls::Signature bls_sig =
+                                bls_utils::from_crypto_signature(response.signature);
                         aggSig.add(bls_sig);
                         result.signers_bls_pubkeys.push_back(request_result.sn.bls_pubkey);
                     }
@@ -305,7 +395,8 @@ BLSRewardsResponse BLSAggregator::rewards_request(
 
                     oxen::log::trace(
                             logcat,
-                            "Reward balance response accepted from {} (BLS {} XKEY {} {}:{})\nWe requested: {}\nThe response had: {}",
+                            "Reward balance response accepted from {} (BLS {} XKEY {} {}:{})\nWe "
+                            "requested: {}\nThe response had: {}",
                             request_result.sn.sn_pubkey,
                             request_result.sn.bls_pubkey,
                             request_result.sn.x_pubkey,
@@ -317,7 +408,8 @@ BLSRewardsResponse BLSAggregator::rewards_request(
                 } catch (const std::exception& e) {
                     oxen::log::warning(
                             logcat,
-                            "Reward balance response rejected from {}: {}\nWe requested: {}\nThe response had{}: {}",
+                            "Reward balance response rejected from {}: {}\nWe requested: {}\nThe "
+                            "response had{}: {}",
                             request_result.sn.sn_pubkey,
                             e.what(),
                             dump_bls_rewards_response(result),
@@ -346,105 +438,34 @@ BLSRewardsResponse BLSAggregator::rewards_request(
     return result;
 }
 
-static std::vector<uint8_t> get_exit_msg_to_sign(cryptonote::network_type nettype, BLSAggregator::ExitType type, const bls_public_key& exiting_pk, uint64_t unix_timestamp)
-{
-    // TODO(doyle): See BLSSigner::proofOfPossession
-    crypto::hash tag{};
-    std::vector<uint8_t> result;
-    if (type == BLSAggregator::ExitType::Normal) {
-        tag = BLSSigner::buildTagHash(BLSSigner::removalTag, nettype);
-        result.reserve(tag.size() + exiting_pk.size() + sizeof(unix_timestamp));
-        result.insert(result.end(), tag.begin(), tag.end());
-        result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
-        auto unix_timestamp_it = reinterpret_cast<uint8_t *>(&unix_timestamp);
-        result.insert(result.end(), unix_timestamp_it, unix_timestamp_it + sizeof(unix_timestamp));
-    } else {
-        assert(type == BLSAggregator::ExitType::Liquidate);
-        tag = BLSSigner::buildTagHash(BLSSigner::liquidateTag, nettype);
-        result.reserve(tag.size() + exiting_pk.size());
-        result.insert(result.end(), tag.begin(), tag.end());
-        result.insert(result.end(), exiting_pk.begin(), exiting_pk.end());
-    }
-    return result;
-}
-
-struct BLSExitRequest
-{
-    bool good;
-    bls_public_key exiting_pk;
-    std::chrono::seconds timestamp;
-};
-
-static BLSExitRequest extract_exit_request(oxenmq::Message& m)
-{
-    BLSExitRequest result{};
-    if (m.data.size() != 1) {
-        m.send_reply(
-                "400",
-                "Bad request: {} command should have one data part; received {}"_format(
-                        "BLS exit", m.data.size()));
-        return result;
-    }
-
-    try {
-        oxenc::bt_dict_consumer d{m.data[0]};
-        result.exiting_pk =
-                tools::make_from_guts<bls_public_key>(d.require<std::string_view>("bls_"
-                                                                                  "pubke"
-                                                                                  "y"));
-        result.timestamp = std::chrono::seconds(
-                tools::make_from_guts<uint64_t>(d.require<std::string_view>("timestamp")));
-    } catch (const std::exception& e) {
-        m.send_reply(
-                "400",
-                "Bad request: BLS exit command specified bad bls pubkey or timestamp: {}"_format(
-                        e.what()));
-        return result;
-    }
-
-    // NOTE: Check if the request is too old. If it's too old we will reject it
-    std::chrono::duration unix_now = std::chrono::high_resolution_clock::now().time_since_epoch();
-    std::chrono::duration time_since_initial_request =
-            result.timestamp > unix_now ? result.timestamp - unix_now : unix_now - result.timestamp;
-    if (time_since_initial_request > service_nodes::BLS_MAX_TIME_ALLOWED_FOR_EXIT_REQUEST) {
-        m.send_reply(
-                "400",
-                "Bad request: BLS exit was too old to consider signing, the request was {} old"_format(
-                        time_since_initial_request.count()));
-        return result;
-    }
-
-    result.good = true;
-    return result;
-}
-
-void BLSAggregator::get_exit(oxenmq::Message& m) {
-    oxen::log::trace(logcat, "Received omq exit signature request");
-    BLSExitRequest exit_request = extract_exit_request(m);
-    if (!exit_request.good)
+void BLSAggregator::get_removal(oxenmq::Message& m) {
+    oxen::log::trace(logcat, "Received omq removal signature request");
+    BLSRemovalRequest removal_request = extract_removal_request(m);
+    if (!removal_request.good)
         return;
 
     // right not its approving everything
-    if (!core.is_node_removable(exit_request.exiting_pk)) {
+    if (!core.is_node_removable(removal_request.remove_pk)) {
         m.send_reply(
                 "403",
-                "Forbidden: The BLS pubkey {} is not currently removable."_format(exit_request.exiting_pk));
+                "Forbidden: The BLS pubkey {} is not currently removable."_format(
+                        removal_request.remove_pk));
         return;
     }
 
     auto& signer = core.get_bls_signer();
 
-    std::vector<uint8_t> msg = get_exit_msg_to_sign(
+    std::vector<uint8_t> msg = get_removal_msg_to_sign(
             core.get_nettype(),
-            BLSAggregator::ExitType::Normal,
-            exit_request.exiting_pk,
-            exit_request.timestamp.count());
+            BLSAggregator::RemovalType::Normal,
+            removal_request.remove_pk,
+            removal_request.timestamp.count());
     bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
-    // exiting BLS pubkey:
-    d.append("exit", tools::view_guts(exit_request.exiting_pk));
-    // signature of *this* snode of the exiting pubkey:
+    // BLS pubkey to remove:
+    d.append("remove", tools::view_guts(removal_request.remove_pk));
+    // signature of *this* snode of the removing pubkey:
     d.append("signature", tools::view_guts(sig));
 
     m.send_reply("200", std::move(d).str());
@@ -452,41 +473,42 @@ void BLSAggregator::get_exit(oxenmq::Message& m) {
 
 void BLSAggregator::get_liquidation(oxenmq::Message& m) {
     oxen::log::trace(logcat, "Received omq liquidation signature request");
-    BLSExitRequest exit_request = extract_exit_request(m);
-    if (!exit_request.good)
+    BLSRemovalRequest removal_request = extract_removal_request(m);
+    if (!removal_request.good)
         return;
 
-    if (!core.is_node_liquidatable(exit_request.exiting_pk)) {
+    if (!core.is_node_liquidatable(removal_request.remove_pk)) {
         m.send_reply(
                 "403",
-                "Forbidden: The BLS key {} is not currently liquidatable"_format(exit_request.exiting_pk));
+                "Forbidden: The BLS key {} is not currently liquidatable"_format(
+                        removal_request.remove_pk));
         return;
     }
 
     auto& signer = core.get_bls_signer();
-    std::vector<uint8_t> msg = get_exit_msg_to_sign(
+    std::vector<uint8_t> msg = get_removal_msg_to_sign(
             core.get_nettype(),
-            BLSAggregator::ExitType::Liquidate,
-            exit_request.exiting_pk,
-            exit_request.timestamp.count());
+            BLSAggregator::RemovalType::Liquidate,
+            removal_request.remove_pk,
+            removal_request.timestamp.count());
     bls_signature sig = signer.signMsg(msg);
 
     oxenc::bt_dict_producer d;
     // BLS key of the node being liquidated:
-    d.append("liquidate", tools::view_guts(exit_request.exiting_pk));
+    d.append("liquidate", tools::view_guts(removal_request.remove_pk));
     // signature of *this* snode of the liquidating pubkey:
     d.append("signature", tools::view_guts(sig));
 
     m.send_reply("200", std::move(d).str());
 }
 
-// Common code for exit and liquidation requests, which only differ in three ways:
+// Common code for removal and liquidation requests, which only differ in three ways:
 // - the endpoint they go to;
 // - the tag that gets used in the msg_to_sign hash; and
 // - the key under which the signed pubkey gets confirmed back to us.
-AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
+AggregateRemovalResponse BLSAggregator::aggregateRemovalOrLiquidate(
         const eth::bls_public_key& bls_pubkey,
-        ExitType type,
+        RemovalType type,
         std::string_view endpoint,
         std::string_view pubkey_key) {
 
@@ -495,10 +517,11 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
     assert(pubkey_key < "signature");  // response dict keys must be processed in sorted order, and
                                        // we expect the pubkey to be in a key that comes first.
 
-    AggregateExitResponse result;
-    result.exit_pubkey = bls_pubkey;
-    result.timestamp   = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    result.msg_to_sign = get_exit_msg_to_sign(core.get_nettype(), type, bls_pubkey, result.timestamp);
+    AggregateRemovalResponse result;
+    result.remove_pubkey = bls_pubkey;
+    result.timestamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    result.msg_to_sign =
+            get_removal_msg_to_sign(core.get_nettype(), type, bls_pubkey, result.timestamp);
 
     std::mutex signers_mutex;
     bls::Signature aggSig;
@@ -519,9 +542,10 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
                                 "Request returned an error: {}"_format(fmt::join(data, " "))};
 
                     oxenc::bt_dict_consumer d{data[1]};
-                    if (result.exit_pubkey != tools::make_from_guts<bls_public_key>(
-                                                      d.require<std::string_view>(pubkey_key)))
-                        throw oxen::traced<std::runtime_error>{"BLS pubkey does not match the request"};
+                    if (result.remove_pubkey != tools::make_from_guts<bls_public_key>(
+                                                        d.require<std::string_view>(pubkey_key)))
+                        throw oxen::traced<std::runtime_error>{
+                                "BLS pubkey does not match the request"};
 
                     auto sig =
                             tools::make_from_guts<bls_signature>(d.require<std::string_view>("signa"
@@ -530,8 +554,9 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
 
                     if (!BLSSigner::verifyMsg(
                                 nettype, sig, request_result.sn.bls_pubkey, result.msg_to_sign)) {
-                        throw oxen::traced<std::runtime_error>{"Invalid BLS signature for BLS pubkey {}"_format(
-                                request_result.sn.bls_pubkey)};
+                        throw oxen::traced<std::runtime_error>{
+                                "Invalid BLS signature for BLS pubkey {}"_format(
+                                        request_result.sn.bls_pubkey)};
                     }
 
                     {
@@ -571,13 +596,14 @@ AggregateExitResponse BLSAggregator::aggregateExitOrLiquidate(
     return result;
 }
 
-AggregateExitResponse BLSAggregator::aggregateExit(const eth::bls_public_key& bls_pubkey) {
-    return aggregateExitOrLiquidate(bls_pubkey, BLSAggregator::ExitType::Normal, "bls.get_exit", "exit");
+AggregateRemovalResponse BLSAggregator::aggregateRemoval(const eth::bls_public_key& bls_pubkey) {
+    return aggregateRemovalOrLiquidate(
+            bls_pubkey, BLSAggregator::RemovalType::Normal, "bls.get_removal", "removal");
 }
 
-AggregateExitResponse BLSAggregator::aggregateLiquidation(const bls_public_key& bls_pubkey) {
-    return aggregateExitOrLiquidate(
-            bls_pubkey, BLSAggregator::ExitType::Liquidate, "bls.get_liquidation", "liquidate");
+AggregateRemovalResponse BLSAggregator::aggregateLiquidation(const bls_public_key& bls_pubkey) {
+    return aggregateRemovalOrLiquidate(
+            bls_pubkey, BLSAggregator::RemovalType::Liquidate, "bls.get_liquidation", "liquidate");
 }
 
 }  // namespace eth

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -17,8 +17,8 @@ struct AggregateSigned {
     bls_signature signature;
 };
 
-struct AggregateExitResponse : AggregateSigned {
-    bls_public_key exit_pubkey;
+struct AggregateRemovalResponse : AggregateSigned {
+    bls_public_key remove_pubkey;
     uint64_t timestamp;
 };
 
@@ -60,12 +60,12 @@ class BLSAggregator {
     /// amount is `0` or height is greater than the current blockchain height.
     BLSRewardsResponse rewards_request(const eth::address& address);
 
-    AggregateExitResponse aggregateExit(const bls_public_key& bls_pubkey);
-    AggregateExitResponse aggregateLiquidation(const bls_public_key& bls_pubkey);
+    AggregateRemovalResponse aggregateRemoval(const bls_public_key& bls_pubkey);
+    AggregateRemovalResponse aggregateLiquidation(const bls_public_key& bls_pubkey);
     BLSRegistrationResponse registration(
             const eth::address& sender, const crypto::public_key& serviceNodePubkey) const;
 
-    enum class ExitType
+    enum class RemovalType
     {
         Normal,
         Liquidate,
@@ -73,12 +73,12 @@ class BLSAggregator {
 
   private:
     void get_reward_balance(oxenmq::Message& m);
-    void get_exit(oxenmq::Message& m);
+    void get_removal(oxenmq::Message& m);
     void get_liquidation(oxenmq::Message& m);
 
-    AggregateExitResponse aggregateExitOrLiquidate(
+    AggregateRemovalResponse aggregateRemovalOrLiquidate(
             const bls_public_key& bls_pubkey,
-            ExitType type,
+            RemovalType type,
             std::string_view endpoint,
             std::string_view pubkey_key);
 

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -535,7 +535,7 @@ inline txversion transaction_prefix::get_max_version_for_hf(hf hf_version) {
 constexpr txtype transaction_prefix::get_max_type_for_hf(hf hf_version) {
     txtype result = txtype::standard;
     if (hf_version >= cryptonote::feature::ETH_BLS)
-        result = txtype::ethereum_service_node_deregister;
+        result = txtype::ethereum_service_node_liquidated;
     else if (hf_version >= hf::hf15_ons)
         result = txtype::oxen_name_system;
     else if (hf_version >= hf::hf14_blink)

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -535,7 +535,7 @@ inline txversion transaction_prefix::get_max_version_for_hf(hf hf_version) {
 constexpr txtype transaction_prefix::get_max_type_for_hf(hf hf_version) {
     txtype result = txtype::standard;
     if (hf_version >= cryptonote::feature::ETH_BLS)
-        result = txtype::ethereum_service_node_liquidated;
+        result = txtype::ethereum_service_node_removal;
     else if (hf_version >= hf::hf15_ons)
         result = txtype::oxen_name_system;
     else if (hf_version >= hf::hf14_blink)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -999,17 +999,6 @@ bool add_service_node_removal_to_tx_extra(
     return true;
 }
 //---------------------------------------------------------------
-bool add_service_node_liquidated_to_tx_extra(
-        std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_liquidated& liquidated) {
-    tx_extra_field field = liquidated;
-    if (!add_tx_extra_field_to_tx_extra(tx_extra, field)) {
-        log::info(logcat, "failed to serialize tx extra for service node liquidated transaction");
-        return false;
-    }
-    return true;
-}
-//---------------------------------------------------------------
 bool get_inputs_money_amount(const transaction& tx, uint64_t& money) {
     money = 0;
     for (const auto& in : tx.vin) {

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -977,10 +977,10 @@ bool add_new_service_node_to_tx_extra(
     return true;
 }
 //---------------------------------------------------------------
-bool add_service_node_leave_request_to_tx_extra(
+bool add_service_node_removal_request_to_tx_extra(
         std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_leave_request& leave_request) {
-    tx_extra_field field = leave_request;
+        const tx_extra_ethereum_service_node_removal_request& removal_request) {
+    tx_extra_field field = removal_request;
     if (!add_tx_extra_field_to_tx_extra(tx_extra, field)) {
         log::info(
                 logcat, "failed to serialize tx extra for service node leave request transaction");
@@ -989,22 +989,22 @@ bool add_service_node_leave_request_to_tx_extra(
     return true;
 }
 //---------------------------------------------------------------
-bool add_service_node_exit_to_tx_extra(
-        std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_service_node_exit& exit_data) {
-    tx_extra_field field = exit_data;
+bool add_service_node_removal_to_tx_extra(
+        std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_service_node_removal& removal_data) {
+    tx_extra_field field = removal_data;
     if (!add_tx_extra_field_to_tx_extra(tx_extra, field)) {
-        log::info(logcat, "failed to serialize tx extra for service node exit transaction");
+        log::info(logcat, "failed to serialize tx extra for service node removal transaction");
         return false;
     }
     return true;
 }
 //---------------------------------------------------------------
-bool add_service_node_deregister_to_tx_extra(
+bool add_service_node_liquidated_to_tx_extra(
         std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_deregister& deregister) {
-    tx_extra_field field = deregister;
+        const tx_extra_ethereum_service_node_liquidated& liquidated) {
+    tx_extra_field field = liquidated;
     if (!add_tx_extra_field_to_tx_extra(tx_extra, field)) {
-        log::info(logcat, "failed to serialize tx extra for service node deregister transaction");
+        log::info(logcat, "failed to serialize tx extra for service node liquidated transaction");
         return false;
     }
     return true;

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -191,14 +191,14 @@ bool get_encrypted_payment_id_from_tx_extra_nonce(
 bool add_burned_amount_to_tx_extra(std::vector<uint8_t>& tx_extra, uint64_t burn);
 bool add_new_service_node_to_tx_extra(
         std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_new_service_node& new_service_node);
-bool add_service_node_leave_request_to_tx_extra(
+bool add_service_node_removal_request_to_tx_extra(
         std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_leave_request& leave_request);
-bool add_service_node_exit_to_tx_extra(
-        std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_service_node_exit& exit_data);
-bool add_service_node_deregister_to_tx_extra(
+        const tx_extra_ethereum_service_node_removal_request& removal_request);
+bool add_service_node_removal_to_tx_extra(
+        std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_service_node_removal& removal_data);
+bool add_service_node_liquidated_to_tx_extra(
         std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_deregister& deregister);
+        const tx_extra_ethereum_service_node_liquidated& liquidated);
 uint64_t get_burned_amount_from_tx_extra(const std::vector<uint8_t>& tx_extra);
 bool is_out_to_acc(
         const account_keys& acc,

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -196,9 +196,6 @@ bool add_service_node_removal_request_to_tx_extra(
         const tx_extra_ethereum_service_node_removal_request& removal_request);
 bool add_service_node_removal_to_tx_extra(
         std::vector<uint8_t>& tx_extra, const tx_extra_ethereum_service_node_removal& removal_data);
-bool add_service_node_liquidated_to_tx_extra(
-        std::vector<uint8_t>& tx_extra,
-        const tx_extra_ethereum_service_node_liquidated& liquidated);
 uint64_t get_burned_amount_from_tx_extra(const std::vector<uint8_t>& tx_extra);
 bool is_out_to_acc(
         const account_keys& acc,

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -685,16 +685,6 @@ struct tx_extra_ethereum_service_node_removal {
     END_SERIALIZE()
 };
 
-struct tx_extra_ethereum_service_node_liquidated {
-    uint8_t version = 0;
-    eth::bls_public_key bls_pubkey;
-
-    BEGIN_SERIALIZE()
-    FIELD(version)
-    FIELD(bls_pubkey)
-    END_SERIALIZE()
-};
-
 // tx_extra_field format, except tx_extra_padding and tx_extra_pub_key:
 //   varint tag;
 //   varint size;
@@ -723,7 +713,6 @@ using tx_extra_field = std::variant<
         tx_extra_ethereum_new_service_node,
         tx_extra_ethereum_service_node_removal_request,
         tx_extra_ethereum_service_node_removal,
-        tx_extra_ethereum_service_node_liquidated,
         tx_extra_padding>;
 }  // namespace cryptonote
 
@@ -770,6 +759,3 @@ BINARY_VARIANT_TAG(
 BINARY_VARIANT_TAG(
         cryptonote::tx_extra_ethereum_service_node_removal,
         cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_REMOVAL);
-BINARY_VARIANT_TAG(
-        cryptonote::tx_extra_ethereum_service_node_liquidated,
-        cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_DEREGISTER);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -56,9 +56,9 @@ constexpr uint8_t TX_EXTRA_TAG_PADDING = 0x00, TX_EXTRA_TAG_PUBKEY = 0x01, TX_EX
                   TX_EXTRA_TAG_SERVICE_NODE_STATE_CHANGE = 0x78, TX_EXTRA_TAG_BURN = 0x79,
                   TX_EXTRA_TAG_OXEN_NAME_SYSTEM = 0x7A,
                   TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE = 0x7C,
-                  TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_LEAVE_REQUEST = 0x7D,
+                  TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_REMOVAL_REQUEST = 0x7D,
                   TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_DEREGISTER = 0x7E,
-                  TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT = 0x7F,
+                  TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_REMOVAL = 0x7F,
 
                   TX_EXTRA_MYSTERIOUS_MINERGATE_TAG = 0xDE;
 
@@ -661,7 +661,7 @@ struct tx_extra_ethereum_new_service_node {
     END_SERIALIZE()
 };
 
-struct tx_extra_ethereum_service_node_leave_request {
+struct tx_extra_ethereum_service_node_removal_request {
     uint8_t version = 0;
     eth::bls_public_key bls_pubkey;
 
@@ -671,7 +671,7 @@ struct tx_extra_ethereum_service_node_leave_request {
     END_SERIALIZE()
 };
 
-struct tx_extra_ethereum_service_node_exit {
+struct tx_extra_ethereum_service_node_removal {
     uint8_t version = 0;
     eth::address eth_address;
     uint64_t amount;
@@ -685,7 +685,7 @@ struct tx_extra_ethereum_service_node_exit {
     END_SERIALIZE()
 };
 
-struct tx_extra_ethereum_service_node_deregister {
+struct tx_extra_ethereum_service_node_liquidated {
     uint8_t version = 0;
     eth::bls_public_key bls_pubkey;
 
@@ -721,9 +721,9 @@ using tx_extra_field = std::variant<
         tx_extra_merge_mining_tag,
         tx_extra_mysterious_minergate,
         tx_extra_ethereum_new_service_node,
-        tx_extra_ethereum_service_node_leave_request,
-        tx_extra_ethereum_service_node_exit,
-        tx_extra_ethereum_service_node_deregister,
+        tx_extra_ethereum_service_node_removal_request,
+        tx_extra_ethereum_service_node_removal,
+        tx_extra_ethereum_service_node_liquidated,
         tx_extra_padding>;
 }  // namespace cryptonote
 
@@ -765,11 +765,11 @@ BINARY_VARIANT_TAG(
         cryptonote::tx_extra_ethereum_new_service_node,
         cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE);
 BINARY_VARIANT_TAG(
-        cryptonote::tx_extra_ethereum_service_node_leave_request,
-        cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_LEAVE_REQUEST);
+        cryptonote::tx_extra_ethereum_service_node_removal_request,
+        cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_REMOVAL_REQUEST);
 BINARY_VARIANT_TAG(
-        cryptonote::tx_extra_ethereum_service_node_exit,
-        cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT);
+        cryptonote::tx_extra_ethereum_service_node_removal,
+        cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_REMOVAL);
 BINARY_VARIANT_TAG(
-        cryptonote::tx_extra_ethereum_service_node_deregister,
+        cryptonote::tx_extra_ethereum_service_node_liquidated,
         cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_DEREGISTER);

--- a/src/cryptonote_basic/txtypes.h
+++ b/src/cryptonote_basic/txtypes.h
@@ -25,9 +25,9 @@ enum class txtype : uint16_t {
     stake,
     oxen_name_system,
     ethereum_new_service_node,
-    ethereum_service_node_leave_request,
-    ethereum_service_node_exit,
-    ethereum_service_node_deregister,
+    ethereum_service_node_removal_request,
+    ethereum_service_node_removal,
+    ethereum_service_node_liquidated,
     _count
 };
 
@@ -49,10 +49,10 @@ inline constexpr std::string_view to_string(txtype type) {
         case txtype::stake: return "stake"sv;
         case txtype::oxen_name_system: return "oxen_name_system"sv;
         case txtype::ethereum_new_service_node: return "ethereum_new_service_node"sv;
-        case txtype::ethereum_service_node_leave_request:
-            return "ethereum_service_node_leave_request"sv;
-        case txtype::ethereum_service_node_exit: return "ethereum_service_node_exit"sv;
-        case txtype::ethereum_service_node_deregister: return "ethereum_service_node_deregister"sv;
+        case txtype::ethereum_service_node_removal_request:
+            return "ethereum_service_node_removal_request"sv;
+        case txtype::ethereum_service_node_removal: return "ethereum_service_node_removal"sv;
+        case txtype::ethereum_service_node_liquidated: return "ethereum_service_node_liquidated"sv;
         default: assert(false); return "xx_unhandled_type"sv;
     }
 }

--- a/src/cryptonote_basic/txtypes.h
+++ b/src/cryptonote_basic/txtypes.h
@@ -27,7 +27,6 @@ enum class txtype : uint16_t {
     ethereum_new_service_node,
     ethereum_service_node_removal_request,
     ethereum_service_node_removal,
-    ethereum_service_node_liquidated,
     _count
 };
 
@@ -52,7 +51,6 @@ inline constexpr std::string_view to_string(txtype type) {
         case txtype::ethereum_service_node_removal_request:
             return "ethereum_service_node_removal_request"sv;
         case txtype::ethereum_service_node_removal: return "ethereum_service_node_removal"sv;
-        case txtype::ethereum_service_node_liquidated: return "ethereum_service_node_liquidated"sv;
         default: assert(false); return "xx_unhandled_type"sv;
     }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -270,6 +270,7 @@ namespace feature {
     constexpr auto PROOF_BTENC = hf::hf18;
     constexpr auto ETH_TRANSITION = hf::hf20_eth_transition;
     constexpr auto ETH_BLS = hf::hf21_eth;
+    constexpr auto SN_PK_IS_ED25519 = hf::hf21_eth;
 }  // namespace feature
 
 enum class network_type : uint8_t { MAINNET = 0, TESTNET, DEVNET, STAGENET, LOCALDEV, FAKECHAIN, UNDEFINED = 255 };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4107,43 +4107,43 @@ bool Blockchain::check_tx_inputs(
                 tvc.m_verbose_error = std::move(fail_reason);
                 return false;
             }
-        } else if (tx.type == txtype::ethereum_service_node_leave_request) {
-            cryptonote::tx_extra_ethereum_service_node_leave_request entry = {};
+        } else if (tx.type == txtype::ethereum_service_node_removal_request) {
+            cryptonote::tx_extra_ethereum_service_node_removal_request entry = {};
             std::string fail_reason;
-            if (!eth::validate_ethereum_service_node_leave_request_tx(
+            if (!eth::validate_ethereum_service_node_removal_request_tx(
                         hf_version, get_current_blockchain_height(), tx, entry, &fail_reason) ||
                 (ethereum_transaction_review_session &&
-                 !ethereum_transaction_review_session->processServiceNodeLeaveRequestTx(
+                 !ethereum_transaction_review_session->processServiceNodeRemovalRequestTx(
                          entry.bls_pubkey, fail_reason))) {
                 log::error(
                         log::Cat("verify"),
-                        "Failed to validate Ethereum Service Node Leave Request TX reason: {}",
+                        "Failed to validate Ethereum Service Node Removal Request TX reason: {}",
                         fail_reason);
                 tvc.m_verbose_error = std::move(fail_reason);
                 return false;
             }
-        } else if (tx.type == txtype::ethereum_service_node_exit) {
-            cryptonote::tx_extra_ethereum_service_node_exit entry = {};
+        } else if (tx.type == txtype::ethereum_service_node_removal) {
+            cryptonote::tx_extra_ethereum_service_node_removal entry = {};
             std::string fail_reason;
-            if (!eth::validate_ethereum_service_node_exit_tx(
+            if (!eth::validate_ethereum_service_node_removal_tx(
                         hf_version, get_current_blockchain_height(), tx, entry, &fail_reason) ||
                 (ethereum_transaction_review_session &&
-                 !ethereum_transaction_review_session->processServiceNodeExitTx(
+                 !ethereum_transaction_review_session->processServiceNodeRemovalTx(
                          entry.eth_address, entry.amount, entry.bls_pubkey, fail_reason))) {
                 log::error(
                         log::Cat("verify"),
-                        "Failed to validate Ethereum Service Node Exit TX reason: {}",
+                        "Failed to validate Ethereum Service Node Removal TX reason: {}",
                         fail_reason);
                 tvc.m_verbose_error = std::move(fail_reason);
                 return false;
             }
-        } else if (tx.type == txtype::ethereum_service_node_deregister) {
-            cryptonote::tx_extra_ethereum_service_node_deregister entry = {};
+        } else if (tx.type == txtype::ethereum_service_node_liquidated) {
+            cryptonote::tx_extra_ethereum_service_node_liquidated entry = {};
             std::string fail_reason;
-            if (!eth::validate_ethereum_service_node_deregister_tx(
+            if (!eth::validate_ethereum_service_node_liquidated_tx(
                         hf_version, get_current_blockchain_height(), tx, entry, &fail_reason) ||
                 (ethereum_transaction_review_session &&
-                 !ethereum_transaction_review_session->processServiceNodeDeregisterTx(
+                 !ethereum_transaction_review_session->processServiceNodeLiquidatedTx(
                          entry.bls_pubkey, fail_reason))) {
                 log::error(
                         log::Cat("verify"),
@@ -4242,7 +4242,7 @@ bool Blockchain::check_tx_inputs(
 
             // Otherwise is a locked key image, if the unlock_height is set, it has been previously
             // requested to unlock
-            if (unlock_height != service_nodes::KEY_IMAGE_AWAITING_UNLOCK_HEIGHT) {
+            if (unlock_height) {
                 tvc.m_double_spend = true;
                 return false;
             }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4137,21 +4137,6 @@ bool Blockchain::check_tx_inputs(
                 tvc.m_verbose_error = std::move(fail_reason);
                 return false;
             }
-        } else if (tx.type == txtype::ethereum_service_node_liquidated) {
-            cryptonote::tx_extra_ethereum_service_node_liquidated entry = {};
-            std::string fail_reason;
-            if (!eth::validate_ethereum_service_node_liquidated_tx(
-                        hf_version, get_current_blockchain_height(), tx, entry, &fail_reason) ||
-                (ethereum_transaction_review_session &&
-                 !ethereum_transaction_review_session->processServiceNodeLiquidatedTx(
-                         entry.bls_pubkey, fail_reason))) {
-                log::error(
-                        log::Cat("verify"),
-                        "Failed to validate Ethereum Service Node Deregister TX reason: {}",
-                        fail_reason);
-                tvc.m_verbose_error = std::move(fail_reason);
-                return false;
-            }
         } else if (tx.type == txtype::state_change) {
             tx_extra_service_node_state_change state_change;
             if (!get_service_node_state_change_from_tx_extra(tx.extra, state_change, hf_version)) {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2793,12 +2793,12 @@ eth::BLSRewardsResponse core::bls_rewards_request(const eth::address& address) {
     return m_bls_aggregator->rewards_request(address);
 }
 //-----------------------------------------------------------------------------------------------
-eth::AggregateExitResponse core::aggregate_exit_request(const eth::bls_public_key& bls_pubkey) {
-    const auto resp = m_bls_aggregator->aggregateExit(bls_pubkey);
+eth::AggregateRemovalResponse core::aggregate_removal_request(const eth::bls_public_key& bls_pubkey) {
+    const auto resp = m_bls_aggregator->aggregateRemoval(bls_pubkey);
     return resp;
 }
 //-----------------------------------------------------------------------------------------------
-eth::AggregateExitResponse core::aggregate_liquidation_request(
+eth::AggregateRemovalResponse core::aggregate_liquidation_request(
         const eth::bls_public_key& bls_pubkey) {
     const auto resp = m_bls_aggregator->aggregateLiquidation(bls_pubkey);
     return resp;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1065,7 +1065,10 @@ bool core::init_service_keys() {
 
     auto style = fg(fmt::terminal_color::yellow) | fmt::emphasis::bold;
     if (m_service_node) {
-        log::info(globallogcat, fg(fmt::terminal_color::cyan) | fmt::emphasis::bold, "Service node public keys:");
+        log::info(
+                globallogcat,
+                fg(fmt::terminal_color::cyan) | fmt::emphasis::bold,
+                "Service node public keys:");
         log::info(globallogcat, style, "- primary: {:x}", keys.pub);
         log::info(globallogcat, style, "- ed25519: {:x}", keys.pub_ed25519);
         // .snode address is the ed25519 pubkey, encoded with base32z and with .snode appended:
@@ -1105,8 +1108,7 @@ oxenmq::AuthLevel core::omq_allow(
     using namespace oxenmq;
     AuthLevel auth = default_auth;
     if (x25519_pubkey_str.size() == sizeof(crypto::x25519_public_key)) {
-        crypto::x25519_public_key x25519_pubkey;
-        std::memcpy(x25519_pubkey.data(), x25519_pubkey_str.data(), x25519_pubkey_str.size());
+        auto x25519_pubkey = tools::make_from_guts<crypto::x25519_public_key>(x25519_pubkey_str);
         auto user_auth = omq_check_access(x25519_pubkey);
         if (user_auth >= AuthLevel::basic) {
             if (user_auth > auth)
@@ -2488,7 +2490,7 @@ bool core::check_incoming_block_size(const std::string& block_blob) const {
 void core::update_omq_sns() {
     // TODO: let callers (e.g. lokinet, ss) subscribe to callbacks when this fires
     oxenmq::pubkey_set active_sns;
-    m_service_node_list.copy_active_x25519_pubkeys(std::inserter(active_sns, active_sns.end()));
+    m_service_node_list.copy_x25519_pubkeys(std::inserter(active_sns, active_sns.end()), m_nettype);
     m_omq->set_active_sns(std::move(active_sns));
 }
 //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -940,8 +940,8 @@ class core : public i_miner_handler {
     get_service_node_blacklisted_key_images() const;
 
     eth::BLSRewardsResponse bls_rewards_request(const eth::address& address);
-    eth::AggregateExitResponse aggregate_exit_request(const eth::bls_public_key& bls_pubkey);
-    eth::AggregateExitResponse aggregate_liquidation_request(const eth::bls_public_key& bls_pubkey);
+    eth::AggregateRemovalResponse aggregate_removal_request(const eth::bls_public_key& bls_pubkey);
+    eth::AggregateRemovalResponse aggregate_liquidation_request(const eth::bls_public_key& bls_pubkey);
     eth::BLSRegistrationResponse bls_registration(
             const eth::address& ethereum_address, const uint64_t fee = 0) const;
 

--- a/src/cryptonote_core/ethereum_transactions.cpp
+++ b/src/cryptonote_core/ethereum_transactions.cpp
@@ -98,31 +98,4 @@ bool validate_ethereum_service_node_removal_tx(
     return true;
 }
 
-bool validate_ethereum_service_node_liquidated_tx(
-        hf hf_version,
-        uint64_t blockchain_height,
-        cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_liquidated& eth_extra,
-        std::string* reason) {
-
-    {
-        if (check_condition(
-                    tx.type != cryptonote::txtype::ethereum_service_node_liquidated,
-                    reason,
-                    "{} uses wrong tx type, expected={}",
-                    tx,
-                    cryptonote::txtype::ethereum_service_node_liquidated))
-            return false;
-
-        if (check_condition(
-                    !cryptonote::get_field_from_tx_extra(tx.extra, eth_extra),
-                    reason,
-                    "{} didn't have ethereum service node liquidated data in the tx_extra",
-                    tx))
-            return false;
-    }
-
-    return true;
-}
-
 }  // namespace eth

--- a/src/cryptonote_core/ethereum_transactions.cpp
+++ b/src/cryptonote_core/ethereum_transactions.cpp
@@ -44,26 +44,26 @@ bool validate_ethereum_new_service_node_tx(
     return true;
 }
 
-bool validate_ethereum_service_node_leave_request_tx(
+bool validate_ethereum_service_node_removal_request_tx(
         hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_leave_request& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_removal_request& eth_extra,
         std::string* reason) {
 
     {
         if (check_condition(
-                    tx.type != cryptonote::txtype::ethereum_service_node_leave_request,
+                    tx.type != cryptonote::txtype::ethereum_service_node_removal_request,
                     reason,
                     "{} uses wrong tx type, expected={}",
                     tx,
-                    cryptonote::txtype::ethereum_service_node_leave_request))
+                    cryptonote::txtype::ethereum_service_node_removal_request))
             return false;
 
         if (check_condition(
                     !cryptonote::get_field_from_tx_extra(tx.extra, eth_extra),
                     reason,
-                    "{} didn't have ethereum service node leave request data in the tx_extra",
+                    "{} didn't have ethereum service node removal request data in the tx_extra",
                     tx))
             return false;
     }
@@ -71,26 +71,26 @@ bool validate_ethereum_service_node_leave_request_tx(
     return true;
 }
 
-bool validate_ethereum_service_node_exit_tx(
+bool validate_ethereum_service_node_removal_tx(
         hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_exit& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_removal& eth_extra,
         std::string* reason) {
 
     {
         if (check_condition(
-                    tx.type != cryptonote::txtype::ethereum_service_node_exit,
+                    tx.type != cryptonote::txtype::ethereum_service_node_removal,
                     reason,
                     "{} uses wrong tx type, expected={}",
                     tx,
-                    cryptonote::txtype::ethereum_service_node_exit))
+                    cryptonote::txtype::ethereum_service_node_removal))
             return false;
 
         if (check_condition(
                     !cryptonote::get_field_from_tx_extra(tx.extra, eth_extra),
                     reason,
-                    "{} didn't have ethereum service node exit data in the tx_extra",
+                    "{} didn't have ethereum service node removal data in the tx_extra",
                     tx))
             return false;
     }
@@ -98,26 +98,26 @@ bool validate_ethereum_service_node_exit_tx(
     return true;
 }
 
-bool validate_ethereum_service_node_deregister_tx(
+bool validate_ethereum_service_node_liquidated_tx(
         hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_deregister& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_liquidated& eth_extra,
         std::string* reason) {
 
     {
         if (check_condition(
-                    tx.type != cryptonote::txtype::ethereum_service_node_deregister,
+                    tx.type != cryptonote::txtype::ethereum_service_node_liquidated,
                     reason,
                     "{} uses wrong tx type, expected={}",
                     tx,
-                    cryptonote::txtype::ethereum_service_node_deregister))
+                    cryptonote::txtype::ethereum_service_node_liquidated))
             return false;
 
         if (check_condition(
                     !cryptonote::get_field_from_tx_extra(tx.extra, eth_extra),
                     reason,
-                    "{} didn't have ethereum service node deregister data in the tx_extra",
+                    "{} didn't have ethereum service node liquidated data in the tx_extra",
                     tx))
             return false;
     }

--- a/src/cryptonote_core/ethereum_transactions.h
+++ b/src/cryptonote_core/ethereum_transactions.h
@@ -30,11 +30,4 @@ bool validate_ethereum_service_node_removal_tx(
         cryptonote::tx_extra_ethereum_service_node_removal& eth_extra,
         std::string* reason);
 
-bool validate_ethereum_service_node_liquidated_tx(
-        cryptonote::hf hf_version,
-        uint64_t blockchain_height,
-        cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_liquidated& eth_extra,
-        std::string* reason);
-
 }  // namespace eth

--- a/src/cryptonote_core/ethereum_transactions.h
+++ b/src/cryptonote_core/ethereum_transactions.h
@@ -16,25 +16,25 @@ bool validate_ethereum_new_service_node_tx(
         cryptonote::tx_extra_ethereum_new_service_node& eth_extra,
         std::string* reason);
 
-bool validate_ethereum_service_node_leave_request_tx(
+bool validate_ethereum_service_node_removal_request_tx(
         cryptonote::hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_leave_request& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_removal_request& eth_extra,
         std::string* reason);
 
-bool validate_ethereum_service_node_exit_tx(
+bool validate_ethereum_service_node_removal_tx(
         cryptonote::hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_exit& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_removal& eth_extra,
         std::string* reason);
 
-bool validate_ethereum_service_node_deregister_tx(
+bool validate_ethereum_service_node_liquidated_tx(
         cryptonote::hf hf_version,
         uint64_t blockchain_height,
         cryptonote::transaction const& tx,
-        cryptonote::tx_extra_ethereum_service_node_deregister& eth_extra,
+        cryptonote::tx_extra_ethereum_service_node_liquidated& eth_extra,
         std::string* reason);
 
 }  // namespace eth

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2854,7 +2854,7 @@ void service_node_list::state_t::update_from_block(
             continue;
         if (my_keys && my_keys->pub == pubkey)
             log::info(
-                    logcat,
+                    globallogcat,
                     fg(fmt::terminal_color::green),
                     "Service node expired (yours): {} at block height: {}",
                     pubkey,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -966,7 +966,7 @@ bool service_node_list::state_t::process_state_change_tx(
                 }
             }
 
-            service_nodes_infos.erase(iter);
+            erase_info(iter);
             return true;
 
         case new_state::decommission:
@@ -1145,7 +1145,7 @@ bool service_node_list::state_t::process_ethereum_deregister_tx(
     else
         log::info(logcat, "Deregistration for service node: {}", snode_key);
 
-    service_nodes_infos.erase(iter);
+    erase_info(iter);
     return true;
 }
 
@@ -1674,7 +1674,7 @@ bool service_node_list::state_t::process_registration_tx(
         }
     }
 
-    service_nodes_infos[key] = std::move(info_ptr);
+    insert_info(key, std::move(info_ptr));
     return true;
 }
 
@@ -1688,7 +1688,7 @@ bool service_node_list::state_t::process_ethereum_registration_tx(
     uint64_t const block_height = cryptonote::get_block_height(block);
 
     try {
-        const auto [key, service_node_info] = validate_and_get_ethereum_registration(
+        auto [key, service_node_info] = validate_and_get_ethereum_registration(
                 nettype, hf_version, tx, block.timestamp, block_height, index);
         // TODO sean -> explore what happens if registration contains duplicate service node pubkey?
         if (sn_list && !sn_list->m_rescanning) {
@@ -1709,7 +1709,7 @@ bool service_node_list::state_t::process_ethereum_registration_tx(
                     "New service node registered from ethereum: {} on height: {}",
                     key,
                     block_height);
-        service_nodes_infos[key] = std::move(service_node_info);
+        insert_info(key, std::move(service_node_info));
         return true;
     } catch (const std::exception& e) {
         log::error(logcat, "Failed to register node from ethereum transaction: {}", e.what());
@@ -2765,6 +2765,18 @@ static void generate_other_quorums(
     }
 }
 
+// Converts an Ed25519 public key to an x25519 pubkey.  Only intended for use with hf >=
+// feature::SN_PK_IS_ED25519 (because before that we don't have a guarantee that a
+// crypto::public_key is actually the correct Ed25519 pubkeys that we want to convert to get the
+// X25519 pubkey).
+static crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk) {
+    crypto::x25519_public_key xpk;
+    if (0 != crypto_sign_ed25519_pk_to_curve25519(xpk.data(), snpk.data()))
+        throw oxen::traced<std::runtime_error>{
+                "Unable to convert SN Ed25519 pubkey {} to X25519 pubkey"_format(snpk)};
+    return xpk;
+}
+
 void service_node_list::state_t::update_from_block(
         cryptonote::BlockchainDB const& db,
         cryptonote::network_type nettype,
@@ -2775,6 +2787,11 @@ void service_node_list::state_t::update_from_block(
         const std::vector<cryptonote::transaction>& txs,
         const service_node_keys* my_keys) {
     ++height;
+    log::debug(
+            logcat,
+            "Updating state_t{} from block for height {}",
+            sn_list ? "" : " (without sn_list yet)",
+            height);
     bool need_swarm_update = false;
     uint64_t block_height = cryptonote::get_block_height(block);
     assert(height == block_height);
@@ -2806,8 +2823,7 @@ void service_node_list::state_t::update_from_block(
             for (size_t quorum_index = 0; quorum_index < pulse_quorum.validators.size();
                  quorum_index++) {
                 crypto::public_key const& key = pulse_quorum.validators[quorum_index];
-                auto& info_ptr = service_nodes_infos[key];
-                service_node_info& new_info = duplicate_info(info_ptr);
+                service_node_info& new_info = duplicate_info(service_nodes_infos[key]);
                 new_info.pulse_sorter.last_height_validating_in_quorum = height;
                 new_info.pulse_sorter.quorum_index = quorum_index;
             }
@@ -2834,28 +2850,28 @@ void service_node_list::state_t::update_from_block(
     for (const crypto::public_key& pubkey :
          get_expired_nodes(db, nettype, block.major_version, block_height)) {
         auto i = service_nodes_infos.find(pubkey);
-        if (i != service_nodes_infos.end()) {
-            if (my_keys && my_keys->pub == pubkey)
-                log::info(
-                        logcat,
-                        fg(fmt::terminal_color::green),
-                        "Service node expired (yours): {} at block height: {}",
-                        pubkey,
-                        block_height);
-            else
-                log::info(
-                        logcat,
-                        "Service node expired: {} at block height: {}",
-                        pubkey,
-                        block_height);
+        if (i == service_nodes_infos.end())
+            continue;
+        if (my_keys && my_keys->pub == pubkey)
+            log::info(
+                    logcat,
+                    fg(fmt::terminal_color::green),
+                    "Service node expired (yours): {} at block height: {}",
+                    pubkey,
+                    block_height);
+        else
+            log::info(
+                    logcat,
+                    "Service node expired: {} at block height: {}",
+                    pubkey,
+                    block_height);
 
-            need_swarm_update = need_swarm_update || i->second->is_active();
-            // NOTE: sn_list is not set in tests when we construct events to replay
-            if (sn_list)
-                sn_list->recently_expired_nodes.emplace(
-                        i->second->bls_public_key, block_height + netconf.ETH_EXIT_BUFFER);
-            service_nodes_infos.erase(i);
-        }
+        need_swarm_update = need_swarm_update || i->second->is_active();
+        // NOTE: sn_list is not set in tests when we construct events to replay
+        if (sn_list)
+            sn_list->recently_expired_nodes.emplace(
+                    i->second->bls_public_key, block_height + netconf.ETH_EXIT_BUFFER);
+        erase_info(i);
     }
 
     //
@@ -2882,20 +2898,27 @@ void service_node_list::state_t::update_from_block(
     for (uint32_t index = 0; index < txs.size(); ++index) {
         const cryptonote::transaction& tx = txs[index];
         if (tx.type == staking_tx_type) {
+            log::debug(logcat, "Processing registration tx");
             process_registration_tx(nettype, block, tx, index, my_keys);
             need_swarm_update += process_contribution_tx(nettype, block, tx, index);
         } else if (tx.type == cryptonote::txtype::state_change) {
+            log::debug(logcat, "Processing state change tx");
             need_swarm_update += process_state_change_tx(
                     state_history, state_archive, alt_states, nettype, block, tx, my_keys);
         } else if (tx.type == cryptonote::txtype::key_image_unlock) {
+            log::debug(logcat, "Processing key image unlock tx");
             process_key_image_unlock_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_new_service_node) {
+            log::debug(logcat, "Processing eth registration tx");
             process_ethereum_registration_tx(nettype, block, tx, index, my_keys);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_leave_request) {
+            log::debug(logcat, "Processing eth unlock tx");
             process_ethereum_unlock_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_exit) {
+            log::debug(logcat, "Processing eth exit tx");
             process_ethereum_exit_tx(nettype, hf_version, block_height, tx);
         } else if (tx.type == cryptonote::txtype::ethereum_service_node_deregister) {
+            log::debug(logcat, "Processing eth deregister tx");
             process_ethereum_deregister_tx(nettype, hf_version, block_height, tx, my_keys);
         }
     }
@@ -2927,6 +2950,12 @@ void service_node_list::state_t::update_from_block(
         }
     }
     generate_other_quorums(*this, active_snode_list, nettype, hf_version);
+
+    // If our x25519 map is empty then try populating it (which only does something if we're into
+    // the unified-pubkey-and-ed-pubkey hardfork).  In normal operation, this only happens once (for
+    // the first post-unified-keys hard fork state block).
+    if (x25519_map.empty())
+        initialize_xpk_map();
 }
 
 void service_node_list::process_block(
@@ -2956,8 +2985,9 @@ void service_node_list::process_block(
                 m_transient.state_added_to_archive = true;
                 if (need_quorum_for_future_states)  // Preserve just quorum
                 {
-                    state_t& state = const_cast<state_t&>(
-                            *it);  // safe: set order only depends on state_t.height
+                    // This const cast is a little ugly, but is safe because we don't touch
+                    // state_t.height (which is all the set order depends on).
+                    state_t& state = const_cast<state_t&>(*it);
                     state.service_nodes_infos = {};
                     state.key_image_blacklist = {};
                     state.only_loaded_quorums = true;
@@ -3843,7 +3873,7 @@ bool service_node_list::handle_uptime_proof(
         return false;
     }
 
-    if (vers.first >= feature::ETH_BLS) {
+    if (vers.first >= feature::SN_PK_IS_ED25519) {
         // Starting at the ETH_BLS hard fork we prohibit proofs with differing pubkey/ed25519
         // pubkey; any mixed node registrations get updated as part of the HF transition.
         if (tools::view_guts(proof->pubkey) != tools::view_guts(proof->pubkey_ed25519)) {
@@ -3852,7 +3882,7 @@ bool service_node_list::handle_uptime_proof(
                     "Rejecting uptime proof from {}: pubkey != pubkey_ed25519 is not allowed since "
                     "HF{}",
                     proof->pubkey,
-                    static_cast<uint8_t>(feature::ETH_BLS));
+                    static_cast<uint8_t>(feature::SN_PK_IS_ED25519));
             return false;
         }
     }
@@ -3885,7 +3915,7 @@ bool service_node_list::handle_uptime_proof(
     assert(proof->proof_hash);  // This gets set during parsing of an incoming proof
     const auto& hash = proof->proof_hash;
 
-    if (vers.first < feature::ETH_BLS) {
+    if (vers.first < feature::SN_PK_IS_ED25519) {
         // pre-ETH_BLS includes a Monero-style (i.e. wrongly computed, though cryptographically
         // equivalent) Ed25519 signature signed by `pubkey`.  (Post-ETH_BLS sends and uses only the
         // proper Ed25519 signature, and requires the pubkeys be the same).
@@ -4030,23 +4060,25 @@ bool service_node_list::handle_uptime_proof(
         iproof.store(iproof.proof->pubkey, m_blockchain);
     }
 
-    if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
-        time_t cutoff = std::chrono::system_clock::to_time_t(now - X25519_MAP_PRUNING_LAG);
-        std::erase_if(x25519_to_pub, [&cutoff](const decltype(x25519_to_pub)::value_type& x) {
-            return x.second.second < cutoff;
-        });
-        x25519_map_last_pruned = now;
+    if (vers.first < feature::SN_PK_IS_ED25519) {
+        if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
+            time_t cutoff = std::chrono::system_clock::to_time_t(now - X25519_MAP_PRUNING_LAG);
+            std::erase_if(x25519_to_pub, [&cutoff](const auto& x) {
+                return x.second.second < cutoff;
+            });
+            x25519_map_last_pruned = now;
+        }
+
+        if (old_x25519 && old_x25519 != derived_x25519_pubkey)
+            x25519_to_pub.erase(old_x25519);
+
+        if (derived_x25519_pubkey)
+            x25519_to_pub[derived_x25519_pubkey] = {
+                    iproof.proof->pubkey, std::chrono::system_clock::to_time_t(now)};
+
+        if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
+            x25519_pkey = derived_x25519_pubkey;
     }
-
-    if (old_x25519 && old_x25519 != derived_x25519_pubkey)
-        x25519_to_pub.erase(old_x25519);
-
-    if (derived_x25519_pubkey)
-        x25519_to_pub[derived_x25519_pubkey] = {
-                iproof.proof->pubkey, std::chrono::system_clock::to_time_t(now)};
-
-    if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
-        x25519_pkey = derived_x25519_pubkey;
 
     return true;
 }
@@ -4073,24 +4105,34 @@ void service_node_list::cleanup_proofs() {
 
 crypto::public_key service_node_list::get_pubkey_from_x25519(
         const crypto::x25519_public_key& x25519) const {
-    std::shared_lock lock{m_x25519_map_mutex};
-    auto it = x25519_to_pub.find(x25519);
-    if (it != x25519_to_pub.end())
-        return it->second.first;
+    if (cryptonote::is_hard_fork_at_least(
+                m_blockchain.nettype(),
+                feature::SN_PK_IS_ED25519,
+                m_blockchain.get_current_blockchain_height())) {
+        std::lock_guard lock{m_sn_mutex};
+        auto it = m_state.x25519_map.find(x25519);
+        if (it != m_state.x25519_map.end())
+            return it->second;
+    } else {
+        std::shared_lock lock{m_x25519_map_mutex};
+        auto it = x25519_to_pub.find(x25519);
+        if (it != x25519_to_pub.end())
+            return it->second.first;
+    }
     return crypto::null<crypto::public_key>;
 }
 
 crypto::public_key service_node_list::get_random_pubkey() {
     std::lock_guard lock{m_sn_mutex};
-    auto it = tools::select_randomly(
-            m_state.service_nodes_infos.begin(), m_state.service_nodes_infos.end());
-    if (it != m_state.service_nodes_infos.end()) {
+    if (auto it = tools::select_randomly(
+                m_state.service_nodes_infos.begin(), m_state.service_nodes_infos.end());
+        it != m_state.service_nodes_infos.end()) {
         return it->first;
-    } else {
-        return m_state.service_nodes_infos.begin()->first;
     }
+    return crypto::null<crypto::public_key>;
 }
 
+// Deprecated: can be remove after HF21
 void service_node_list::initialize_x25519_map() {
     auto locks = tools::unique_locks(m_sn_mutex, m_x25519_map_mutex);
 
@@ -4107,8 +4149,7 @@ void service_node_list::initialize_x25519_map() {
 std::string service_node_list::remote_lookup(std::string_view xpk) {
     if (xpk.size() != sizeof(crypto::x25519_public_key))
         return "";
-    crypto::x25519_public_key x25519_pub;
-    std::memcpy(x25519_pub.data(), xpk.data(), xpk.size());
+    auto x25519_pub = tools::make_from_guts<crypto::x25519_public_key>(xpk);
 
     auto pubkey = get_pubkey_from_x25519(x25519_pub);
     if (!pubkey) {
@@ -4313,7 +4354,6 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
             // only two valid values here: initial for a node that has never been recommissioned, or
             // 0 for a recommission.
 
-            auto was = info.recommission_credit;
             if (info.decommission_count <= info.is_decommissioned())
                 // Has never been decommissioned (or is currently in the first decommission), so add
                 // initial starting credit
@@ -4337,7 +4377,40 @@ service_node_list::state_t::state_t(service_node_list* snl, state_serialized&& s
         assert(info.version == tools::enum_top<decltype(info.version)>);
         service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));
     }
+
+    initialize_xpk_map();
+
     quorums = quorum_for_serialization_to_quorum_manager(state.quorums);
+}
+
+void service_node_list::state_t::initialize_xpk_map() {
+    // Compute the x25519 -> pubkey mappings for this state for post-merged-pubkey hardforks.
+    // (Before that the primary and Ed keys might differ, and we need the Ed key to get the correct
+    // X key, which only happens once we get a proof).
+    assert(x25519_map.empty());
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        for (const auto& [snpk, _ignore] : service_nodes_infos)
+            x25519_map[snpk_to_xpk(snpk)] = snpk;
+}
+
+void service_node_list::state_t::insert_info(
+        const crypto::public_key& pubkey, std::shared_ptr<service_node_info>&& info_ptr) {
+    service_nodes_infos[pubkey] = std::move(info_ptr);
+
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                           sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        x25519_map[snpk_to_xpk(pubkey)] = pubkey;
+}
+
+service_nodes_infos_t::iterator service_node_list::state_t::erase_info(
+        const service_nodes_infos_t::iterator& it) {
+    const auto& snpk = it->first;
+    if (sn_list && cryptonote::is_hard_fork_at_least(
+                           sn_list->m_blockchain.nettype(), feature::SN_PK_IS_ED25519, height))
+        x25519_map.erase(snpk_to_xpk(snpk));
+
+    return service_nodes_infos.erase(it);
 }
 
 bool service_node_list::load(const uint64_t current_height) {
@@ -4516,7 +4589,10 @@ bool service_node_list::load(const uint64_t current_height) {
         mine.timestamp = mine.effective_timestamp = 0;
     }
 
-    initialize_x25519_map();
+    if (!cryptonote::is_hard_fork_at_least(
+            m_blockchain.nettype(), feature::SN_PK_IS_ED25519, current_height))
+        initialize_x25519_map();
+    // else the x25519 map is part of state_t
 
     log::info(globallogcat, "Service node data loaded successfully, height: {}", m_state.height);
     log::info(

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -857,17 +857,17 @@ class service_node_list {
                 const cryptonote::transaction& tx,
                 uint32_t index,
                 const service_node_keys* my_keys);
-        bool process_ethereum_unlock_tx(
+        bool process_ethereum_removal_request_tx(
                 cryptonote::network_type nettype,
                 cryptonote::hf hf_version,
                 uint64_t block_height,
                 const cryptonote::transaction& tx);
-        bool process_ethereum_exit_tx(
+        bool process_ethereum_removal_tx(
                 cryptonote::network_type nettype,
                 cryptonote::hf hf_version,
                 uint64_t block_height,
                 const cryptonote::transaction& tx);
-        bool process_ethereum_deregister_tx(
+        bool process_ethereum_liquidated_tx(
                 cryptonote::network_type nettype,
                 cryptonote::hf hf_version,
                 uint64_t block_height,
@@ -888,7 +888,8 @@ class service_node_list {
     void record_timestamp_participation(crypto::public_key const& pubkey, bool participated);
     void record_timesync_status(crypto::public_key const& pubkey, bool synced);
 
-    // TODO oxen delete this function after HF20
+    // TODO oxen delete this function after HF20 (it is only used for mempool selection, not
+    // consensus).
     bool is_premature_unlock(
             cryptonote::network_type nettype,
             cryptonote::hf hf_version,

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -867,12 +867,6 @@ class service_node_list {
                 cryptonote::hf hf_version,
                 uint64_t block_height,
                 const cryptonote::transaction& tx);
-        bool process_ethereum_liquidated_tx(
-                cryptonote::network_type nettype,
-                cryptonote::hf hf_version,
-                uint64_t block_height,
-                const cryptonote::transaction& tx,
-                const service_node_keys* my_keys);
         payout get_block_leader() const;
         payout get_block_producer(uint8_t pulse_round) const;
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -187,7 +187,6 @@ inline constexpr size_t FILL_SWARM_LOWER_PERCENTILE = 25;
 inline constexpr size_t DECOMMISSIONED_REDISTRIBUTION_LOWER_PERCENTILE = 0;
 // The upper swarm percentile that will be randomly selected during stealing
 inline constexpr size_t STEALING_SWARM_UPPER_PERCENTILE = 75;
-inline constexpr uint64_t KEY_IMAGE_AWAITING_UNLOCK_HEIGHT = 0;
 
 inline constexpr uint64_t STATE_CHANGE_TX_LIFETIME_IN_BLOCKS = VOTE_LIFETIME;
 
@@ -238,10 +237,10 @@ inline constexpr uint8_t THRESHOLD_SECONDS_OUT_OF_SYNC = 30;
 // If the below percentage of service nodes are out of sync we will consider our clock out of sync
 inline constexpr uint8_t MAXIMUM_EXTERNAL_OUT_OF_SYNC = 80;
 
-// When a service node receives a request to sign an exit request for a BLS node, this values
+// When a service node receives a request to sign an removal request for a BLS node, this values
 // determines how old that request is allowed to be from the time it was initiated to us receiving
 // it, that we will consider signing it.
-inline constexpr std::chrono::seconds BLS_MAX_TIME_ALLOWED_FOR_EXIT_REQUEST = std::chrono::minutes(3);
+inline constexpr auto BLS_MAX_TIME_ALLOWED_FOR_REMOVAL_REQUEST = 3min;
 
 // The SN operator must contribute at least 25% of the node's requirement, expressed as portions
 // (for pre-HF19 registrations).

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -265,16 +265,6 @@ bool tx_memory_pool::have_duplicated_non_standard_tx(
                     get_transaction_hash(tx));
             return true;
         }
-    } else if (tx.type == txtype::ethereum_service_node_liquidated) {
-        cryptonote::tx_extra_ethereum_service_node_liquidated data = {};
-        if (!cryptonote::get_field_from_tx_extra(tx.extra, data)) {
-            log::error(
-                    logcat,
-                    "Could not get ethereum service node liquidated data from tx: {}, tx to add "
-                    "is possibly invalid, rejecting",
-                    get_transaction_hash(tx));
-            return true;
-        }
     } else {
         if (tx.type != txtype::standard && tx.type != txtype::stake) {
             // NOTE(oxen): This is a developer error. If we come across this in production, be

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -54,7 +54,7 @@ Proof::Proof(
     serialized_proof = bt_encode_uptime_proof(hardfork);
     proof_hash = crypto::keccak(serialized_proof);
 
-    if (hardfork < feature::ETH_BLS)
+    if (hardfork < feature::SN_PK_IS_ED25519)
         // Starting from HF21 we have guaranteed unified pubkey/ed25519 pubkey, so don't need to
         // send the old primary SN signature anymore: the single ed25519 signature does it all.
         crypto::generate_signature(proof_hash, keys.pub, keys.key, sig);
@@ -146,7 +146,7 @@ cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request Proof::generate_request(hf ha
     cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request request;
     assert(!serialized_proof.empty());
     request.proof = serialized_proof;
-    if (hardfork < feature::ETH_BLS) {
+    if (hardfork < feature::SN_PK_IS_ED25519) {
         // Starting at the full ETH hardfork we only send the ed25519 sig (because ed and primary
         // pubkeys are guaranteed unified starting at HF21).
         request.sig = tools::view_guts(sig);

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -332,25 +332,12 @@ bool command_parser_executor::print_sn_status(const std::vector<std::string>& ar
 }
 
 bool command_parser_executor::set_log_level(const std::vector<std::string>& args) {
-    if (args.size() > 1) {
-        std::cout << "use: set_log [<log_level_number_0-4> | <categories>]" << std::endl;
+    if (args.empty()) {
+        std::cout << "use: set_log [critical|error|warning|info|debug|trace] [category=LEVEL ...]" << std::endl;
         return true;
     }
 
-    if (args.empty()) {
-        return m_executor.set_log_categories("+");
-    }
-
-    uint16_t l = 0;
-    if (epee::string_tools::get_xtype_from_string(l, args[0])) {
-        if (4 < l) {
-            std::cout << "wrong number range, use: set_log <log_level_number_0-4>" << std::endl;
-            return true;
-        }
-        return m_executor.set_log_level(l);
-    } else {
-        return m_executor.set_log_categories(args.front());
-    }
+    return m_executor.set_log_level("{}"_format(fmt::join(args, ", ")));
 }
 
 bool command_parser_executor::print_height(const std::vector<std::string>& args) {

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -111,10 +111,12 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
     m_command_lookup.set_handler(
             "prepare_eth_registration",
             [this](const auto& x) { return m_parser.prepare_eth_registration(x); },
-            "prepare_eth_registration <operator address> [multi-contributor contract address] [\"print_only\"]",
-            "Interactive prompt to prepare a service node registration for submission to eth.  By default"
-            " this information is submitted to INSERT_URL_HERE to make it easy to submit your registration."
-            "  If you would prefer to just print the information, put print_only as the final argument.");
+            "prepare_eth_registration <operator address> [multi-contributor contract address] "
+            "[\"print_only\"]",
+            "Interactive prompt to prepare a service node registration for submission to eth.  By "
+            "default this information is submitted to INSERT_URL_HERE to make it easy to submit "
+            "your registration.  If you would prefer to just print the information, append "
+            "print_only as the final argument.");
 
     m_command_lookup.set_handler(
             "print_sn",
@@ -166,8 +168,9 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
     m_command_lookup.set_handler(
             "set_log",
             [this](const auto& x) { return m_parser.set_log_level(x); },
-            "set_log <level>|<{+,-,}categories>",
-            "Change the current log level/categories where <level> is a number 0-4.");
+            "set_log [LEVEL] [CATEGORY=LEVEL ...]",
+            "Change the current global log level and/or category-specific log levels.  LEVEL is "
+            "one of critical/error/warning/info/debug/trace.");
     m_command_lookup.set_handler(
             "diff",
             [this](const auto& x) { return m_parser.show_difficulty(x); },

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1788,7 +1788,7 @@ static void append_printable_service_node_list_entry(
         stream << indent2
                << "Registration: Hardfork Version: " << entry["registration_hf_version"].get<int>()
                << "; Height: " << entry["registration_height"].get<uint64_t>() << "; Expiry: ";
-        if (expiry_height == service_nodes::KEY_IMAGE_AWAITING_UNLOCK_HEIGHT)
+        if (!expiry_height)
             stream << "Staking Infinitely (stake unlock not requested)\n";
         else {
             uint64_t delta_height =

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2287,18 +2287,11 @@ bool rpc_command_executor::prepare_registration(bool force_registration) {
     auto& snode_keys = *maybe_keys;
 
     if (hf_version >= cryptonote::feature::ETH_BLS) {
-        // TODO FIXME XXX
-        tools::fail_msg_writer("FIXME: REPLACE THIS FOR feature::ETH_BLS");
-        assert(false);
-
-        tools::success_msg_writer(
-                "Service Node Pubkey: {}\n"
-                "Service Node Signature: {}\n",
-                snode_keys.value<std::string>("service_node_pubkey", ""),
-                snode_keys.value<std::string>(
-                        "service_node_signature",
-                        ""));  // Assuming 'service_node_signature' is the key for signature
-        return true;
+        tools::fail_msg_writer(
+                "prepare_registration is no longer usable as of HF {}; you should use the "
+                "`prepare_eth_registration` command instead",
+                static_cast<int>(cryptonote::feature::ETH_BLS));
+        return false;
     }
 
     auto nettype = cryptonote::network_type_from_string(info["nettype"].get<std::string_view>());

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -867,28 +867,20 @@ bool rpc_command_executor::print_quorum_state(
     return true;
 }
 
-bool rpc_command_executor::set_log_level(int8_t level) {
-    try {
-        invoke<SET_LOG_LEVEL>(json{{"level", level}});
-    } catch (const std::exception& e) {
-        tools::fail_msg_writer("Failed to set log level: {}", e.what());
+bool rpc_command_executor::set_log_level(std::string categories) {
+    auto maybe_categories = try_running(
+            [this, &categories] {
+                return invoke<SET_LOG_LEVEL>(json{{"categories", std::move(categories)}});
+            },
+            "Failed to set log level");
+    if (!maybe_categories)
         return false;
-    }
 
-    tools::success_msg_writer("Log level set to {:d}", level);
-    return true;
-}
-
-bool rpc_command_executor::set_log_categories(std::string categories) {
-    // auto maybe_categories = try_running([this, &categories] { return
-    // invoke<SET_LOG_CATEGORIES>(json{{"categories", std::move(categories)}}); }, "Failed to set
-    // log categories"); if (!maybe_categories) return false;
-    // auto& categories_response = *maybe_categories;
-    auto categories_response =
-            make_request<SET_LOG_CATEGORIES>(json{{"categories", std::move(categories)}});
+    auto& cats = *maybe_categories;
 
     tools::success_msg_writer(
-            "Log categories are now {}", categories_response["categories"].get<std::string_view>());
+            "Applied log categories {}",
+            fmt::join(cats["applied"].get<std::vector<std::string_view>>(), ", "));
 
     return true;
 }

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -178,9 +178,7 @@ class rpc_command_executor final {
     bool print_quorum_state(
             std::optional<uint64_t> start_height, std::optional<uint64_t> end_height);
 
-    bool set_log_level(int8_t level);
-
-    bool set_log_categories(std::string categories);
+    bool set_log_level(std::string categories);
 
     bool print_height();
 

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -150,10 +150,6 @@ struct extra_printer {
         return "Ethereum Service Node Removal: version {}, eth address {}, amount {}, bls key {}"_format(
                 x.version, x.eth_address, print_money(x.amount), x.bls_pubkey);
     }
-    std::string operator()(const tx_extra_ethereum_service_node_liquidated& x) {
-        return "Ethereum Service Node Liquidated: version {}, bls key {}"_format(
-                x.version, x.bls_pubkey);
-    }
 };
 
 static void print_extra_fields(const std::vector<cryptonote::tx_extra_field>& fields) {

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -142,16 +142,16 @@ struct extra_printer {
                 contributors_info,
                 x.signature);
     }
-    std::string operator()(const tx_extra_ethereum_service_node_leave_request& x) {
-        return "Ethereum Service Node Leave Request: version {}, bls key {}"_format(
+    std::string operator()(const tx_extra_ethereum_service_node_removal_request& x) {
+        return "Ethereum Service Node Remove Request: version {}, bls key {}"_format(
                 x.version, x.bls_pubkey);
     }
-    std::string operator()(const tx_extra_ethereum_service_node_exit& x) {
-        return "Ethereum Service Node Exit: version {}, eth address {}, amount {}, bls key {}"_format(
+    std::string operator()(const tx_extra_ethereum_service_node_removal& x) {
+        return "Ethereum Service Node Removal: version {}, eth address {}, amount {}, bls key {}"_format(
                 x.version, x.eth_address, print_money(x.amount), x.bls_pubkey);
     }
-    std::string operator()(const tx_extra_ethereum_service_node_deregister& x) {
-        return "Ethereum Service Node Deregister: version {}, bls key {}"_format(
+    std::string operator()(const tx_extra_ethereum_service_node_liquidated& x) {
+        return "Ethereum Service Node Liquidated: version {}, bls key {}"_format(
                 x.version, x.bls_pubkey);
     }
 };

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -32,7 +32,6 @@ struct TransactionReviewSession {
 
     std::list<NewServiceNodeTx> new_service_nodes;
     std::list<ServiceNodeRemovalRequestTx> removal_requests;
-    std::list<ServiceNodeLiquidatedTx> liquidations;
     std::list<ServiceNodeRemovalTx> removals;
 
     friend class L2Tracker;
@@ -72,7 +71,6 @@ struct TransactionReviewSession {
             const uint64_t amount,
             const bls_public_key& bls_pubkey,
             std::string& fail_reason);
-    bool processServiceNodeLiquidatedTx(const bls_public_key& bls_pubkey, std::string& fail_reason);
 
     /// Called to check that all L2 state changes were found via the process... methods.  Returns
     /// true if there are no leftover expected L2 state changes left, false if there are still L2

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -31,9 +31,9 @@ struct TransactionReviewSession {
     bool active = false;
 
     std::list<NewServiceNodeTx> new_service_nodes;
-    std::list<ServiceNodeLeaveRequestTx> leave_requests;
-    std::list<ServiceNodeDeregisterTx> deregs;
-    std::list<ServiceNodeExitTx> exits;
+    std::list<ServiceNodeRemovalRequestTx> removal_requests;
+    std::list<ServiceNodeLiquidatedTx> liquidations;
+    std::list<ServiceNodeRemovalTx> removals;
 
     friend class L2Tracker;
 
@@ -65,14 +65,14 @@ struct TransactionReviewSession {
             const eth::address& eth_address,
             const crypto::public_key& service_node_pubkey,
             std::string& fail_reason);
-    bool processServiceNodeLeaveRequestTx(
+    bool processServiceNodeRemovalRequestTx(
             const bls_public_key& bls_pubkey, std::string& fail_reason);
-    bool processServiceNodeExitTx(
+    bool processServiceNodeRemovalTx(
             const eth::address& eth_address,
             const uint64_t amount,
             const bls_public_key& bls_pubkey,
             std::string& fail_reason);
-    bool processServiceNodeDeregisterTx(const bls_public_key& bls_pubkey, std::string& fail_reason);
+    bool processServiceNodeLiquidatedTx(const bls_public_key& bls_pubkey, std::string& fail_reason);
 
     /// Called to check that all L2 state changes were found via the process... methods.  Returns
     /// true if there are no leftover expected L2 state changes left, false if there are still L2

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -266,18 +266,6 @@ TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log) {
             std::tie(bls_pk) = tools::split_hex_into<skip<12 + 20>, bls_public_key>(log.data);
             break;
         }
-        case TransactionType::ServiceNodeLiquidated: {
-            // event ServiceNodeLiquidated(
-            //      uint64 indexed serviceNodeID,
-            //      address recipient,
-            //      BN256G1.G1Point pubkey);
-            // service node id is a topic so only address and pubkey are in data
-            // address is 32 bytes (with 12-byte prefix padding)
-            // pubkey is 64 bytes
-            auto& [bls_pk] = result.emplace<ServiceNodeLiquidatedTx>();
-            std::tie(bls_pk) = tools::split_hex_into<skip<12 + 20>, bls_public_key>(log.data);
-            break;
-        }
         case TransactionType::ServiceNodeRemoval: {
             // event ServiceNodeRemoval(
             //      uint64 indexed serviceNodeID,
@@ -452,10 +440,6 @@ std::string NewServiceNodeTx::to_string() const {
 
 std::string ServiceNodeRemovalRequestTx::to_string() const {
     return "{} [bls_pubkey={}]"_format(state_change_name<ServiceNodeRemovalRequestTx>(), bls_pubkey);
-}
-
-std::string ServiceNodeLiquidatedTx::to_string() const {
-    return "{} [bls_pubkey={}]"_format(state_change_name<ServiceNodeLiquidatedTx>(), bls_pubkey);
 }
 
 std::string ServiceNodeRemovalTx::to_string() const {

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -18,7 +18,6 @@ namespace eth {
 enum class TransactionType {
     NewServiceNode,
     ServiceNodeRemovalRequest,
-    ServiceNodeLiquidated,
     ServiceNodeRemoval,
     Other
 };
@@ -46,12 +45,6 @@ struct ServiceNodeRemovalRequestTx : L2StateChange {
     std::string to_string() const;
 };
 
-struct ServiceNodeLiquidatedTx : L2StateChange {
-    bls_public_key bls_pubkey;
-
-    std::string to_string() const;
-};
-
 struct ServiceNodeRemovalTx : L2StateChange {
     eth::address eth_address;
     uint64_t amount;
@@ -65,13 +58,11 @@ constexpr std::string_view state_change_name() = delete;
 template <> inline constexpr std::string_view state_change_name<NewServiceNodeTx>() { return "new service node"sv; }
 template <> inline constexpr std::string_view state_change_name<ServiceNodeRemovalRequestTx>() { return "removal request"sv; }
 template <> inline constexpr std::string_view state_change_name<ServiceNodeRemovalTx>() { return "SN removal"sv; }
-template <> inline constexpr std::string_view state_change_name<ServiceNodeLiquidatedTx>() { return "SN liquidation"sv; }
 
 using TransactionStateChangeVariant = std::variant<
         std::monostate,
         NewServiceNodeTx,
         ServiceNodeRemovalRequestTx,
-        ServiceNodeLiquidatedTx,
         ServiceNodeRemovalTx>;
 
 TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log);

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -17,9 +17,9 @@ namespace eth {
 
 enum class TransactionType {
     NewServiceNode,
-    ServiceNodeLeaveRequest,
-    ServiceNodeDeregister,
-    ServiceNodeExit,
+    ServiceNodeRemovalRequest,
+    ServiceNodeLiquidated,
+    ServiceNodeRemoval,
     Other
 };
 
@@ -40,19 +40,19 @@ struct NewServiceNodeTx : L2StateChange {
     std::string to_string() const;
 };
 
-struct ServiceNodeLeaveRequestTx : L2StateChange {
+struct ServiceNodeRemovalRequestTx : L2StateChange {
     bls_public_key bls_pubkey;
 
     std::string to_string() const;
 };
 
-struct ServiceNodeDeregisterTx : L2StateChange {
+struct ServiceNodeLiquidatedTx : L2StateChange {
     bls_public_key bls_pubkey;
 
     std::string to_string() const;
 };
 
-struct ServiceNodeExitTx : L2StateChange {
+struct ServiceNodeRemovalTx : L2StateChange {
     eth::address eth_address;
     uint64_t amount;
     bls_public_key bls_pubkey;
@@ -63,16 +63,16 @@ struct ServiceNodeExitTx : L2StateChange {
 template <std::derived_from<L2StateChange> Tx>
 constexpr std::string_view state_change_name() = delete;
 template <> inline constexpr std::string_view state_change_name<NewServiceNodeTx>() { return "new service node"sv; }
-template <> inline constexpr std::string_view state_change_name<ServiceNodeLeaveRequestTx>() { return "leave request"sv; }
-template <> inline constexpr std::string_view state_change_name<ServiceNodeExitTx>() { return "SN exit"sv; }
-template <> inline constexpr std::string_view state_change_name<ServiceNodeDeregisterTx>() { return "SN liquidation"sv; }
+template <> inline constexpr std::string_view state_change_name<ServiceNodeRemovalRequestTx>() { return "removal request"sv; }
+template <> inline constexpr std::string_view state_change_name<ServiceNodeRemovalTx>() { return "SN removal"sv; }
+template <> inline constexpr std::string_view state_change_name<ServiceNodeLiquidatedTx>() { return "SN liquidation"sv; }
 
 using TransactionStateChangeVariant = std::variant<
         std::monostate,
         NewServiceNodeTx,
-        ServiceNodeLeaveRequestTx,
-        ServiceNodeDeregisterTx,
-        ServiceNodeExitTx>;
+        ServiceNodeRemovalRequestTx,
+        ServiceNodeLiquidatedTx,
+        ServiceNodeRemovalTx>;
 
 TransactionStateChangeVariant getLogTransaction(const ethyl::LogEntry& log);
 inline bool is_state_change(const TransactionStateChangeVariant& v) {

--- a/src/logging/oxen_logger.cpp
+++ b/src/logging/oxen_logger.cpp
@@ -83,7 +83,7 @@ void apply_categories_string(std::string_view categories) {
     extract_categories(categories).apply();
 }
 
-void LogCats::apply() {
+std::list<std::string> LogCats::apply() {
     std::list<std::string> applied;
     if (default_level) {
         log::reset_level(*default_level);
@@ -98,11 +98,13 @@ void LogCats::apply() {
 
     if (!applied.empty())
         log::info(logcat, "Applied log categories: {}", fmt::join(applied, ", "));
+
+    return applied;
 }
 
 void init(const std::string& log_location, std::string_view log_levels, bool log_to_stdout) {
     auto cats = extract_categories(log_levels);
-    if (!cats.default_level && cats.cat_levels.empty() && !log_levels.empty()) {
+    if (cats.empty() && !log_levels.empty()) {
         std::cerr << "Incorrect log level string: " << log_levels << std::endl;
         throw std::runtime_error{"Invalid log level or log categories"};
     }

--- a/src/logging/oxen_logger.h
+++ b/src/logging/oxen_logger.h
@@ -54,8 +54,13 @@ void apply_categories_string(std::string_view categories);
 struct LogCats {
     std::optional<log::Level> default_level;
     std::unordered_map<std::string, log::Level> cat_levels;
-    // Applies the settings in the object to the global logger.
-    void apply();
+
+    // True if this object contains no parsed levels (either neither a default nor any category levels)
+    bool empty() const { return !default_level && cat_levels.empty(); }
+
+    // Applies the settings in the object to the global logger.  Returns the actual setting applied
+    // (i.e. not including redundant or unparseable settings).
+    std::list<std::string> apply();
 };
 
 /// Given a log level string this extracts the default and individual category levels applied by the

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -81,7 +81,7 @@ inline constexpr network_config config{
         testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_EXIT_BUFFER,
+        testnet::ETH_REMOVAL_BUFFER,
         ETHEREUM_CHAIN_ID,
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -46,7 +46,7 @@ inline constexpr network_config config{
         testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_EXIT_BUFFER,
+        testnet::ETH_REMOVAL_BUFFER,
         mainnet::ETHEREUM_CHAIN_ID,
         mainnet::ETHEREUM_REWARDS_CONTRACT,
         mainnet::ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -61,7 +61,7 @@ inline constexpr network_config config{
         testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_EXIT_BUFFER,
+        testnet::ETH_REMOVAL_BUFFER,
         devnet::ETHEREUM_CHAIN_ID,
         devnet::ETHEREUM_REWARDS_CONTRACT,
         devnet::ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -76,7 +76,7 @@ inline constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 720;
 
 inline constexpr uint64_t STORE_LONG_TERM_STATE_INTERVAL = 10000;
 
-inline constexpr uint64_t ETH_EXIT_BUFFER = 7 * 24h / TARGET_BLOCK_TIME;
+inline constexpr uint64_t ETH_REMOVAL_BUFFER = 7 * 24h / TARGET_BLOCK_TIME;
 
 // TODO: To be set for mainnet during TGE
 inline constexpr uint32_t ETHEREUM_CHAIN_ID = -1;
@@ -120,7 +120,7 @@ inline constexpr network_config config{
         SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_EXIT_BUFFER,
+        ETH_REMOVAL_BUFFER,
         ETHEREUM_CHAIN_ID,
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/network_config.h
+++ b/src/network_config/network_config.h
@@ -105,11 +105,12 @@ struct network_config final {
     // event of too many popped or reorged blocks.
     const uint64_t STORE_LONG_TERM_STATE_INTERVAL;
 
-    /// (HF21+) Number of blocks after a registration expires (i.e. regular unlocks, *not* deregs)
-    /// during which the node is protected from liquidation-with-penalty.  Regular exits can still
-    /// be submitted to remove it from the ETH pubkey list, but *not* penalizing liquidation (which
-    /// also remove it but award a penalty reward to the liquidator).
-    const uint64_t ETH_EXIT_BUFFER;
+    /// (HF21+) Number of blocks after a registration expires (i.e. regular requested removals,
+    /// *not* deregs) during which the node is protected from liquidation-with-penalty.  Regular
+    /// removals can still be submitted to remove it from the ETH pubkey list, but *not* penalizing
+    /// liquidation (which also remove it but award a penalty reward to the liquidator) during this
+    /// buffer period.
+    const uint64_t ETH_REMOVAL_BUFFER;
 
     // Details of the ethereum smart contract managing rewards and chain its kept on:
     const uint32_t ETHEREUM_CHAIN_ID;

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -46,7 +46,7 @@ inline constexpr std::array GOVERNANCE_WALLET_ADDRESS = {
 inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
 
 // Much shorter than mainnet so that you can test this more easily.
-inline constexpr uint64_t ETH_EXIT_BUFFER = 2h / mainnet::TARGET_BLOCK_TIME;
+inline constexpr uint64_t ETH_REMOVAL_BUFFER = 2h / mainnet::TARGET_BLOCK_TIME;
 
 inline constexpr uint32_t ETHEREUM_CHAIN_ID = 421614;
 inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0xEF43cd64528eA89966E251d4FE17c660222D2c9d"sv;
@@ -84,7 +84,7 @@ inline constexpr network_config config{
         testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_EXIT_BUFFER,
+        ETH_REMOVAL_BUFFER,
         ETHEREUM_CHAIN_ID,
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -53,7 +53,7 @@ inline constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 4;
 inline constexpr size_t PULSE_MIN_SERVICE_NODES = 12;  // == pulse quorum size
 
 // Much shorter than mainnet so that you can test this more easily.
-inline constexpr uint64_t ETH_EXIT_BUFFER = 1h / mainnet::TARGET_BLOCK_TIME;
+inline constexpr uint64_t ETH_REMOVAL_BUFFER = 1h / mainnet::TARGET_BLOCK_TIME;
 
 // FIXME!
 inline constexpr uint32_t ETHEREUM_CHAIN_ID = -1;
@@ -92,7 +92,7 @@ inline constexpr network_config config{
         SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_EXIT_BUFFER,
+        ETH_REMOVAL_BUFFER,
         ETHEREUM_CHAIN_ID,
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -777,10 +777,6 @@ namespace {
             set("amount", x.amount);
             set("bls_pubkey", x.bls_pubkey);
         }
-        void operator()(const tx_extra_ethereum_service_node_liquidated& x) {
-            set("type", "ethereum_service_node_liquidated");
-            set("bls_pubkey", x.bls_pubkey);
-        }
 
         // Ignore these fields:
         void operator()(const tx_extra_padding&) {}

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -767,18 +767,18 @@ namespace {
             }
             set("contributors", contributors);
         }
-        void operator()(const tx_extra_ethereum_service_node_leave_request& x) {
-            set("type", "ethereum_service_node_leave_request");
+        void operator()(const tx_extra_ethereum_service_node_removal_request& x) {
+            set("type", "ethereum_service_node_removal_request");
             set("bls_pubkey", x.bls_pubkey);
         }
-        void operator()(const tx_extra_ethereum_service_node_exit& x) {
-            set("type", "ethereum_service_node_exit");
+        void operator()(const tx_extra_ethereum_service_node_removal& x) {
+            set("type", "ethereum_service_node_removal");
             set("eth_address", x.eth_address);
             set("amount", x.amount);
             set("bls_pubkey", x.bls_pubkey);
         }
-        void operator()(const tx_extra_ethereum_service_node_deregister& x) {
-            set("type", "ethereum_service_node_deregister");
+        void operator()(const tx_extra_ethereum_service_node_liquidated& x) {
+            set("type", "ethereum_service_node_liquidated");
             set("bls_pubkey", x.bls_pubkey);
         }
 
@@ -2557,9 +2557,9 @@ void core_rpc_server::invoke(BLS_REWARDS_REQUEST& rpc, rpc_context) {
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_EXIT_REQUEST& rpc, rpc_context) {
-    const auto response = m_core.aggregate_exit_request(rpc.request.bls_pubkey);
+    const auto response = m_core.aggregate_removal_request(rpc.request.bls_pubkey);
     rpc.response["status"] = STATUS_OK;
-    rpc.response_hex["bls_pubkey"] = response.exit_pubkey;
+    rpc.response_hex["bls_pubkey"] = response.remove_pubkey;
     rpc.response_hex["msg_to_sign"] =
             oxenc::to_hex(response.msg_to_sign.begin(), response.msg_to_sign.end());
     rpc.response_hex["signature"] = response.signature;
@@ -2571,7 +2571,7 @@ void core_rpc_server::invoke(BLS_EXIT_REQUEST& rpc, rpc_context) {
 void core_rpc_server::invoke(BLS_LIQUIDATION_REQUEST& rpc, rpc_context) {
     const auto response = m_core.aggregate_liquidation_request(rpc.request.bls_pubkey);
     rpc.response["status"] = STATUS_OK;
-    rpc.response_hex["bls_pubkey"] = response.exit_pubkey;
+    rpc.response_hex["bls_pubkey"] = response.remove_pubkey;
     rpc.response_hex["msg_to_sign"] =
             oxenc::to_hex(response.msg_to_sign.begin(), response.msg_to_sign.end());
     rpc.response_hex["signature"] = response.signature;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -155,7 +155,6 @@ class core_rpc_server {
     void invoke(GET_BLOCK_HASH& req, rpc_context context);
     void invoke(GET_PEER_LIST& pl, rpc_context context);
     void invoke(SET_LOG_LEVEL& set_log_level, rpc_context context);
-    void invoke(SET_LOG_CATEGORIES& set_log_categories, rpc_context context);
     void invoke(BANNED& banned, rpc_context context);
     void invoke(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_context context);
     void invoke(GET_VERSION& version, rpc_context context);

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -50,7 +50,6 @@ void parse_request(PRUNE_BLOCKCHAIN& prune_blockchain, rpc_input in);
 void parse_request(REPORT_PEER_STATUS& report_peer_status, rpc_input in);
 void parse_request(SET_BANS& set_bans, rpc_input in);
 void parse_request(SET_LIMIT& limit, rpc_input in);
-void parse_request(SET_LOG_CATEGORIES& set_log_categories, rpc_input in);
 void parse_request(SET_LOG_LEVEL& set_log_level, rpc_input in);
 void parse_request(START_MINING& start_mining, rpc_input in);
 void parse_request(STORAGE_SERVER_PING& storage_server_ping, rpc_input in);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6465,7 +6465,7 @@ bool simple_wallet::query_locked_stakes(bool print_details, bool print_key_image
         return a.service_node_pubkey < b.service_node_pubkey;
     });
     std::stable_partition(sns.begin(), sns.end(), [](const auto& a) {
-        return a.requested_unlock_height != service_nodes::KEY_IMAGE_AWAITING_UNLOCK_HEIGHT;
+        return a.requested_unlock_height > 0;
     });
 
     for (auto& node_info : sns) {
@@ -6539,7 +6539,7 @@ bool simple_wallet::query_locked_stakes(bool print_details, bool print_key_image
         // If we aren't showing key images then all the key image details get omitted.
 
         msg += "Service Node: {}\n"_format(node_info.service_node_pubkey);
-        if (node_info.requested_unlock_height != service_nodes::KEY_IMAGE_AWAITING_UNLOCK_HEIGHT)
+        if (node_info.requested_unlock_height)
             msg += "Unlock height: {}\n"_format(node_info.requested_unlock_height);
 
         bool just_me = contributors.size() == 1;


### PR DESCRIPTION
- The oxen code currently is a bit confusing in its terminology for ETH-invoked leaving: we have "exit", "deregistration", "liquidation" and "removal" referenced at different parts, but these aren't immediately mappable to the smart contract.  This unifies the terminology to match the smart contract events (i.e. removal, liquidation).

- Drop `ServiceNodeLiquidated` event handling.  We don't (and it doesn't look like we have anytime recently) actually process these when they arrive in the L2 provider logs, and moreover we don't *need* to because liquidation also emits a ServiceNodeRemoval which we accept and mine into blocks.

- Switch high_resolution_clock -> system_clock to fix portability issues

- Add a fixme around the currently broken SN removal handling

(Plus the code from #1686 that this builds on top of)