### PR TITLE
Truncate the L2 provider URLs that are logged

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -127,4 +127,33 @@ std::string_view string_safe_substr(std::string_view src, size_t pos, size_t siz
     }
     return result;
 }
+
+std::string mask_string(std::string_view src, size_t unmasked_size)
+{
+    std::string_view prefix;
+    std::string_view suffix;
+
+    // NOTE: Take the first 'unmasked_sizes' bytes from the start and end, the
+    // rest of the string is masked. If a really short string is passed in
+    // then we only take 1 character from the start and end and mask the rest.
+    //
+    // If an empty string is passed in then string_safe_substr is defined to
+    // return the empty string.
+    if ((unmasked_size * 2) >= src.size()) {
+        prefix = tools::string_safe_substr(src, 0, 1);
+        suffix = src.size() ? tools::string_safe_substr(src, src.size() - 1, 1) : "";
+    } else {
+        prefix = tools::string_safe_substr(src, 0, unmasked_size);
+        suffix = tools::string_safe_substr(src, src.size() - unmasked_size, unmasked_size);
+    }
+
+    std::string result = fmt::format("{}...{}", prefix, suffix);
+    return result;
+}
+
+std::string mask_string4(std::string_view src)
+{
+    std::string result = mask_string(src, 4);
+    return result;
+}
 }  // namespace tools

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -193,4 +193,21 @@ std::string_view find_prefixed_value(It begin, It end, std::string_view prefix) 
 /// out-of-bounds, the a slice to the end of the string is returned of 0 size. This function hence
 /// guarantees that a valid string will always be returned irrespective of input.
 std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept;
+
+/// Create a masked string where the first and last 'unmasked_size' bytes are
+/// preserved and the remainder of the string is truncated with '...'.
+///
+/// If 'src' is empty the masked string simply returns '...'. If the mask is
+/// larger than the string then only the first and last character is preserved with the remainder of
+/// the string is masked.
+///
+/// For example:
+///   "hello world" with an unmasked size of 2 results in "he...ld"
+///   "hello world" with an unmasked size of 4 results in "hell...orld"
+///   "hello"       with an unmasked size of 4 results in "h...d"
+///   ""            with an unmasked size of 4 results in "..."
+std::string mask_string(std::string_view src, size_t unmasked_size);
+
+/// Invokes 'mask_string' with an 'unmasked_size' of 4
+std::string mask_string4(std::string_view src);
 }  // namespace tools

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -194,20 +194,25 @@ std::string_view find_prefixed_value(It begin, It end, std::string_view prefix) 
 /// guarantees that a valid string will always be returned irrespective of input.
 std::string_view string_safe_substr(std::string_view src, size_t pos, size_t size) noexcept;
 
-/// Create a masked string where the first and last 'unmasked_size' bytes are
-/// preserved and the remainder of the string is truncated with '...'.
-///
-/// If 'src' is empty the masked string simply returns '...'. If the mask is
-/// larger than the string then only the first and last character is preserved with the remainder of
-/// the string is masked.
+/// Trim a URL's contents by masking the path with '...'
 ///
 /// For example:
-///   "hello world" with an unmasked size of 2 results in "he...ld"
-///   "hello world" with an unmasked size of 4 results in "hell...orld"
-///   "hello"       with an unmasked size of 4 results in "h...d"
-///   ""            with an unmasked size of 4 results in "..."
-std::string mask_string(std::string_view src, size_t unmasked_size);
-
-/// Invokes 'mask_string' with an 'unmasked_size' of 4
-std::string mask_string4(std::string_view src);
+///   https://10.24.0.1:9547 --> https://10.24.0.1:9547
+///   https://10.25.0.2:9547 --> https://10.25.0.2:9547
+///   http://10.24.0.1:9547 --> http://10.24.0.1:9547
+///   10.24.0.1:9547 --> 10.24.0.1:9547
+///   10.25.0.1 --> 10.25.0.1
+///   https://10.25.0.1/abcdef --> https://10.25.0.1/…def
+///   http://10.24.0.1:9547 --> http://10.24.0.1:9547
+///   https://10.24.0.1/ --> https://10.24.0.1/
+///   https://10.24.0.1:9547/a --> https://10.24.0.1:9547/a
+///   https://10.24.0.1:9547/ab --> https://10.24.0.1:9547/ab
+///   https://10.24.0.1:9547/abc --> https://10.24.0.1:9547/abc
+///   https://10.24.0.1:9547/abcd --> https://10.24.0.1:9547/…bcd
+///   https://10.24.0.1:9547/abcde --> https://10.24.0.1:9547/…cde
+///   https://10.24.0.1:9547/secret-stuff --> https://10.24.0.1:9547/…uff
+///   https://user:pass@10.24.0.1:9547 --> https://…@10.24.0.1:9547
+///   https://user:pass@10.24.0.1/stuff --> https://…@10.24.0.1/…uff
+///   ws://user:pass@10.24.0.1:9547/stuff --> ws://…@10.24.0.1:9547/…uff
+std::string trim_url(std::string_view src);
 }  // namespace tools

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -684,7 +684,7 @@ bool core::init(
                     provider_count++;
                 }
             } catch (const std::exception& e) {
-                log::critical(logcat, "Invalid l2-provider argument '{}': {}", tools::mask_string4(provider), e.what());
+                log::critical(logcat, "Invalid l2-provider argument '{}': {}", tools::trim_url(provider), e.what());
                 return false;
             }
         }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -684,7 +684,7 @@ bool core::init(
                     provider_count++;
                 }
             } catch (const std::exception& e) {
-                log::critical(logcat, "Invalid l2-provider argument '{}': {}", provider, e.what());
+                log::critical(logcat, "Invalid l2-provider argument '{}': {}", tools::mask_string4(provider), e.what());
                 return false;
             }
         }

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -129,7 +129,7 @@ void L2Tracker::update_state() {
                                 level,
                                 "{} [{}] is lagging (height {} < {})",
                                 name,
-                                url,
+                                tools::mask_string4(url),
                                 hi.height,
                                 best_height);
                 }
