### PR TITLE
Add new `get_pending_events` RPC endpoint

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4187,7 +4187,7 @@ bool Blockchain::check_tx_inputs(
 
         if (tx.type == txtype::ethereum_new_service_node) {
             if (!eth::validate_event_tx<eth::event::NewServiceNode>(
-                        hf_version, tx, tvc.m_verbose_error)) {
+                        hf_version, tx, &tvc.m_verbose_error)) {
                 log::error(
                         log::Cat("verify"),
                         "Failed to validate Ethereum New Service Node TX reason: {}",
@@ -4196,7 +4196,7 @@ bool Blockchain::check_tx_inputs(
             }
         } else if (tx.type == txtype::ethereum_service_node_removal_request) {
             if (!eth::validate_event_tx<eth::event::ServiceNodeRemovalRequest>(
-                        hf_version, tx, tvc.m_verbose_error)) {
+                        hf_version, tx, &tvc.m_verbose_error)) {
                 log::error(
                         log::Cat("verify"),
                         "Failed to validate Ethereum Service Node Removal Request TX reason: {}",
@@ -4205,7 +4205,7 @@ bool Blockchain::check_tx_inputs(
             }
         } else if (tx.type == txtype::ethereum_service_node_removal) {
             if (!eth::validate_event_tx<eth::event::ServiceNodeRemoval>(
-                        hf_version, tx, tvc.m_verbose_error)) {
+                        hf_version, tx, &tvc.m_verbose_error)) {
                 log::error(
                         log::Cat("verify"),
                         "Failed to validate Ethereum Service Node Removal TX reason: {}",

--- a/src/cryptonote_core/ethereum_transactions.h
+++ b/src/cryptonote_core/ethereum_transactions.h
@@ -7,34 +7,42 @@
 #include "cryptonote_config.h"
 #include "l2_tracker/events.h"
 
+namespace cryptonote {
+class Blockchain;
+}
+
 namespace eth {
 
 template <std::derived_from<event::L2StateChange> Event>
-bool extract_event(
-        const cryptonote::transaction& tx, Event& evt, std::string& fail_reason) {
+bool extract_event(const cryptonote::transaction& tx, Event& evt, std::string* fail_reason) {
     if (cryptonote::get_field_from_tx_extra(tx.extra, evt))
         return true;
-    fail_reason = "{} didn't have ethereum {} data in the tx_extra"_format(tx, Event::description);
+    if (fail_reason)
+        *fail_reason =
+                "{} didn't have ethereum {} data in the tx_extra"_format(tx, Event::description);
     return false;
 }
 
 template <std::derived_from<event::L2StateChange> Event>
 bool validate_event_tx(
-        cryptonote::hf hf_version, const cryptonote::transaction& tx, std::string& reason) {
+        cryptonote::hf hf_version, const cryptonote::transaction& tx, std::string* reason) {
     if (hf_version < cryptonote::feature::ETH_BLS) {
-        reason = "{} is attempting to provide an L2 transactions before HF{}"_format(
-                tx, static_cast<int>(hf_version));
+        if (reason)
+            *reason = "{} is attempting to provide an L2 transactions before HF{}"_format(
+                    tx, static_cast<int>(hf_version));
         return false;
     }
     if (tx.type != Event::txtype) {
-        reason = "{} uses wrong tx type, expected={}"_format(tx, Event::txtype);
+        if (reason)
+            *reason = "{} uses wrong tx type, expected={}"_format(tx, Event::txtype);
         return false;
     }
     Event evt;
     if (!extract_event(tx, evt, reason))
         return false;
     if (evt.l2_height == 0) {
-        reason = "{} tx's L2 event is missing l2_height"_format(tx);
+        if (reason)
+            *reason = "{} tx's L2 event is missing l2_height"_format(tx);
         return false;
     }
     return true;
@@ -43,11 +51,17 @@ bool validate_event_tx(
 /// Extract the state change event details from a transaction.  If no state change is present in the
 /// transaction then `fail_reason` is set and std::monostate is returned.
 event::StateChangeVariant extract_event(
-        cryptonote::hf hf_version, const cryptonote::transaction& tx, std::string& fail_reason);
+        const cryptonote::transaction& tx, std::string* fail_reason = nullptr);
+
+/// Extracts an event from the blockchain given a txid.
+event::StateChangeVariant extract_event(
+        cryptonote::Blockchain& chain,
+        const crypto::hash& txid,
+        std::string* fail_reason = nullptr);
 
 /// Extracts the L2Height from an eth event.  Returns nullopt if not an eth event (or even
 /// extraction fails).
 std::optional<uint64_t> extract_event_l2_height(
-        cryptonote::hf hf_version, const cryptonote::transaction& tx);
+        const cryptonote::transaction& tx, std::string* fail_reason = nullptr);
 
 }  // namespace eth

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1701,7 +1701,7 @@ namespace {
                             return goto_preparing_for_next_round(context);
                         }
                         std::string fail;
-                        auto event = eth::extract_event(block.major_version, tx, fail);
+                        auto event = eth::extract_event(tx, &fail);
                         if (std::holds_alternative<std::monostate>(event)) {
                             log::info(
                                     logcat,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3038,8 +3038,7 @@ void service_node_list::state_t::update_from_block(
                     log::info(logcat, "State change tx {} confirmed by votes", txhash);
 
                     std::string fail;
-                    auto event = eth::extract_event(
-                            block.major_version, sn_list->blockchain.db().get_tx(txhash), fail);
+                    auto event = eth::extract_event(sn_list->blockchain.db().get_tx(txhash), &fail);
                     if (std::holds_alternative<std::monostate>(event))
                         throw oxen::traced<std::runtime_error>{
                                 "Internal error: did not find state change tx data in blockchain database: {}"_format(

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -237,7 +237,7 @@ bool tx_memory_pool::have_duplicated_non_standard_tx(
         }
     } else if (is_l2_event_tx(tx.type)) {
         std::string fail;
-        auto event = eth::extract_event(hard_fork_version, tx, fail);
+        auto event = eth::extract_event(tx, &fail);
         if (std::holds_alternative<std::monostate>(event)) {
             log::error(
                     logcat,
@@ -251,7 +251,7 @@ bool tx_memory_pool::have_duplicated_non_standard_tx(
             if (pool_tx.type != tx.type)
                 continue;
 
-            auto pool_event = eth::extract_event(hard_fork_version, pool_tx, fail);
+            auto pool_event = eth::extract_event(pool_tx, &fail);
             if (std::holds_alternative<std::monostate>(pool_event)) {
                 log::info(
                         logcat,
@@ -472,7 +472,7 @@ bool tx_memory_pool::add_tx(
             meta.relayed = opts.relayed;
             meta.do_not_relay = opts.do_not_relay;
             if (is_l2_event_tx(tx.type))
-                meta.l2_height = eth::extract_event_l2_height(hf_version, tx).value_or(0);
+                meta.l2_height = eth::extract_event_l2_height(tx).value_or(0);
             meta.double_spend_seen =
                     (have_tx_keyimges_as_spent(tx) ||
                      have_duplicated_non_standard_tx(tx, hf_version));
@@ -515,7 +515,7 @@ bool tx_memory_pool::add_tx(
         meta.relayed = opts.relayed;
         meta.do_not_relay = opts.do_not_relay;
         if (is_l2_event_tx(tx.type))
-            meta.l2_height = eth::extract_event_l2_height(hf_version, tx).value_or(0);
+            meta.l2_height = eth::extract_event_l2_height(tx).value_or(0);
         meta.double_spend_seen = false;
         meta.bf_padding = 0;
         memset(meta.padding1, 0, sizeof(meta.padding1));

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -149,6 +149,7 @@ class core_rpc_server {
     void invoke(SYNC_INFO& sync, rpc_context context);
     void invoke(GET_SERVICE_NODE_STATUS& sns, rpc_context context);
     void invoke(GET_SERVICE_NODES& sns, rpc_context context);
+    void invoke(GET_PENDING_EVENTS& sns, rpc_context context);
     void invoke(GET_LIMIT& limit, rpc_context context);
     void invoke(SET_LIMIT& limit, rpc_context context);
     void invoke(IS_KEY_IMAGE_SPENT& spent, rpc_context context);


### PR DESCRIPTION
This adds a new `get_pending_events` RPC endpoint that returns the current pending event info, along with current votes for those events.

Also changed here:

- removed the hf_version argument from event extract code; anywhere that calls this that needs to call about the current hf version is *already* hf-gated and so the extra check isn't doing anything.
- Made the fail_reason string an optional pointer for eth extraction as sometimes we don't need to get the failure reason.