### PR TITLE
Add a hack to wipe the database files if the old stagenet db is found

### DIFF
--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -714,6 +714,9 @@ class core final {
     const fs::path& get_config_directory() const { return m_config_folder; }
 
   private:
+    std::unique_ptr<BlockchainDB> init_blockchain_db(
+            fs::path datadir, const boost::program_options::variables_map& vm);
+
     /**
      * @copydoc Blockchain::add_new_block
      *
@@ -844,8 +847,8 @@ class core final {
     std::array<uint16_t, 3> ss_version;
     std::array<uint16_t, 3> lokinet_version;
 
-    tx_memory_pool mempool;         //!< transaction pool instance
-    Blockchain blockchain;  //!< Blockchain instance
+    tx_memory_pool mempool;  //!< transaction pool instance
+    Blockchain blockchain;   //!< Blockchain instance
 
     service_nodes::service_node_list service_node_list;
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -281,6 +281,8 @@ class node_server
     bool islimitup = false;
     bool islimitdown = false;
 
+    fs::path get_peerlist_file() const;
+
     CHAIN_LEVIN_INVOKE_MAP2(p2p_connection_context);  // move levin_commands_handler interface
                                                       // invoke(...) callbacks into invoke map
     CHAIN_LEVIN_NOTIFY_MAP2(p2p_connection_context);  // move levin_commands_handler interface

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -119,11 +119,21 @@ void node_server<t_payload_net_handler>::init_options(
     command_line::add_arg(desc, arg_limit_rate_down);
     command_line::add_arg(desc, arg_limit_rate);
 }
+
+template <class t_payload_net_handler>
+fs::path node_server<t_payload_net_handler>::get_peerlist_file() const {
+    fs::path p2p_filename = cryptonote::P2P_NET_DATA_FILENAME;
+    if (m_nettype == cryptonote::network_type::STAGENET)
+        // Kludge for stagenet reboot
+        p2p_filename += u8".v2";
+    return m_config_folder / p2p_filename;
+}
+
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::init_config() {
     TRY_ENTRY();
-    auto storage = peerlist_storage::open(m_config_folder / cryptonote::P2P_NET_DATA_FILENAME);
+    auto storage = peerlist_storage::open(get_peerlist_file());
     if (storage)
         m_peerlist_storage = std::move(*storage);
 
@@ -816,7 +826,7 @@ bool node_server<t_payload_net_handler>::store_config() {
     for (auto& zone : m_network_zones)
         zone.second.m_peerlist.get_peerlist(active);
 
-    const auto state_file_path = m_config_folder / cryptonote::P2P_NET_DATA_FILENAME;
+    const auto state_file_path = get_peerlist_file();
     if (!m_peerlist_storage.store(state_file_path, active)) {
         log::warning(logcat, "Failed to save config to file {}", state_file_path);
         return false;


### PR DESCRIPTION
When using a specific data directory, we might try loading an (old) lmdb, which won't work, so if we encounter the old stagenet block 1, we drop the existing dbs and reinitialize from nothing.