@@ -159,9 +159,9 @@ void L2Tracker::update_state() {
                                 "{} [{}] is not responding or is behind; switching to {} [{}] as "
                                 "primary L2 source",
                                 old_primary.name,
-                                old_primary.url,
+                                tools::mask_string4(old_primary.url),
                                 new_primary.name,
-                                new_primary.url);
+                                tools::mask_string4(new_primary.url));
                         primary_down = primary_last_warned = std::chrono::steady_clock::now();
                     } else {
                         // We *were* on a backup but now are switching back to the primary
@@ -171,7 +171,7 @@ void L2Tracker::update_state() {
                                 "{} [{}] is available again; switching back to it as primary L2 "
                                 "source",
                                 new_primary.name,
-                                new_primary.url);
+                                tools::mask_string4(new_primary.url));
                         primary_down.reset();
                     }
                 }
@@ -183,7 +183,7 @@ void L2Tracker::update_state() {
                             logcat,
                             "{} [{}] is still unavailable",
                             client_info()[0].name,
-                            client_info()[0].url);
+                            tools::mask_string4(client_info()[0].url));
                     primary_last_warned = now;
                 }
             }
@@ -511,16 +511,17 @@ bool L2Tracker::check_chain_id() const {
 
     auto clients = provider.getClients();
     for (auto& ci : chain_ids) {
-        auto& name = clients[ci.index].name;
-        auto& url = clients[ci.index].url;
+        auto& name             = clients[ci.index].name;
+        auto& url              = clients[ci.index].url;
+        std::string masked_url = tools::mask_string4(url);
         if (!ci.success)
-            log::warning(logcat, "Failed to retrieve L2 chain ID from {} [{}]", name, url);
+            log::warning(logcat, "Failed to retrieve L2 chain ID from {} [{}]", name, masked_url);
         else if (ci.chainId != chain_id) {
             log::critical(
                     logcat,
                     "L2 provider {} [{}] has invalid chain ID 0x{:x} (chainId 0x{:x} is required)",
                     name,
-                    url,
+                    masked_url,
                     ci.chainId,
                     chain_id);
             bad = true;
@@ -529,7 +530,7 @@ bool L2Tracker::check_chain_id() const {
                     logcat,
                     "L2 provider {} [{}] returned correct chainId 0x{:x}",
                     name,
-                    url,
+                    masked_url,
                     ci.chainId);
         }
     }

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -129,7 +129,7 @@ void L2Tracker::update_state() {
                                 level,
                                 "{} [{}] is lagging (height {} < {})",
                                 name,
-                                tools::mask_string4(url),
+                                tools::trim_url(url),
                                 hi.height,
                                 best_height);
                 }
@@ -159,9 +159,9 @@ void L2Tracker::update_state() {
                                 "{} [{}] is not responding or is behind; switching to {} [{}] as "
                                 "primary L2 source",
                                 old_primary.name,
-                                tools::mask_string4(old_primary.url),
+                                tools::trim_url(old_primary.url),
                                 new_primary.name,
-                                tools::mask_string4(new_primary.url));
+                                tools::trim_url(new_primary.url));
                         primary_down = primary_last_warned = std::chrono::steady_clock::now();
                     } else {
                         // We *were* on a backup but now are switching back to the primary
@@ -171,7 +171,7 @@ void L2Tracker::update_state() {
                                 "{} [{}] is available again; switching back to it as primary L2 "
                                 "source",
                                 new_primary.name,
-                                tools::mask_string4(new_primary.url));
+                                tools::trim_url(new_primary.url));
                         primary_down.reset();
                     }
                 }
@@ -183,7 +183,7 @@ void L2Tracker::update_state() {
                             logcat,
                             "{} [{}] is still unavailable",
                             client_info()[0].name,
-                            tools::mask_string4(client_info()[0].url));
+                            tools::trim_url(client_info()[0].url));
                     primary_last_warned = now;
                 }
             }
@@ -511,17 +511,17 @@ bool L2Tracker::check_chain_id() const {
 
     auto clients = provider.getClients();
     for (auto& ci : chain_ids) {
-        auto& name             = clients[ci.index].name;
-        auto& url              = clients[ci.index].url;
-        std::string masked_url = tools::mask_string4(url);
+        auto& name = clients[ci.index].name;
+        auto& url = clients[ci.index].url;
+        std::string trimmed_url = tools::trim_url(url);
         if (!ci.success)
-            log::warning(logcat, "Failed to retrieve L2 chain ID from {} [{}]", name, masked_url);
+            log::warning(logcat, "Failed to retrieve L2 chain ID from {} [{}]", name, trimmed_url);
         else if (ci.chainId != chain_id) {
             log::critical(
                     logcat,
                     "L2 provider {} [{}] has invalid chain ID 0x{:x} (chainId 0x{:x} is required)",
                     name,
-                    masked_url,
+                    trimmed_url,
                     ci.chainId,
                     chain_id);
             bad = true;
@@ -530,7 +530,7 @@ bool L2Tracker::check_chain_id() const {
                     logcat,
                     "L2 provider {} [{}] returned correct chainId 0x{:x}",
                     name,
-                    masked_url,
+                    trimmed_url,
                     ci.chainId);
         }
     }


### PR DESCRIPTION
Truncate the URL in logs so that user specific RPC nodes aren't logged.