### PR TITLE
Optimization: coalesce payments before inserting

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -335,8 +335,28 @@ std::string BlockchainSQLite::get_address_str(const cryptonote::batch_sn_payment
                 cryptonote::get_account_address_as_str(m_nettype, 0, addr.address_info.address);
     return address_str;
 }
+std::pair<int, std::string> BlockchainSQLite::get_address_str(
+        const std::variant<eth::address, cryptonote::account_public_address>& addr,
+        uint64_t batching_interval) {
+    std::pair<int, std::string> result;
+    auto& [offset, address_str] = result;
+    if (auto* eth_addr = std::get_if<eth::address>(&addr)) {
+        offset = 0;  // ignored for SENT
+        address_str = "0x{:x}"_format(*eth_addr);
+    } else {
+        auto* oxen_addr = std::get_if<cryptonote::account_public_address>(&addr);
+        assert(oxen_addr);
+        offset = batching_interval == 0 ? 0
+                                        : static_cast<int>(oxen_addr->modulus(batching_interval));
+        auto& cached = address_str_cache[*oxen_addr];
+        if (cached.empty())
+            cached = cryptonote::get_account_address_as_str(m_nettype, 0, *oxen_addr);
+        address_str = cached;
+    }
+    return result;
+}
 
-bool BlockchainSQLite::add_sn_rewards(const std::vector<cryptonote::batch_sn_payment>& payments) {
+bool BlockchainSQLite::add_sn_rewards(const block_payments& payments) {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
     auto insert_payment = prepared_st(
             "INSERT INTO batched_payments_accrued (address, payout_offset, amount) VALUES (?, ?, ?)"
@@ -344,37 +364,34 @@ bool BlockchainSQLite::add_sn_rewards(const std::vector<cryptonote::batch_sn_pay
 
     const auto& netconf = get_config(m_nettype);
 
-    for (auto& payment : payments) {
-        auto offset =
-                static_cast<int>(payment.address_info.address.modulus(netconf.BATCHING_INTERVAL));
-        auto amt = static_cast<int64_t>(payment.amount);
-        const auto address_str = get_address_str(payment);
+    for (auto& [addr, amt] : payments) {
+        auto [offset, address_str] = get_address_str(addr, netconf.BATCHING_INTERVAL);
+        auto amount = static_cast<int64_t>(amt);
         log::trace(
                 logcat,
                 "Adding record for SN reward contributor {} to database with amount {}",
                 address_str,
                 amt);
-        db::exec_query(insert_payment, address_str, offset, amt);
+        db::exec_query(insert_payment, address_str, offset, amount);
         insert_payment->reset();
     }
 
     return true;
 }
 
-bool BlockchainSQLite::subtract_sn_rewards(
-        const std::vector<cryptonote::batch_sn_payment>& payments) {
+bool BlockchainSQLite::subtract_sn_rewards(const block_payments& payments) {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
     auto update_payment = prepared_st(
             "UPDATE batched_payments_accrued SET amount = (amount - ?) WHERE address = ?");
 
-    for (auto& payment : payments) {
-        const auto address_str = get_address_str(payment);
-        auto result =
-                db::exec_query(update_payment, static_cast<int64_t>(payment.amount), address_str);
+    for (auto& [addr, amt] : payments) {
+        auto [offset, address_str] = get_address_str(addr, 0);
+        auto result = db::exec_query(update_payment, static_cast<int64_t>(amt), address_str);
         if (!result) {
             log::error(
                     logcat,
-                    "tried to subtract payment from an address that doesn't exist: {}",
+                    "tried to subtract payment from an address that doesn't exist or has "
+                    "insufficient balance: {}",
                     address_str);
             return false;
         }
@@ -463,11 +480,11 @@ BlockchainSQLite::get_all_accrued_rewards() {
     return result;
 }
 
-void BlockchainSQLite::calculate_rewards(
+void BlockchainSQLite::add_rewards(
         hf /*hf_version*/,
         uint64_t distribution_amount,
         const service_nodes::service_node_info& sn_info,
-        std::vector<cryptonote::batch_sn_payment>& payments) {
+        block_payments& payments) const {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
     // Find out how much is due for the operator: fee_portions/PORTIONS * reward
@@ -477,13 +494,12 @@ void BlockchainSQLite::calculate_rewards(
 
     assert(operator_fee <= distribution_amount);
 
-    payments.clear();
     // Pay the operator fee to the operator
     if (operator_fee > 0) {
-        if (sn_info.operator_ethereum_address)
-            payments.emplace_back(sn_info.operator_ethereum_address, operator_fee);
-        else
-            payments.emplace_back(sn_info.operator_address, operator_fee);
+        auto& balance = sn_info.operator_ethereum_address
+                              ? payments[sn_info.operator_ethereum_address]
+                              : payments[sn_info.operator_address];
+        balance += operator_fee;
     }
     // Pay the balance to all the contributors (including the operator again)
     uint64_t total_contributed_to_sn = std::accumulate(
@@ -498,10 +514,9 @@ void BlockchainSQLite::calculate_rewards(
         uint64_t c_reward = mul128_div64(
                 contributor.amount, distribution_amount - operator_fee, total_contributed_to_sn);
         if (c_reward > 0) {
-            if (contributor.ethereum_address)
-                payments.emplace_back(contributor.ethereum_address, c_reward);
-            else
-                payments.emplace_back(contributor.address, c_reward);
+            auto& balance = contributor.ethereum_address ? payments[contributor.ethereum_address]
+                                                         : payments[contributor.address];
+            balance += c_reward;
         }
     }
 }
@@ -511,10 +526,11 @@ void BlockchainSQLite::calculate_rewards(
 bool BlockchainSQLite::reward_handler(
         const cryptonote::block& block,
         const service_nodes::service_node_list::state_t& service_nodes_state,
-        bool add) {
+        bool add,
+        block_payments payments) {
     // The method we call do actually handle the change: either `add_sn_payments` if add is true,
     // `subtract_sn_payments` otherwise:
-    bool (BlockchainSQLite::*add_or_subtract)(const std::vector<cryptonote::batch_sn_payment>&) =
+    auto add_or_subtract =
             add ? &BlockchainSQLite::add_sn_rewards : &BlockchainSQLite::subtract_sn_rewards;
 
     assert(block.major_version >= hf::hf19_reward_batching);
@@ -525,8 +541,6 @@ bool BlockchainSQLite::reward_handler(
         throw oxen::traced<std::logic_error>{"Reward distribution amount is too large"};
 
     uint64_t block_reward = block.reward * BATCH_REWARD_FACTOR;
-    std::vector<cryptonote::batch_sn_payment> payments;
-    payments.reserve(10);
 
     std::lock_guard a_s_lock{address_str_cache_mutex};
 
@@ -538,15 +552,11 @@ bool BlockchainSQLite::reward_handler(
             throw oxen::traced<std::logic_error>{"Invalid payment: block reward is too small"};
         if (uint64_t tx_fees = block_reward - base_sn_reward; tx_fees > 0 && block.has_pulse()) {
             if (auto pulse_leader = service_nodes_state.get_block_producer()) {
-                calculate_rewards(
+                add_rewards(
                         block.major_version,
                         tx_fees,
                         *service_nodes_state.service_nodes_infos.at(pulse_leader),
                         payments);
-                // Takes the block producer and adds its contributors to the batching database for
-                // the transaction fees
-                if (!(this->*add_or_subtract)(payments))
-                    return false;
             }
         }
         block_reward = base_sn_reward;
@@ -557,16 +567,8 @@ bool BlockchainSQLite::reward_handler(
     const auto payable_service_nodes =
             service_nodes_state.payable_service_nodes_infos(block.get_height(), m_nettype);
     const uint64_t N = payable_service_nodes.size();
-    for (const auto& [node_pubkey, node_info] : payable_service_nodes) {
-        // TODO: optimize.  Right now we get each payment to each contributor for each SN then do an
-        // SQL insertion for that amount.  This seems inefficient compared to summing all the
-        // amounts in a data structure and then passing the sums rather than individual summands
-        // into SQLite.
-        calculate_rewards(block.major_version, block_reward / N, *node_info, payments);
-        // Takes the node and adds its contributors to the batching database
-        if (!(this->*add_or_subtract)(payments))
-            return false;
-    }
+    for (const auto& [node_pubkey, node_info] : payable_service_nodes)
+        add_rewards(block.major_version, block_reward / N, *node_info, payments);
 
     // Step 3: Add Governance reward to the list
     if (m_nettype != cryptonote::network_type::FAKECHAIN &&
@@ -581,13 +583,23 @@ bool BlockchainSQLite::reward_handler(
         }
         uint64_t foundation_reward =
                 cryptonote::governance_reward_formula(block.major_version) * BATCH_REWARD_FACTOR;
-        payments.clear();
-        payments.emplace_back(parsed_governance_addr.second.address, foundation_reward);
-        if (!(this->*add_or_subtract)(payments))
-            return false;
+        payments[parsed_governance_addr.second.address] += foundation_reward;
     }
 
+    if (!(this->*add_or_subtract)(payments))
+        return false;
+
     return true;
+}
+
+block_payments BlockchainSQLite::get_delayed_payments(uint64_t height) {
+    block_payments payments;
+    auto delayed_payments_st = prepared_results<std::string_view, int64_t>(
+            "SELECT eth_address, amount FROM delayed_payments WHERE payout_height = ?",
+            static_cast<int64_t>(height));
+    for (auto [addr_str, amount] : delayed_payments_st)
+        payments[tools::make_from_hex_guts<eth::address>(addr_str)] += amount;
+    return payments;
 }
 
 bool BlockchainSQLite::add_block(
@@ -644,23 +656,8 @@ bool BlockchainSQLite::add_block(
             return false;
         }
 
-        // Process delayed payments due at this block height
-        auto delayed_payments_st = prepared_results<std::string_view, int64_t>(
-                "SELECT eth_address, amount FROM delayed_payments WHERE payout_height = ?",
-                static_cast<int64_t>(block_height));
-        std::vector<cryptonote::batch_sn_payment> delayed_payments;
-        for (auto [eth_address_str, amount] : delayed_payments_st) {
-            eth::address eth_address;
-            tools::load_from_hex_guts(eth_address_str, eth_address);
-            delayed_payments.emplace_back(eth_address, amount);
-        }
-
-        // Add delayed payments to accrued payments
-        if (!delayed_payments.empty()) {
-            add_sn_rewards(delayed_payments);
-        }
-
-        if (!reward_handler(block, service_nodes_state, /*add=*/true))
+        if (!reward_handler(
+                    block, service_nodes_state, /*add=*/true, get_delayed_payments(block_height)))
             return false;
 
         increment_height();
@@ -697,23 +694,7 @@ bool BlockchainSQLite::pop_block(
     try {
         SQLite::Transaction transaction{db, SQLite::TransactionBehavior::IMMEDIATE};
 
-        // Process delayed payments due at this block height
-        auto delayed_payments_st = prepared_results<std::string_view, int64_t>(
-                "SELECT eth_address, amount FROM delayed_payments WHERE payout_height = ?",
-                static_cast<int64_t>(block_height));
-        std::vector<cryptonote::batch_sn_payment> delayed_payments;
-        for (auto [eth_address_str, amount] : delayed_payments_st) {
-            eth::address eth_address;
-            tools::load_from_hex_guts(eth_address_str, eth_address);
-            delayed_payments.emplace_back(eth_address, amount);
-        }
-
-        // Subtract delayed payments from accrued payments
-        if (!delayed_payments.empty()) {
-            subtract_sn_rewards(delayed_payments);
-        }
-
-        if (!reward_handler(block, service_nodes_state, /*add=*/false))
+        if (!reward_handler(block, service_nodes_state, /*add=*/false, get_delayed_payments(block_height)))
             return false;
 
         // Add back to the database payments that had been made in this block

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -41,6 +41,9 @@ namespace cryptonote {
 
 fs::path check_if_copy_filename(std::string_view db_path);
 
+using block_payments = std::
+        unordered_map<std::variant<eth::address, cryptonote::account_public_address>, uint64_t>;
+
 class BlockchainSQLite : public db::Database {
   public:
     explicit BlockchainSQLite(cryptonote::network_type nettype, fs::path db_path);
@@ -60,21 +63,25 @@ class BlockchainSQLite : public db::Database {
 
     void blockchain_detached(uint64_t new_height);
 
-    // add_sn_rewards/subtract_sn_rewards -> passing an array of addresses and amounts. These will
-    // be added or subtracted to the database for each address specified. If the address does not
-    // exist it will be created.
-    bool add_sn_rewards(const std::vector<cryptonote::batch_sn_payment>& payments);
-    bool subtract_sn_rewards(const std::vector<cryptonote::batch_sn_payment>& payments);
+    // add_sn_rewards/subtract_sn_rewards -> passing a map of addresses and amounts. These will be
+    // added or subtracted to the database for each address specified. If the address does not exist
+    // it will be created.
+    bool add_sn_rewards(const block_payments& payments);
+    bool subtract_sn_rewards(const block_payments& payments);
 
   private:
     bool reward_handler(
             const cryptonote::block& block,
             const service_nodes::service_node_list::state_t& service_nodes_state,
-            bool add);
+            bool add,
+            block_payments payments = {});
+
+    block_payments get_delayed_payments(uint64_t height);
 
     std::unordered_map<account_public_address, std::string> address_str_cache;
     std::pair<hf, cryptonote::address_parse_info> parsed_governance_addr = {hf::none, {}};
     std::string get_address_str(const cryptonote::batch_sn_payment& addr);
+    std::pair<int, std::string> get_address_str(const std::variant<eth::address, cryptonote::account_public_address>& addr, uint64_t batching_interval);
     std::mutex address_str_cache_mutex;
 
   public:
@@ -94,18 +101,18 @@ class BlockchainSQLite : public db::Database {
     // created in a coinbase transaction on that block given the current batching DB state.
     std::vector<cryptonote::batch_sn_payment> get_sn_payments(uint64_t block_height);
 
-    // calculate_rewards -> takes the list of contributors from sn_info with their SN contribution
-    // amounts and will calculate how much of the block rewards should be the allocated to the
-    // contributors. The function will set a list suitable for passing to add_sn_rewards into the
-    // vector (any existing values will be cleared).
+    // Takes the list of contributors from sn_info with their SN contribution amounts and will
+    // calculate how much of the block rewards should be the allocated to the contributors. The
+    // function will *add* the calculated amounts to the value in the given `payments`, creating new
+    // entries (at value 0) as needed and adding to values that are already present.  Existing
+    // values in the map are *not* cleared or replaced.
     //
-    // Note that distribution_amount here is typically passed as milli-atomic OXEN for extra
-    // precision.
-    void calculate_rewards(
+    // Note that distribution_amount here is passed as milli-atomic OXEN for extra precision.
+    void add_rewards(
             hf hf_version,
             uint64_t distribution_amount,
             const service_nodes::service_node_info& sn_info,
-            std::vector<cryptonote::batch_sn_payment>& rewards);
+            block_payments& payments) const;
 
     // add/pop_block -> takes a block that contains new block rewards to be batched and added to the
     // database and/or batching payments that need to be subtracted from the database, in addition
@@ -120,7 +127,8 @@ class BlockchainSQLite : public db::Database {
             const cryptonote::block& block,
             const service_nodes::service_node_list::state_t& service_nodes_state);
 
-    bool return_staked_amount_to_user(const std::vector<cryptonote::batch_sn_payment>& payments, uint64_t delay_blocks);
+    bool return_staked_amount_to_user(
+            const std::vector<cryptonote::batch_sn_payment>& payments, uint64_t delay_blocks);
 
     // validate_batch_payment -> used to make sure that list of miner_tx_vouts is correct. Compares
     // the miner_tx_vouts with a list previously extracted payments to make sure that the correct


### PR DESCRIPTION
On mainnet there are a substantial number of addresses that receive payments from multiple SNs at each block.  Previously we were performing separate INSERT statements for each of these payments.

This commit optimizes it to accumulate all of the amounts to each address and then pays out the accumulated amounts, i.e. with one query per paid address instead of one per address per SN.

This makes syncing and subsystem rescanning a little more than twice as fast (once into the batching part of the chain, i.e. after HF19).  I go from syncing around 75-90 blocks/second to around 175-200 blocks per second, and rescanning about 2.2x faster (with a 2/3 reduction in the amount of time spent in the batch part of rescanning specifically):

Before:

    [+0.143s] [global:info|cryptonote_core/blockchain.cpp:374] Loading blocks into oxen subsystems, scanning blockchain from height: 1080001 to: 1100111 (snl: 1080001, ons: 1100111, sqlite: 1086858)
    [+0.143s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1080001 (0.000s) (snl: 0.000s, ons: 0.000s, batch: 0.000s)
    [+10.787s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1087401 (10.488s) (snl: 5.841s, ons: 0.000s, batch: 4.512s)
    [+21.468s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1088601 (10.674s) (snl: 0.925s, ons: 0.000s, batch: 9.730s)
    [+32.111s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1089801 (10.639s) (snl: 0.923s, ons: 0.000s, batch: 9.692s)
    [+42.289s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1090901 (10.012s) (snl: 0.856s, ons: 0.000s, batch: 9.140s)
    [+53.159s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1092101 (10.861s) (snl: 0.933s, ons: 0.000s, batch: 9.909s)
    [+1m03.207s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1093201 (10.044s) (snl: 0.876s, ons: 0.000s, batch: 9.148s)
    [+1m13.313s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1094301 (10.102s) (snl: 0.847s, ons: 0.000s, batch: 9.206s)
    [+1m23.448s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1095401 (10.129s) (snl: 0.877s, ons: 0.000s, batch: 9.208s)
    [+1m33.580s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1096501 (10.128s) (snl: 0.866s, ons: 0.000s, batch: 9.228s)
    [+1m43.672s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1097601 (10.086s) (snl: 0.904s, ons: 0.000s, batch: 9.166s)
    [+1m54.294s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1098801 (10.618s) (snl: 0.929s, ons: 0.000s, batch: 9.676s)
    [+2m04.828s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1100001 (10.529s) (snl: 0.913s, ons: 0.000s, batch: 9.606s)
    [+2m05.801s] [global:info|cryptonote_core/blockchain.cpp:497] Done recalculating oxen subsystems in 125.66s (15.69s snl; 0.00s ons; 108.22s batch)

After:

    [+0.141s] [global:info|cryptonote_core/blockchain.cpp:374] Loading blocks into oxen subsystems, scanning blockchain from height: 1080001 to: 1100111 (snl: 1080001, ons: 1100111, sqlite: 1086858)
    [+0.141s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1080001 (0.000s) (snl: 0.000s, ons: 0.000s, batch: 0.000s)
    [+10.586s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1088101 (10.297s) (snl: 6.404s, ons: 0.000s, batch: 3.745s)
    [+20.974s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1090801 (10.224s) (snl: 2.059s, ons: 0.000s, batch: 8.122s)
    [+31.329s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1093501 (10.348s) (snl: 2.096s, ons: 0.000s, batch: 8.206s)
    [+41.653s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1096101 (10.320s) (snl: 2.052s, ons: 0.000s, batch: 8.163s)
    [+51.854s] [global:info|cryptonote_core/blockchain.cpp:398] ... scanning height 1098701 (10.197s) (snl: 2.086s, ons: 0.000s, batch: 8.071s)
    [+57.376s] [global:info|cryptonote_core/blockchain.cpp:497] Done recalculating oxen subsystems in 57.23s (14.70s snl; 0.00s ons; 36.31s batch)

(These results were on my workstation with a reasonably fast, idle nvme drive; on slower drives I'd expect the relative speedup to be larger still).