### PR TITLE
Fix incorrect returning of stakes and regen SNL & SQL DB metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 11.0.4
+    VERSION 11.0.5
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Wistful Wagyu")
 # Version update notes:

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -452,7 +452,7 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
 
     for (auto [address, amount] : accrued_amounts) {
         auto& p = payments.emplace_back();
-        p.amount = sql_db_money::db_amount(amount / BATCH_REWARD_FACTOR * BATCH_REWARD_FACTOR); /* truncate to atomic OXEN */
+        p.amount = reward_money::db_amount(amount / BATCH_REWARD_FACTOR * BATCH_REWARD_FACTOR); /* truncate to atomic OXEN */
         [[maybe_unused]] bool addr_ok =
                 cryptonote::get_account_address_from_str(p.address_info, m_nettype, address);
         assert(addr_ok);
@@ -847,7 +847,7 @@ bool BlockchainSQLite::validate_batch_payment(
             cryptonote::get_deterministic_keypair_from_height(block_height);
     for (size_t vout_index = 0; vout_index < miner_tx_vouts.size(); vout_index++) {
         const auto& [pubkey, amt] = miner_tx_vouts[vout_index];
-        auto amount = sql_db_money::coin_amount(amt);
+        auto amount = reward_money::coin_amount(amt);
         const auto& from_db = calculated_payments_from_batching_db[vout_index];
         if (amount.to_db() != from_db.amount.to_db()) {
             log::error(

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -847,7 +847,7 @@ bool BlockchainSQLite::validate_batch_payment(
             cryptonote::get_deterministic_keypair_from_height(block_height);
     for (size_t vout_index = 0; vout_index < miner_tx_vouts.size(); vout_index++) {
         const auto& [pubkey, amt] = miner_tx_vouts[vout_index];
-        auto amount = sql_db_money::db_amount(amt);
+        auto amount = sql_db_money::coin_amount(amt);
         const auto& from_db = calculated_payments_from_batching_db[vout_index];
         if (amount.to_db() != from_db.amount.to_db()) {
             log::error(

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -840,7 +840,7 @@ bool BlockchainSQLite::validate_batch_payment(
             calculated_payments_from_batching_db.begin(),
             calculated_payments_from_batching_db.end(),
             uint64_t(0),
-            [](auto&& a, auto&& b) { return a + b.amount.to_coin(); });
+            [](auto&& a, auto&& b) { return a + b.coin_amount(); });
     uint64_t total_oxen_payout_in_vouts = 0;
     std::vector<batch_sn_payment> finalised_payments;
     cryptonote::keypair const deterministic_keypair =

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -156,7 +156,6 @@ class BlockchainSQLite : public db::Database {
     // to be marked as paid in the paid_amounts vector. Block height will be added to the
     // batched_payments_paid database as height_paid.
     bool save_payments(uint64_t block_height, const std::vector<batch_sn_payment>& paid_amounts);
-    std::vector<cryptonote::batch_sn_payment> get_block_payments(uint64_t block_height);
     bool delete_block_payments(uint64_t block_height);
 
     uint64_t height;

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -761,8 +761,8 @@ bls_exit_liquidation_response bls_aggregator::exit_liquidation_request(
     // NOTE: Lookup the BLS pubkey associated with the Ed25519 pubkey.
     std::optional<eth::bls_public_key> maybe_bls_pubkey{};
     for (const auto& it : core.service_node_list.recently_removed_nodes()) {
-        if (it.pubkey == pubkey) {
-            maybe_bls_pubkey = it.bls_pubkey;
+        if (it.service_node_pubkey == pubkey) {
+            maybe_bls_pubkey = it.info.bls_public_key;
             break;
         }
     }

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -74,23 +74,23 @@ struct address_parse_info {
     KV_MAP_SERIALIZABLE
 };
 
-// Strongly-typed money amount used to interface with the SQL DB when inserting
-// money into the DB. Amounts stored in the DB use a higher precision by a
-// factor of `BATCH_REWARD_FACTOR`.
-struct sql_db_money {
+// Strongly-typed money amount used to calculate rewards at a higher precision by a factory of
+// `BATCH_REWARD_FACTOR`. Money amounts are stored at the higher precision in the DB.
+struct reward_money {
 
     // Construct a money value from an atomic $COIN amount.
-    static sql_db_money coin_amount(uint64_t amount) { return {.amount = amount * BATCH_REWARD_FACTOR}; }
+    static reward_money coin_amount(uint64_t amount) { return {.amount = amount * BATCH_REWARD_FACTOR}; }
 
-    // Construct a money value from an atomic $COIN amount denoted in DB units. DB units have more
-    // precision to minimise integer division errors.
-    static sql_db_money db_amount(uint64_t amount)   { return {.amount = amount}; }
+    // Construct a money value from an atomic $COIN amount denoted with the extra precision
+    // (pre-multiplied with `BATCH_REWARD_FACTOR`) suitable for storing in the DB. There is more
+    // precision to minimise integer division errors in reward calculations.
+    static reward_money db_amount(uint64_t amount)   { return {.amount = amount}; }
 
     uint64_t to_coin() const { return amount / BATCH_REWARD_FACTOR; }
 
     uint64_t to_db() const { return amount; }
 
-    constexpr auto operator<=>(const sql_db_money& rhs) const = default;
+    constexpr auto operator<=>(const reward_money& rhs) const = default;
 
     uint64_t amount{0};
 };
@@ -98,13 +98,13 @@ struct sql_db_money {
 struct batch_sn_payment {
     cryptonote::address_parse_info address_info{};
     eth::address eth_address{};
-    sql_db_money amount;
+    reward_money amount;
     batch_sn_payment() = default;
-    batch_sn_payment(const cryptonote::address_parse_info& addr_info, sql_db_money amt) :
+    batch_sn_payment(const cryptonote::address_parse_info& addr_info, reward_money amt) :
             address_info{addr_info}, amount{amt} {}
-    batch_sn_payment(const cryptonote::account_public_address& addr, sql_db_money amt) :
+    batch_sn_payment(const cryptonote::account_public_address& addr, reward_money amt) :
             address_info{addr, 0}, amount{amt} {}
-    batch_sn_payment(const eth::address& addr, sql_db_money amt) :
+    batch_sn_payment(const eth::address& addr, reward_money amt) :
             eth_address{addr}, amount{amt} {}
 };
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -99,6 +99,7 @@ struct batch_sn_payment {
     cryptonote::address_parse_info address_info{};
     eth::address eth_address{};
     reward_money amount;
+
     batch_sn_payment() = default;
     batch_sn_payment(const cryptonote::address_parse_info& addr_info, reward_money amt) :
             address_info{addr_info}, amount{amt} {}
@@ -106,6 +107,8 @@ struct batch_sn_payment {
             address_info{addr, 0}, amount{amt} {}
     batch_sn_payment(const eth::address& addr, reward_money amt) :
             eth_address{addr}, amount{amt} {}
+
+    uint64_t coin_amount() const { return amount.to_coin(); }
 };
 
 #pragma pack(push, 1)

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -90,7 +90,7 @@ struct sql_db_money {
 
     uint64_t to_db() const { return amount; }
 
-    bool operator==(const sql_db_money& rhs) const { return amount == rhs.amount; }
+    constexpr auto operator<=>(const sql_db_money& rhs) const = default;
 
     uint64_t amount{0};
 };

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -122,13 +122,6 @@ struct public_integrated_address_outer_blob {
 };
 #pragma pack(pop)
 
-inline std::string return_first_address(
-        const std::string_view url, const std::vector<std::string>& addresses, bool dnssec_valid) {
-    if (addresses.empty())
-        return {};
-    return addresses[0];
-}
-
 /************************************************************************/
 /* Cryptonote helper functions                                          */
 /************************************************************************/

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -171,6 +171,7 @@ static constexpr std::array stagenet_hard_forks = {
         hard_fork{hf::hf14_blink, 0, 1, 1724084014},
         hard_fork{hf::hf21_eth, 0, 250, 1724084021},
         hard_fork{hf::hf21_eth, 1, 14760, 1726009200},
+        hard_fork{hf::hf21_eth, 2, 18840, 1726498800},
 };
 
 template <size_t N>

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1597,7 +1597,7 @@ bool Blockchain::validate_block_rewards(
                 batched_sn_payments.begin(),
                 batched_sn_payments.end(),
                 uint64_t{0},
-                [&](auto a, auto b) { return a + b.amount.to_coin(); });
+                [&](auto a, auto b) { return a + b.coin_amount(); });
     } else {
         max_base_reward += reward_parts.base_miner + reward_parts.service_node_total;
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1597,7 +1597,7 @@ bool Blockchain::validate_block_rewards(
                 batched_sn_payments.begin(),
                 batched_sn_payments.end(),
                 uint64_t{0},
-                [&](auto a, auto b) { return a + b.amount; });
+                [&](auto a, auto b) { return a + b.amount.to_coin(); });
     } else {
         max_base_reward += reward_parts.base_miner + reward_parts.service_node_total;
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3406,7 +3406,7 @@ std::vector<eth::bls_public_key> Blockchain::get_removable_nodes() const {
             uint16_t port = 0;
             for (const service_nodes::service_node_list::recently_removed_node&
                          recently_removed_it : service_node_list.recently_removed_nodes()) {
-                if (it != recently_removed_it.bls_pubkey)
+                if (it != recently_removed_it.info.bls_public_key)
                     continue;
                 protocol_dereg =
                         recently_removed_it.type ==

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1180,8 +1180,8 @@ bool core::is_node_liquidatable(const eth::bls_public_key& node_bls_pubkey) {
     // list, it's been deregistered from _OR_ it voluntarily exited the SNL.
     uint64_t height = blockchain.get_current_blockchain_height();
     for (const service_nodes::service_node_list::recently_removed_node& it : service_node_list.recently_removed_nodes()) {
-        assert(it.bls_pubkey && "Invalid null key got inserted into the recently removed list");
-        if (it.bls_pubkey == node_bls_pubkey) {
+        assert(it.info.bls_public_key && "Invalid null key got inserted into the recently removed list");
+        if (it.info.bls_public_key == node_bls_pubkey) {
             bool result = height >= it.liquidation_height;
             return result;
         }

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -483,7 +483,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
         assert(hard_fork_version >= hf::hf19_reward_batching);
         for (const auto& reward : sn_rwds) {
             assert(reward.amount.to_db() % BATCH_REWARD_FACTOR == 0 && "Check that the thousandth's OXEN has been truncated off");
-            auto atomic_amt = reward.amount.to_coin();
+            auto atomic_amt = reward.coin_amount();
             rewards.emplace_back(reward_type::snode, reward.address_info.address, atomic_amt);
             total_sn_rewards += atomic_amt;
         }
@@ -564,7 +564,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
 
     block_rewards = std::accumulate(
             batched_rewards.begin(), batched_rewards.end(), uint64_t{0}, [](uint64_t x, auto&& y) {
-                return x + y.amount.to_coin();
+                return x + y.coin_amount();
             });
 
     // lock

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -406,10 +406,10 @@ std::pair<bool, uint64_t> construct_miner_tx(
 
             if (hard_fork_version >= hf::hf19_reward_batching) {
                 for (size_t i = 0; i < p_payouts.size(); i++)
-                    batched_rewards.emplace_back(p_payouts[i].address, split_rewards[i]);
+                    batched_rewards.emplace_back(p_payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
             } else {
                 for (size_t i = 0; i < p_payouts.size(); i++)
-                    rewards.push_back({reward_type::snode, p_payouts[i].address, split_rewards[i]});
+                    rewards.emplace_back(reward_type::snode, p_payouts[i].address, split_rewards[i]);
             }
         }
 
@@ -417,11 +417,10 @@ std::pair<bool, uint64_t> construct_miner_tx(
                 leader.payouts, leader_reward, true /*distribute_remainder*/);
         if (hard_fork_version >= hf::hf19_reward_batching) {
             for (size_t i = 0; i < leader.payouts.size(); i++)
-                batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i]);
+                batched_rewards.emplace_back(leader.payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
         } else {
             for (size_t i = 0; i < leader.payouts.size(); i++)
-                rewards.push_back(
-                        {reward_type::snode, leader.payouts[i].address, split_rewards[i]});
+                rewards.emplace_back(reward_type::snode, leader.payouts[i].address, split_rewards[i]);
         }
     } else {
         // MINED BLOCKS
@@ -434,10 +433,9 @@ std::pair<bool, uint64_t> construct_miner_tx(
         if (uint64_t miner_amount = reward_parts.base_miner + reward_parts.miner_fee;
             miner_amount) {
             if (hard_fork_version >= hf::hf19_reward_batching) {
-                batched_rewards.emplace_back(miner_tx_context.miner_block_producer, miner_amount);
+                batched_rewards.emplace_back(miner_tx_context.miner_block_producer, sql_db_money::coin_amount(miner_amount));
             } else {
-                rewards.push_back(
-                        {reward_type::miner, miner_tx_context.miner_block_producer, miner_amount});
+                rewards.emplace_back(reward_type::miner, miner_tx_context.miner_block_producer, miner_amount);
             }
         }
 
@@ -448,11 +446,10 @@ std::pair<bool, uint64_t> construct_miner_tx(
                     hard_fork_version >= hf::hf16_pulse /*distribute_remainder*/);
             if (hard_fork_version >= hf::hf19_reward_batching) {
                 for (size_t i = 0; i < leader.payouts.size(); i++)
-                    batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i]);
+                    batched_rewards.emplace_back(leader.payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
             } else {
                 for (size_t i = 0; i < leader.payouts.size(); i++)
-                    rewards.push_back(
-                            {reward_type::snode, leader.payouts[i].address, split_rewards[i]});
+                    rewards.emplace_back(reward_type::snode, leader.payouts[i].address, split_rewards[i]);
             }
         }
     }
@@ -485,8 +482,8 @@ std::pair<bool, uint64_t> construct_miner_tx(
     if (!sn_rwds.empty()) {
         assert(hard_fork_version >= hf::hf19_reward_batching);
         for (const auto& reward : sn_rwds) {
-            assert(reward.amount % BATCH_REWARD_FACTOR == 0);
-            auto atomic_amt = reward.amount / BATCH_REWARD_FACTOR;
+            assert(reward.amount.to_db() % BATCH_REWARD_FACTOR == 0 && "Check that the thousandth's OXEN has been truncated off");
+            auto atomic_amt = reward.amount.to_coin();
             rewards.emplace_back(reward_type::snode, reward.address_info.address, atomic_amt);
             total_sn_rewards += atomic_amt;
         }
@@ -567,7 +564,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
 
     block_rewards = std::accumulate(
             batched_rewards.begin(), batched_rewards.end(), uint64_t{0}, [](uint64_t x, auto&& y) {
-                return x + y.amount;
+                return x + y.amount.to_coin();
             });
 
     // lock

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -406,7 +406,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
 
             if (hard_fork_version >= hf::hf19_reward_batching) {
                 for (size_t i = 0; i < p_payouts.size(); i++)
-                    batched_rewards.emplace_back(p_payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
+                    batched_rewards.emplace_back(p_payouts[i].address, reward_money::coin_amount(split_rewards[i]));
             } else {
                 for (size_t i = 0; i < p_payouts.size(); i++)
                     rewards.emplace_back(reward_type::snode, p_payouts[i].address, split_rewards[i]);
@@ -417,7 +417,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
                 leader.payouts, leader_reward, true /*distribute_remainder*/);
         if (hard_fork_version >= hf::hf19_reward_batching) {
             for (size_t i = 0; i < leader.payouts.size(); i++)
-                batched_rewards.emplace_back(leader.payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
+                batched_rewards.emplace_back(leader.payouts[i].address, reward_money::coin_amount(split_rewards[i]));
         } else {
             for (size_t i = 0; i < leader.payouts.size(); i++)
                 rewards.emplace_back(reward_type::snode, leader.payouts[i].address, split_rewards[i]);
@@ -433,7 +433,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
         if (uint64_t miner_amount = reward_parts.base_miner + reward_parts.miner_fee;
             miner_amount) {
             if (hard_fork_version >= hf::hf19_reward_batching) {
-                batched_rewards.emplace_back(miner_tx_context.miner_block_producer, sql_db_money::coin_amount(miner_amount));
+                batched_rewards.emplace_back(miner_tx_context.miner_block_producer, reward_money::coin_amount(miner_amount));
             } else {
                 rewards.emplace_back(reward_type::miner, miner_tx_context.miner_block_producer, miner_amount);
             }
@@ -446,7 +446,7 @@ std::pair<bool, uint64_t> construct_miner_tx(
                     hard_fork_version >= hf::hf16_pulse /*distribute_remainder*/);
             if (hard_fork_version >= hf::hf19_reward_batching) {
                 for (size_t i = 0; i < leader.payouts.size(); i++)
-                    batched_rewards.emplace_back(leader.payouts[i].address, sql_db_money::coin_amount(split_rewards[i]));
+                    batched_rewards.emplace_back(leader.payouts[i].address, reward_money::coin_amount(split_rewards[i]));
             } else {
                 for (size_t i = 0; i < leader.payouts.size(); i++)
                     rewards.emplace_back(reward_type::snode, leader.payouts[i].address, split_rewards[i]);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1665,23 +1665,26 @@ void service_node_list::state_t::process_new_ethereum_tx(
         log::info(
                 globallogcat,
                 fg(fmt::terminal_color::green),
-                "New service node {} tx from ethereum: {} (THIS NODE) @ height: {}; awaiting "
+                "New service node {} tx ({}) from ethereum: {} (THIS NODE) @ height: {}; awaiting "
                 "confirmations",
                 type,
+                cryptonote::get_transaction_hash(tx),
                 snpk,
                 block_height);
     else if (tx.type == cryptonote::txtype::ethereum_staking_requirement_updated)
         log::info(
                 globallogcat,
-                "Service node staking requirement tx from ethereum changing to {} SENT @ height: "
+                "Service node staking requirement tx ({}) from ethereum changing to {} SENT @ height: "
                 "{}; awaiting confirmations",
                 cryptonote::print_money(val),
+                cryptonote::get_transaction_hash(tx),
                 block_height);
     else
         log::debug(
                 logcat,
-                "New service node {} tx from ethereum: {} @ height: {}; awaiting confirmations",
+                "New service node {} tx ({}) from ethereum: {} @ height: {}; awaiting confirmations",
                 type,
+                cryptonote::get_transaction_hash(tx),
                 snpk,
                 block_height);
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1910,7 +1910,7 @@ bool service_node_list::state_t::process_confirmed_event(
     }
 
     // NOTE: Apply the slash penalty to the operator
-    if (slash_amount > returned_stakes[0].amount.to_coin()) {
+    if (slash_amount > returned_stakes[0].coin_amount()) {
         log::error(
                 logcat,
                 "ETH exit of BLS pubkey {} rejected: SN {} returned amount {} is less than the "
@@ -1918,10 +1918,10 @@ bool service_node_list::state_t::process_confirmed_event(
                 node->info.bls_public_key,
                 node->service_node_pubkey,
                 slash_amount,
-                returned_stakes[0].amount.to_coin());
+                returned_stakes[0].coin_amount());
         return false;
     }
-    returned_stakes[0].amount = cryptonote::reward_money::coin_amount(returned_stakes[0].amount.to_coin() - slash_amount);
+    returned_stakes[0].amount = cryptonote::reward_money::coin_amount(returned_stakes[0].coin_amount() - slash_amount);
 
     if (my_keys && my_keys->pub == node->service_node_pubkey)
         log::info(
@@ -3951,7 +3951,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                 if (paid_amount != batch_payment.amount)
                     throw oxen::traced<std::runtime_error>{
                             "Batched reward payout incorrect: expected {}, not {}"_format(
-                                    batch_payment.amount.to_coin(), paid_amount.to_coin())};
+                                    batch_payment.coin_amount(), paid_amount.to_coin())};
 
                 crypto::public_key out_eph_public_key{};
                 if (!cryptonote::get_deterministic_output_key(

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1895,7 +1895,7 @@ bool service_node_list::state_t::process_confirmed_event(
         // This leads us to storing a cryptonote address in the delayed payments which causes the
         // network to stall as code tries to deserialise that address into an eth address and fails.
         if (contributor.ethereum_address) {
-            returned_stakes.emplace_back(contributor.ethereum_address, cryptonote::sql_db_money::coin_amount(contributor.amount));
+            returned_stakes.emplace_back(contributor.ethereum_address, cryptonote::reward_money::coin_amount(contributor.amount));
         }
     }
 
@@ -1921,7 +1921,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 returned_stakes[0].amount.to_coin());
         return false;
     }
-    returned_stakes[0].amount = cryptonote::sql_db_money::coin_amount(returned_stakes[0].amount.to_coin() - slash_amount);
+    returned_stakes[0].amount = cryptonote::reward_money::coin_amount(returned_stakes[0].amount.to_coin() - slash_amount);
 
     if (my_keys && my_keys->pub == node->service_node_pubkey)
         log::info(
@@ -3921,12 +3921,12 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
         } break;
 
         case verify_mode::batched_sn_rewards: {
-            cryptonote::sql_db_money total_payout_in_our_db = std::accumulate(
+            cryptonote::reward_money total_payout_in_our_db = std::accumulate(
                     batched_sn_payments.begin(),
                     batched_sn_payments.end(),
-                    cryptonote::sql_db_money{},
+                    cryptonote::reward_money{},
                     [](auto&& a, auto&& b) {
-                        return cryptonote::sql_db_money::db_amount(a.to_db() + b.amount.to_db());
+                        return cryptonote::reward_money::db_amount(a.to_db() + b.amount.to_db());
                     });
 
             uint64_t total_payout_in_vouts = 0;
@@ -3946,7 +3946,7 @@ void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info)
                     throw oxen::traced<std::runtime_error>{
                             "Batched reward payout invalid: exceeds maximum possible payout size"};
 
-                auto paid_amount = cryptonote::sql_db_money::coin_amount(vout.amount);
+                auto paid_amount = cryptonote::reward_money::coin_amount(vout.amount);
                 total_payout_in_vouts += paid_amount.to_coin();
                 if (paid_amount != batch_payment.amount)
                     throw oxen::traced<std::runtime_error>{

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1834,9 +1834,9 @@ bool service_node_list::state_t::process_confirmed_event(
     } else if (oxen::log::get_level(logcat) <= oxen::log::Level::trace) {
         oxen::log::trace(
                 logcat,
-                "ETH exit event for BLS\nEvent\n{}\n\nRecently Removed Entry\n{}",
-                serialization::dump_json(*node),
-                serialization::dump_json(const_cast<eth::event::ServiceNodeExit&>(exit)));
+                "ETH exit event for BLS\nRecently Removed Entry\n{}\nExit\n{}",
+                serialization::dump_json(*node, 2),
+                serialization::dump_json(const_cast<eth::event::ServiceNodeExit&>(exit), 2));
     }
 
     // NOTE: Check that the amount to be refunded is well-formed

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1680,7 +1680,7 @@ void service_node_list::state_t::process_new_ethereum_tx(
                 cryptonote::get_transaction_hash(tx),
                 block_height);
     else
-        log::debug(
+        log::info(
                 logcat,
                 "New service node {} tx ({}) from ethereum: {} @ height: {}; awaiting confirmations",
                 type,
@@ -1743,7 +1743,7 @@ bool service_node_list::state_t::process_confirmed_event(
                     key,
                     height);
         else
-            log::debug(
+            log::info(
                     logcat,
                     "Confirmed service node registration from ethereum: {} on height: {}",
                     key,
@@ -1796,7 +1796,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 height,
                 unlock_height);
     else
-        log::debug(
+        log::info(
                 logcat,
                 "Service node exit initiated for {} @ height {}; exit height: {}",
                 snode_pk,
@@ -1973,7 +1973,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 cryptonote::print_money(new_staking_requirement),
                 height);
     } else {
-        log::debug(
+        log::info(
                 logcat,
                 fg(fmt::terminal_color::yellow),
                 "Confirmed a non-changing staking requirement transaction ({}) @ height {}",

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1678,7 +1678,7 @@ void service_node_list::state_t::process_new_ethereum_tx(
                 cryptonote::print_money(val),
                 block_height);
     else
-        log::info(
+        log::debug(
                 logcat,
                 "New service node {} tx from ethereum: {} @ height: {}; awaiting confirmations",
                 type,
@@ -1740,7 +1740,7 @@ bool service_node_list::state_t::process_confirmed_event(
                     key,
                     height);
         else
-            log::info(
+            log::debug(
                     logcat,
                     "Confirmed service node registration from ethereum: {} on height: {}",
                     key,
@@ -1793,7 +1793,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 height,
                 unlock_height);
     else
-        log::info(
+        log::debug(
                 logcat,
                 "Service node exit initiated for {} @ height {}; exit height: {}",
                 snode_pk,
@@ -1970,7 +1970,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 cryptonote::print_money(new_staking_requirement),
                 height);
     } else {
-        log::info(
+        log::debug(
                 logcat,
                 fg(fmt::terminal_color::yellow),
                 "Confirmed a non-changing staking requirement transaction ({}) @ height {}",

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -779,13 +779,15 @@ class service_node_list {
 
         template <class Archive>
         void serialize_object(Archive& ar) {
-            uint8_t version = 0;
+            uint8_t version = 1;
             field_varint(ar, "version", version);
             field(ar, "pubkey", pubkey);
             field(ar, "bls_pubkey", bls_pubkey);
             field_varint(ar, "height", height);
             field_varint(ar, "liquidation_height", liquidation_height);
             field_varint(ar, "type", type);
+            if (version >= 1)
+                field_varint(ar, "staking_requirement", staking_requirement);
             field(ar, "contributors", contributors);
             field_varint(ar, "public_ip", public_ip);
             field_varint(ar, "qnet_port", qnet_port);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -659,12 +659,12 @@ class service_node_list {
             for (const auto& recently_removed_it : m_state.recently_removed_nodes) {
 
                 // NOTE: Look for their latest IP/port from an uptime proof
-                auto it = proofs.find(recently_removed_it.pubkey);
+                auto it = proofs.find(recently_removed_it.service_node_pubkey);
                 if (it != proofs.end() && it->second.proof) {
                     auto& proof = *it->second.proof;
                     *out++ = service_node_address{
-                            recently_removed_it.pubkey,
-                            recently_removed_it.bls_pubkey,
+                            recently_removed_it.service_node_pubkey,
+                            recently_removed_it.info.bls_public_key,
                             it->second.pubkey_x25519,
                             proof.public_ip,
                             proof.qnet_port};
@@ -675,9 +675,9 @@ class service_node_list {
                 if (recently_removed_it.public_ip == 0 || recently_removed_it.qnet_port == 0)
                     continue;
                 *out++ = service_node_address{
-                        recently_removed_it.pubkey,
-                        recently_removed_it.bls_pubkey,
-                        snpk_to_xpk(recently_removed_it.pubkey),
+                        recently_removed_it.service_node_pubkey,
+                        recently_removed_it.info.bls_public_key,
+                        snpk_to_xpk(recently_removed_it.service_node_pubkey),
                         recently_removed_it.public_ip,
                         recently_removed_it.qnet_port};
             }
@@ -767,30 +767,37 @@ class service_node_list {
             deregister,
         };
 
-        crypto::public_key pubkey;       // SN primary ed25519 key
-        eth::bls_public_key bls_pubkey;  // SN primary bls key
-        uint64_t height;                 // Height at which the SN exited/deregistered
-        uint64_t liquidation_height;     // Height at which the SN is eligible for liquidation
-        type_t type;                     // Event that occurred to remove this SN
-        uint64_t staking_requirement;    // Staking requirement this SN had to fulfill
-        std::vector<service_node_info::contributor_t> contributors;  // Contributors for the SN
-        uint32_t public_ip;  // Last known public IP of this SN (may be outdated)
-        uint16_t qnet_port;  // Last known quorumnet port of this SN (may be outdated)
+        uint64_t height;              // Height at which the SN exited/deregistered
+        uint64_t liquidation_height;  // Height at which the SN is eligible for liquidation
+        type_t type;                  // Event that occurred to remove this SN
+        uint32_t public_ip;           // Last known public IP of this SN (may be outdated)
+        uint16_t qnet_port;           // Last known quorumnet port of this SN (may be outdated)
+        crypto::public_key service_node_pubkey;  // SN primary ed25519 key
+        service_node_info info;  // Info copied from the SNL and frozen at point of exit
 
         template <class Archive>
         void serialize_object(Archive& ar) {
             uint8_t version = 1;
             field_varint(ar, "version", version);
-            field(ar, "pubkey", pubkey);
-            field(ar, "bls_pubkey", bls_pubkey);
+            if (version == 0) { // NOTE: v0 we completely discard and force a full-rescan
+                crypto::public_key pubkey;
+                eth::bls_public_key bls_pubkey;
+                field(ar, "pubkey", pubkey);
+                field(ar, "bls_pubkey", bls_pubkey);
+            }
             field_varint(ar, "height", height);
             field_varint(ar, "liquidation_height", liquidation_height);
             field_varint(ar, "type", type);
-            if (version >= 1)
-                field_varint(ar, "staking_requirement", staking_requirement);
-            field(ar, "contributors", contributors);
+            if (version == 0) {
+                std::vector<service_node_info::contributor_t> contributors;
+                field(ar, "contributors", contributors);
+            }
             field_varint(ar, "public_ip", public_ip);
             field_varint(ar, "qnet_port", qnet_port);
+            if (version >= 1) {
+                field(ar, "service_node_pubkey", service_node_pubkey);
+                field(ar, "info", info);
+            }
         }
     };
 
@@ -950,12 +957,13 @@ class service_node_list {
     struct data_for_serialization {
         enum struct version_t : uint8_t {
             version_0,
-            version_1,
+            version_1_create_recently_removed_nodes,
+            version_2_regen_recently_removed_nodes_w_sn_info,
             count,
         };
-        static version_t get_version(cryptonote::hf /*hf_version*/) { return version_t::version_1; }
+        static version_t get_version(cryptonote::hf /*hf_version*/) { return version_t::version_2_regen_recently_removed_nodes_w_sn_info; }
 
-        version_t version{version_t::version_1};
+        version_t version{version_t::version_2_regen_recently_removed_nodes_w_sn_info};
         std::vector<quorum_for_serialization> quorum_states;
         std::vector<state_serialized> states;
         void clear() {

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -211,6 +211,7 @@ inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS = {
         proof_version{{cryptonote::hf::hf19_reward_batching, 6}, {10, 6, 0}, {0, 9, 11}, {2, 8, 0}},
         proof_version{{cryptonote::hf::hf21_eth, 0}, {11, 0, 3}, {0, 9, 11}, {2, 8, 0}},
         proof_version{{cryptonote::hf::hf21_eth, 1}, {11, 0, 4}, {0, 9, 11}, {2, 8, 0}},
+        proof_version{{cryptonote::hf::hf21_eth, 2}, {11, 0, 5}, {0, 9, 11}, {2, 8, 0}},
 };
 
 using swarm_id_t = uint64_t;


### PR DESCRIPTION
Currently the network has the incorrect stake amounts to unlock to operators because the stake amount was not correctly multiplied by `BATCH_REWARD_FACTOR`  when inserted into the SQL DB. The `staking_requirement` was also not serialized to disk (so once the node restarts that value gets set to `0`) and when the exit is processed, the stake amount to return gets clamped to `0`. Right now only 2 exits have been done on the network which are from my nodes.

This patch fixes that and increments the version of the SNL which will trigger everyone to recalculate the values in the DB and the metadata (and correctly store the `staking_requirement`). 

If the network tries to claim now there'll be inconsistencies in the amount of rewards claimable by the operator (me) and the aggregation will fail. The more operators that upgrade the better as the BLS aggregation will have less non-signers and more nodes with this patch will agree on the _correct_ amounts to return.

Additionally noticed another adjacent bug where if you had multiple exits in the one block, only the first stake would get queued for unlocking and the rest was dropped due to an insert conflict.

More specifically:

- The SQL DB was not deconflicting when inserting a delayed payment (e.g. returning stake after exit). It has primary key on `(eth_address, payout_height)` which meant that if you had multiple stakes returning on the same height, it'd just completely ignore the payment, and hence incorrectly return only the first stake that you unlocked. Fixed this by adding a deconflict step to sum the amounts if they do.

More broadly, at a higher level the primary key looks out of place since the table is not really relational but it did help catch this error and the end result of coalescing rows is more ideal than having individual rows for each payment.

- `BlockchainSQLite::reset_database()` was not dropping some tables causing left-over data to persist in the DB which caused the regeneration of data to fail. So we now drop the `delayed_payments` table and set the `height` to `0`. 

- Fix `service_node_list::public_key_lookup` not searching the `recently_removed_nodes` list. The code path that relies on this fix is purely cosmetic and is used to log to the log files, so no repercussions here.

- In the `recently_removed_nodes` instead of just pulling out individual fields from the `service_node_info` on erase, store the whole struct which is useful for populating the BLS endpoints that end-user applications consume and helps them maintain a consistent view of a node as it transitions out of the network.

- The exit code was not storing the stake amounts into the DB in the correct units. I've introduced a `sql_db_money` which strongly types the units so that the conversion of monetary units is explicit at the DB interface.