### PR TITLE
Update local-devnet Web3 version and rawTransaction calls

### DIFF
--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -74,7 +74,7 @@ class ServiceNodeRewardContract:
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash   = self.web3.eth.send_raw_transaction(signed_tx.raw_transaction)
 
         # SENT Contract Address deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
         address_check_err_msg = ("If this assert triggers, the rewards contract ABI has been "
@@ -95,7 +95,7 @@ class ServiceNodeRewardContract:
             "from": self.acc.address,
             'nonce': self.web3.eth.get_transaction_count(self.acc.address)})
         signed_tx = self.web3.eth.account.sign_transaction(unsent_tx, private_key=self.acc.key)
-        self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        self.web3.eth.send_raw_transaction(signed_tx.raw_transaction)
 
     # Add more methods as needed to interact with the smart contract
     def getContractDeployedInLatestBlock(self):
@@ -121,7 +121,7 @@ class ServiceNodeRewardContract:
         return self.contract.functions.stakingRequirement().call()
 
     def submitSignedTX(self, tx_label, signed_tx):
-        result     = self.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        result     = self.web3.eth.send_raw_transaction(signed_tx.raw_transaction)
         tx_receipt = self.web3.eth.wait_for_transaction_receipt(result)
         self.web3.eth.wait_for_transaction_receipt(result)
 

--- a/utils/local-devnet/requirements.txt
+++ b/utils/local-devnet/requirements.txt
@@ -1,0 +1,1 @@
+web3==7.2.0; python_version >='3.9'

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -325,9 +325,9 @@ class SNNetwork:
         self.sn_contract.addBLSPublicKey(ethereum_add_bls_args)
 
         # Advance the Arbitrum blockchain so that the SN registration is observed in oxen
-        ethereum.evm_mine(self.sn_contract.web3);
-        ethereum.evm_mine(self.sn_contract.web3);
-        ethereum.evm_mine(self.sn_contract.web3);
+        ethereum.evm_mine(self.sn_contract.web3)
+        ethereum.evm_mine(self.sn_contract.web3)
+        ethereum.evm_mine(self.sn_contract.web3)
 
         # NOTE: Log all the SNs in the contract ####################################################
         contract_sn_id_it = 0
@@ -376,7 +376,7 @@ class SNNetwork:
             "from": self.sn_contract.acc.address,
             'nonce': self.sn_contract.web3.eth.get_transaction_count(self.sn_contract.acc.address)})
         signed_tx = self.sn_contract.web3.eth.account.sign_transaction(unsent_tx, private_key=self.sn_contract.acc.key)
-        self.sn_contract.web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        self.sn_contract.web3.eth.send_raw_transaction(signed_tx.raw_transaction)
         self.sn_contract.foundation_pool_contract.functions.payoutReleased().call()
 
         vprint("Foundation pool balance: {}".format(self.sn_contract.erc20balance(self.sn_contract.foundation_pool_address)))


### PR DESCRIPTION
Adds a requirements.txt to define web3/python versions. Use `pip install -r requirements.txt` to setup.

Updates deprecated rawTransaction calls to raw_transaction.