### PR TITLE
Fix mempool selector

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1713,15 +1713,14 @@ bool service_node_list::state_t::process_confirmed_event(
             log::info(
                     globallogcat,
                     fg(fmt::terminal_color::green),
-                    "New service node registration from ethereum: {} (THIS NODE) @ height: {}; "
-                    "awaiting confirmations",
+                    "Confirmed service node registration from ethereum: {} (THIS NODE) @ height: "
+                    "{}",
                     key,
                     height);
         else
             log::info(
                     logcat,
-                    "New service node registration from ethereum: {} on height: {}; awaiting "
-                    "confirmations",
+                    "Confirmed service node registration from ethereum: {} on height: {}",
                     key,
                     height);
         insert_info(key, std::move(service_node_info));

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -444,7 +444,8 @@ bool tx_memory_pool::add_tx(
 
     crypto::hash max_used_block_id{};
     uint64_t max_used_block_height = 0;
-    cryptonote::txpool_tx_meta_t meta;
+    cryptonote::txpool_tx_meta_t meta{};
+
     bool inputs_okay = check_tx_inputs(
             [&tx]() -> cryptonote::transaction& { return tx; },
             id,
@@ -462,10 +463,6 @@ bool tx_memory_pool::add_tx(
         if (opts.kept_by_block) {
             meta.weight = tx_weight;
             meta.fee = fee;
-            meta.max_used_block_id = null<hash>;
-            meta.max_used_block_height = 0;
-            meta.last_failed_height = 0;
-            meta.last_failed_id = null<hash>;
             meta.kept_by_block = opts.kept_by_block;
             meta.receive_time = receive_time;
             meta.last_relayed_time = receive_time;
@@ -476,9 +473,6 @@ bool tx_memory_pool::add_tx(
             meta.double_spend_seen =
                     (have_tx_keyimges_as_spent(tx) ||
                      have_duplicated_non_standard_tx(tx, hf_version));
-            meta.bf_padding = 0;
-            memset(meta.padding1, 0, sizeof(meta.padding1));
-            memset(meta.padding2, 0, sizeof(meta.padding2));
             try {
                 m_parsed_tx_cache.insert(std::make_pair(id, tx));
                 std::unique_lock b_lock{m_blockchain};
@@ -508,8 +502,6 @@ bool tx_memory_pool::add_tx(
         meta.fee = fee;
         meta.max_used_block_id = max_used_block_id;
         meta.max_used_block_height = max_used_block_height;
-        meta.last_failed_height = 0;
-        meta.last_failed_id = null<hash>;
         meta.receive_time = receive_time;
         meta.last_relayed_time = receive_time;
         meta.relayed = opts.relayed;
@@ -517,9 +509,6 @@ bool tx_memory_pool::add_tx(
         if (is_l2_event_tx(tx.type))
             meta.l2_height = eth::extract_event_l2_height(hf_version, tx).value_or(0);
         meta.double_spend_seen = false;
-        meta.bf_padding = 0;
-        memset(meta.padding1, 0, sizeof(meta.padding1));
-        memset(meta.padding2, 0, sizeof(meta.padding2));
 
         try {
             if (opts.kept_by_block)


### PR DESCRIPTION
The mempool meta info was not setting l2_height for non-L2 event transactions, which left l2_height as an uninitialized value, but this would later break when selecting transactions because such a transaction would have an L2 height that failed the max-L2-height check with:

    [txpool:debug|cryptonote_core/tx_pool.cpp:1917] Considering cf7d58354caf7e8c62fe37a2cd84268d139ee5f0195f04b5f156d286c9fffe75, weight 472, current block weight 0/299400, current reward 0.000000000
    [txpool:debug|cryptonote_core/tx_pool.cpp:1925]   state change from L2 height 94205658036688 is not in in admissable L2 heights <= 73294606

which caused non-L2 events to get stuck in the mempool until some node happened to lead a pulse quorum that had a sufficiently low value.

This fixes it to zero-initialize the meta struct so that this won't happen (and then removes all the now-redundant zero assignments).