### PR TITLE
Local devnet not testable due to l2 window

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -587,7 +587,7 @@ foreach(curl_arch ${curl_arches})
     --enable-crypto-auth --disable-ntlm-wb --disable-tls-srp --disable-unix-sockets --disable-cookies
     --enable-http-auth --enable-doh --disable-mime --enable-dateparse --disable-netrc --without-libidn2
     --disable-progress-meter --without-brotli --with-zlib=${DEPS_DESTDIR}
-    --without-ssl --without-schannel --without-secure-transport
+    --with-ssl --without-zstd --without-schannel --without-secure-transport
     --without-nghttp2 --without-nghttp3 --without-ngtcp2 --without-quiche
     --without-librtmp --disable-versioned-symbols --enable-hidden-symbols
     --without-zsh-functions-dir --without-fish-functions-dir

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -168,6 +168,8 @@ static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8
     for (uint8_t increment = 0;; increment++) {
         messageWithI[messageWithI.size() - 1] = increment;
 
+        oxen::log::trace(logcat, "msgi: {}", oxenc::to_hex(messageWithI.begin(), messageWithI.end()));
+
         // NOTE: Solidity's BN256G2.hashToField(msg, tag) => (x1, x2, b)
         mcl::bn::Fp x1 = {}, x2 = {};
         bool b = false;
@@ -311,6 +313,18 @@ bls_signature BLSSigner::proofOfPossession(
     msg.insert(msg.end(), bls_pkey.begin(), bls_pkey.end());
     msg.insert(msg.end(), sender.begin(), sender.end());
     msg.insert(msg.end(), serviceNodePubkey.begin(), serviceNodePubkey.end());
+
+    oxen::log::debug(
+            logcat,
+            "Generating proof-of-possession with parameters\n"
+            "Tag:        {}\n"
+            "BLS Pubkey: {}\n"
+            "Sender:     {}\n"
+            "SN Pubkey:  {}",
+            tag,
+            bls_pkey,
+            sender,
+            serviceNodePubkey);
 
     bls_signature result = signMsg(msg);
     return result;

--- a/src/bls/bls_signer.cpp
+++ b/src/bls/bls_signer.cpp
@@ -168,8 +168,6 @@ static mcl::bn::G2 map_to_g2(std::span<const uint8_t> msg, std::span<const uint8
     for (uint8_t increment = 0;; increment++) {
         messageWithI[messageWithI.size() - 1] = increment;
 
-        oxen::log::trace(logcat, "msgi: {}", oxenc::to_hex(messageWithI.begin(), messageWithI.end()));
-
         // NOTE: Solidity's BN256G2.hashToField(msg, tag) => (x1, x2, b)
         mcl::bn::Fp x1 = {}, x2 = {};
         bool b = false;

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -155,6 +155,17 @@ static constexpr std::array devnet_hard_forks = {
         hard_fork{hf::hf21_eth, 0, 409, 1716310020},
 };
 
+static constexpr std::array local_devnet_hard_forks = {
+        hard_fork{hf::hf7, 0, 0, 1716310007},
+        hard_fork{hf::hf14_blink, 0, 1, 1716310014},
+        hard_fork{hf::hf16_pulse, 0, 250, 1716310016},
+        hard_fork{hf::hf17, 0, 255, 1716310017},
+        hard_fork{hf::hf18, 0, 256, 1716310018},
+        hard_fork{hf::hf19_reward_batching, 0, 257, 1716310019},
+        hard_fork{hf::hf20_eth_transition, 0, 410, 1716310020},
+        hard_fork{hf::hf21_eth, 0, 411, 1716310020},
+};
+
 static constexpr std::array stagenet_hard_forks = {
         hard_fork{hf::hf7, 0, 0, 1720230000},
         hard_fork{hf::hf14_blink, 0, 1, 1720230014},
@@ -202,8 +213,8 @@ std::span<const hard_fork> get_hard_forks(network_type type) {
         case network_type::MAINNET: return mainnet_hard_forks;
         case network_type::STAGENET: return stagenet_hard_forks;
         case network_type::TESTNET: return testnet_hard_forks;
-        case network_type::DEVNET:
-        case network_type::LOCALDEV: return devnet_hard_forks;
+        case network_type::DEVNET: return devnet_hard_forks;
+        case network_type::LOCALDEV: return local_devnet_hard_forks;
         case network_type::FAKECHAIN: return fakechain_hardforks;
         case network_type::UNDEFINED:;
     }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -98,6 +98,13 @@ inline constexpr auto ETH_L2_DEFAULT_CHECK_INTERVAL = 2min;
 inline constexpr int ETH_L2_DEFAULT_CHECK_THRESHOLD = 120;
 
 
+// How frequently the reward rate gets recomputed for inclusion into Oxen blocks.  An Oxen block
+// that has a l2_height of x must include the reward computed at the highest block height <= x that
+// is divisible by this number.  For instance, if this is 1000, an Oxen block with height
+// l2_height=12345678 must contain the reward value computed at height 12345000.  (The default
+// updates every 10 minutes with the Arbitrum 250ms block time).
+inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 10min / 250ms;
+
 // Fallback used in wallet if no fee is available from RPC:
 inline constexpr uint64_t FEE_PER_BYTE_V13 = 215;
 // 0.005 OXEN per tx output (in addition to the per-byte fee), starting in v18:

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -97,14 +97,6 @@ inline constexpr auto ETH_L2_DEFAULT_CHECK_INTERVAL = 2min;
 // out of sync on Arbitrum).
 inline constexpr int ETH_L2_DEFAULT_CHECK_THRESHOLD = 120;
 
-
-// How frequently the reward rate gets recomputed for inclusion into Oxen blocks.  An Oxen block
-// that has a l2_height of x must include the reward computed at the highest block height <= x that
-// is divisible by this number.  For instance, if this is 1000, an Oxen block with height
-// l2_height=12345678 must contain the reward value computed at height 12345000.  (The default
-// updates every 10 minutes with the Arbitrum 250ms block time).
-inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 10min / 250ms;
-
 // Fallback used in wallet if no fee is available from RPC:
 inline constexpr uint64_t FEE_PER_BYTE_V13 = 215;
 // 0.005 OXEN per tx output (in addition to the per-byte fee), starting in v18:

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1810,6 +1810,7 @@ bool Blockchain::create_block_template_internal(
                     "block");
             return false;
         }
+        log::trace(logcat, "L2 reward retrieved {} (L2 height {}) for block {}", *l2_reward, b.l2_height, height);
     }
 
     // Add transactions in mempool to block

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -78,7 +78,7 @@ size_t constexpr STORE_LONG_TERM_STATE_INTERVAL = 10000;
 constexpr auto X25519_MAP_PRUNING_INTERVAL = 5min;
 constexpr auto X25519_MAP_PRUNING_LAG = 24h;
 static_assert(
-        X25519_MAP_PRUNING_LAG > cryptonote::config::mainnet::UPTIME_PROOF_VALIDITY,
+        X25519_MAP_PRUNING_LAG > cryptonote::config::mainnet::config.UPTIME_PROOF_VALIDITY,
         "x25519 map pruning lag is too short!");
 
 static uint64_t short_term_state_cull_height(hf hf_version, uint64_t block_height) {

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -600,7 +600,8 @@ uint64_t L2Tracker::get_latest_height() const {
 
 uint64_t L2Tracker::get_safe_height() const {
     std::shared_lock lock{mutex};
-    return SAFE_BLOCKS >= latest_height ? 0 : latest_height - SAFE_BLOCKS;
+    const cryptonote::network_config& config = cryptonote::get_config(core.get_nettype());
+    return config.L2_TRACKER_SAFE_BLOCKS >= latest_height ? 0 : latest_height - config.L2_TRACKER_SAFE_BLOCKS;
 }
 
 uint64_t L2Tracker::get_confirmed_height() const {

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -170,11 +170,6 @@ class L2Tracker {
     std::chrono::milliseconds PROVIDERS_CHECK_INTERVAL = cryptonote::ETH_L2_DEFAULT_CHECK_INTERVAL;
     uint64_t PROVIDERS_CHECK_THRESHOLD = cryptonote::ETH_L2_DEFAULT_CHECK_THRESHOLD;
 
-    // How many blocks behind the last known head we use for the "safe" height, i.e. the cutoff
-    // height for state change inclusions when building pulse blocks (so that we don't send things
-    // that are too new that other nodes might not know about yet).  The default is 30s behind.
-    static constexpr uint64_t SAFE_BLOCKS = 30s / 250ms;
-
     // Returns the reward rate for the given L2 height.  Returns nullopt if we don't know/haven't
     // retrieved it yet (and so this should generally be called with a safe height, not the current
     // L2 height).  (Note that L2 reward rates only change on L2 block heights divisible by

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -86,6 +86,7 @@ inline constexpr network_config config{
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,
         mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
+        mainnet::L2_TRACKER_SAFE_BLOCKS,
 };
 
 }  // namespace cryptonote::config::devnet

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -4,89 +4,69 @@
 #include "testnet.h"
 
 namespace cryptonote::config::devnet {
-
-inline constexpr uint64_t HEIGHT_ESTIMATE_HEIGHT = 0;
-inline constexpr time_t HEIGHT_ESTIMATE_TIMESTAMP = 1597170000;
-inline constexpr uint64_t PUBLIC_ADDRESS_BASE58_PREFIX = 3930;             // ~ dV1 .. dV3
-inline constexpr uint64_t PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 4442;  // ~ dVA .. dVC
-inline constexpr uint64_t PUBLIC_SUBADDRESS_BASE58_PREFIX = 5850;          // ~dVa .. dVc
-inline constexpr uint16_t P2P_DEFAULT_PORT = 38856;
-inline constexpr uint16_t RPC_DEFAULT_PORT = 38857;
-inline constexpr uint16_t QNET_DEFAULT_PORT = 38859;
-inline constexpr boost::uuids::uuid const NETWORK_ID = {
-        {0xa9,
-         0xf7,
-         0x5c,
-         0x7d,
-         0x5d,
-         0x17,
-         0xcb,
-         0x6b,
-         0x1b,
-         0xf4,
-         0x63,
-         0x79,
-         0x7a,
-         0x57,
-         0xab,
-         0xd5}};
-inline constexpr std::string_view GENESIS_TX =
-        "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
-        "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"
-        "656f247200000000000000000000000000000000000000000000000000000000000000000000"sv;
-inline constexpr uint32_t GENESIS_NONCE = 12345;
-
-inline constexpr std::array GOVERNANCE_WALLET_ADDRESS = {
-        // hardfork v7-9
-        "dV3EhSE1xXgSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M4A7Uimp"sv,
-        // hardfork v10
-        "dV3EhSE1xXgSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M4A7Uimp"sv,
-};
-
-inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
-
-inline constexpr uint32_t ETHEREUM_CHAIN_ID = 421614;
-inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0xB333811db68888800a23E79b38E401451d97aEdD"sv;
-inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x8B11c5777EE7BFC1F1195A9ef0506Ae7846CC5b8"sv;
-
 inline constexpr network_config config{
-        network_type::DEVNET,
-        HEIGHT_ESTIMATE_HEIGHT,
-        HEIGHT_ESTIMATE_TIMESTAMP,
-        PUBLIC_ADDRESS_BASE58_PREFIX,
-        PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        P2P_DEFAULT_PORT,
-        RPC_DEFAULT_PORT,
-        QNET_DEFAULT_PORT,
-        NETWORK_ID,
-        GENESIS_TX,
-        GENESIS_NONCE,
-        mainnet::GOVERNANCE_REWARD_INTERVAL,
-        GOVERNANCE_WALLET_ADDRESS,
-        mainnet::UPTIME_PROOF_TOLERANCE,
-        mainnet::UPTIME_PROOF_STARTUP_DELAY,
-        mainnet::UPTIME_PROOF_CHECK_INTERVAL,
-        testnet::UPTIME_PROOF_FREQUENCY,
-        testnet::UPTIME_PROOF_VALIDITY,
-        false, // storage & lokinet
-        mainnet::TARGET_BLOCK_TIME,
-        mainnet::PULSE_STAGE_TIMEOUT,
-        mainnet::PULSE_ROUND_TIMEOUT,
-        mainnet::PULSE_MAX_START_ADJUSTMENT,
-        testnet::PULSE_MIN_SERVICE_NODES,
-        testnet::BATCHING_INTERVAL,
-        mainnet::MIN_BATCH_PAYMENT_AMOUNT,
-        mainnet::LIMIT_BATCH_OUTPUTS,
-        testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_REMOVAL_BUFFER,
-        ETHEREUM_CHAIN_ID,
-        ETHEREUM_REWARDS_CONTRACT,
-        ETHEREUM_POOL_CONTRACT,
-        mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
-        mainnet::L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::DEVNET,
+        .HEIGHT_ESTIMATE_HEIGHT = 0,
+        .HEIGHT_ESTIMATE_TIMESTAMP = 1597170000,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = 3930,             // ~ dV1 .. dV3
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 4442,  // ~ dVA .. dVC
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = 5850,          // ~ dVa .. dVc
+        .P2P_DEFAULT_PORT = 38856,
+        .RPC_DEFAULT_PORT = 38857,
+        .QNET_DEFAULT_PORT = 38859,
+        .NETWORK_ID =
+                {{0xa9,
+                  0xf7,
+                  0x5c,
+                  0x7d,
+                  0x5d,
+                  0x17,
+                  0xcb,
+                  0x6b,
+                  0x1b,
+                  0xf4,
+                  0x63,
+                  0x79,
+                  0x7a,
+                  0x57,
+                  0xab,
+                  0xd5}},
+        .GENESIS_TX =
+                "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
+                "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"
+                "656f247200000000000000000000000000000000000000000000000000000000000000000000"sv,
+        .GENESIS_NONCE = 12345,
+        .GOVERNANCE_REWARD_INTERVAL = mainnet::config.GOVERNANCE_REWARD_INTERVAL,
+        .GOVERNANCE_WALLET_ADDRESS =
+                {
+                        "dV3EhSE1xXgSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYd"
+                        "gzZhDLMTo9uEv82M4A7Uimp",  // HF7-9
+                        "dV3EhSE1xXgSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYd"
+                        "gzZhDLMTo9uEv82M4A7Uimp",  // HF10
+                },
+        .UPTIME_PROOF_TOLERANCE = mainnet::config.UPTIME_PROOF_TOLERANCE,
+        .UPTIME_PROOF_STARTUP_DELAY = 5s,
+        .UPTIME_PROOF_CHECK_INTERVAL = mainnet::config.UPTIME_PROOF_CHECK_INTERVAL,
+        .UPTIME_PROOF_FREQUENCY = testnet::config.UPTIME_PROOF_FREQUENCY,
+        .UPTIME_PROOF_VALIDITY = testnet::config.UPTIME_PROOF_VALIDITY,
+        .HAVE_STORAGE_AND_LOKINET = false,  // storage & lokinet
+        .TARGET_BLOCK_TIME = mainnet::TARGET_BLOCK_TIME,
+        .PULSE_STAGE_TIMEOUT = mainnet::config.PULSE_STAGE_TIMEOUT,
+        .PULSE_ROUND_TIMEOUT = mainnet::config.PULSE_ROUND_TIMEOUT,
+        .PULSE_MAX_START_ADJUSTMENT = mainnet::config.PULSE_MAX_START_ADJUSTMENT,
+        .PULSE_MIN_SERVICE_NODES = testnet::config.PULSE_MIN_SERVICE_NODES,
+        .BATCHING_INTERVAL = testnet::config.BATCHING_INTERVAL,
+        .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
+        .LIMIT_BATCH_OUTPUTS = mainnet::config.LIMIT_BATCH_OUTPUTS,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = testnet::config.SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
+                mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+        .STORE_LONG_TERM_STATE_INTERVAL = mainnet::config.STORE_LONG_TERM_STATE_INTERVAL,
+        .ETH_REMOVAL_BUFFER = testnet::config.ETH_REMOVAL_BUFFER,
+        .ETHEREUM_CHAIN_ID = 421614,
+        .ETHEREUM_REWARDS_CONTRACT = "0xB333811db68888800a23E79b38E401451d97aEdD",
+        .ETHEREUM_POOL_CONTRACT = "0x8B11c5777EE7BFC1F1195A9ef0506Ae7846CC5b8",
+        .L2_REWARD_POOL_UPDATE_BLOCKS = mainnet::config.L2_REWARD_POOL_UPDATE_BLOCKS,
+        .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
 };
-
 }  // namespace cryptonote::config::devnet

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -4,55 +4,48 @@
 #include "testnet.h"
 
 namespace cryptonote::config::fakechain {
-
-// Fakechain uptime proofs are 60x faster than mainnet, because this really only runs on a
-// hand-crafted, typically local temporary network.
-inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
-inline constexpr auto UPTIME_PROOF_CHECK_INTERVAL = 5s;
-inline constexpr auto UPTIME_PROOF_FREQUENCY = 1min;
-inline constexpr auto UPTIME_PROOF_VALIDITY = 2min + 5s;
-
-inline constexpr auto GOVERNANCE_REWARD_INTERVAL = 200min;
-
 inline constexpr network_config config{
-        network_type::FAKECHAIN,
-        mainnet::HEIGHT_ESTIMATE_HEIGHT,
-        mainnet::HEIGHT_ESTIMATE_TIMESTAMP,
-        mainnet::PUBLIC_ADDRESS_BASE58_PREFIX,
-        mainnet::PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        mainnet::PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        mainnet::P2P_DEFAULT_PORT,
-        mainnet::RPC_DEFAULT_PORT,
-        mainnet::QNET_DEFAULT_PORT,
-        mainnet::NETWORK_ID,
-        mainnet::GENESIS_TX,
-        mainnet::GENESIS_NONCE,
-        GOVERNANCE_REWARD_INTERVAL,
-        mainnet::GOVERNANCE_WALLET_ADDRESS,
-        mainnet::UPTIME_PROOF_TOLERANCE,
-        UPTIME_PROOF_STARTUP_DELAY,
-        UPTIME_PROOF_CHECK_INTERVAL,
-        UPTIME_PROOF_FREQUENCY,
-        UPTIME_PROOF_VALIDITY,
-        false, // storage & lokinet
-        mainnet::TARGET_BLOCK_TIME,
-        mainnet::PULSE_STAGE_TIMEOUT,
-        mainnet::PULSE_ROUND_TIMEOUT,
-        mainnet::PULSE_MAX_START_ADJUSTMENT,
-        mainnet::PULSE_MIN_SERVICE_NODES,
-        testnet::BATCHING_INTERVAL,
-        mainnet::MIN_BATCH_PAYMENT_AMOUNT,
-        mainnet::LIMIT_BATCH_OUTPUTS,
-        testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_REMOVAL_BUFFER,
-        mainnet::ETHEREUM_CHAIN_ID,
-        mainnet::ETHEREUM_REWARDS_CONTRACT,
-        mainnet::ETHEREUM_POOL_CONTRACT,
-        mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
-        mainnet::L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::FAKECHAIN,
+        .HEIGHT_ESTIMATE_HEIGHT = mainnet::config.HEIGHT_ESTIMATE_HEIGHT,
+        .HEIGHT_ESTIMATE_TIMESTAMP = mainnet::config.HEIGHT_ESTIMATE_TIMESTAMP,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = mainnet::config.PUBLIC_ADDRESS_BASE58_PREFIX,
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX =
+                mainnet::config.PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = mainnet::config.PUBLIC_SUBADDRESS_BASE58_PREFIX,
+        .P2P_DEFAULT_PORT = mainnet::config.P2P_DEFAULT_PORT,
+        .RPC_DEFAULT_PORT = mainnet::config.RPC_DEFAULT_PORT,
+        .QNET_DEFAULT_PORT = mainnet::config.QNET_DEFAULT_PORT,
+        .NETWORK_ID = mainnet::config.NETWORK_ID,
+        .GENESIS_TX = mainnet::config.GENESIS_TX,
+        .GENESIS_NONCE = mainnet::config.GENESIS_NONCE,
+        .GOVERNANCE_REWARD_INTERVAL = 200min,
+        .GOVERNANCE_WALLET_ADDRESS = mainnet::config.GOVERNANCE_WALLET_ADDRESS,
+        .UPTIME_PROOF_TOLERANCE = mainnet::config.UPTIME_PROOF_TOLERANCE,
+        // Fakechain uptime proofs are 60x faster than mainnet, because this
+        // really only runs on a hand-crafted, typically local temporary
+        // network.
+        .UPTIME_PROOF_STARTUP_DELAY = 5s,
+        .UPTIME_PROOF_CHECK_INTERVAL = 5s,
+        .UPTIME_PROOF_FREQUENCY = 1min,
+        .UPTIME_PROOF_VALIDITY = 2min + 5s,
+        .HAVE_STORAGE_AND_LOKINET = false,
+        .TARGET_BLOCK_TIME = mainnet::config.TARGET_BLOCK_TIME,
+        .PULSE_STAGE_TIMEOUT = mainnet::config.PULSE_STAGE_TIMEOUT,
+        .PULSE_ROUND_TIMEOUT = mainnet::config.PULSE_ROUND_TIMEOUT,
+        .PULSE_MAX_START_ADJUSTMENT = mainnet::config.PULSE_MAX_START_ADJUSTMENT,
+        .PULSE_MIN_SERVICE_NODES = mainnet::config.PULSE_MIN_SERVICE_NODES,
+        .BATCHING_INTERVAL = testnet::config.BATCHING_INTERVAL,
+        .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
+        .LIMIT_BATCH_OUTPUTS = mainnet::config.LIMIT_BATCH_OUTPUTS,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = testnet::config.SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
+                mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+        .STORE_LONG_TERM_STATE_INTERVAL = mainnet::config.STORE_LONG_TERM_STATE_INTERVAL,
+        .ETH_REMOVAL_BUFFER = testnet::config.ETH_REMOVAL_BUFFER,
+        .ETHEREUM_CHAIN_ID = mainnet::config.ETHEREUM_CHAIN_ID,
+        .ETHEREUM_REWARDS_CONTRACT = mainnet::config.ETHEREUM_REWARDS_CONTRACT,
+        .ETHEREUM_POOL_CONTRACT = mainnet::config.ETHEREUM_POOL_CONTRACT,
+        .L2_REWARD_POOL_UPDATE_BLOCKS = mainnet::config.L2_REWARD_POOL_UPDATE_BLOCKS,
+        .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
 };
-
-
 }  // namespace cryptonote::config::fakechain

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -51,6 +51,7 @@ inline constexpr network_config config{
         mainnet::ETHEREUM_REWARDS_CONTRACT,
         mainnet::ETHEREUM_POOL_CONTRACT,
         mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
+        mainnet::L2_TRACKER_SAFE_BLOCKS,
 };
 
 

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -15,59 +15,55 @@
 //
 // A local-devnet can be deployed by running
 // `utils/local-devnet/service_node_network.py`
-
 namespace cryptonote::config::localdev {
-
-inline constexpr uint32_t ETHEREUM_CHAIN_ID = 31337;
-inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"sv;
-inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"sv;
-
-inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 1;
-static constexpr uint64_t L2_TRACKER_SAFE_BLOCKS = 0;
-
-inline constexpr auto TARGET_BLOCK_TIME = 6s;
-inline constexpr auto PULSE_STAGE_TIMEOUT = 1s;
-inline constexpr auto PULSE_ROUND_TIMEOUT = 3s;
-inline constexpr auto PULSE_MAX_START_ADJUSTMENT = 3s;
-
 inline constexpr network_config config{
-        network_type::LOCALDEV,
-        devnet::HEIGHT_ESTIMATE_HEIGHT,
-        devnet::HEIGHT_ESTIMATE_TIMESTAMP,
-        devnet::PUBLIC_ADDRESS_BASE58_PREFIX,
-        devnet::PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        devnet::PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        devnet::P2P_DEFAULT_PORT,
-        devnet::RPC_DEFAULT_PORT,
-        devnet::QNET_DEFAULT_PORT,
-        devnet::NETWORK_ID,
-        devnet::GENESIS_TX,
-        devnet::GENESIS_NONCE,
-        mainnet::GOVERNANCE_REWARD_INTERVAL,
-        devnet::GOVERNANCE_WALLET_ADDRESS,
-        mainnet::UPTIME_PROOF_TOLERANCE,
-        mainnet::UPTIME_PROOF_STARTUP_DELAY,
-        mainnet::UPTIME_PROOF_CHECK_INTERVAL,
-        testnet::UPTIME_PROOF_FREQUENCY,
-        testnet::UPTIME_PROOF_VALIDITY,
-        false, // storage & lokinet
-        TARGET_BLOCK_TIME,
-        PULSE_STAGE_TIMEOUT,
-        PULSE_ROUND_TIMEOUT,
-        PULSE_MAX_START_ADJUSTMENT,
-        testnet::PULSE_MIN_SERVICE_NODES,
-        testnet::BATCHING_INTERVAL,
-        mainnet::MIN_BATCH_PAYMENT_AMOUNT,
-        mainnet::LIMIT_BATCH_OUTPUTS,
-        testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        testnet::ETH_REMOVAL_BUFFER,
-        ETHEREUM_CHAIN_ID,
-        ETHEREUM_REWARDS_CONTRACT,
-        ETHEREUM_POOL_CONTRACT,
-        L2_REWARD_POOL_UPDATE_BLOCKS,
-        L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::LOCALDEV,
+        .HEIGHT_ESTIMATE_HEIGHT = devnet::config.HEIGHT_ESTIMATE_HEIGHT,
+        .HEIGHT_ESTIMATE_TIMESTAMP = devnet::config.HEIGHT_ESTIMATE_TIMESTAMP,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = devnet::config.PUBLIC_ADDRESS_BASE58_PREFIX,
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX =
+                devnet::config.PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = devnet::config.PUBLIC_SUBADDRESS_BASE58_PREFIX,
+        .P2P_DEFAULT_PORT = devnet::config.P2P_DEFAULT_PORT,
+        .RPC_DEFAULT_PORT = devnet::config.RPC_DEFAULT_PORT,
+        .QNET_DEFAULT_PORT = devnet::config.QNET_DEFAULT_PORT,
+        .NETWORK_ID = devnet::config.NETWORK_ID,
+        .GENESIS_TX = devnet::config.GENESIS_TX,
+        .GENESIS_NONCE = devnet::config.GENESIS_NONCE,
+        .GOVERNANCE_REWARD_INTERVAL = mainnet::config.GOVERNANCE_REWARD_INTERVAL,
+        .GOVERNANCE_WALLET_ADDRESS = devnet::config.GOVERNANCE_WALLET_ADDRESS,
+        .UPTIME_PROOF_TOLERANCE = mainnet::config.UPTIME_PROOF_TOLERANCE,
+        .UPTIME_PROOF_STARTUP_DELAY = mainnet::config.UPTIME_PROOF_STARTUP_DELAY,
+        .UPTIME_PROOF_CHECK_INTERVAL = mainnet::config.UPTIME_PROOF_CHECK_INTERVAL,
+        .UPTIME_PROOF_FREQUENCY = testnet::config.UPTIME_PROOF_FREQUENCY,
+        .UPTIME_PROOF_VALIDITY = testnet::config.UPTIME_PROOF_VALIDITY,
+        .HAVE_STORAGE_AND_LOKINET = false,
+        .TARGET_BLOCK_TIME = 6s,
+        .PULSE_STAGE_TIMEOUT = 1s,
+        .PULSE_ROUND_TIMEOUT = 3s,
+        .PULSE_MAX_START_ADJUSTMENT = 3s,
+        .PULSE_MIN_SERVICE_NODES = testnet::config.PULSE_MIN_SERVICE_NODES,
+        .BATCHING_INTERVAL = testnet::config.BATCHING_INTERVAL,
+        .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
+        .LIMIT_BATCH_OUTPUTS = mainnet::config.LIMIT_BATCH_OUTPUTS,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = testnet::config.SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
+                mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+        .STORE_LONG_TERM_STATE_INTERVAL = mainnet::config.STORE_LONG_TERM_STATE_INTERVAL,
+        .ETH_REMOVAL_BUFFER = testnet::config.ETH_REMOVAL_BUFFER,
+        .ETHEREUM_CHAIN_ID = 31337,
+        .ETHEREUM_REWARDS_CONTRACT = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"sv,
+        .ETHEREUM_POOL_CONTRACT = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"sv,
+        // Set the reward rate, polled from the smart contract to be sampled
+        // essentially every block because everything is running locally.
+        // This is needed for tests because we are running Pulse nodes
+        // which means block producing is slowed down due to round
+        // timings and IPC. The L2 similarly is updating in lock-step with
+        // the Oxen workchain.
+        .L2_REWARD_POOL_UPDATE_BLOCKS = 1,
+        // All Session nodes are connected to the same RPC provider (e.g.
+        // Foundry's Anvil) which is also running locally hence we have a very
+        // low threshold for the number of blocks to trail the tip by.
+        .L2_TRACKER_SAFE_BLOCKS = 0,
 };
-
 }  // namespace cryptonote::config::localdev

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -62,9 +62,9 @@ inline constexpr network_config config{
         mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         mainnet::STORE_LONG_TERM_STATE_INTERVAL,
         testnet::ETH_REMOVAL_BUFFER,
-        devnet::ETHEREUM_CHAIN_ID,
-        devnet::ETHEREUM_REWARDS_CONTRACT,
-        devnet::ETHEREUM_POOL_CONTRACT,
+        ETHEREUM_CHAIN_ID,
+        ETHEREUM_REWARDS_CONTRACT,
+        ETHEREUM_POOL_CONTRACT,
         L2_REWARD_POOL_UPDATE_BLOCKS,
 };
 

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -23,6 +23,7 @@ inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0x5FC8d32690cc91D4c39d9d3abcB
 inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"sv;
 
 inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 1;
+static constexpr uint64_t L2_TRACKER_SAFE_BLOCKS = 0;
 
 inline constexpr auto TARGET_BLOCK_TIME = 6s;
 inline constexpr auto PULSE_STAGE_TIMEOUT = 1s;
@@ -66,6 +67,7 @@ inline constexpr network_config config{
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,
         L2_REWARD_POOL_UPDATE_BLOCKS,
+        L2_TRACKER_SAFE_BLOCKS,
 };
 
 }  // namespace cryptonote::config::localdev

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -22,7 +22,7 @@ inline constexpr uint32_t ETHEREUM_CHAIN_ID = 31337;
 inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"sv;
 inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"sv;
 
-inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 4;
+inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 1;
 
 inline constexpr auto TARGET_BLOCK_TIME = 6s;
 inline constexpr auto PULSE_STAGE_TIMEOUT = 1s;

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -38,10 +38,10 @@ inline constexpr network_config config{
         .UPTIME_PROOF_FREQUENCY = testnet::config.UPTIME_PROOF_FREQUENCY,
         .UPTIME_PROOF_VALIDITY = testnet::config.UPTIME_PROOF_VALIDITY,
         .HAVE_STORAGE_AND_LOKINET = false,
-        .TARGET_BLOCK_TIME = 6s,
-        .PULSE_STAGE_TIMEOUT = 1s,
-        .PULSE_ROUND_TIMEOUT = 3s,
-        .PULSE_MAX_START_ADJUSTMENT = 3s,
+        .TARGET_BLOCK_TIME = 10s,
+        .PULSE_STAGE_TIMEOUT = 3s,
+        .PULSE_ROUND_TIMEOUT = 4s,
+        .PULSE_MAX_START_ADJUSTMENT = 4s,
         .PULSE_MIN_SERVICE_NODES = testnet::config.PULSE_MIN_SERVICE_NODES,
         .BATCHING_INTERVAL = testnet::config.BATCHING_INTERVAL,
         .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
@@ -64,6 +64,6 @@ inline constexpr network_config config{
         // All Session nodes are connected to the same RPC provider (e.g.
         // Foundry's Anvil) which is also running locally hence we have a very
         // low threshold for the number of blocks to trail the tip by.
-        .L2_TRACKER_SAFE_BLOCKS = 0,
+        .L2_TRACKER_SAFE_BLOCKS = 1,
 };
 }  // namespace cryptonote::config::localdev

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -85,8 +85,11 @@ inline constexpr std::string_view ETHEREUM_REWARDS_CONTRACT =
 inline constexpr std::string_view ETHEREUM_POOL_CONTRACT =
         "0x0000000000000000000000000000000000000000";
 
-// Update every ~10 minutes with the Arbitrum ~250ms block time:
+// Update every ~10 minutes with an Arbitrum ~250ms block time:
 inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 10min / 250ms;
+
+// The default is 30s behind with an Arbitrum ~250ms block time:
+static constexpr uint64_t L2_TRACKER_SAFE_BLOCKS = 30s / 250ms;
 
 inline constexpr network_config config{
         network_type::MAINNET,
@@ -125,6 +128,7 @@ inline constexpr network_config config{
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,
         L2_REWARD_POOL_UPDATE_BLOCKS,
+        L2_TRACKER_SAFE_BLOCKS,
 };
 
 }  // namespace cryptonote::config::mainnet

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -1,134 +1,79 @@
 #pragma once
 
-#include <array>
 #include <boost/uuid/uuid.hpp>
 #include <cstdint>
-#include <ctime>
-#include <string_view>
 
 #include "../cryptonote_config.h"
 #include "network_config.h"
 
 using namespace std::literals;
-
-// Various configuration defaults and network-dependent settings
 namespace cryptonote::config::mainnet {
-
-inline constexpr uint64_t HEIGHT_ESTIMATE_HEIGHT = 582088;
-inline constexpr time_t HEIGHT_ESTIMATE_TIMESTAMP = 1595359932;
-
 inline constexpr auto TARGET_BLOCK_TIME = 2min;
-
-inline constexpr uint64_t PUBLIC_ADDRESS_BASE58_PREFIX = 114;
-inline constexpr uint64_t PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 115;
-inline constexpr uint64_t PUBLIC_SUBADDRESS_BASE58_PREFIX = 116;
-inline constexpr uint16_t P2P_DEFAULT_PORT = 22022;
-inline constexpr uint16_t RPC_DEFAULT_PORT = 22023;
-inline constexpr uint16_t QNET_DEFAULT_PORT = 22025;
-inline constexpr boost::uuids::uuid const NETWORK_ID = {
-        {0x46,
-         0x61,
-         0x72,
-         0x62,
-         0x61,
-         0x75,
-         0x74,
-         0x69,
-         0x2a,
-         0x4c,
-         0x61,
-         0x75,
-         0x66,
-         0x65,
-         0x79}};  // Bender's nightmare
-inline constexpr std::string_view GENESIS_TX =
-        "021e01ff000380808d93f5d771027c4fd4553bc9886f1f49e3f76d945bf71e8632a94e6c177b19cb"
-        "c780e7e6bdb48080b4ccd4dfc60302c8b9f6461f58ef3f2107e577c7425d06af584a1c7482bf1906"
-        "0e84059c98b4c3808088fccdbcc32302732b53b0b0db706fcc3087074fb4b786da5ab72b2065699f"
-        "9453448b0db27f892101ed71f2ce3fc70d7b2036f8a4e4b3fb75c66c12184b55a908e7d1a1d69955"
-        "66cf00"sv;
-inline constexpr uint32_t GENESIS_NONCE = 1022201;
-
-inline constexpr auto GOVERNANCE_REWARD_INTERVAL = 7 * 24h;
-inline constexpr std::array GOVERNANCE_WALLET_ADDRESS = {
-        // hardfork v7-10:
-        "LCFxT37LAogDn1jLQKf4y7aAqfi21DjovX9qyijaLYQSdrxY1U5VGcnMJMjWrD9RhjeK5Lym67wZ73uh9AujXLQ1RKmXEyL"sv,
-        // hardfork v11
-        "LDBEN6Ut4NkMwyaXWZ7kBEAx8X64o6YtDhLXUP26uLHyYT4nFmcaPU2Z2fauqrhTLh4Qfr61pUUZVLaTHqAdycETKM1STrz"sv,
-};
-
-inline constexpr uint64_t HARDFORK_DEREGISTRATION_GRACE_PERIOD = 7 * 24h / TARGET_BLOCK_TIME;
-inline constexpr auto UPTIME_PROOF_TOLERANCE = 5min;
-inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 30s;
-inline constexpr auto UPTIME_PROOF_CHECK_INTERVAL = 30s;
-inline constexpr auto UPTIME_PROOF_FREQUENCY = 1h;
-inline constexpr auto UPTIME_PROOF_VALIDITY = 2h + 5min;
-
-inline constexpr auto PULSE_STAGE_TIMEOUT = 10s;
-inline constexpr auto PULSE_ROUND_TIMEOUT = 1min;
-inline constexpr auto PULSE_MAX_START_ADJUSTMENT = 30s;
-inline constexpr size_t PULSE_MIN_SERVICE_NODES = 50;
-
-inline constexpr uint64_t BATCHING_INTERVAL = 2520;
-inline constexpr uint64_t MIN_BATCH_PAYMENT_AMOUNT = 1'000'000'000;  // 1 OXEN (in atomic units)
-inline constexpr uint64_t LIMIT_BATCH_OUTPUTS = 15;
-inline constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 720;
-
-inline constexpr uint64_t STORE_LONG_TERM_STATE_INTERVAL = 10000;
-
-inline constexpr uint64_t ETH_REMOVAL_BUFFER = 7 * 24h / TARGET_BLOCK_TIME;
-
-// TODO: To be set for mainnet during TGE
-inline constexpr uint32_t ETHEREUM_CHAIN_ID = -1;
-inline constexpr std::string_view ETHEREUM_REWARDS_CONTRACT =
-        "0x0000000000000000000000000000000000000000";
-inline constexpr std::string_view ETHEREUM_POOL_CONTRACT =
-        "0x0000000000000000000000000000000000000000";
-
-// Update every ~10 minutes with an Arbitrum ~250ms block time:
-inline constexpr uint64_t L2_REWARD_POOL_UPDATE_BLOCKS = 10min / 250ms;
-
-// The default is 30s behind with an Arbitrum ~250ms block time:
-static constexpr uint64_t L2_TRACKER_SAFE_BLOCKS = 30s / 250ms;
-
 inline constexpr network_config config{
-        network_type::MAINNET,
-        HEIGHT_ESTIMATE_HEIGHT,
-        HEIGHT_ESTIMATE_TIMESTAMP,
-        PUBLIC_ADDRESS_BASE58_PREFIX,
-        PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        P2P_DEFAULT_PORT,
-        RPC_DEFAULT_PORT,
-        QNET_DEFAULT_PORT,
-        NETWORK_ID,
-        GENESIS_TX,
-        GENESIS_NONCE,
-        GOVERNANCE_REWARD_INTERVAL,
-        GOVERNANCE_WALLET_ADDRESS,
-        UPTIME_PROOF_TOLERANCE,
-        UPTIME_PROOF_STARTUP_DELAY,
-        UPTIME_PROOF_CHECK_INTERVAL,
-        UPTIME_PROOF_FREQUENCY,
-        UPTIME_PROOF_VALIDITY,
-        true,  // storage & lokinet
-        TARGET_BLOCK_TIME,
-        PULSE_STAGE_TIMEOUT,
-        PULSE_ROUND_TIMEOUT,
-        PULSE_MAX_START_ADJUSTMENT,
-        PULSE_MIN_SERVICE_NODES,
-        BATCHING_INTERVAL,
-        MIN_BATCH_PAYMENT_AMOUNT,
-        LIMIT_BATCH_OUTPUTS,
-        SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_REMOVAL_BUFFER,
-        ETHEREUM_CHAIN_ID,
-        ETHEREUM_REWARDS_CONTRACT,
-        ETHEREUM_POOL_CONTRACT,
-        L2_REWARD_POOL_UPDATE_BLOCKS,
-        L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::MAINNET,
+        .HEIGHT_ESTIMATE_HEIGHT = 582088,
+        .HEIGHT_ESTIMATE_TIMESTAMP = 1595359932,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = 114,
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 115,
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = 116,
+        .P2P_DEFAULT_PORT = 22022,
+        .RPC_DEFAULT_PORT = 22023,
+        .QNET_DEFAULT_PORT = 22025,
+        .NETWORK_ID =
+                {{0x46,
+                  0x61,
+                  0x72,
+                  0x62,
+                  0x61,
+                  0x75,
+                  0x74,
+                  0x69,
+                  0x2a,
+                  0x4c,
+                  0x61,
+                  0x75,
+                  0x66,
+                  0x65,
+                  0x79}},  // Bender's nightmare
+        .GENESIS_TX =
+                "021e01ff000380808d93f5d771027c4fd4553bc9886f1f49e3f76d945bf71e8632a94e6c177b19cbc7"
+                "80e7e6bdb48080b4ccd4dfc60302c8b9f6461f58ef3f2107e577c7425d06af584a1c7482bf19060e84"
+                "059c98b4c3808088fccdbcc32302732b53b0b0db706fcc3087074fb4b786da5ab72b2065699f945344"
+                "8b0db27f892101ed71f2ce3fc70d7b2036f8a4e4b3fb75c66c12184b55a908e7d1a1d6995566cf00",
+        .GENESIS_NONCE = 1022201,
+        .GOVERNANCE_REWARD_INTERVAL = 7 * 24h,
+        .GOVERNANCE_WALLET_ADDRESS =
+                {
+                        "LCFxT37LAogDn1jLQKf4y7aAqfi21DjovX9qyijaLYQSdrxY1U5VGcnMJMjWrD9RhjeK5Lym67"
+                        "wZ73uh9AujXLQ1RKmXEyL",  // HF7-10
+                        "LDBEN6Ut4NkMwyaXWZ7kBEAx8X64o6YtDhLXUP26uLHyYT4nFmcaPU2Z2fauqrhTLh4Qfr61pU"
+                        "UZVLaTHqAdycETKM1STrz",  // HF11
+                },
+        .UPTIME_PROOF_TOLERANCE = 5min,
+        .UPTIME_PROOF_STARTUP_DELAY = 30s,
+        .UPTIME_PROOF_CHECK_INTERVAL = 30s,
+        .UPTIME_PROOF_FREQUENCY = 1h,
+        .UPTIME_PROOF_VALIDITY = 2h + 5min,
+        .HAVE_STORAGE_AND_LOKINET = true,
+        .TARGET_BLOCK_TIME = TARGET_BLOCK_TIME,
+        .PULSE_STAGE_TIMEOUT = 10s,
+        .PULSE_ROUND_TIMEOUT = 1min,
+        .PULSE_MAX_START_ADJUSTMENT = 30s,
+        .PULSE_MIN_SERVICE_NODES = 50,
+        .BATCHING_INTERVAL = 2520,
+        .MIN_BATCH_PAYMENT_AMOUNT = 1'000'000'000,  // 1 OXEN (in atomic units)
+        .LIMIT_BATCH_OUTPUTS = 15,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 720,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD = 7 * 24h / TARGET_BLOCK_TIME,
+        .STORE_LONG_TERM_STATE_INTERVAL = 10'000,
+        .ETH_REMOVAL_BUFFER = 7 * 24h / TARGET_BLOCK_TIME,
+        // TODO: To be set closer to mainnet TGE
+        .ETHEREUM_CHAIN_ID = static_cast<uint32_t>(-1),
+        .ETHEREUM_REWARDS_CONTRACT = "0x0000000000000000000000000000000000000000",
+        .ETHEREUM_POOL_CONTRACT = "0x0000000000000000000000000000000000000000",
+        // Update every ~10 minutes with an Arbitrum ~250ms block time:
+        .L2_REWARD_POOL_UPDATE_BLOCKS = 10min / 250ms,
+        // The default is 30s behind with an Arbitrum ~250ms block time:
+        .L2_TRACKER_SAFE_BLOCKS = 30s / 250ms,
 };
-
 }  // namespace cryptonote::config::mainnet

--- a/src/network_config/network_config.h
+++ b/src/network_config/network_config.h
@@ -123,6 +123,11 @@ struct network_config final {
     // l2_height=12345678 must contain the reward value computed at height 12345000.
     const uint64_t L2_REWARD_POOL_UPDATE_BLOCKS;
 
+    // How many blocks behind the last known head we use for the "safe" height, i.e. the cutoff
+    // height for state change inclusions when building pulse blocks (so that we don't send things
+    // that are too new that other nodes might not know about yet).
+    const uint64_t L2_TRACKER_SAFE_BLOCKS;
+
     constexpr std::string_view governance_wallet_address(hf hard_fork_version) const {
         const auto wallet_switch =
                 (NETWORK_TYPE == network_type::MAINNET || NETWORK_TYPE == network_type::FAKECHAIN)
@@ -130,6 +135,7 @@ struct network_config final {
                         : hf::hf10_bulletproofs;
         return GOVERNANCE_WALLET_ADDRESS[hard_fork_version >= wallet_switch ? 1 : 0];
     }
+
 };
 
 }  // namespace cryptonote

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -1,95 +1,73 @@
 #pragma once
 
-#include "devnet.h"
 #include "mainnet.h"
+#include "testnet.h"
 
 namespace cryptonote::config::stagenet {
-
-inline constexpr uint64_t HEIGHT_ESTIMATE_HEIGHT = 0;
-inline constexpr time_t HEIGHT_ESTIMATE_TIMESTAMP = 1720140000;
-inline constexpr uint64_t PUBLIC_ADDRESS_BASE58_PREFIX = 4888;             // ~ ST2 .. ST4
-inline constexpr uint64_t PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 5272;  // ~ ST9 .. STB
-inline constexpr uint64_t PUBLIC_SUBADDRESS_BASE58_PREFIX = 5656;          // ~ STF .. STJ
-inline constexpr uint16_t P2P_DEFAULT_PORT = 11022;
-inline constexpr uint16_t RPC_DEFAULT_PORT = 11023;
-inline constexpr uint16_t QNET_DEFAULT_PORT = 11025;
-inline constexpr boost::uuids::uuid const NETWORK_ID = {
-        {0x61,
-         0x6c,
-         0x6c,
-         0x79,
-         0x6f,
-         0x75,
-         0x72,
-         0x53,
-         0x45,
-         0x4e,
-         0x54,
-         0x61,
-         0x72,
-         0x65,
-         0x62,
-         0x65}};
-inline constexpr std::string_view GENESIS_TX =
-        "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
-        "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"
-        "656f247200000000000000000000000000000000000000000000000000000000000000000000"sv;
-inline constexpr uint32_t GENESIS_NONCE = 12345;
-
-inline constexpr std::array GOVERNANCE_WALLET_ADDRESS = {
-        // hardfork v7-9
-        "ST4BqQJpS2t8otav3yWwwX4eM4xTE1isFPNsGYyPVkDQeUPjmw4kJsW8NHWYq2FZcGMsVuqrBwGTfZydWyvzXoG22r2BJuPRf"sv,
-        // hardfork v10
-        "ST4BqQJpS2t8otav3yWwwX4eM4xTE1isFPNsGYyPVkDQeUPjmw4kJsW8NHWYq2FZcGMsVuqrBwGTfZydWyvzXoG22r2BJuPRf"sv,
-};
-
-inline constexpr auto UPTIME_PROOF_STARTUP_DELAY = 5s;
-
-// Much shorter than mainnet so that you can test this more easily.
-inline constexpr uint64_t ETH_REMOVAL_BUFFER = 2h / mainnet::TARGET_BLOCK_TIME;
-
-inline constexpr uint32_t ETHEREUM_CHAIN_ID = 421614;
-inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0xEF43cd64528eA89966E251d4FE17c660222D2c9d"sv;
-inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x408bCc6C9b942ECc4F289C080d2A1a2a3617Aff8"sv;
-
 inline constexpr network_config config{
-        network_type::STAGENET,
-        HEIGHT_ESTIMATE_HEIGHT,
-        HEIGHT_ESTIMATE_TIMESTAMP,
-        PUBLIC_ADDRESS_BASE58_PREFIX,
-        PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        P2P_DEFAULT_PORT,
-        RPC_DEFAULT_PORT,
-        QNET_DEFAULT_PORT,
-        NETWORK_ID,
-        GENESIS_TX,
-        GENESIS_NONCE,
-        mainnet::GOVERNANCE_REWARD_INTERVAL,
-        GOVERNANCE_WALLET_ADDRESS,
-        mainnet::UPTIME_PROOF_TOLERANCE,
-        mainnet::UPTIME_PROOF_STARTUP_DELAY,
-        mainnet::UPTIME_PROOF_CHECK_INTERVAL,
-        testnet::UPTIME_PROOF_FREQUENCY,
-        testnet::UPTIME_PROOF_VALIDITY,
-        false,  // storage & lokinet
-        mainnet::TARGET_BLOCK_TIME,
-        mainnet::PULSE_STAGE_TIMEOUT,
-        mainnet::PULSE_ROUND_TIMEOUT,
-        mainnet::PULSE_MAX_START_ADJUSTMENT,
-        testnet::PULSE_MIN_SERVICE_NODES,
-        testnet::BATCHING_INTERVAL,
-        mainnet::MIN_BATCH_PAYMENT_AMOUNT,
-        mainnet::LIMIT_BATCH_OUTPUTS,
-        testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_REMOVAL_BUFFER,
-        ETHEREUM_CHAIN_ID,
-        ETHEREUM_REWARDS_CONTRACT,
-        ETHEREUM_POOL_CONTRACT,
-        mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
-        mainnet::L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::STAGENET,
+        .HEIGHT_ESTIMATE_HEIGHT = 0,
+        .HEIGHT_ESTIMATE_TIMESTAMP = 1720140000,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = 4888,             // ~ ST2 .. ST4
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 5272,  // ~ ST9 .. STB
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = 5656,          // ~ STF .. STJ
+        .P2P_DEFAULT_PORT = 11022,
+        .RPC_DEFAULT_PORT = 11023,
+        .QNET_DEFAULT_PORT = 11025,
+        .NETWORK_ID =
+                {{0x61,
+                  0x6c,
+                  0x6c,
+                  0x79,
+                  0x6f,
+                  0x75,
+                  0x72,
+                  0x53,
+                  0x45,
+                  0x4e,
+                  0x54,
+                  0x61,
+                  0x72,
+                  0x65,
+                  0x62,
+                  0x65}},
+        .GENESIS_TX =
+                "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec1526d"
+                "a33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c656f"
+                "247200000000000000000000000000000000000000000000000000000000000000000000",
+        .GENESIS_NONCE = 12345,
+        .GOVERNANCE_REWARD_INTERVAL = mainnet::config.GOVERNANCE_REWARD_INTERVAL,
+        .GOVERNANCE_WALLET_ADDRESS =
+                {
+                        "ST4BqQJpS2t8otav3yWwwX4eM4xTE1isFPNsGYyPVkDQeUPjmw4kJsW8NHWYq2FZcGMsVuqrBw"
+                        "GTfZydWyvzXoG22r2BJuPRf",  // HF7-9
+                        "ST4BqQJpS2t8otav3yWwwX4eM4xTE1isFPNsGYyPVkDQeUPjmw4kJsW8NHWYq2FZcGMsVuqrBw"
+                        "GTfZydWyvzXoG22r2BJuPRf",  // HF10
+                },
+        .UPTIME_PROOF_TOLERANCE = mainnet::config.UPTIME_PROOF_TOLERANCE,
+        .UPTIME_PROOF_STARTUP_DELAY = 5s,
+        .UPTIME_PROOF_CHECK_INTERVAL = mainnet::config.UPTIME_PROOF_CHECK_INTERVAL,
+        .UPTIME_PROOF_FREQUENCY = testnet::config.UPTIME_PROOF_FREQUENCY,
+        .UPTIME_PROOF_VALIDITY = testnet::config.UPTIME_PROOF_VALIDITY,
+        .HAVE_STORAGE_AND_LOKINET = false,  // storage & lokinet
+        .TARGET_BLOCK_TIME = mainnet::TARGET_BLOCK_TIME,
+        .PULSE_STAGE_TIMEOUT = mainnet::config.PULSE_STAGE_TIMEOUT,
+        .PULSE_ROUND_TIMEOUT = mainnet::config.PULSE_ROUND_TIMEOUT,
+        .PULSE_MAX_START_ADJUSTMENT = mainnet::config.PULSE_MAX_START_ADJUSTMENT,
+        .PULSE_MIN_SERVICE_NODES = testnet::config.PULSE_MIN_SERVICE_NODES,
+        .BATCHING_INTERVAL = testnet::config.BATCHING_INTERVAL,
+        .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
+        .LIMIT_BATCH_OUTPUTS = mainnet::config.LIMIT_BATCH_OUTPUTS,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = testnet::config.SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
+                mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+        .STORE_LONG_TERM_STATE_INTERVAL = mainnet::config.STORE_LONG_TERM_STATE_INTERVAL,
+        // Much shorter than mainnet so that you can test this more easily.
+        .ETH_REMOVAL_BUFFER = 2h / mainnet::config.TARGET_BLOCK_TIME,
+        .ETHEREUM_CHAIN_ID = 421614,
+        .ETHEREUM_REWARDS_CONTRACT = "0xEF43cd64528eA89966E251d4FE17c660222D2c9d"sv,
+        .ETHEREUM_POOL_CONTRACT = "0x408bCc6C9b942ECc4F289C080d2A1a2a3617Aff8"sv,
+        .L2_REWARD_POOL_UPDATE_BLOCKS = mainnet::config.L2_REWARD_POOL_UPDATE_BLOCKS,
+        .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
 };
-
 }  // namespace cryptonote::config::stagenet

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -89,6 +89,7 @@ inline constexpr network_config config{
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,
         mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
+        mainnet::L2_TRACKER_SAFE_BLOCKS,
 };
 
 }  // namespace cryptonote::config::stagenet

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -97,6 +97,7 @@ inline constexpr network_config config{
         ETHEREUM_REWARDS_CONTRACT,
         ETHEREUM_POOL_CONTRACT,
         mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
+        mainnet::L2_TRACKER_SAFE_BLOCKS,
 };
 
 }  // namespace cryptonote::config::testnet

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -3,101 +3,71 @@
 #include "mainnet.h"
 
 namespace cryptonote::config::testnet {
-
-inline constexpr uint64_t HEIGHT_ESTIMATE_HEIGHT = 339767;
-inline constexpr time_t HEIGHT_ESTIMATE_TIMESTAMP = 1595360006;
-inline constexpr uint64_t PUBLIC_ADDRESS_BASE58_PREFIX = 156;
-inline constexpr uint64_t PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 157;
-inline constexpr uint64_t PUBLIC_SUBADDRESS_BASE58_PREFIX = 158;
-inline constexpr uint16_t P2P_DEFAULT_PORT = 38156;
-inline constexpr uint16_t RPC_DEFAULT_PORT = 38157;
-inline constexpr uint16_t QNET_DEFAULT_PORT = 38159;
-inline constexpr boost::uuids::uuid const NETWORK_ID = {{
-        0x22,
-        0x3a,
-        0x78,
-        0x65,
-        0xe1,
-        0x6f,
-        0xca,
-        0xb8,
-        0x02,
-        0xa1,
-        0xdc,
-        0x17,
-        0x61,
-        0x64,
-        0x15,
-        0xbe,
-}};
-inline constexpr std::string_view GENESIS_TX =
-        "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
-        "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"
-        "656f247200000000000000000000000000000000000000000000000000000000000000000000"sv;
-inline constexpr uint32_t GENESIS_NONCE = 12345;
-
-inline constexpr auto GOVERNANCE_REWARD_INTERVAL = 2000min;
-inline constexpr std::array GOVERNANCE_WALLET_ADDRESS = {
-        // hardfork v7-9
-        "T6Tnu9YUgVcSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M482ypm7"sv,
-        // hardfork v10
-        "T6Tnu9YUgVcSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M482ypm7"sv,
-};
-
-// Testnet uptime proofs are 6x faster than mainnet (devnet config also uses these)
-inline constexpr auto UPTIME_PROOF_FREQUENCY = 10min;
-inline constexpr auto UPTIME_PROOF_VALIDITY = 21min;
-inline constexpr uint64_t BATCHING_INTERVAL = 20;
-inline constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 4;
-
-inline constexpr size_t PULSE_MIN_SERVICE_NODES = 12;  // == pulse quorum size
-
-// Much shorter than mainnet so that you can test this more easily.
-inline constexpr uint64_t ETH_REMOVAL_BUFFER = 1h / mainnet::TARGET_BLOCK_TIME;
-
-// FIXME!
-inline constexpr uint32_t ETHEREUM_CHAIN_ID = -1;
-inline constexpr auto ETHEREUM_REWARDS_CONTRACT = "0x0000000000000000000000000000000000000000"sv;
-inline constexpr auto ETHEREUM_POOL_CONTRACT = "0x0000000000000000000000000000000000000000"sv;
-
 inline constexpr network_config config{
-        network_type::TESTNET,
-        HEIGHT_ESTIMATE_HEIGHT,
-        HEIGHT_ESTIMATE_TIMESTAMP,
-        PUBLIC_ADDRESS_BASE58_PREFIX,
-        PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX,
-        PUBLIC_SUBADDRESS_BASE58_PREFIX,
-        P2P_DEFAULT_PORT,
-        RPC_DEFAULT_PORT,
-        QNET_DEFAULT_PORT,
-        NETWORK_ID,
-        GENESIS_TX,
-        GENESIS_NONCE,
-        GOVERNANCE_REWARD_INTERVAL,
-        GOVERNANCE_WALLET_ADDRESS,
-        mainnet::UPTIME_PROOF_TOLERANCE,
-        mainnet::UPTIME_PROOF_STARTUP_DELAY,
-        mainnet::UPTIME_PROOF_CHECK_INTERVAL,
-        UPTIME_PROOF_FREQUENCY,
-        UPTIME_PROOF_VALIDITY,
-        true, // storage & lokinet
-        mainnet::TARGET_BLOCK_TIME,
-        mainnet::PULSE_STAGE_TIMEOUT,
-        mainnet::PULSE_ROUND_TIMEOUT,
-        mainnet::PULSE_MAX_START_ADJUSTMENT,
-        PULSE_MIN_SERVICE_NODES,
-        BATCHING_INTERVAL,
-        mainnet::MIN_BATCH_PAYMENT_AMOUNT,
-        mainnet::LIMIT_BATCH_OUTPUTS,
-        SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
-        mainnet::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
-        mainnet::STORE_LONG_TERM_STATE_INTERVAL,
-        ETH_REMOVAL_BUFFER,
-        ETHEREUM_CHAIN_ID,
-        ETHEREUM_REWARDS_CONTRACT,
-        ETHEREUM_POOL_CONTRACT,
-        mainnet::L2_REWARD_POOL_UPDATE_BLOCKS,
-        mainnet::L2_TRACKER_SAFE_BLOCKS,
+        .NETWORK_TYPE = network_type::TESTNET,
+        .HEIGHT_ESTIMATE_HEIGHT = 339767,
+        .HEIGHT_ESTIMATE_TIMESTAMP = 1595360006,
+        .PUBLIC_ADDRESS_BASE58_PREFIX = 156,
+        .PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 157,
+        .PUBLIC_SUBADDRESS_BASE58_PREFIX = 158,
+        .P2P_DEFAULT_PORT = 38156,
+        .RPC_DEFAULT_PORT = 38157,
+        .QNET_DEFAULT_PORT = 38159,
+        .NETWORK_ID = {{
+                0x22,
+                0x3a,
+                0x78,
+                0x65,
+                0xe1,
+                0x6f,
+                0xca,
+                0xb8,
+                0x02,
+                0xa1,
+                0xdc,
+                0x17,
+                0x61,
+                0x64,
+                0x15,
+                0xbe,
+        }},
+        .GENESIS_TX =
+                "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
+                "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"
+                "656f247200000000000000000000000000000000000000000000000000000000000000000000"sv,
+        .GENESIS_NONCE = 12345,
+        .GOVERNANCE_REWARD_INTERVAL = 2000min,
+        .GOVERNANCE_WALLET_ADDRESS =
+                {
+                        "T6Tnu9YUgVcSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M482ypm7"sv,  // HF7-9
+                        "T6Tnu9YUgVcSzswBgVioqFNTfcqGopvTrcYjs4YDLHUfU64DuHxFoEmbwoyipTidGiTXx5EuYdgzZhDLMTo9uEv82M482ypm7"sv,  // HF10
+                },
+        .UPTIME_PROOF_TOLERANCE = mainnet::config.UPTIME_PROOF_TOLERANCE,
+        .UPTIME_PROOF_STARTUP_DELAY = mainnet::config.UPTIME_PROOF_STARTUP_DELAY,
+        .UPTIME_PROOF_CHECK_INTERVAL = mainnet::config.UPTIME_PROOF_CHECK_INTERVAL,
+        // Testnet uptime proofs are 6x faster than mainnet (devnet config also uses these)
+        .UPTIME_PROOF_FREQUENCY = 10min,
+        .UPTIME_PROOF_VALIDITY = 21min,
+        .HAVE_STORAGE_AND_LOKINET = true,  // storage & lokinet
+        .TARGET_BLOCK_TIME = mainnet::config.TARGET_BLOCK_TIME,
+        .PULSE_STAGE_TIMEOUT = mainnet::config.PULSE_STAGE_TIMEOUT,
+        .PULSE_ROUND_TIMEOUT = mainnet::config.PULSE_ROUND_TIMEOUT,
+        .PULSE_MAX_START_ADJUSTMENT = mainnet::config.PULSE_MAX_START_ADJUSTMENT,
+        .PULSE_MIN_SERVICE_NODES = 12,  // == pulse quorum size
+        .BATCHING_INTERVAL = 20,
+        .MIN_BATCH_PAYMENT_AMOUNT = mainnet::config.MIN_BATCH_PAYMENT_AMOUNT,
+        .LIMIT_BATCH_OUTPUTS = mainnet::config.LIMIT_BATCH_OUTPUTS,
+        .SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 4,
+        .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
+                mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+        .STORE_LONG_TERM_STATE_INTERVAL = mainnet::config.STORE_LONG_TERM_STATE_INTERVAL,
+        // Much shorter than mainnet so that you can test this more easily.
+        .ETH_REMOVAL_BUFFER = 1h / mainnet::config.TARGET_BLOCK_TIME,
+        // FIXME!
+        .ETHEREUM_CHAIN_ID = static_cast<uint32_t>(-1),
+        .ETHEREUM_REWARDS_CONTRACT = "0x0000000000000000000000000000000000000000",
+        .ETHEREUM_POOL_CONTRACT = "0x0000000000000000000000000000000000000000",
+        .L2_REWARD_POOL_UPDATE_BLOCKS = mainnet::config.L2_REWARD_POOL_UPDATE_BLOCKS,
+        .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
 };
-
 }  // namespace cryptonote::config::testnet

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -207,7 +207,8 @@ void core_rpc_server::invoke(GET_INFO& info, [[maybe_unused]] rpc_context contex
     auto& bs = m_core.get_blockchain_storage();
     auto& db = bs.get_db();
     const cryptonote::block top_block = db.get_top_block();
-    auto height = top_block.height + 1;  // turn top block height into blockchain height
+    auto top_height = get_block_height(top_block);
+    auto height = top_height + 1;  // turn top block height into blockchain height
 
     info.response["height"] = height;
     info.response["l2_height"] = top_block.l2_height;
@@ -226,7 +227,7 @@ void core_rpc_server::invoke(GET_INFO& info, [[maybe_unused]] rpc_context contex
     }
 
     if (cryptonote::checkpoint_t checkpoint;
-        db.get_immutable_checkpoint(&checkpoint, top_block.height)) {
+        db.get_immutable_checkpoint(&checkpoint, top_height)) {
         info.response["immutable_height"] = checkpoint.height;
         info.response_hex["immutable_block_hash"] = checkpoint.block_hash;
     }
@@ -257,11 +258,11 @@ void core_rpc_server::invoke(GET_INFO& info, [[maybe_unused]] rpc_context contex
     info.response["nettype"] = network_type_to_string(nettype);
 
     try {
-        auto cd = db.get_block_cumulative_difficulty(top_block.height);
+        auto cd = db.get_block_cumulative_difficulty(top_height);
         info.response["cumulative_difficulty"] = cd;
     } catch (std::exception const& e) {
         info.response["status"] = "Error retrieving cumulative difficulty at height " +
-                                  std::to_string(top_block.height);
+                                  std::to_string(top_height);
         return;
     }
 

--- a/tests/unit_tests/base58.cpp
+++ b/tests/unit_tests/base58.cpp
@@ -508,7 +508,7 @@ TEST(get_account_address_from_str, fails_on_invalid_address_prefix)
 
 TEST(get_account_address_from_str, fails_on_invalid_address_content)
 {
-  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::PUBLIC_ADDRESS_BASE58_PREFIX, test_serialized_keys.substr(1));
+  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::config.PUBLIC_ADDRESS_BASE58_PREFIX, test_serialized_keys.substr(1));
 
   cryptonote::address_parse_info info;
   ASSERT_FALSE(cryptonote::get_account_address_from_str(info, cryptonote::network_type::MAINNET, addr_str));
@@ -518,7 +518,7 @@ TEST(get_account_address_from_str, fails_on_invalid_address_spend_key)
 {
   std::string serialized_keys_copy = test_serialized_keys;
   serialized_keys_copy[0] = '\0';
-  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::PUBLIC_ADDRESS_BASE58_PREFIX, serialized_keys_copy);
+  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::config.PUBLIC_ADDRESS_BASE58_PREFIX, serialized_keys_copy);
 
   cryptonote::address_parse_info info;
   ASSERT_FALSE(cryptonote::get_account_address_from_str(info, cryptonote::network_type::MAINNET, addr_str));
@@ -528,7 +528,7 @@ TEST(get_account_address_from_str, fails_on_invalid_address_view_key)
 {
   std::string serialized_keys_copy = test_serialized_keys;
   serialized_keys_copy.back() = '\0';
-  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::PUBLIC_ADDRESS_BASE58_PREFIX, serialized_keys_copy);
+  std::string addr_str = base58::encode_addr(cryptonote::config::mainnet::config.PUBLIC_ADDRESS_BASE58_PREFIX, serialized_keys_copy);
 
   cryptonote::address_parse_info info;
   ASSERT_FALSE(cryptonote::get_account_address_from_str(info, cryptonote::network_type::MAINNET, addr_str));

--- a/tests/unit_tests/bls.cpp
+++ b/tests/unit_tests/bls.cpp
@@ -120,26 +120,19 @@ TEST(BLS, signatures) {
     auto sig1b = bls_utils::to_crypto_signature(bls_utils::from_crypto_signature(sig1));
     EXPECT_EQ("{}"_format(sig1), "{}"_format(sig1b));
     EXPECT_EQ(sig1a.getStr(), bls_utils::from_crypto_signature(sig1b).getStr());
-    EXPECT_TRUE(sig1a.verifyHash(signer.getPubkey(), hash1.data(), hash1.size()));
-    EXPECT_TRUE(sig1a.verifyHash(bls_utils::from_crypto_pubkey(pk), hash1.data(), hash1.size()));
-
-    EXPECT_TRUE(bls_utils::from_crypto_signature(sig1).verifyHash(
-            bls_utils::from_crypto_pubkey(pk), hash1.data(), hash1.size()));
+    EXPECT_TRUE(signer.verifyMsg(bls_utils::to_crypto_signature(sig1a), bls_utils::to_crypto_pubkey(signer.getPubkey()), hash1));
+    EXPECT_TRUE(signer.verifyMsg(sig1b, pk, hash1));
 
     EXPECT_EQ(
             "{}"_format(sig1),
-            "054a64cf51abcccf1e3db61b38bd84556834d652b59758d5860e541653eb2e44"
-            "0900de2368d7bdf4a83233d96cb8ab81461ebfe87ea6e73b56864e03e693a2be"
-            "29fcf509fa071fa7d8c569a2f8003ffc386ac07ad787815a5f906c4fd2405bef"
-            "2a84e7afd7fcb6d3299312906d0f56b3ea80603ee8688f05f68cb03a7c0db4f6");
+            "0935f61237111bdf49d7b67232def51e267ff84a9c76503d95aee6ba3a94443c16558636a14f7ab3767cde"
+            "88e5b2021157888ca26908d0d052dfd44b3b8b5c6617a1f756b90523ecc8e9d9744b0e1f6a1ca310533227"
+            "378fd44012cdf44bbaf826559955b29a5fc7a5af1ff0f0318747ce80101abe9ed97ab256977b7c25a7d6");
     EXPECT_TRUE(signer.verifyMsg(sig1, pk, hash1));
 
     auto sig2 = signer.signMsg(hash2);
     EXPECT_EQ(
             "{}"_format(sig2),
-            "3025a58f31717081510467944556989cfb0676e0f135f2cd7151442dd404385e"
-            "2671e7a21c2bee7840c54b839718dd2c665cc0376c6d78cd6d5ab62f3036ea14"
-            "1d86c93f8884a2ca97b893fbea2d1629c237231668fd86ce43b00abf6d8d68fa"
-            "2bc306182916f2d1633c82cd2b78794a049554da9ff68e72fefeb9680590e9fb");
+            "0a6f2c1693aceac3220fb57277d33203022339b21fca05bd2751cfdf50359ad628d633ff8e214bfa1fed2334fd1d7db512fcd43bba173a84d443fe6d333d64540960da53f247c635af26128574190e91f40d899fefdda43b9f2c17fccf97cf062f82c037ba9e20e63e0bc72bc672e35643adad660e4afe60357c26c83bce7a2b");
     EXPECT_TRUE(signer.verifyMsg(sig2, pk, hash2));
 }

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -65,7 +65,7 @@ TEST(SQLITE, AddSNRewards)
   EXPECT_EQ(sqliteDB.batching_count(), 1);
 
   std::vector<cryptonote::batch_sn_payment> p1;
-  const auto expected_payout = wallet_address.address.next_payout_height(0, cryptonote::config::mainnet::BATCHING_INTERVAL);
+  const auto expected_payout = wallet_address.address.next_payout_height(0, cryptonote::config::mainnet::config.BATCHING_INTERVAL);
   p1 = sqliteDB.get_sn_payments(expected_payout - 1);
   EXPECT_EQ(p1.size(), 0);
 

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -224,19 +224,6 @@ class SNNetwork:
 
         self.print_wallet_balances()
 
-        vprint("Sending fake lokinet/ss pings")
-        for sn in self.sns:
-            sn.ping()
-
-        vprint("Send uptime proofs at height 389 (HF20) to propagate BLS pubkeys")
-        for sn in self.sns:
-            sn.send_uptime_proof()
-
-        vprint("Waiting for proofs to propagate:", flush=True)
-        for sn in self.sns:
-            wait_for(lambda: all_service_nodes_proofed(sn), timeout=120)
-        vprint(timestamp=False)
-
         # This commented out code will register the last SN through Mikes wallet (Has done every other SN)
         # for sn in self.sns[-1:]:
             # self.mike.register_sn(sn)
@@ -248,12 +235,25 @@ class SNNetwork:
         # Register the last SN through Bobs wallet (Has not done any others)
         # and also get 9 other wallets to contribute the rest of the node with a 10% operator fee
         self.bob.register_sn_for_contributions(sn=self.sns[-1], cut=10, amount=coins(28), staking_requirement=self.sns[0].get_staking_requirement())
-        self.sync_nodes(self.mine(20), timeout=120) # Mining to 409
+        self.sync_nodes(self.mine(21), timeout=120) # Mining to height 410
         self.print_wallet_balances()
         for wallet in self.extrawallets:
             wallet.contribute_to_sn(self.sns[-1], coins(8))
 
-        self.sync_nodes(self.mine(1), timeout=120)
+        vprint("Sending fake lokinet/ss pings")
+        for sn in self.sns:
+            sn.ping()
+
+        vprint("Send uptime proofs at height 411 (HF20) to propagate BLS pubkeys")
+        for sn in self.sns:
+            sn.send_uptime_proof()
+
+        vprint("Waiting for proofs to propagate:", flush=True)
+        for sn in self.sns:
+            wait_for(lambda: all_service_nodes_proofed(sn), timeout=120)
+        vprint(timestamp=False)
+
+        self.sync_nodes(self.mine(1), timeout=120) # Mining to height 411
 
         # Pull out some useful keys to local variables
         sn0_pubkey            = self.ethsns[0].get_service_keys().pubkey

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -305,78 +305,78 @@ class SNNetwork:
         assert self.sn_contract.numberServiceNodes() == 13, f"Expected 13 service nodes, received {contract_sn_count}"
 
         # Sleep and let pulse quorum do work
-        sleep_time = 120
-        vprint(f"Sleeping now, awaiting pulse quorum to generate blocks, blockchain height is {self.ethsns[0].height()}");
-        time.sleep(sleep_time)
-        vprint(f"Waking up after sleeping for {sleep_time}s, blockchain height is {self.ethsns[0].height()}");
+        # sleep_time = 120
+        # vprint(f"Sleeping now, awaiting pulse quorum to generate blocks, blockchain height is {self.ethsns[0].height()}");
+        # time.sleep(sleep_time)
+        # vprint(f"Waking up after sleeping for {sleep_time}s, blockchain height is {self.ethsns[0].height()}");
 
         # NOTE: BLS rewards claim ##################################################################
         # Claim rewards for Address
-        rewards = self.ethsns[0].get_bls_rewards(hardhat_account_no_0x)
-        vprint(rewards)
-        rewardsAccount = rewards["result"]["address"]
-        assert rewardsAccount.lower() == hardhat_account_no_0x.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhat_account_no_0x.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
+        # rewards = self.ethsns[0].get_bls_rewards(hardhat_account_no_0x)
+        # vprint(rewards)
+        # rewardsAccount = rewards["result"]["address"]
+        # assert rewardsAccount.lower() == hardhat_account_no_0x.lower(), f"Rewards account '{rewardsAccount.lower()}' does not match hardhat account '{hardhat_account_no_0x.lower()}'. We have the private key for the hardhat account and use it to claim rewards from the contract"
 
-        vprint("Contract rewards before updating has ['available', 'claimed'] respectively: ",
-               self.sn_contract.recipients(hardhat_account),
-               " for ",
-               hardhat_account_no_0x)
+        # vprint("Contract rewards before updating has ['available', 'claimed'] respectively: ",
+        #        self.sn_contract.recipients(hardhat_account),
+        #        " for ",
+        #        hardhat_account_no_0x)
 
 
         # TODO: We send the required balance from the hardhat account to the
         # contract to guarantee that claiming will succeed. We should hook up
         # the pool to the rewards contract and fund the contract from there.
-        unsent_tx = self.sn_contract.erc20_contract.functions.transfer(self.sn_contract.contract_address, rewards["result"]["amount"] + 100).build_transaction({
-            "from": self.sn_contract.acc.address,
-            'nonce': self.sn_contract.web3.eth.get_transaction_count(self.sn_contract.acc.address)})
-        signed_tx = self.sn_contract.web3.eth.account.sign_transaction(unsent_tx, private_key=self.sn_contract.acc.key)
-        self.sn_contract.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-        self.sn_contract.foundation_pool_contract.functions.payoutReleased().call()
+        # unsent_tx = self.sn_contract.erc20_contract.functions.transfer(self.sn_contract.contract_address, rewards["result"]["amount"] + 100).build_transaction({
+        #     "from": self.sn_contract.acc.address,
+        #     'nonce': self.sn_contract.web3.eth.get_transaction_count(self.sn_contract.acc.address)})
+        # signed_tx = self.sn_contract.web3.eth.account.sign_transaction(unsent_tx, private_key=self.sn_contract.acc.key)
+        # self.sn_contract.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        # self.sn_contract.foundation_pool_contract.functions.payoutReleased().call()
 
-        vprint("Foundation pool balance: {}".format(self.sn_contract.erc20balance(self.sn_contract.foundation_pool_address)))
-        vprint("Rewards contract balance: {}".format(self.sn_contract.erc20balance(self.sn_contract.contract_address)))
+        # vprint("Foundation pool balance: {}".format(self.sn_contract.erc20balance(self.sn_contract.foundation_pool_address)))
+        # vprint("Rewards contract balance: {}".format(self.sn_contract.erc20balance(self.sn_contract.contract_address)))
 
         # NOTE: Then update the rewards blaance
-        self.sn_contract.updateRewardsBalance(
-                hardhat_account,
-                rewards["result"]["amount"],
-                rewards["result"]["signature"],
-                rewards["result"]["non_signer_indices"])
+        # self.sn_contract.updateRewardsBalance(
+        #         hardhat_account,
+        #         rewards["result"]["amount"],
+        #         rewards["result"]["signature"],
+        #         rewards["result"]["non_signer_indices"])
 
-        vprint("Contract rewards update executed, has ['available', 'claimed'] now respectively: ",
-               self.sn_contract.recipients(hardhat_account),
-               " for ",
-               hardhat_account_no_0x)
+        # vprint("Contract rewards update executed, has ['available', 'claimed'] now respectively: ",
+        #        self.sn_contract.recipients(hardhat_account),
+        #        " for ",
+        #        hardhat_account_no_0x)
 
-        vprint("Balance for '{}' before claim {}".format(hardhat_account, self.sn_contract.erc20balance(hardhat_account)))
+        # vprint("Balance for '{}' before claim {}".format(hardhat_account, self.sn_contract.erc20balance(hardhat_account)))
 
         # NOTE: Now claim the rewards
-        self.sn_contract.claimRewards()
-        vprint("Contract rewards after claim is now ['available', 'claimed'] respectively: ",
-               self.sn_contract.recipients(hardhat_account),
-               " for ",
-               hardhat_account)
-        vprint("Balance for '{}' after claim {}".format(hardhat_account, self.sn_contract.erc20balance(hardhat_account)))
+        # self.sn_contract.claimRewards()
+        # vprint("Contract rewards after claim is now ['available', 'claimed'] respectively: ",
+        #        self.sn_contract.recipients(hardhat_account),
+        #        " for ",
+        #        hardhat_account)
+        # vprint("Balance for '{}' after claim {}".format(hardhat_account, self.sn_contract.erc20balance(hardhat_account)))
 
         # Initiate Removal of BLS Key ##############################################################
-        sn_to_remove_index       = random.randint(0, len(self.sns) - 1)
-        sn_to_remove_bls_pubkey  = self.sns[sn_to_remove_index].get_service_keys().bls_pubkey
-        sn_to_remove_contract_id = self.sn_contract.getServiceNodeID(sn_to_remove_bls_pubkey)
+        # sn_to_remove_index       = random.randint(0, len(self.sns) - 1)
+        # sn_to_remove_bls_pubkey  = self.sns[sn_to_remove_index].get_service_keys().bls_pubkey
+        # sn_to_remove_contract_id = self.sn_contract.getServiceNodeID(sn_to_remove_bls_pubkey)
 
-        vprint("Randomly chose to remove SN {} with BLS key {}, submitting request".format(sn_to_remove_contract_id, sn_to_remove_bls_pubkey))
-        self.sn_contract.initiateRemoveBLSPublicKey(sn_to_remove_contract_id)
+        # vprint("Randomly chose to remove SN {} with BLS key {}, submitting request".format(sn_to_remove_contract_id, sn_to_remove_bls_pubkey))
+        # self.sn_contract.initiateRemoveBLSPublicKey(sn_to_remove_contract_id)
 
-        days_30_in_seconds = 60 * 60 * 24 * 30
-        ethereum.evm_increaseTime(self.sn_contract.web3, days_30_in_seconds)
-        ethereum.evm_mine(self.sn_contract.web3)
+        # days_30_in_seconds = 60 * 60 * 24 * 30
+        # ethereum.evm_increaseTime(self.sn_contract.web3, days_30_in_seconds)
+        # ethereum.evm_mine(self.sn_contract.web3)
 
         # Exit Node ################################################################################
-        exit_request = self.ethsns[0].get_exit_request(sn_to_remove_bls_pubkey)
-        vprint("Exit request aggregated: {}".format(exit_request))
-        self.sn_contract.removeBLSPublicKeyWithSignature(exit_request["result"]["bls_pubkey"],
-                                                         exit_request["result"]["timestamp"],
-                                                         exit_request["result"]["signature"],
-                                                         exit_request["result"]["non_signer_indices"])
+        # exit_request = self.ethsns[0].get_exit_request(sn_to_remove_bls_pubkey)
+        # vprint("Exit request aggregated: {}".format(exit_request))
+        # self.sn_contract.removeBLSPublicKeyWithSignature(exit_request["result"]["bls_pubkey"],
+        #                                                  exit_request["result"]["timestamp"],
+        #                                                  exit_request["result"]["signature"],
+        #                                                  exit_request["result"]["non_signer_indices"])
 
         # Liquidate Node ###########################################################################
         # exit = self.ethsns[0].get_liquidation_request(ethereum_add_bls_args["bls_pubkey"])

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -283,8 +283,10 @@ class SNNetwork:
         self.sn_contract.start()
 
         # Register a SN via the Ethereum smart contract
-        vprint("Preparing to submit registration to Eth w/ address {} for SN {}".format(hardhat_account, sn0_pubkey))
         ethereum_add_bls_args = self.ethsns[0].get_ethereum_registration_args(hardhat_account_no_0x)
+        vprint("Preparing to submit registration to Eth w/ address {} for SN {} ({})".format(hardhat_account,
+                                                                                             sn0_pubkey,
+                                                                                             ethereum_add_bls_args))
         self.sn_contract.addBLSPublicKey(ethereum_add_bls_args)
 
         # NOTE: Log all the SNs in the contract ####################################################


### PR DESCRIPTION
The local devnet broke for a bit because of the L2 rewrite. It's still broken actually in terms of the rewards claim and it's something I'd like to work on but has been side lined to attend some other issues re: the launch of the public network. I've been sitting on these changes for a few weeks now and they're starting to get bit-rot so now's a good time to check it in.

- Use designated initialisers to initialise network_config. There were some variables, can't remember which ones that were pulling mainnet configuration but being used in test networks that were caught with this.
- I typically do static builds, always, and CURL was currently being built without SSL which meant that testing stagenet with a Arbitrum provider using `https` was failing. I added SSL to the build, curiously though this didn't seem to pull in a dynamic dependency on OpenSSL not sure why. Also had to omit zstd because we don't build that yet, but we should eventually ...
- Make local devnet use its own hardforks for testing purposes
- Move L2Tracker::SAFE_BLOCKS into network config (local devnet wants this very small so that we can test L2 transactions easily. All nodes in the local devnet are connected to the same RPC provider anyway).
- Correctly use `get_block_height` instead of `top_block.height` which is the same kind of bug with the uninitialised `block.hash` bug fixed last week 
- Fix the BLSSigner tests because we now exclusively use `verifyMsg` and `signMsg` which matches the audited cryptography in the contracts. This meant the expected test results change.