### PR TITLE
Fix stake change event processing

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -680,7 +680,7 @@ inline txversion transaction_prefix::get_max_version_for_hf(hf hf_version) {
 constexpr txtype transaction_prefix::get_max_type_for_hf(hf hf_version) {
     txtype result = txtype::standard;
     if (hf_version >= cryptonote::feature::ETH_BLS)
-        result = txtype::ethereum_service_node_removal;
+        result = txtype::ethereum_staking_requirement_updated;
     else if (hf_version >= hf::hf15_ons)
         result = txtype::oxen_name_system;
     else if (hf_version >= hf::hf14_blink)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4185,30 +4185,12 @@ bool Blockchain::check_tx_inputs(
             return false;
         }
 
-        if (tx.type == txtype::ethereum_new_service_node) {
-            if (!eth::validate_event_tx<eth::event::NewServiceNode>(
-                        hf_version, tx, &tvc.m_verbose_error)) {
+        if (is_l2_event_tx(tx.type)) {
+            if (!eth::validate_event_tx(tx.type, hf_version, tx, &tvc.m_verbose_error)) {
                 log::error(
                         log::Cat("verify"),
-                        "Failed to validate Ethereum New Service Node TX reason: {}",
-                        tvc.m_verbose_error);
-                return false;
-            }
-        } else if (tx.type == txtype::ethereum_service_node_removal_request) {
-            if (!eth::validate_event_tx<eth::event::ServiceNodeRemovalRequest>(
-                        hf_version, tx, &tvc.m_verbose_error)) {
-                log::error(
-                        log::Cat("verify"),
-                        "Failed to validate Ethereum Service Node Removal Request TX reason: {}",
-                        tvc.m_verbose_error);
-                return false;
-            }
-        } else if (tx.type == txtype::ethereum_service_node_removal) {
-            if (!eth::validate_event_tx<eth::event::ServiceNodeRemoval>(
-                        hf_version, tx, &tvc.m_verbose_error)) {
-                log::error(
-                        log::Cat("verify"),
-                        "Failed to validate Ethereum Service Node Removal TX reason: {}",
+                        "Failed to validate {} TX: {}",
+                        tx.type,
                         tvc.m_verbose_error);
                 return false;
             }

--- a/src/cryptonote_core/ethereum_transactions.h
+++ b/src/cryptonote_core/ethereum_transactions.h
@@ -48,6 +48,12 @@ bool validate_event_tx(
     return true;
 }
 
+bool validate_event_tx(
+        cryptonote::txtype txtype,
+        cryptonote::hf hf_version,
+        const cryptonote::transaction& tx,
+        std::string* reason);
+
 /// Extract the state change event details from a transaction.  If no state change is present in the
 /// transaction then `fail_reason` is set and std::monostate is returned.
 event::StateChangeVariant extract_event(

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3164,6 +3164,7 @@ void service_node_list::state_t::update_from_block(
             case txtype::ethereum_new_service_node:
             case txtype::ethereum_service_node_removal:
             case txtype::ethereum_service_node_removal_request:
+            case txtype::ethereum_staking_requirement_updated:
                 log::debug(logcat, "Processing new (unconfirmed) eth tx");
                 process_new_ethereum_tx(block, tx, my_keys);
                 break;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -905,7 +905,7 @@ class service_node_list {
 
         // An overridden staking requirement from the L2 contract (after confirmations); if 0 then
         // the default staking requirement applies.
-        uint64_t staking_requirement;
+        uint64_t staking_requirement{0};
 
         service_node_list* sn_list;
 

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -39,7 +39,9 @@ namespace {
              : event_sig == contract::event::ServiceNodeRemovalRequest
                      ? EventType::ServiceNodeRemovalRequest
              : event_sig == contract::event::ServiceNodeRemoval ? EventType::ServiceNodeRemoval
-                                                                : EventType::Other;
+             : event_sig == contract::event::StakingRequirementUpdated
+                     ? EventType::StakingRequirementUpdated
+                     : EventType::Other;
     }
 
 }  // namespace


### PR DESCRIPTION
Fixes bugs from PR #1714 - stake changes event txes weren't getting properly extracted or processed.  This fixes them, and simplifies the eth L2 state change processing code a bit.