### PR TITLE
Add staking information to get_info RPC for other clients to use

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -301,6 +301,10 @@ void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
                                                  : "v" + std::to_string(OXEN_VERSION[0]) +
                                                            "; Height: " + std::to_string(height);
 
+    uint64_t staking_requirement = m_core.service_node_list.get_staking_requirement();
+    info.response["staking_requirement"] = staking_requirement;
+    info.response["max_contributors"] = oxen::MAX_CONTRIBUTORS_HF19;
+    info.response["min_operator_contribution"] = oxen::MINIMUM_OPERATOR_CONTRIBUTION(staking_requirement);
     info.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add some staking information to `get_info` which can be used by the staking backend instead of hardcoding values in there (it's still reporting 120 $SENT as the staking requirement)