### PR TITLE
Version clear out to 0 meant serialized version is always reset after…

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4079,8 +4079,8 @@ bool service_node_list::store() {
     for (data_for_serialization* serialize_entry : data) {
         if (serialize_entry->version != serialize_version)
             m_transient.state_added_to_archive = true;
-        serialize_entry->version = serialize_version;
         serialize_entry->clear();
+        serialize_entry->version = serialize_version;
     }
 
     m_transient.cache_short_term_data.quorum_states.reserve(m_transient.old_quorum_states.size());


### PR DESCRIPTION
… it is updated

In `service_node_list::store` we have a small loop that resets the `data_for_serialization`

```cpp
    for (data_for_serialization* serialize_entry : data) {
        if (serialize_entry->version != serialize_version)
            m_transient.state_added_to_archive = true;
        serialize_entry->version = serialize_version;
        serialize_entry->clear();
    }
```

Which calls `clear` after `serialize_entry->version = serialize_version`. The `clear` resets the version back to `0` causing the SNL in stagenet to rescan every time because the version nevers ends up being saved as v1.

I've moved the version assignment to after the clear to fix that.