### PR TITLE
Support querying rewards by ETH address

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -419,32 +419,32 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     return payments;
 }
 
-static std::pair<uint64_t, uint64_t> get_accrued_earnings_impl(BlockchainSQLite& db, const std::string& address, uint64_t height) {
+static std::pair<uint64_t, uint64_t> get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address, uint64_t height) {
     log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
-    auto earnings = db.prepared_maybe_get<int64_t>(
+    auto rewards = db.prepared_maybe_get<int64_t>(
             R"(
         SELECT amount
         FROM batched_payments_accrued
         WHERE address = ?
     )", address);
-    auto result = std::make_pair(height, static_cast<uint64_t>(earnings.value_or(0) / 1000));
+    auto result = std::make_pair(height, static_cast<uint64_t>(rewards.value_or(0) / 1000));
     return result;
 }
 
-std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings(const eth::address& address) {
+std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_rewards(const eth::address& address) {
     std::string address_string = fmt::format("0x{:x}", address);
-    auto result = get_accrued_earnings_impl(*this, address_string, height);
+    auto result = get_accrued_rewards_impl(*this, address_string, height);
     return result;
 }
 
-std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_earnings(const account_public_address& address) {
+std::pair<uint64_t, uint64_t> BlockchainSQLite::get_accrued_rewards(const account_public_address& address) {
     std::string address_string = get_account_address_as_str(m_nettype, false /*subaddress*/, address);
-    auto result = get_accrued_earnings_impl(*this, address_string, height);
+    auto result = get_accrued_rewards_impl(*this, address_string, height);
     return result;
 }
 
 std::pair<std::vector<std::string>, std::vector<uint64_t>>
-BlockchainSQLite::get_all_accrued_earnings() {
+BlockchainSQLite::get_all_accrued_rewards() {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
     std::pair<std::vector<std::string>, std::vector<uint64_t>> result;

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -78,17 +78,17 @@ class BlockchainSQLite : public db::Database {
     std::mutex address_str_cache_mutex;
 
   public:
-    // get_accrued_earnings -> queries the database for the amount that has been accrued to
+    // get_accrued_rewards -> queries the database for the amount that has been accrued to
     // the Ethereum `address` will return the atomic value in oxen that the service node is owed.
-    std::pair<uint64_t, uint64_t> get_accrued_earnings(const eth::address& address);
+    std::pair<uint64_t, uint64_t> get_accrued_rewards(const eth::address& address);
 
-    // See `get_accrued_earnings`
-    std::pair<uint64_t, uint64_t> get_accrued_earnings(const account_public_address& address);
+    // See `get_accrued_rewards`
+    std::pair<uint64_t, uint64_t> get_accrued_rewards(const account_public_address& address);
 
-    // get_all_accrued_earnings -> queries the database for all the amount that has been accrued to
+    // get_all_accrued_rewards -> queries the database for all the amount that has been accrued to
     // service nodes will return 2 vectors corresponding to the addresses and the atomic value in
     // oxen that the service nodes are owed.
-    std::pair<std::vector<std::string>, std::vector<uint64_t>> get_all_accrued_earnings();
+    std::pair<std::vector<std::string>, std::vector<uint64_t>> get_all_accrued_rewards();
 
     // get_payments -> passing a block height will return an array of payments that should be
     // created in a coinbase transaction on that block given the current batching DB state.

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -249,7 +249,7 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
         return;
 
     auto [batchdb_height, amount] =
-            core.get_blockchain_storage().sqlite_db().get_accrued_earnings(eth_addr);
+            core.get_blockchain_storage().sqlite_db().get_accrued_rewards(eth_addr);
     if (amount == 0) {
         m.send_reply("400", "Address '{}' has a zero balance in the database"_format(eth_addr));
         return;
@@ -281,7 +281,7 @@ void BLSAggregator::get_reward_balance(oxenmq::Message& m) {
 
 BLSRewardsResponse BLSAggregator::rewards_request(const eth::address& address) {
 
-    auto [height, amount] = core.get_blockchain_storage().sqlite_db().get_accrued_earnings(address);
+    auto [height, amount] = core.get_blockchain_storage().sqlite_db().get_accrued_rewards(address);
 
     // FIXME: make this async
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -200,7 +200,7 @@ class core_rpc_server {
     void invoke(GET_ALTERNATE_CHAINS& get_alternate_chains, rpc_context context);
     void invoke(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_context context);
     void invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_context context);
-    void invoke(GET_ACCRUED_BATCHED_EARNINGS& get_accrued_batched_earnings, rpc_context context);
+    void invoke(GET_ACCRUED_REWARDS& rpc, rpc_context context);
     void invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_context context);
 
     // Deprecated Monero NIH binary endpoints:

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -416,8 +416,8 @@ void parse_request(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_input in) {
             get_output_histogram.request.unlocked);
 }
 
-void parse_request(GET_ACCRUED_BATCHED_EARNINGS& get_accrued_batched_earnings, rpc_input in) {
-    get_values(in, "addresses", get_accrued_batched_earnings.request.addresses);
+void parse_request(GET_ACCRUED_REWARDS& rpc, rpc_input in) {
+    get_values(in, "addresses", rpc.request.addresses);
 }
 
 void parse_request(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -15,7 +15,7 @@ inline void parse_request(NO_ARGS&, rpc_input) {}
 void parse_request(BANNED& banned, rpc_input in);
 void parse_request(FLUSH_CACHE& flush_cache, rpc_input in);
 void parse_request(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_input in);
-void parse_request(GET_ACCRUED_BATCHED_EARNINGS& get_accrued_batched_earnings, rpc_input in);
+void parse_request(GET_ACCRUED_REWARDS& rpc, rpc_input in);
 void parse_request(GET_FEE_ESTIMATE& get_fee_estimate, rpc_input in);
 void parse_request(GET_BLOCK& get_block, rpc_input in);
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -714,7 +714,7 @@ void from_json(const nlohmann::json& j, block_header_response& h);
 ///     to service nodes and governance.  As of Oxen 10 (HF 19) this is the *earned* amount, but
 ///     not the *paid* amount which occurs in batches.
 ///   - `coinbase_payouts` -- The amount of OXEN paid out in this block.  As of Oxen 10 (HF 19),
-///     this reflects the current batched amounts being paid from earnings batched over previous
+///     this reflects the current batched amounts being paid from rewards batched over previous
 ///     blocks, not the amounts *earned* in the current block.
 ///   - `block_size` -- The block size in bytes.
 ///   - `block_weight` -- The block weight in bytes.
@@ -2145,7 +2145,7 @@ struct GET_SERVICE_NODE_STATUS : NO_ARGS {
     static constexpr auto names() { return NAMES("get_service_node_status"); }
 };
 
-/// RPC: blockchain/get_accrued_batched_earnings
+/// RPC: blockchain/get_accrued_rewards
 ///
 /// Retrieve the current "balance" of accrued service node rewards for the given addresses.
 ///
@@ -2155,10 +2155,9 @@ struct GET_SERVICE_NODE_STATUS : NO_ARGS {
 ///
 /// Outputs:
 ///  - `balances` -- a dict where keys are the wallet addresses and values are the balance (in
-///    atomic OXEN units).
-struct GET_ACCRUED_BATCHED_EARNINGS : PUBLIC {
-    static constexpr auto names() { return NAMES("get_accrued_batched_earnings"); }
-
+///    atomic SENT units).
+struct GET_ACCRUED_REWARDS : PUBLIC {
+    static constexpr auto names() { return NAMES("get_accrued_rewards"); }
     struct request_parameters {
         std::vector<std::string> addresses;
     } request;
@@ -2738,7 +2737,7 @@ using core_rpc_types = tools::type_list<
         BANNED,
         FLUSH_CACHE,
         FLUSH_TRANSACTION_POOL,
-        GET_ACCRUED_BATCHED_EARNINGS,
+        GET_ACCRUED_REWARDS,
         GET_ALTERNATE_CHAINS,
         GET_BANS,
         GET_FEE_ESTIMATE,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -15269,12 +15269,12 @@ std::unordered_map<std::string, wallet2::ons_detail> wallet2::get_ons_cache() {
 
 void wallet2::refresh_batching_cache() {
     nlohmann::json req_params{{"addresses", std::vector<std::string>{}}};
-    auto res = m_http_client.json_rpc("get_accrued_batched_earnings", req_params);
+    auto res = m_http_client.json_rpc(rpc::GET_ACCRUED_REWARDS::names()[0], req_params);
     THROW_WALLET_EXCEPTION_IF(
             res["status"] == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
     THROW_WALLET_EXCEPTION_IF(
             res["status"] != rpc::STATUS_OK,
-            error::get_accrued_batched_earnings_error,
+            error::get_accrued_rewards_error,
             res["status"]);
 
     auto records = res["balances"].get<std::unordered_map<std::string, uint64_t>>();

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -731,10 +731,10 @@ struct wallet_files_doesnt_correspond : public wallet_logic_error {
                     "File {} does not correspond to {}"_format(wallet_file, keys_file)} {}
 };
 //----------------------------------------------------------------------------------------------------
-struct get_accrued_batched_earnings_error : public wallet_rpc_error {
-    explicit get_accrued_batched_earnings_error(std::string&& loc, const std::string& request) :
+struct get_accrued_rewards_error : public wallet_rpc_error {
+    explicit get_accrued_rewards_error(std::string&& loc, const std::string& request) :
             wallet_rpc_error(
-                    std::move(loc), "Failed to get accrued batched service node rewards", request) {
+                    std::move(loc), "Failed to get accrued rewards", request) {
     }
 };
 //----------------------------------------------------------------------------------------------------

--- a/utils/local-devnet/commands/getaccruedbalance.py
+++ b/utils/local-devnet/commands/getaccruedbalance.py
@@ -20,8 +20,8 @@ def instruct_daemon(method, params):
     except:
         print('No response from daemon, check daemon is running on this machine')
 
-# answer = instruct_daemon('get_accrued_batched_earnings', {"addresses": [config.wallet_address]})
-answer = instruct_daemon('get_accrued_batched_earnings', {"addresses": []})
+# answer = instruct_daemon('get_accrued_rewards', {"addresses": [config.wallet_address]})
+answer = instruct_daemon('get_accrued_rewards', {"addresses": []})
 print(json.dumps(answer, indent=4, sort_keys=True))
 
 


### PR DESCRIPTION
I've also renamed the earnings terminology to rewards. This matches all our documentation and other code references (BLS_REWARDS_REQUEST, service node rewards...) having this differ causes confusion.

This will be used to forward reward amounts onto the staking website.