### PR TITLE
Fix various oxend command line commands

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1053,6 +1053,8 @@ bool core::init_service_keys() {
     } else {
         keys.key.zero();
         keys.pub.zero();
+        keys.key_bls.zero();
+        keys.pub_bls.zero();
     }
 
     auto style = fg(fmt::terminal_color::yellow) | fmt::emphasis::bold;

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -107,6 +107,7 @@ bool command_parser_executor::print_sn_state_changes(const std::vector<std::stri
         std::cout << "start_height should be a number" << std::endl;
         return false;
     }
+    args_list.pop_front();
 
     if (!parse_if_present(args_list, end_height, "end height"))
         return false;
@@ -806,6 +807,11 @@ show_list:
 }
 
 bool command_parser_executor::claim_rewards(const std::vector<std::string>& args) {
+    if (args.size() != 1) {
+        tools::fail_msg_writer("Invalid arguments.  Expected: claim_rewards <eth_address>\n");
+        return false;
+    }
+
     return m_executor.claim_rewards(args[0]);
 }
 

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -304,8 +304,8 @@ or "default" to return the limit to its default value.)");
     m_command_lookup.set_handler(
             "claim_rewards",
             [this](const auto& x) { return m_parser.claim_rewards(x); },
-            "claim_rewards",
-            "Provides a link to the website that allows claiming of ERC-20 rewards");
+            "claim_rewards ETH_ADDRESS",
+            "Generates a network reward signature that allows claiming of SENT rewards");
     m_command_lookup.set_handler(
             "test_trigger_uptime_proof",
             [this](const auto&) {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -42,6 +42,7 @@
 #include <ctime>
 #include <exception>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <stack>
 #include <string>
@@ -317,25 +318,25 @@ bool rpc_command_executor::print_checkpoints(
     if (!maybe_checkpoints)
         return false;
 
-    auto checkpoints = *maybe_checkpoints;
+    auto& checkpoints = maybe_checkpoints->at("checkpoints");
 
     std::string entry;
-    auto entry_append = std::back_inserter(entry);
     if (print_json)
-        entry.append(checkpoints.dump());
+        entry = checkpoints.dump();
     else {
         for (size_t i = 0; i < checkpoints.size(); i++) {
             auto& cp = checkpoints[i];
+            int type = cp["type"].get<int>();
             fmt::format_to(
-                    entry_append,
-                    "[{}] Type: {} Height: {} Hash: {}\n",
+                    std::back_inserter(entry),
+                    "[{}] Type: {}, Height: {}, Hash: {}\n",
                     i,
-                    cp["type"].get<std::string_view>(),
+                    type == 0 ? "hard-coded" : "Service Node",
                     cp["height"].get<int64_t>(),
                     cp["block_hash"].get<std::string_view>());
         }
         if (entry.empty())
-            entry.append("No Checkpoints");
+            entry = "No Checkpoints";
     }
 
     tools::success_msg_writer() + entry;
@@ -355,28 +356,22 @@ bool rpc_command_executor::print_sn_state_changes(
     if (!maybe_sn_state)
         return false;
 
-    auto sn_state_changes = *maybe_sn_state;
+    auto changes = *maybe_sn_state;
 
-    auto writer = tools::success_msg_writer();
-
-    writer.append(
-            "Service Node State Changes (blocks {}-{})\n",
-            sn_state_changes["start_height"].get<std::string_view>(),
-            sn_state_changes["end_height"].get<std::string_view>());
-    writer.append(
-            " Recommissions:       {}",
-            sn_state_changes["total_recommission"].get<std::string_view>());
-    writer.append(
-            " Unlocks:             {}", sn_state_changes["total_unlock"].get<std::string_view>());
-    writer.append(
-            " Decommissions:       {}",
-            sn_state_changes["total_decommission"].get<std::string_view>());
-    writer.append(
-            " Deregistrations:     {}",
-            sn_state_changes["total_deregister"].get<std::string_view>());
-    writer.append(
+    tools::success_msg_writer(
+            "Service Node State Changes (blocks {}-{})\n"
+            " Recommissions:       {}\n"
+            " Unlocks:             {}\n"
+            " Decommissions:       {}\n"
+            " Deregistrations:     {}\n"
             " IP change penalties: {}",
-            sn_state_changes["total_ip_change_penalty"].get<std::string_view>());
+            changes["start_height"].get<int>(),
+            changes["end_height"].get<int>(),
+            changes["total_recommission"].get<int>(),
+            changes["total_unlock"].get<int>(),
+            changes["total_decommission"].get<int>(),
+            changes["total_deregister"].get<int>(),
+            changes["total_ip_change_penalty"].get<int>());
 
     return true;
 }
@@ -677,20 +672,19 @@ bool rpc_command_executor::mining_status() {
 
     bool mining_busy = false;
     auto& mres = *maybe_mining_info;
-    if (mres["status"] == STATUS_BUSY)
+    if (mres["status"].get<std::string_view>() == STATUS_BUSY)
         mining_busy = true;
-    else if (mres["status"] != STATUS_OK) {
+    else if (mres["status"].get<std::string_view>() != STATUS_OK) {
         tools::fail_msg_writer("Failed to retrieve mining info");
         return false;
     }
     bool active = mres["active"].get<bool>();
-    long speed = mres["speed"].get<long>();
     if (mining_busy || !active)
         tools::msg_writer("Not currently mining");
     else {
         tools::msg_writer(
                 "Mining at {} with {} threads",
-                get_mining_speed(speed),
+                get_mining_speed(mres["speed"].get<long>()),
                 mres["threads_count"].get<int>());
         tools::msg_writer("Mining address: {}", mres["address"].get<std::string_view>());
     }
@@ -733,7 +727,7 @@ bool rpc_command_executor::print_connections() {
             "Up (kB/s)",
             "Up(now)");
 
-    for (auto& info : conns) {
+    for (auto& info : conns["connections"]) {
         tools::msg_writer(
                 row_fmt,
                 "{} {}:{}"_format(
@@ -960,7 +954,7 @@ bool rpc_command_executor::print_transaction(
     auto prunable_hex = tx.value<std::string_view>("prunable", ""sv);
     bool pruned = !prunable_hash.empty() && prunable_hex.empty();
 
-    bool in_pool = tx["in_pool"].get<bool>();
+    bool in_pool = tx.value("in_pool", false);
     if (in_pool)
         tools::success_msg_writer("Found in pool");
     else
@@ -1211,10 +1205,7 @@ bool rpc_command_executor::print_transaction_pool_stats() {
     return true;
 }
 
-bool rpc_command_executor::start_mining(
-        std::string address,
-        int num_threads,
-        int num_blocks) {
+bool rpc_command_executor::start_mining(std::string address, int num_threads, int num_blocks) {
     json args{
             {"num_blocks", num_blocks},
             {"threads_count", num_threads},
@@ -1277,10 +1268,10 @@ bool rpc_command_executor::out_peers(bool set, uint32_t limit) {
         return false;
     auto& out_peers = *maybe_out_peers;
 
-    const std::string s = out_peers["out_peers"] == (uint32_t)-1
-                                ? "unlimited"
-                                : out_peers["out_peers"].get<std::string>();
-    tools::msg_writer().append("Max number of out peers set to {}\n", s);
+    auto peers = out_peers["out_peers"].get<uint32_t>();
+    tools::msg_writer().append(
+            "Max number of outgoing peers set to {}\n",
+            peers == std::numeric_limits<uint32_t>::max() ? "unlimited" : "{}"_format(peers));
 
     return true;
 }
@@ -1295,10 +1286,10 @@ bool rpc_command_executor::in_peers(bool set, uint32_t limit) {
         return false;
     auto& in_peers = *maybe_in_peers;
 
-    const std::string s = in_peers["in_peers"] == (uint32_t)-1
-                                ? "unlimited"
-                                : in_peers["in_peers"].get<std::string>();
-    tools::msg_writer().append("Max number of in peers set to {}\n", s);
+    auto peers = in_peers["in_peers"].get<uint32_t>();
+    tools::msg_writer().append(
+            "Max number of incoming peers set to {}\n",
+            peers == std::numeric_limits<uint32_t>::max() ? "unlimited" : "{}"_format(peers));
 
     return true;
 }
@@ -1308,14 +1299,13 @@ bool rpc_command_executor::print_bans() {
             try_running([this] { return invoke<GET_BANS>(); }, "Failed to retrieve ban list");
     if (!maybe_bans)
         return false;
-    auto bans = *maybe_bans;
 
-    if (!bans.empty()) {
-        for (auto i = bans.begin(); i != bans.end(); ++i) {
+    if (auto it = maybe_bans->find("bans"); it != maybe_bans->end() && !it->empty()) {
+        for (const auto& ban : *it) {
             tools::msg_writer(
                     "{} banned for {} seconds",
-                    (*i)["host"].get<std::string_view>(),
-                    (*i)["seconds"].get<int64_t>());
+                    ban["host"].get<std::string_view>(),
+                    ban["seconds"].get<int64_t>());
         }
     } else
         tools::msg_writer("No IPs are banned");
@@ -1355,9 +1345,7 @@ bool rpc_command_executor::banned(const std::string& address) {
 
     if (banned_response["banned"].get<bool>())
         tools::msg_writer(
-                "{} is banned for {} seconds",
-                address,
-                banned_response["seconds"].get<std::string_view>());
+                "{} is banned for {} seconds", address, banned_response["seconds"].get<int64_t>());
     else
         tools::msg_writer("{} is not banned", address);
 
@@ -1848,7 +1836,8 @@ static void append_printable_service_node_list_entry(
                     entry["storage_lmq_port"].get<uint16_t>());
 
         // NOTE: Quorumnet port is omitted if we haven't received a uptime proof yet
-        if (auto quorumnet_port_it = entry.find("quorumnet_port"); quorumnet_port_it != entry.end()) {
+        if (auto quorumnet_port_it = entry.find("quorumnet_port");
+            quorumnet_port_it != entry.end()) {
             uint16_t quorumnet_port = *quorumnet_port_it;
             stream << ": {} (oxen quorums)"_format(quorumnet_port);
         } else {
@@ -2164,7 +2153,9 @@ bool rpc_command_executor::flush_cache(bool bad_txs, bool bad_blocks) {
     return true;
 }
 
-bool rpc_command_executor::claim_rewards(const std::string& address) {
+bool rpc_command_executor::claim_rewards(std::string_view address) {
+    if (address.starts_with("0x"))
+        address.remove_prefix(2);
     auto maybe_withdrawal_response = try_running(
             [this, address] {
                 return invoke<BLS_REWARDS_REQUEST>(json{{"address", address}});
@@ -2175,10 +2166,7 @@ bool rpc_command_executor::claim_rewards(const std::string& address) {
     auto& withdrawal_response = *maybe_withdrawal_response;
 
     tools::msg_writer(
-            "Address: {0:s}\n Amount: {1:d}\n Height: {2:d}\n Signature: {3:s}\n"
-            " Link to claim rewards: "
-            "https://oxen-eth-webpage.vercel.app/"
-            "?amount={1:d}&address={0:s}&height={2:d}&sig={3:s}\n",
+            "Address: {}\nAmount: {}\nHeight: {}\nSignature: {}\n",
             withdrawal_response["address"].get<std::string_view>(),
             withdrawal_response["amount"].get<uint64_t>(),
             withdrawal_response["height"].get<uint64_t>(),
@@ -2230,13 +2218,28 @@ bool rpc_command_executor::print_sn_key() {
 
     auto my_sn_keys = *maybe_service_keys;
 
+    std::string_view snpk = my_sn_keys.value("service_node_pubkey", ""sv);
+    std::string_view edpk = my_sn_keys["service_node_ed25519_pubkey"].get<std::string_view>();
+    std::string maybe_sn_pubkey, maybe_bls;
+    if (!snpk.empty() && snpk != edpk)
+        maybe_sn_pubkey = " Legacy Public Key: {}\n"_format(snpk);
+    if (std::string_view blspk = my_sn_keys.value("service_node_bls_pubkey", ""sv); !blspk.empty())
+        maybe_bls = "    BLS Public Key: {}\n"_format(blspk);
+
     tools::success_msg_writer(
-            "Service Node Public Key: {}\n"
-            "     Ed25519 Public Key: {}\n"
-            "      X25519 Public Key: {}",
-            my_sn_keys["service_node_pubkey"].get<std::string_view>(),
-            my_sn_keys["service_node_ed25519_pubkey"].get<std::string_view>(),
-            my_sn_keys["service_node_x25519_pubkey"].get<std::string_view>());
+            "{}"
+            "Ed25519 Public Key: {}\n"
+            " X25519 Public Key: {}\n"
+            "{}"
+            "{}",
+            maybe_sn_pubkey,
+            edpk,
+            my_sn_keys["service_node_x25519_pubkey"].get<std::string_view>(),
+            maybe_bls,
+            my_sn_keys.value("is_service_node", false) ? ""
+                                                       : "Note: this oxend is NOT configured as a "
+                                                         "service node");
+
     return true;
 }
 
@@ -2816,7 +2819,8 @@ bool rpc_command_executor::check_blockchain_pruning() {
         return false;
     auto& pruning = *maybe_pruning;
 
-    tools::success_msg_writer("Blockchain {} pruned", pruning["pruning_seed"] ? "is" : "is not");
+    tools::success_msg_writer(
+            "Blockchain {} pruned", pruning["pruning_seed"].get<uint64_t>() > 0 ? "is" : "is not");
     return true;
 }
 
@@ -2831,7 +2835,10 @@ bool rpc_command_executor::version() {
 }
 
 bool rpc_command_executor::test_trigger_uptime_proof() {
-    return invoke<TEST_TRIGGER_UPTIME_PROOF>(json{{}}, "Failed to trigger uptime proof");
+    tools::success_msg_writer(
+            "{}",
+            invoke<TEST_TRIGGER_UPTIME_PROOF>(json{{}}, "Failed to trigger uptime proof").dump());
+    return true;
 }
 
 }  // namespace daemonize

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -266,7 +266,7 @@ class rpc_command_executor final {
 
     bool flush_cache(bool bad_txs, bool invalid_blocks);
 
-    bool claim_rewards(const std::string& address);
+    bool claim_rewards(std::string_view address);
 
     bool version();
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1763,6 +1763,7 @@ void core_rpc_server::invoke(HARD_FORK_INFO& hfinfo, rpc_context) {
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_BANS& get_bans, rpc_context) {
+    get_bans.response["bans"] = nlohmann::json::array();
     auto now = time(nullptr);
     std::map<std::string, time_t> blocked_hosts = m_p2p.get_blocked_hosts();
     for (std::map<std::string, time_t>::const_iterator i = blocked_hosts.begin();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -312,8 +312,8 @@ void core_rpc_server::invoke(GET_NET_STATS& get_net_stats, rpc_context) {
                 epee::net_utils::network_throttle_manager::m_lock_get_global_throttle_out};
         auto [packets, bytes] =
                 epee::net_utils::network_throttle_manager::get_global_throttle_out().get_stats();
-        get_net_stats.response["total_packets_in"] = packets;
-        get_net_stats.response["total_bytes_in"] = bytes;
+        get_net_stats.response["total_packets_out"] = packets;
+        get_net_stats.response["total_bytes_out"] = bytes;
     }
     get_net_stats.response["status"] = STATUS_OK;
 }
@@ -2036,12 +2036,14 @@ void core_rpc_server::invoke(SET_LIMIT& limit, rpc_context) {
 void core_rpc_server::invoke(OUT_PEERS& out_peers, rpc_context) {
     if (out_peers.request.set)
         m_p2p.change_max_out_public_peers(out_peers.request.out_peers);
+    out_peers.response["out_peers"] = m_p2p.get_max_out_public_peers();
     out_peers.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(IN_PEERS& in_peers, rpc_context) {
     if (in_peers.request.set)
         m_p2p.change_max_in_public_peers(in_peers.request.in_peers);
+    in_peers.response["in_peers"] = m_p2p.get_max_in_public_peers();
     in_peers.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
@@ -2568,7 +2570,9 @@ void core_rpc_server::invoke(GET_SERVICE_KEYS& get_service_keys, rpc_context) {
         get_service_keys.response_hex["service_node_pubkey"] = keys.pub;
     get_service_keys.response_hex["service_node_ed25519_pubkey"] = keys.pub_ed25519;
     get_service_keys.response_hex["service_node_x25519_pubkey"] = keys.pub_x25519;
-    get_service_keys.response_hex["service_node_bls_pubkey"] = keys.pub_bls;
+    if (keys.pub_bls)
+        get_service_keys.response_hex["service_node_bls_pubkey"] = keys.pub_bls;
+    get_service_keys.response["is_service_node"] = m_core.service_node();
     get_service_keys.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1817,11 +1817,14 @@ struct GET_SERVICE_NODE_REGISTRATION_CMD : RPC_COMMAND {
 /// Outputs:
 ///
 /// - `status` -- General RPC status string. `"OK"` means everything looks good.
-/// - `service_node_pubkey` -- The queried daemon's service node public key.  Will be empty if not
+/// - `service_node_pubkey` -- The queried daemon's service node public key.  Will be omitted if not
 ///   running as a service node.
 /// - `service_node_ed25519_pubkey` -- The daemon's ed25519 auxiliary public key.
 /// - `service_node_x25519_pubkey` -- The daemon's x25519 auxiliary public key.
-/// - `service_node_bls_pubkey` -- The daemon's BLS auxiliary public key.
+/// - `service_node_bls_pubkey` -- The daemon's BLS auxiliary public key.  Will be omitted if not
+///   running as a service node.
+/// - `is_service_node` -- true/false indicating whether this daemon is configured and running in
+///   service node mode.
 struct GET_SERVICE_KEYS : NO_ARGS {
     static constexpr auto names() { return NAMES("get_service_keys", "get_service_node_key"); }
 };


### PR DESCRIPTION
Fix various broken oxend commands:

- claim_rewards had various bugs: - help output did not indicate that it takes an argument. - segfaulted if called without an argument. - printed some private URL instead of just the data needed. - didn't accept a 0x prefixed address
- banned threw a json exception
- bans threw a json exception
- check_blockchain_pruning threw a json exception
- print_cn threw a json exception
- mining_status threw a json exception
- print_checkpoints threw a json exception
- out_peers threw a json exception
- out_peers rpc endpoint didn't return the current value (despite the doc saying it should)
- in_peers threw a json exception
- in_peers rpc endpoint didn't return the current value (despite the doc saying it should)
- print_checkpoints threw a json exception
- get_net_stats threw a json exception because the rpc endpoint set `..._in` twice instead of setting `..._out`.
- print_sn_keys threw a json exception
- print_sn_keys printed garbage for the bls pubkey when not running as a service node because the bls pubkey was never initialized; fixed to zero the key when not a service node, and omit the key from the rpc endpoint when null.
- changed print_sn_keys to not print the legacy key when the same as the Ed public key.
- print_sn_state_changes:
  - threw a json exception
  - formatting was incorrect
  - end_height was not properly parsed
- print_tx threw a json exception
- test_trigger_uptime_proof threw a json exception