### PR TITLE
Unit test occassional failure fix

### DIFF
--- a/tests/unit_tests/oxen_name_system.cpp
+++ b/tests/unit_tests/oxen_name_system.cpp
@@ -111,7 +111,7 @@ TEST(oxen_name_system, value_encrypt_and_decrypt)
     ASSERT_TRUE(mval.encrypt(name));
     ASSERT_TRUE(mval.encrypted);
 
-    mval.buffer[0] = 'Z';
+    mval.buffer[0] ^= 1;  // Flip a single bit
     ASSERT_FALSE(mval.decrypt(name, type));
     ASSERT_TRUE(mval.encrypted);
   }


### PR DESCRIPTION
Fix unit test that had a 1/256 chance of a spurious failure (i.e. if the encrypted value already happens to equal 'Z').

This appears to have happened here: https://ci.oxen.rocks/oxen-io/oxen-core/3184/2/3