### PR TITLE
Add ETH beneficiary to contributors

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -580,7 +580,7 @@ void BlockchainSQLite::add_rewards(
     // Pay the operator fee to the operator
     if (operator_fee > 0) {
         if (use_eth_address) {
-            assert(sn_info.contributors.size()); // NOTE: Be paranoid, check contributors size
+            assert(sn_info.contributors.size());  // NOTE: Be paranoid, check contributors size
             eth::address fee_recipient = sn_info.contributors.size()
                                                ? sn_info.contributors[0].ethereum_beneficiary
                                                : sn_info.operator_ethereum_address;

--- a/src/bls/bls_crypto.cpp
+++ b/src/bls/bls_crypto.cpp
@@ -554,15 +554,15 @@ void pubkey_aggregator::add(const bls_public_key& pubkey, bool _negate) {
     if (auto ec = g1.unmarshal(tools::span_guts(pubkey)); ec != std::error_code{})
         throw oxen::traced<std::invalid_argument>{"Invalid BLS public key: " + ec.message()};
     if (_negate)
-        g1.neg();
+        g1 = g1.neg();
 
     if (!aggregate_)
         aggregate_ = std::make_unique<bn256::g1>(std::move(g1));
     else
-        aggregate_->add(g1);
+        *aggregate_ = aggregate_->add(g1);
 }
 void pubkey_aggregator::subtract(const bls_public_key& pubkey) {
-    return add(pubkey, true);
+    add(pubkey, true);
 }
 
 bls_public_key pubkey_aggregator::get() const {
@@ -583,11 +583,11 @@ void signature_aggregator::add(const bls_signature& signature, bool _negate) {
     if (auto ec = g2.unmarshal(sig_swapped); ec != std::error_code{})
         throw oxen::traced<std::invalid_argument>{"Invalid BLS signature: " + ec.message()};
     if (_negate)
-        g2.neg();
+        g2 = g2.neg();
     if (!aggregate_)
         aggregate_ = std::make_unique<bn256::g2>(std::move(g2));
     else
-        aggregate_->add(g2);
+        *aggregate_ = aggregate_->add(g2);
 }
 void signature_aggregator::subtract(const bls_signature& signature) {
     return add(signature, true);

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -691,10 +691,8 @@ inline txversion transaction_prefix::get_max_version_for_hf(hf hf_version) {
 
 constexpr txtype transaction_prefix::get_max_type_for_hf(hf hf_version) {
     txtype result = txtype::standard;
-    if (hf_version >= hf::hf22_eth_beneficiary)
+    if (hf_version >= cryptonote::feature::ETH_BLS)
         result = txtype::ethereum_new_service_node_v2;
-    else if (hf_version >= cryptonote::feature::ETH_BLS)
-        result = txtype::ethereum_staking_requirement_updated;
     else if (hf_version >= hf::hf15_ons)
         result = txtype::oxen_name_system;
     else if (hf_version >= hf::hf14_blink)

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -691,7 +691,9 @@ inline txversion transaction_prefix::get_max_version_for_hf(hf hf_version) {
 
 constexpr txtype transaction_prefix::get_max_type_for_hf(hf hf_version) {
     txtype result = txtype::standard;
-    if (hf_version >= cryptonote::feature::ETH_BLS)
+    if (hf_version >= hf::hf22_eth_beneficiary)
+        result = txtype::ethereum_new_service_node_v2;
+    else if (hf_version >= cryptonote::feature::ETH_BLS)
         result = txtype::ethereum_staking_requirement_updated;
     else if (hf_version >= hf::hf15_ons)
         result = txtype::oxen_name_system;

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -980,6 +980,16 @@ bool add_new_service_node_to_tx_extra(
     return true;
 }
 //---------------------------------------------------------------
+bool add_new_service_node_v2_to_tx_extra(
+        std::vector<uint8_t>& tx_extra, const eth::event::NewServiceNodeV2& new_service_node) {
+    tx_extra_field field = new_service_node;
+    if (!add_tx_extra_field_to_tx_extra(tx_extra, field)) {
+        log::info(logcat, "failed to serialize tx extra for new service node transaction");
+        return false;
+    }
+    return true;
+}
+//---------------------------------------------------------------
 bool add_service_node_exit_request_to_tx_extra(
         std::vector<uint8_t>& tx_extra, const eth::event::ServiceNodeExitRequest& exit_request) {
     tx_extra_field field = exit_request;

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -192,6 +192,8 @@ bool get_encrypted_payment_id_from_tx_extra_nonce(
 bool add_burned_amount_to_tx_extra(std::vector<uint8_t>& tx_extra, uint64_t burn);
 bool add_new_service_node_to_tx_extra(
         std::vector<uint8_t>& tx_extra, const eth::event::NewServiceNode& new_service_node);
+bool add_new_service_node_v2_to_tx_extra(
+        std::vector<uint8_t>& tx_extra, const eth::event::NewServiceNodeV2& new_service_node);
 bool add_service_node_exit_request_to_tx_extra(
         std::vector<uint8_t>& tx_extra, const eth::event::ServiceNodeExitRequest& exit_request);
 bool add_service_node_exit_to_tx_extra(

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -58,6 +58,7 @@ constexpr uint8_t TX_EXTRA_TAG_PADDING = 0x00, TX_EXTRA_TAG_PUBKEY = 0x01, TX_EX
                   TX_EXTRA_TAG_ETHEREUM_STAKING_REQUIREMENT_UPDATED = 0x7B,
                   TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE = 0x7C,
                   TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT_REQUEST = 0x7D,
+                  TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE_V2 = 0x7E,
                   TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT = 0x7F,
 
                   TX_EXTRA_MYSTERIOUS_MINERGATE_TAG = 0xDE;
@@ -671,6 +672,7 @@ using tx_extra_field = std::variant<
         tx_extra_tx_key_image_proofs,
         tx_extra_tx_key_image_unlock,
         eth::event::NewServiceNode,
+        eth::event::NewServiceNodeV2,
         eth::event::ServiceNodeExitRequest,
         eth::event::ServiceNodeExit,
         eth::event::StakingRequirementUpdated,
@@ -715,6 +717,7 @@ BINARY_VARIANT_TAG(cryptonote::tx_extra_burn, cryptonote::TX_EXTRA_TAG_BURN);
 BINARY_VARIANT_TAG(
         cryptonote::tx_extra_oxen_name_system, cryptonote::TX_EXTRA_TAG_OXEN_NAME_SYSTEM);
 BINARY_VARIANT_TAG(eth::event::NewServiceNode, cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE);
+BINARY_VARIANT_TAG(eth::event::NewServiceNodeV2, cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE_V2);
 BINARY_VARIANT_TAG(
         eth::event::ServiceNodeExitRequest,
         cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT_REQUEST);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -717,7 +717,8 @@ BINARY_VARIANT_TAG(cryptonote::tx_extra_burn, cryptonote::TX_EXTRA_TAG_BURN);
 BINARY_VARIANT_TAG(
         cryptonote::tx_extra_oxen_name_system, cryptonote::TX_EXTRA_TAG_OXEN_NAME_SYSTEM);
 BINARY_VARIANT_TAG(eth::event::NewServiceNode, cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE);
-BINARY_VARIANT_TAG(eth::event::NewServiceNodeV2, cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE_V2);
+BINARY_VARIANT_TAG(
+        eth::event::NewServiceNodeV2, cryptonote::TX_EXTRA_TAG_ETHEREUM_NEW_SERVICE_NODE_V2);
 BINARY_VARIANT_TAG(
         eth::event::ServiceNodeExitRequest,
         cryptonote::TX_EXTRA_TAG_ETHEREUM_SERVICE_NODE_EXIT_REQUEST);

--- a/src/cryptonote_basic/txtypes.h
+++ b/src/cryptonote_basic/txtypes.h
@@ -28,12 +28,13 @@ enum class txtype : uint16_t {
     ethereum_service_node_exit_request,
     ethereum_service_node_exit,
     ethereum_staking_requirement_updated,
+    ethereum_new_service_node_v2,
     _count
 };
 
 inline constexpr bool is_l2_event_tx(txtype type) {
     return type >= txtype::ethereum_new_service_node &&
-           type <= txtype::ethereum_staking_requirement_updated;
+           type <= txtype::ethereum_new_service_node_v2;
 }
 
 inline constexpr std::string_view to_string(txversion v) {
@@ -54,6 +55,7 @@ inline constexpr std::string_view to_string(txtype type) {
         case txtype::stake: return "stake"sv;
         case txtype::oxen_name_system: return "oxen_name_system"sv;
         case txtype::ethereum_new_service_node: return "ethereum_new_service_node"sv;
+        case txtype::ethereum_new_service_node_v2: return "ethereum_new_service_node_V2"sv;
         case txtype::ethereum_service_node_exit_request:
             return "ethereum_service_node_exit_request"sv;
         case txtype::ethereum_service_node_exit: return "ethereum_service_node_exit"sv;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -252,6 +252,7 @@ enum class hf : uint8_t {
     hf19_reward_batching,
     hf20_eth_transition,  // Temp period: registrations disabled, BLS pubkeys in proofs
     hf21_eth,             // Full transition: registrations from ETH
+    hf22_eth_beneficiary, // Add beneficiary to eth::event::Contributor (and into TX hashes which affects consensus)
 
     _next,
     none = 0
@@ -267,7 +268,7 @@ constexpr auto hf_prev(hf x) {
 
 // This is here to make sure the numeric value of the top hf enum value is correct (i.e.
 // hf21_sent == 21 numerically); bump this when adding a new hf.
-static_assert(static_cast<uint8_t>(hf_max) == 21);
+static_assert(static_cast<uint8_t>(hf_max) == 22);
 
 // Constants for which hardfork activates various features:
 namespace feature {

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -252,7 +252,6 @@ enum class hf : uint8_t {
     hf19_reward_batching,
     hf20_eth_transition,  // Temp period: registrations disabled, BLS pubkeys in proofs
     hf21_eth,             // Full transition: registrations from ETH
-    hf22_eth_beneficiary, // Add beneficiary to eth::event::Contributor (and into TX hashes which affects consensus)
 
     _next,
     none = 0
@@ -268,7 +267,7 @@ constexpr auto hf_prev(hf x) {
 
 // This is here to make sure the numeric value of the top hf enum value is correct (i.e.
 // hf21_sent == 21 numerically); bump this when adding a new hf.
-static_assert(static_cast<uint8_t>(hf_max) == 22);
+static_assert(static_cast<uint8_t>(hf_max) == 21);
 
 // Constants for which hardfork activates various features:
 namespace feature {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3361,7 +3361,9 @@ std::vector<eth::bls_public_key> Blockchain::get_removable_nodes() const {
                 [&bls_pubkeys_in_snl]<typename Event>(
                         const Event& e,
                         const service_nodes::service_node_list::unconfirmed_l2_tx&) {
-                    if constexpr (std::is_same_v<Event, eth::event::NewServiceNode>) {
+                    if constexpr (
+                            std::is_same_v<Event, eth::event::NewServiceNode> ||
+                            std::is_same_v<Event, eth::event::NewServiceNodeV2>) {
                         bls_pubkeys_in_snl.push_back(e.bls_pubkey);
                     } else {
                         static_assert(

--- a/src/cryptonote_core/ethereum_transactions.cpp
+++ b/src/cryptonote_core/ethereum_transactions.cpp
@@ -14,6 +14,8 @@ bool validate_event_tx(
     switch (tx_type) {
         case txtype::ethereum_new_service_node:
             return validate_event_tx<event::NewServiceNode>(hf_version, tx, reason);
+        case txtype::ethereum_new_service_node_v2:
+            return validate_event_tx<event::NewServiceNodeV2>(hf_version, tx, reason);
         case txtype::ethereum_service_node_exit:
             return validate_event_tx<event::ServiceNodeExit>(hf_version, tx, reason);
         case txtype::ethereum_service_node_exit_request:
@@ -39,6 +41,9 @@ event::StateChangeVariant extract_event(
     switch (tx.type) {
         case cryptonote::txtype::ethereum_new_service_node:
             success = extract_event(tx, result.emplace<event::NewServiceNode>(), fail_reason);
+            break;
+        case cryptonote::txtype::ethereum_new_service_node_v2:
+            success = extract_event(tx, result.emplace<event::NewServiceNodeV2>(), fail_reason);
             break;
         case cryptonote::txtype::ethereum_service_node_exit_request:
             success =

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -426,15 +426,16 @@ static registration_details eth_reg_v2_details(
     return reg;
 }
 
-static eth::event::NewServiceNodeV2 convert_eth_event_new_service_node_to_v2(const eth::event::NewServiceNode& value)
-{
+static eth::event::NewServiceNodeV2 convert_eth_event_new_service_node_to_v2(
+        const eth::event::NewServiceNode& value) {
     auto result = eth::event::NewServiceNodeV2(value.chain_id, value.l2_height);
     result.fee = value.fee;
     result.sn_pubkey = value.sn_pubkey;
     result.bls_pubkey = value.bls_pubkey;
     result.contributors.reserve(value.contributors.size());
     for (auto it : value.contributors)
-        result.contributors.emplace_back(it.address /*address*/, it.address /*beneficiary*/, it.amount);
+        result.contributors.emplace_back(
+                it.address /*address*/, it.address /*beneficiary*/, it.amount);
     result.ed_signature = value.ed_signature;
     return result;
 }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -1109,6 +1109,13 @@ class service_node_list {
                 uint32_t index,
                 const service_node_keys* my_keys);
         bool process_confirmed_event(
+                const eth::event::NewServiceNodeV2& new_sn,
+                cryptonote::network_type nettype,
+                cryptonote::hf hf_version,
+                uint64_t height,
+                uint32_t index,
+                const service_node_keys* my_keys);
+        bool process_confirmed_event(
                 const eth::event::ServiceNodeExitRequest& rem_req,
                 cryptonote::network_type nettype,
                 cryptonote::hf hf_version,
@@ -1342,7 +1349,7 @@ struct registration_details {
         crypto::signature signature;
         crypto::ed25519_signature ed_signature;
     };
-    std::vector<eth::event::Contributor> eth_contributions;
+    std::vector<eth::event::ContributorV2> eth_contributions;
     eth::bls_public_key bls_pubkey;
 };
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -246,11 +246,12 @@ struct service_node_info  // registration information
     };
 
     struct contributor_t {
-        uint8_t version = 1;
+        uint8_t version = 2;
         uint64_t amount = 0;
         uint64_t reserved = 0;
         cryptonote::account_public_address address{};
         eth::address ethereum_address{};
+        eth::address ethereum_beneficiary{};
         std::vector<contribution_t> locked_contributions;
 
         contributor_t() = default;
@@ -270,7 +271,8 @@ struct service_node_info  // registration information
             field(ar, "locked_contributions", locked_contributions);
             if (version >= 1)
                 field(ar, "ethereum_address", ethereum_address);
-            ;
+            if (version >= 2)
+                field(ar, "ethereum_beneficiary", ethereum_beneficiary);
         }
     };
 
@@ -958,13 +960,12 @@ class service_node_list {
             version_0,
             version_1_create_recently_removed_nodes,
             version_2_regen_recently_removed_nodes_w_sn_info,
+            version_3_eth_beneficiary,
             count,
         };
-        static version_t get_version(cryptonote::hf /*hf_version*/) {
-            return version_t::version_2_regen_recently_removed_nodes_w_sn_info;
-        }
+        static version_t get_version(cryptonote::hf /*hf_version*/) { return version_t::version_3_eth_beneficiary; }
 
-        version_t version{version_t::version_2_regen_recently_removed_nodes_w_sn_info};
+        version_t version{version_t::version_3_eth_beneficiary};
         std::vector<quorum_for_serialization> quorum_states;
         std::vector<state_serialized> states;
         void clear() {
@@ -1328,7 +1329,6 @@ bool tx_get_staking_components_and_amounts(
         staking_components* contribution);
 
 using contribution = std::pair<cryptonote::account_public_address, uint64_t>;
-using eth_contribution = std::pair<eth::address, uint64_t>;
 struct registration_details {
     crypto::public_key service_node_pubkey;
     std::vector<contribution> reserved;
@@ -1342,7 +1342,7 @@ struct registration_details {
         crypto::signature signature;
         crypto::ed25519_signature ed_signature;
     };
-    std::vector<eth_contribution> eth_contributions;
+    std::vector<eth::event::Contributor> eth_contributions;
     eth::bls_public_key bls_pubkey;
 };
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -963,7 +963,9 @@ class service_node_list {
             version_3_eth_beneficiary,
             count,
         };
-        static version_t get_version(cryptonote::hf /*hf_version*/) { return version_t::version_3_eth_beneficiary; }
+        static version_t get_version(cryptonote::hf /*hf_version*/) {
+            return version_t::version_3_eth_beneficiary;
+        }
 
         version_t version{version_t::version_3_eth_beneficiary};
         std::vector<quorum_for_serialization> quorum_states;

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -141,6 +141,21 @@ struct extra_printer {
                 fmt::join(contributors, ", "),
                 x.ed_signature);
     }
+    std::string operator()(const eth::event::NewServiceNodeV2& x) {
+
+        std::vector<std::string> contributors;
+        for (const auto& contributor : x.contributors)
+            contributors.push_back("{{address: {}, beneficiary: {}, amount: {}}}"_format(
+                    contributor.address, contributor.beneficiary, print_money(contributor.amount)));
+        return "New Ethereum Service Node v2: L2 0x{:x}@{}, SN: {}, BLS pub: {}, fee: {}, contributors: [{}], signature: {}"_format(
+                x.chain_id,
+                x.l2_height,
+                x.sn_pubkey,
+                x.bls_pubkey,
+                x.fee,
+                fmt::join(contributors, ", "),
+                x.ed_signature);
+    }
     std::string operator()(const eth::event::ServiceNodeExitRequest& x) {
         return "Ethereum Service Node Exit Request: L2 0x{:x}@{}, BLS pub: {}"_format(
                 x.chain_id, x.l2_height, x.bls_pubkey);

--- a/src/l2_tracker/contracts.cpp
+++ b/src/l2_tracker/contracts.cpp
@@ -10,7 +10,7 @@ namespace event {
 
     const crypto::hash NewServiceNodeV2 = crypto::keccak(
             "NewServiceNodeV2(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),"
-            "(address,uint256,uint256)[])"sv);
+            "((address,address),uint256)[])"sv);
 
     // TODO: Rename the contract event from Removal to Exit as this follows the terminology we've
     // been using to refer to it

--- a/src/l2_tracker/contracts.cpp
+++ b/src/l2_tracker/contracts.cpp
@@ -8,6 +8,10 @@ namespace event {
             "NewServiceNode(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),"
             "(address,uint256)[])"sv);
 
+    const crypto::hash NewServiceNodeV2 = crypto::keccak(
+            "NewServiceNodeV2(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),"
+            "(address,uint256,uint256)[])"sv);
+
     // TODO: Rename the contract event from Removal to Exit as this follows the terminology we've
     // been using to refer to it
     const crypto::hash ServiceNodeExitRequest =

--- a/src/l2_tracker/contracts.cpp
+++ b/src/l2_tracker/contracts.cpp
@@ -9,8 +9,8 @@ namespace event {
             "(address,uint256)[])"sv);
 
     const crypto::hash NewServiceNodeV2 = crypto::keccak(
-            "NewServiceNodeV2(uint64,address,(uint256,uint256),(uint256,uint256,uint256,uint16),"
-            "((address,address),uint256)[])"sv);
+            "NewServiceNodeV2(uint8,uint64,address,(uint256,uint256),(uint256,uint256,uint256,"
+            "uint16),((address,address),uint256)[])"sv);
 
     // TODO: Rename the contract event from Removal to Exit as this follows the terminology we've
     // been using to refer to it

--- a/src/l2_tracker/contracts.h
+++ b/src/l2_tracker/contracts.h
@@ -18,6 +18,7 @@ inline constexpr std::string_view pool_address(const cryptonote::network_type ne
 namespace event {
 
     extern const crypto::hash NewServiceNode;
+    extern const crypto::hash NewServiceNodeV2;
     extern const crypto::hash ServiceNodeExitRequest;
     extern const crypto::hash ServiceNodeExit;
     extern const crypto::hash StakingRequirementUpdated;

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -11,7 +11,7 @@
 #include "crypto/crypto.h"
 #include "crypto/eth.h"
 #include "cryptonote_basic/txtypes.h"
-#include "cryptonote_basic/hardfork.h"
+#include "serialization/optional.h"
 
 using namespace std::literals;
 
@@ -92,10 +92,15 @@ struct ContributorV2 {
         auto version = tools::enum_top<Version>;
         field_varint(ar, "version", version, [](auto v) { return v > Version::version_invalid && v < Version::_count; });
         field(ar, "address", address);
-        field(ar, "beneficiary", beneficiary);
+
+        std::optional<eth::address> serialized_beneficiary;
+        if (Archive::is_serializer && beneficiary != address)
+            serialized_beneficiary = beneficiary;
+        field(ar, "beneficiary", serialized_beneficiary);
+        if (Archive::is_deserializer)
+            beneficiary = serialized_beneficiary ? *serialized_beneficiary : address;
+
         field_varint(ar, "amount", amount);
-
-
     }
 };
 

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -122,7 +122,6 @@ struct NewServiceNodeV2 : L2StateChange {
 
     template <class Archive>
     void serialize_object(Archive& ar) {
-        [[maybe_unused]] uint8_t version = 0;
         field_varint(ar, "version", version);
         field_varint(ar, "chain_id", chain_id);
         field_varint(ar, "l2_height", l2_height);

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -30,7 +30,7 @@ struct L2StateChange {
 
 struct Contributor {
     eth::address address;
-    uint64_t     amount;
+    uint64_t amount;
 
     auto operator<=>(const Contributor& o) const = default;
 
@@ -83,14 +83,16 @@ struct ContributorV2 {
 
     eth::address address;
     eth::address beneficiary;
-    uint64_t     amount;
+    uint64_t amount;
 
     auto operator<=>(const ContributorV2& o) const = default;
 
     template <class Archive>
     void serialize_object(Archive& ar) {
         auto version = tools::enum_top<Version>;
-        field_varint(ar, "version", version, [](auto v) { return v > Version::version_invalid && v < Version::_count; });
+        field_varint(ar, "version", version, [](auto v) {
+            return v > Version::version_invalid && v < Version::_count;
+        });
         field(ar, "address", address);
 
         std::optional<eth::address> serialized_beneficiary;
@@ -137,7 +139,6 @@ struct NewServiceNodeV2 : L2StateChange {
     static constexpr cryptonote::txtype txtype = cryptonote::txtype::ethereum_new_service_node_v2;
     static constexpr std::string_view description = "new SNv2"sv;
 };
-
 
 struct ServiceNodeExitRequest : L2StateChange {
     bls_public_key bls_pubkey = crypto::null<bls_public_key>;

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -105,6 +105,8 @@ struct ContributorV2 {
 };
 
 struct NewServiceNodeV2 : L2StateChange {
+    enum class Version { invalid = -1, v0, _count };
+    Version version = Version::v0;
     crypto::public_key sn_pubkey = crypto::null<crypto::public_key>;
     bls_public_key bls_pubkey = crypto::null<bls_public_key>;
     crypto::ed25519_signature ed_signature = crypto::null<crypto::ed25519_signature>;

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -90,10 +90,12 @@ struct ContributorV2 {
     template <class Archive>
     void serialize_object(Archive& ar) {
         auto version = tools::enum_top<Version>;
-        field_varint(ar, "version", version, [](auto v) { return v < Version::_count; });
+        field_varint(ar, "version", version, [](auto v) { return v > Version::version_invalid && v < Version::_count; });
         field(ar, "address", address);
         field(ar, "beneficiary", beneficiary);
         field_varint(ar, "amount", amount);
+
+
     }
 };
 

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -92,8 +92,8 @@ struct ContributorV2 {
         auto version = tools::enum_top<Version>;
         field_varint(ar, "version", version, [](auto v) { return v < Version::_count; });
         field(ar, "address", address);
-        field_varint(ar, "amount", amount);
         field(ar, "beneficiary", beneficiary);
+        field_varint(ar, "amount", amount);
     }
 };
 
@@ -126,7 +126,7 @@ struct NewServiceNodeV2 : L2StateChange {
 
     std::strong_ordering operator<=>(const NewServiceNodeV2& o) const = default;
 
-    static constexpr cryptonote::txtype txtype = cryptonote::txtype::ethereum_new_service_node;
+    static constexpr cryptonote::txtype txtype = cryptonote::txtype::ethereum_new_service_node_v2;
     static constexpr std::string_view description = "new SNv2"sv;
 };
 

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -346,7 +346,7 @@ void L2Tracker::add_to_mempool(const event::StateChangeVariant& tx_variant) {
                     tx.type = txtype::ethereum_new_service_node;
                     add_new_service_node_to_tx_extra(tx.extra, arg);
                 } else if constexpr (std::is_same_v<T, event::NewServiceNodeV2>) {
-                    tx.type = txtype::ethereum_new_service_node;
+                    tx.type = txtype::ethereum_new_service_node_v2;
                     add_new_service_node_v2_to_tx_extra(tx.extra, arg);
                 } else if constexpr (std::is_same_v<T, event::ServiceNodeExitRequest>) {
                     tx.type = txtype::ethereum_service_node_exit_request;
@@ -470,43 +470,13 @@ void L2Tracker::update_logs() {
                                     std::chrono::steady_clock::now() - started}
                                     .count());
 
-                    // TODO: Each node is going to observe L2 transactions at a different time from
-                    // each other (even in normal network operating conditions) network latency in
-                    // Oxen block propagation or getting caught in a small network partition e.t.c
-                    //
-                    // This would mean that the HF version we snap at the time we generate a log
-                    // event _may_ differ from other nodes that parsed logs earlier/later. This will
-                    // cause L2 events to potentially be serialised differently into a transaction.
-                    //
-                    // I think this is problematic in edge cases where the blockchain straddles a
-                    // hardforking height, some see HF+0, and slower nodes see HF-1.
-                    //
-                    // In those instances, the slower nodes may serialise the tx_extra differently,
-                    // generate a different hash and if they're in the quorum for the next block
-                    // they would fail to produce a block.
-                    //
-                    // The network will roll through the quorums until a sufficient majority of
-                    // those that observed logs with a matching HF are met and they generate a
-                    // block.
-                    //
-                    // Does the network recover from this? Or, if the slower nodes receive a block
-                    // that they don't have TX for, do they request the TX (the correctly serialised
-                    // L2 log event/tx_extra) from the P2P layer? If that's the case then this
-                    // situation would be so rare that it's not a problem, network is generally
-                    // resilient to it with time.
-                    //
-                    // In our pre-existing TX extra `tx_extra_service_node_state_change` has a
-                    // version field but I think it too also just accepts that, that, is a even more
-                    // rare case so it doesn't seem like we handle it.
-                    auto hf_version = core.blockchain.get_network_version();
-
                     for (const auto& log : *logs) {
                         if (!log.blockNumber) {
                             log::error(logcat, "Log item from L2 provider without a blockNumber!");
                             continue;
                         }
                         try {
-                            auto tx = get_log_event(hf_version, chain_id, log);
+                            auto tx = get_log_event(chain_id, log);
                             add_to_mempool(tx);
                             if (auto* reg = std::get_if<event::NewServiceNode>(&tx))
                                 recent_regs.add(std::move(*reg), *log.blockNumber);
@@ -518,14 +488,26 @@ void L2Tracker::update_logs() {
                                 recent_exits.add(std::move(*exit), *log.blockNumber);
                             else if (auto* req = std::get_if<event::StakingRequirementUpdated>(&tx))
                                 recent_req_changes.add(std::move(*req), *log.blockNumber);
-                            else
+                            else {
                                 assert(tx.index() == 0);
+                            }
                         } catch (const std::exception& e) {
+
+                            fmt::memory_buffer buffer{};
+                            fmt::format_to(std::back_inserter(buffer), "The raw blob was (32 byte chunks/line):\n\n");
+                            std::string_view hex = log.data;
+                            while (hex.size()) {
+                                std::string_view chunk = tools::string_safe_substr(hex, 0, 64); // Grab 32 byte chunk
+                                fmt::format_to(std::back_inserter(buffer), "  {}\n", chunk);    // Output the chunk
+                                hex = tools::string_safe_substr(hex, 64, hex.size());           // Advance the hex
+                            }
+
                             log::error(
                                     logcat,
                                     "Failed to convert L2 state change transaction to an Oxen "
-                                    "state change transaction: {}",
-                                    e.what());
+                                    "state change transaction: {}\n\n{}",
+                                    e.what(),
+                                    fmt::to_string(buffer));
                             continue;
                         }
                     }

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -494,12 +494,19 @@ void L2Tracker::update_logs() {
                         } catch (const std::exception& e) {
 
                             fmt::memory_buffer buffer{};
-                            fmt::format_to(std::back_inserter(buffer), "The raw blob was (32 byte chunks/line):\n\n");
+                            fmt::format_to(
+                                    std::back_inserter(buffer),
+                                    "The raw blob was (32 byte chunks/line):\n\n");
                             std::string_view hex = log.data;
                             while (hex.size()) {
-                                std::string_view chunk = tools::string_safe_substr(hex, 0, 64); // Grab 32 byte chunk
-                                fmt::format_to(std::back_inserter(buffer), "  {}\n", chunk);    // Output the chunk
-                                hex = tools::string_safe_substr(hex, 64, hex.size());           // Advance the hex
+                                std::string_view chunk = tools::string_safe_substr(
+                                        hex, 0, 64);  // Grab 32 byte chunk
+                                fmt::format_to(
+                                        std::back_inserter(buffer),
+                                        "  {}\n",
+                                        chunk);  // Output the chunk
+                                hex = tools::string_safe_substr(
+                                        hex, 64, hex.size());  // Advance the hex
                             }
 
                             log::error(

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -40,6 +40,7 @@ class L2Tracker {
 
     // l2_height => recent events at that height
     RecentEvents<event::NewServiceNode> recent_regs;
+    RecentEvents<event::NewServiceNodeV2> recent_regs_v2;
     RecentEvents<event::ServiceNodeExitRequest> recent_unlocks;
     RecentEvents<event::ServiceNodeExit> recent_exits;
     RecentEvents<event::StakingRequirementUpdated> recent_req_changes;
@@ -150,6 +151,7 @@ class L2Tracker {
     // Returns true/false for whether we have recently observed the given event from the L2 tracker
     // logs.  This is used for pulse confirmation voting.
     bool get_vote_for(const event::NewServiceNode& reg) const;
+    bool get_vote_for(const event::NewServiceNodeV2& reg) const;
     bool get_vote_for(const event::ServiceNodeExit& exit) const;
     bool get_vote_for(const event::ServiceNodeExitRequest& unlock) const;
     bool get_vote_for(const event::StakingRequirementUpdated& req_change) const;

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -20,25 +20,31 @@ namespace {
 
     enum class EventType {
         NewServiceNode,
+        NewServiceNodeV2,
         ServiceNodeExitRequest,
         ServiceNodeExit,
         StakingRequirementUpdated,
         Other
     };
 
-    EventType get_log_type(const ethyl::LogEntry& log) {
+    EventType get_log_type(const ethyl::LogEntry& log, cryptonote::hf hf_version) {
         if (log.topics.empty())
             throw std::runtime_error("No topics in log entry");
 
         auto event_sig = tools::make_from_hex_guts<crypto::hash>(log.topics[0]);
-
-        return event_sig == contract::event::NewServiceNode ? EventType::NewServiceNode
-             : event_sig == contract::event::ServiceNodeExitRequest
-                     ? EventType::ServiceNodeExitRequest
-             : event_sig == contract::event::ServiceNodeExit ? EventType::ServiceNodeExit
-             : event_sig == contract::event::StakingRequirementUpdated
-                     ? EventType::StakingRequirementUpdated
-                     : EventType::Other;
+        if (event_sig == contract::event::NewServiceNode)
+            return EventType::NewServiceNode;
+        if (event_sig == contract::event::ServiceNodeExitRequest)
+            return EventType::ServiceNodeExitRequest;
+        if (event_sig == contract::event::ServiceNodeExit)
+            return EventType::ServiceNodeExit;
+        if (event_sig == contract::event::StakingRequirementUpdated)
+            return EventType::StakingRequirementUpdated;
+        if (hf_version >= cryptonote::hf::hf22_eth_beneficiary) {
+            if (event_sig == contract::event::NewServiceNodeV2)
+                return EventType::NewServiceNodeV2;
+        }
+        return EventType::Other;
     }
 
 }  // namespace
@@ -79,7 +85,49 @@ static std::string log_new_service_node_tx(
     fmt::memory_buffer buffer{};
     fmt::format_to(
             std::back_inserter(buffer),
-            "New service node TX components were:\n"
+            "New SN TX components were:\n"
+            "- SN Public Key:     {}\n"
+            "- BLS Public Key:    {}\n"
+            "- ED25519 Signature: {}\n"
+            "- Fee:               {}\n"
+            "- Contributor(s):    {}\n",
+            item.sn_pubkey,
+            item.bls_pubkey,
+            item.ed_signature,
+            item.fee,
+            item.contributors.size());
+
+    for (size_t index = 0; index < item.contributors.size(); index++) {
+        const auto& contributor = item.contributors[index];
+        fmt::format_to(
+                std::back_inserter(buffer),
+                "  - {:02} [address: {}, amount: {}]\n",
+                index,
+                contributor.address,
+                contributor.amount);
+    }
+
+    fmt::format_to(std::back_inserter(buffer), "\nThe raw blob was (32 byte chunks/line):\n\n");
+    std::string_view it = hex;
+    if (it.starts_with("0x") || it.starts_with("0X"))
+        it.remove_prefix(2);
+
+    while (it.size()) {
+        std::string_view chunk = tools::string_safe_substr(it, 0, 64);  // Grab 32 byte chunk
+        fmt::format_to(std::back_inserter(buffer), "  {}\n", chunk);    // Output the chunk
+        it = tools::string_safe_substr(it, 64, it.size());              // Advance the it
+    }
+
+    std::string result = fmt::to_string(buffer);
+    return result;
+}
+
+static std::string log_new_service_node_v2_tx(
+        const event::NewServiceNodeV2& item, std::string_view hex) {
+    fmt::memory_buffer buffer{};
+    fmt::format_to(
+            std::back_inserter(buffer),
+            "New SNv2 TX components were:\n"
             "- SN Public Key:     {}\n"
             "- BLS Public Key:    {}\n"
             "- ED25519 Signature: {}\n"
@@ -220,17 +268,8 @@ event::StateChangeVariant get_log_event(cryptonote::hf hf_version, const uint64_
         return result;
     }
 
-    switch (get_log_type(log)) {
+    switch (get_log_type(log, hf_version)) {
         case EventType::NewServiceNode: {
-            // TODO: We can't just update the NewServiceNode event with new fields without
-            // versioning otherwise nodes won't be able to parse old L2 TXs at the boundary of a
-            // smart contract upgrade.
-            //
-            // There are hacks around this, like currently if no L2 is set, we sync unconditionally-
-            // or pausing the contract around the upgrade so that nodes only observe the new
-            // structure. But this all breaks if you sync the chain with an archive node, and so the
-            // below code needs to be version aware to parse the blob correctly.
-
             // event NewServiceNode(
             //      uint64 indexed serviceNodeID,
             //      address initiator,
@@ -242,10 +281,7 @@ event::StateChangeVariant get_log_event(cryptonote::hf hf_version, const uint64_
             //      },
             //      [ // Contributors contributors[]
             //        {
-            //          { // struct Staker
-            //            address addr,
-            //            address beneficiary,
-            //          }
+            //          address addr,
             //          uint256 stakeAmount,
             //        }
             //      ]
@@ -339,17 +375,147 @@ event::StateChangeVariant get_log_event(cryptonote::hf hf_version, const uint64_
             // TODO: Validate the amount, can't be 0, should be min contribution. Is this done in
             // the SNL? Maybe.
             for (size_t index = 0; index < num_contributors; index++) {
-                auto& [version, addr, beneficiary, amt] = item.contributors.emplace_back();
-                version = event::Contributor::hardfork_to_version(hf_version);
+                auto& [addr, amt] = item.contributors.emplace_back();
+                u256 amt256;
+                std::tie(addr, amt256, contrib_hex) =
+                        tools::split_hex_into<skip<12>, eth::address, u256, std::string_view>(contrib_hex);
+                amt = tools::decode_integer_be(amt256);
+            }
+
+            oxen::log::debug(logcat, "{}", log_new_service_node_tx(item, log.data));
+            if (hf_version >= cryptonote::hf::hf22_eth_beneficiary) { // NOTE: Upgrade to V2
+                auto v2 = event::NewServiceNodeV2(item.chain_id, item.l2_height);
+                v2.sn_pubkey = item.sn_pubkey;
+                v2.bls_pubkey = item.bls_pubkey;
+                v2.ed_signature = item.ed_signature;
+                v2.fee = item.fee;
+                v2.contributors.resize(item.contributors.size());
+                for (const auto& it : item.contributors)
+                    v2.contributors.emplace_back(it.address, it.address /*beneficiary*/, it.amount);
+            }
+            break;
+        }
+
+        case EventType::NewServiceNodeV2: {
+            // event NewServiceNode(
+            //      uint64 indexed serviceNodeID,
+            //      address initiator,
+            //      { // struct ServiceNodeParams
+            //          BN256G1.G1Point pubkey,
+            //          uint256 serviceNodePubkey,
+            //          (uint256,uint256) serviceNodeSignature,
+            //          uint256 fee,
+            //      },
+            //      [ // Contributors contributors[]
+            //        {
+            //          { // struct Staker
+            //            address addr,
+            //            address beneficiary,
+            //          }
+            //          uint256 stakeAmount,
+            //        }
+            //      ]
+            //
+            // Note:
+            // - address is 32 bytes, the first 12 of which are padding
+            // - fee is between 0 and 10000, despite being packed into a gigantic 256-bit int.
+
+            auto& item = result.emplace<event::NewServiceNodeV2>(chain_id, l2_height);
+
+            u256 fee256, c_offset, c_len;
+            std::string_view contrib_hex;
+            std::tie(
+                    item.bls_pubkey,
+                    item.sn_pubkey,
+                    item.ed_signature,
+                    fee256,
+                    c_offset,
+                    c_len,
+                    contrib_hex) =
+                    tools::split_hex_into<
+                            skip<12 + 20>,
+                            bls_public_key,
+                            crypto::public_key,
+                            crypto::ed25519_signature,
+                            u256,
+                            u256,
+                            u256,
+                            std::string_view>(log.data);
+
+            // NOTE: Decode fee and that it is within acceptable range
+            item.fee = tools::decode_integer_be(fee256);
+            if (item.fee > cryptonote::STAKING_FEE_BASIS)
+                throw oxen::traced<std::invalid_argument>{
+                        "Invalid NewServiceNode data: fee must be in [0, {}]"_format(
+                                cryptonote::STAKING_FEE_BASIS)};
+
+            // NOTE: Verify that the number of contributors in the blob is
+            // within maximum range
+            uint64_t num_contributors = tools::decode_integer_be(c_len);
+            if (num_contributors > oxen::MAX_CONTRIBUTORS_HF19) {
+                throw oxen::traced<std::invalid_argument>(
+                        "Invalid NewServiceNode data: {}\n{}"_format(
+                                log_more_contributors_than_allowed(
+                                        num_contributors,
+                                        oxen::MAX_CONTRIBUTORS_HF19,
+                                        item.bls_pubkey,
+                                        log.blockNumber,
+                                        /*index*/ std::optional<uint64_t>()),
+                                log_new_service_node_v2_tx(item, log.data)));
+            }
+
+            // NOTE: Verify that there's atleast one contributor
+            if (num_contributors <= 0) {
+                throw oxen::traced<std::invalid_argument>(
+                        "Invalid NewServiceNode data: There must be atleast one contributor, "
+                        "received 0\n{}"
+                        ""_format(log_new_service_node_v2_tx(item, log.data)));
+            }
+            item.contributors.reserve(num_contributors);
+
+            // NOTE: Verify that the offset to the dynamic part of the
+            // contributors array is correct.
+            const uint64_t c_offset_value = tools::decode_integer_be(c_offset);
+            const uint64_t expected_c_offset_value = 32 /*ID*/ + 32 /*recipient*/ + 64 /*BLS Key*/ +
+                                                     32 /*SN Key*/ + 64 /*SN Sig*/ + 32 /*Fee*/;
+            if (c_offset_value != expected_c_offset_value) {
+                throw oxen::traced<std::invalid_argument>(
+                        "Invalid NewServiceNode data: The offset to the contributor payload ({} "
+                        "bytes) did not match the offset we derived {}\n{}"
+                        ""_format(
+                                c_offset_value,
+                                expected_c_offset_value,
+                                log_new_service_node_v2_tx(item, log.data)));
+            }
+
+            // NOTE: Verify the length of the contributor blob
+            const size_t expected_contrib_hex_size =
+                    2 /*hex*/ * num_contributors * (/*address*/ 32 + /*amount*/ 32);
+            if (contrib_hex.size() != expected_contrib_hex_size) {
+                throw oxen::traced<std::invalid_argument>{
+                        "Invalid NewServiceNode data: The hex payload length ({}) derived for "
+                        "{} contributors did not match the size we derived of {} hex characters\n"
+                        "{}"_format(
+                                contrib_hex.size(),
+                                num_contributors,
+                                expected_contrib_hex_size,
+                                log_new_service_node_v2_tx(item, log.data))};
+            }
+
+            // TODO: Validate the amount, can't be 0, should be min contribution. Is this done in
+            // the SNL? Maybe.
+            for (size_t index = 0; index < num_contributors; index++) {
+                auto& [addr, beneficiary, amt] = item.contributors.emplace_back();
                 u256 amt256;
                 std::tie(addr, beneficiary, amt256, contrib_hex) =
                         tools::split_hex_into<skip<12>, eth::address, eth::address, u256, std::string_view>(contrib_hex);
                 amt = tools::decode_integer_be(amt256);
             }
 
-            oxen::log::debug(logcat, "{}", log_new_service_node_tx(item, log.data));
+            oxen::log::debug(logcat, "{}", log_new_service_node_v2_tx(item, log.data));
             break;
         }
+
         case EventType::ServiceNodeExitRequest: {
             // event ServiceNodeRemovalRequest(
             //      uint64 indexed serviceNodeID,
@@ -604,7 +770,7 @@ ContractServiceNode RewardsContract::service_nodes(
 
     for (size_t i = 0; i < result.contributorsSize; i++) {
         try {
-            auto& [version, addr, beneficiary, amount] = result.contributors[i];
+            auto& [addr, beneficiary, amount] = result.contributors[i];
             u256 amt;
             std::tie(addr, beneficiary, amt, contrib_data) =
                     tools::split_hex_into<skip<12>, eth::address, eth::address, u256, std::string_view>(

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -31,7 +31,7 @@ struct ContractServiceNode {
     uint64_t addedTimestamp;
     uint64_t leaveRequestTimestamp;
     uint64_t deposit;
-    std::array<event::Contributor, oxen::MAX_CONTRIBUTORS_HF19> contributors;
+    std::array<event::ContributorV2, oxen::MAX_CONTRIBUTORS_HF19> contributors;
     size_t contributorsSize;
 };
 

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -17,7 +17,7 @@ struct LogEntry;
 
 namespace eth {
 
-event::StateChangeVariant get_log_event(uint64_t chain_id, const ethyl::LogEntry& log);
+event::StateChangeVariant get_log_event(cryptonote::hf hf_version, uint64_t chain_id, const ethyl::LogEntry& log);
 inline bool is_state_change(const event::StateChangeVariant& v) {
     return v.index() > 0;
 }

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -17,7 +17,7 @@ struct LogEntry;
 
 namespace eth {
 
-event::StateChangeVariant get_log_event(cryptonote::hf hf_version, uint64_t chain_id, const ethyl::LogEntry& log);
+event::StateChangeVariant get_log_event(uint64_t chain_id, const ethyl::LogEntry& log);
 inline bool is_state_change(const event::StateChangeVariant& v) {
     return v.index() > 0;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2989,7 +2989,8 @@ void core_rpc_server::fill_sn_response_entry(
             auto& c = contributors.emplace_back(json{{"amount", contributor.amount}});
             if (contributor.ethereum_address) {
                 json_binary_proxy{c["address"], binary_format} = contributor.ethereum_address;
-                json_binary_proxy{c["beneficiary"], binary_format} = contributor.ethereum_beneficiary;
+                json_binary_proxy{c["beneficiary"], binary_format} =
+                        contributor.ethereum_beneficiary;
             } else
                 c["address"] = cryptonote::get_account_address_as_str(
                         m_core.get_nettype(), false /*subaddress*/, contributor.address);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2971,9 +2971,10 @@ void core_rpc_server::fill_sn_response_entry(
         auto& contributors = (entry["contributors"] = json::array());
         for (const auto& contributor : info.contributors) {
             auto& c = contributors.emplace_back(json{{"amount", contributor.amount}});
-            if (contributor.ethereum_address)
+            if (contributor.ethereum_address) {
                 json_binary_proxy{c["address"], binary_format} = contributor.ethereum_address;
-            else
+                json_binary_proxy{c["beneficiary"], binary_format} = contributor.ethereum_beneficiary;
+            } else
                 c["address"] = cryptonote::get_account_address_as_str(
                         m_core.get_nettype(), false /*subaddress*/, contributor.address);
             if (contributor.reserved != contributor.amount)
@@ -3098,9 +3099,10 @@ void core_rpc_server::invoke(GET_PENDING_EVENTS& sns, rpc_context) {
                     res["contributors"] = json::array();
                     auto& contr = res["contributors"];
                     auto contr_hex = res_hex["contributors"];
-                    for (const auto& [addr, amt] : e.contributors) {
-                        contr.push_back(json{{"amount", amt}});
-                        contr_hex.back()["address"] = addr;
+                    for (const auto& it : e.contributors) {
+                        contr.push_back(json{{"amount", it.amount}});
+                        contr_hex.back()["address"] = it.address;
+                        contr_hex.back()["beneficiary"] = it.beneficiary;
                     }
                 } else if constexpr (std::is_same_v<Event, eth::event::ServiceNodeExitRequest>) {
                     sns.response["unlocks"].push_back(std::move(entry));

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -240,9 +240,4 @@ class binary_archiver : public serializer {
     std::ios_base::iostate exc_restore_;
 };
 
-// True if Archive is a binary archiver or unarchiver
-template <typename Archive>
-constexpr bool is_binary = std::is_base_of_v<binary_archiver, Archive> ||
-                           std::is_base_of_v<binary_unarchiver, Archive>;
-
 }  // namespace serialization

--- a/src/serialization/json_archive.h
+++ b/src/serialization/json_archive.h
@@ -120,6 +120,9 @@ struct json_archiver : public serializer {
         serialize_blob(blobs.data(), blobs.size() * sizeof(T));
     }
 
+    // writes a literal null value; used by optional.h, only for non-binary serialization.
+    void serialize_null() { set(nullptr); }
+
     void write_variant_tag(std::string_view t) { tag(t); }
 
   private:

--- a/src/serialization/optional.h
+++ b/src/serialization/optional.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/// Serialization of std::optionals.
+
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+#include "serialization.h"
+
+namespace serialization {
+
+template <class Archive, class T>
+void serialize_value(Archive& ar, std::optional<T>& v) {
+    using I = std::remove_cv_t<T>;
+
+    bool have_value = v.has_value();
+    if constexpr (is_binary<Archive>)
+        ar.serialize_int(have_value);
+
+    if (have_value) {
+        if (Archive::is_deserializer && !v.has_value())
+            v.emplace();
+        if constexpr (std::is_same_v<I, uint32_t> || std::is_same_v<I, uint64_t>)
+            varint(ar, *v);
+        else
+            value(ar, *v);
+    } else if constexpr (Archive::is_serializer) {
+        if constexpr (!is_binary<Archive>)
+            ar.serialize_null();
+    } else {  // deserializing && !have_value
+        v.reset();
+    }
+}
+
+}  // namespace serialization

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -114,8 +114,8 @@
  *     public:
  *       template <class Archive>
  *       void serialize_object(Archive& ar) {
- *         field(ar, v1);
- *         field(ar, v2);
+ *         field(ar, "v1", v1);
+ *         field(ar, "v2", v2);
  *       }
  *     };
  *
@@ -368,5 +368,13 @@ void serialize(Archive& ar, T& v) {
     value(ar, v);
     done(ar);
 }
+
+class binary_archiver;
+class binary_unarchiver;
+
+// True if Archive is a binary archiver or unarchiver
+template <typename Archive>
+constexpr bool is_binary = std::is_base_of_v<binary_archiver, Archive> ||
+                           std::is_base_of_v<binary_unarchiver, Archive>;
 
 }  // namespace serialization

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -290,8 +290,8 @@ class Daemon(RPCDaemon):
     def get_exit_liquidation_request(self, ed25519_pubkey, liquidate=False):
         return self.json_rpc("bls_exit_liquidation_request", {"pubkey": ed25519_pubkey, "liquidate": liquidate}, timeout=1000).json()
 
-    def get_accrued_rewards(self, ed25519_keys) -> list[AccruedRewards]:
-        json                         = self.json_rpc("get_accrued_rewards", {"addresses": ed25519_keys}).json()
+    def get_accrued_rewards(self, addresses) -> list[AccruedRewards]:
+        json                         = self.json_rpc("get_accrued_rewards", {"addresses": addresses}).json()
         balance_array                = json['result']['balances']
         result: list[AccruedRewards] = []
         for address, balance in balance_array.items():

--- a/utils/local-devnet/ethereum.py
+++ b/utils/local-devnet/ethereum.py
@@ -871,6 +871,12 @@ contract_abi = json.loads("""
       "anonymous": false,
       "inputs": [
         {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        },
+        {
           "indexed": true,
           "internalType": "uint64",
           "name": "serviceNodeID",

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -299,8 +299,9 @@ class SNNetwork:
             total_staked = 0
 
             for entry in contributors:
-                contributor              = ContractServiceNodeContributor()
-                contributor.addr         = hardhat_account # Default to the hardhat account
+                contributor                    = ContractServiceNodeContributor()
+                contributor.staker.addr        = hardhat_account # Default to the hardhat account
+                contributor.staker.beneficiary = hardhat_account # Default to the hardhat account
 
                 # Use the oxen amount proportionally as the SENT amount
                 contributor.stakedAmount = int((entry["amount"] / oxen_staking_requirement * contract_staking_requirement))

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -297,8 +297,7 @@ class SNNetwork:
         contract_staking_requirement = self.sn_contract.stakingRequirement()
         seed_node_list      = []
         for sn in self.sns:
-            node      = ContractSeedServiceNode(sn.get_service_keys().bls_pubkey)
-            assert node.pubkey is not None
+            node         = ContractSeedServiceNode(sn.get_service_keys().bls_pubkey, sn.get_service_keys().ed25519_pubkey)
             contributors = sn.sn_status()["service_node_state"]["contributors"]
             total_staked = 0
 


### PR DESCRIPTION
The necessary oxen-core updates that pairs with https://github.com/oxen-io/eth-sn-contracts/pull/87

Seems to be working. The new contracts emit a `NewServiceNodeV2` which we parse to get the new beneficiary information. When payments are done we ensure we assign a reward to the beneficiary, not, the staker's address. 

In order to make this backwards compatible I've bumped the version of the SNL so on launch everyone will recalculate the SNL and augment all contributors with a beneficiary that is simply the same address as the contributor. Since all the code will use the new structure with beneficiaries we can start paying out to "beneficiaries" even with v1 `NewServiceNode` events.

The only thing that is gated is when it's acceptable to start stuffing V2 `NewServiceNode` data into transactions which affect consensus. For this we will hardfork the network, then, once everyone has upgrade and has the capability to parse the V2 blobs, then, we upgrade the contract so that it starts emitting the new contributor layout.

Earlier I made the wrong assumption that we need to gate the serialisation of the blob by hardfork, that was incorrect and would introduce consensus issues. Universally, when the contract is updated- no node on the network is going to disagree on what version they saw, it'll always be consistently V1 or V2 blobs, never inconsistent between each other so there's no real problem there.