### PR TITLE
P2p fixes

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -397,7 +397,7 @@ class node_server
             PeerType peer_type = PeerType::white,
             uint64_t first_seen_stamp = 0);
     // Draw from a truncated exponential with the given rate, truncated to produce values in [0,
-    // N+1), and then take the integer floor to get a [0, N] value.  This distribution prefers
+    // N), and then take the integer floor to get a [0, N-1] value.  This distribution prefers
     // earlier values: with the default rate and the *untruncated* distribution, [0] is selected
     // around 13% of the time, indices in 0-9 are selected with probability 0.75 (this is where the
     // default comes from), and indices < 20 are selected with probability 0.9375, and indices < 50
@@ -406,7 +406,7 @@ class node_server
     // The *truncated* distribution scales these probabilities up slightly depending on the amount
     // of truncation.  (For example, with max_index of 19, those probabilities increase by a factor
     // of 1.06667, and with max_index of 9, they increase by 4/3).
-    size_t get_random_exp_index(size_t max_index, double rate = 0.13862943611198906);
+    size_t get_random_exp_index(size_t size, double rate = 0.13862943611198906);
     bool is_peer_used(const peerlist_entry& peer);
     bool is_peer_used(const anchor_peerlist_entry& peer);
     bool is_addr_connected(const epee::net_utils::network_address& peer);

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -396,7 +396,17 @@ class node_server
             uint64_t last_seen_stamp = 0,
             PeerType peer_type = PeerType::white,
             uint64_t first_seen_stamp = 0);
-    size_t get_random_index_with_fixed_probability(size_t max_index);
+    // Draw from a truncated exponential with the given rate, truncated to produce values in [0,
+    // N+1), and then take the integer floor to get a [0, N] value.  This distribution prefers
+    // earlier values: with the default rate and the *untruncated* distribution, [0] is selected
+    // around 13% of the time, indices in 0-9 are selected with probability 0.75 (this is where the
+    // default comes from), and indices < 20 are selected with probability 0.9375, and indices < 50
+    // with probability ~0.999.
+    //
+    // The *truncated* distribution scales these probabilities up slightly depending on the amount
+    // of truncation.  (For example, with max_index of 19, those probabilities increase by a factor
+    // of 1.06667, and with max_index of 9, they increase by 4/3).
+    size_t get_random_exp_index(size_t max_index, double rate = 0.13862943611198906);
     bool is_peer_used(const peerlist_entry& peer);
     bool is_peer_used(const anchor_peerlist_entry& peer);
     bool is_addr_connected(const epee::net_utils::network_address& peer);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1031,23 +1031,22 @@ bool node_server<t_payload_net_handler>::do_peer_timed_sync(
 
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
-size_t node_server<t_payload_net_handler>::get_random_exp_index(const size_t max_index, const double rate) {
-    if (max_index == 0)
-        return max_index;
+size_t node_server<t_payload_net_handler>::get_random_exp_index(const size_t size, const double rate) {
+    if (size <= 1)
+        return 0;
 
     // (See net_node.h)
 
     crypto::random_device rng;
     const double u = std::uniform_real_distribution{}(rng);
     // For non-truncated exponential we could use: -1/rate * log(1-u), (or
-    // std::exponential_distribution) but then we'd have to repeat until we got a value <
-    // max_index+1, which is technically unbounded computational time.  Instead we mutate the
-    // calculation like this, which gives us exponential, but truncated to [0, max_index+1), without
-    // looping:
+    // std::exponential_distribution) but then we'd have to repeat until we got a value < size,
+    // which is technically unbounded computational time.  Instead we mutate the calculation like
+    // this, which gives us exponential, but truncated to [0, size), without looping:
     const size_t res = static_cast<size_t>(
-            -1.0 / rate * std::log(1.0 - u * (1.0 - std::exp(-rate * (max_index + 1)))));
+            -1.0 / rate * std::log(1.0 - u * (1.0 - std::exp(-rate * size))));
 
-    log::debug(logcat, "Random connection index={} (max_index={})", res, max_index);
+    log::debug(logcat, "Random connection index={} (size={})", res, size);
     return res;
 }
 //-----------------------------------------------------------------------------------


### PR DESCRIPTION
p2p peer selection was broken, to put it mildly, which tends to lead to peer starvation particularly on testnet/devnet/stagenet where there is high churn.


Edit: This has made out `decafXX` stagenet nodes (now running on this branch) stay consistently at 7-8 "out" nodes per server, where previously they were all in the 0-4 range.