### PR TITLE
Fix stale top hash on reorg

### DIFF
--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1109,8 +1109,7 @@ namespace {
     }
 
     round_state wait_for_next_block(
-            round_context& context,
-            cryptonote::Blockchain const& blockchain) {
+            round_context& context, cryptonote::Blockchain const& blockchain) {
         //
         // NOTE: If the top hash stored in the pulse context is the same as the top block's hash
         // then we've already attempted Pulse with the current state of the blockchain and
@@ -1123,7 +1122,8 @@ namespace {
             for (static crypto::hash last_hash = {}; last_hash != top_hash; last_hash = top_hash)
                 log::debug(
                         logcat,
-                        "{}Network is currently producing block {} (w/ parent {}), waiting until next block",
+                        "{}Network is currently producing block {} (w/ parent {}), "
+                        "waiting until next block",
                         log_prefix(context),
                         chain_height,
                         top_hash);
@@ -1199,7 +1199,7 @@ namespace {
                             : (now - context.wait_for_next_block.round_0_start_time);
             size_t round_usize = time_since_block / conf.PULSE_ROUND_TIMEOUT;
 
-            if (round_usize > 255) { // Network stalled
+            if (round_usize > 255) {  // Network stalled
                 log::info(
                         logcat,
                         "{}Pulse has timed out, reverting to accepting miner blocks only.",
@@ -1305,7 +1305,8 @@ namespace {
         if (context.wait_for_next_block.top_hash != top_hash) {
             log::debug(
                     logcat,
-                    "{}Top block changed (from {} to {}) whilst waiting for round {}, restarting Pulse stages",
+                    "{}Top block changed (from {} to {}) whilst waiting for round {}, "
+                    "restarting Pulse stages",
                     log_prefix(context),
                     context.wait_for_next_block.top_hash,
                     top_hash,

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1110,7 +1110,6 @@ namespace {
     }
 
     round_state wait_for_next_block(
-            uint64_t hf16_height,
             round_context& context,
             cryptonote::Blockchain const& blockchain) {
         //
@@ -1223,8 +1222,7 @@ namespace {
                             : (now - context.wait_for_next_block.round_0_start_time);
             size_t round_usize = time_since_block / conf.PULSE_ROUND_TIMEOUT;
 
-            if (round_usize > 255)  // Network stalled
-            {
+            if (round_usize > 255) { // Network stalled
                 log::info(
                         logcat,
                         "{}Pulse has timed out, reverting to accepting miner blocks only.",
@@ -2057,7 +2055,7 @@ void main(void* quorumnet_state, cryptonote::core& core) {
             case round_state::null_state: context.state = round_state::wait_for_next_block; break;
 
             case round_state::wait_for_next_block:
-                context.state = wait_for_next_block(*hf16, context, blockchain);
+                context.state = wait_for_next_block(context, blockchain);
                 break;
 
             case round_state::prepare_for_round:


### PR DESCRIPTION
- Remove unused variables in Pulse functions
- Track the top hash instead of the top height
 
Prior to this, when the blockchain reorg-ed to the same height (e.g: replaced the top block) the top height remains the same but the block has changed which means the next Pulse quorum has changed. We were only tracking the top height which meant that it was essentially guaranteed that after a reorg we would churn through a bunch of quorums until we found a quorum that consisted primarily of nodes that _didn't_ reorg. The nodes that did reorg will be generating the incorrect quorums and hence trying to conduct Pulse with the wrong nodes.

Instead track the hash which means if we encounter this situation, the nodes will detect it immediately and reconfigure the Pulse state machine to work with the new data.

This change also simplifies the initial gathering of state to extracting information from the top block instead of going back to the DB for the top height, timestamp and top hash which is subject to a data race (if we by chance happen to initiate a Pulse round just as we received new blocks).