### PR TITLE
Reject malformed blocks in the parse and validate stage

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1649,6 +1649,22 @@ std::vector<uint64_t> absolute_output_offsets_to_relative(const std::vector<uint
         b.hash = *block_hash;
         b.set_hash_valid(true);
     }
+
+    if ((b.major_version >= feature::ETH_BLS) == b.miner_tx.has_value()) {
+        log::error(
+                logcat,
+                "HF {} blocks {} have a miner tx ({})",
+                static_cast<int>(b.major_version),
+                b.major_version >= feature::ETH_BLS ? "must not" : "must",
+                obj_to_json_str(b),
+                oxenc::to_hex(b_blob));
+        return false;
+    }
+
+    if (b.miner_tx && !b.miner_tx->is_miner_tx()) {
+        log::error(logcat, "Block {} has a miner TX but it is missing the mining output data, blob: {}", obj_to_json_str(b), oxenc::to_hex(b_blob));
+        return false;
+    }
     return true;
 }
 //---------------------------------------------------------------

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1150,22 +1150,7 @@ namespace cryptonote
         ++m_sync_bad_spans_downloaded;
         return 1;
       }
-      if ((b.major_version >= feature::ETH_BLS) == b.miner_tx.has_value())
-      {
-        log::error(logcat, "sent wrong block: HF {} blocks {} have a miner tx ({}), dropping connection",
-                static_cast<int>(b.major_version), b.major_version >= feature::ETH_BLS ? "must not" : "must",
-                oxenc::to_hex(block_entry.block));
-        drop_connection(context, false, false);
-        ++m_sync_bad_spans_downloaded;
-        return 1;
-      }
-      if (b.miner_tx && !b.miner_tx->is_miner_tx())
-      {
-        log::error(logcat, "sent wrong block: miner tx is invalid, dropping connection", oxenc::to_hex(block_entry.block));
-        drop_connection(context, false, false);
-        ++m_sync_bad_spans_downloaded;
-        return 1;
-      }
+
       if (start_height == std::numeric_limits<uint64_t>::max())
         start_height = b.get_height();
 


### PR DESCRIPTION
It's possible to submit a block on the P2P layer that parses correctly but has an incorrect miner TX. This causes a crash because of a std::optional nullopt dereference when calculating the block hash that accesses the miner TX unsafely.

Additionally a default initialised block sets the miner transaction to nullopt but the major version to 7 which is where a miner TX is mandated. This block construction innocently passes a bunch of checks and then code that assumes that the block is trusted input data ends up leading to an exception being thrown when the block hash is calculated as it tries to read the miner TX.

This pulls the check much earlier so that the block is relatively "well-formed" when it is parsed and passes the validate stage (but the specific implementation details like TX content may still be invalid) that the block can be forwarded down to upper layers in the codebase

--

Default initialised blocks still pose a problem and is a footgun to be passing around default initialised blocks (because they generate a bad miner tx value). There's another bug somewhere hidden in the P2P layer where default initialised blocks are slipping through instead of the block parsed from the blob (and infact can be exploited by a malicious peer sending zero-init blocks when requested for a height to cause a crash which is mitigated in this PR).