### PR TITLE
Add support for serialization of std::optionals

### DIFF
--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -240,9 +240,4 @@ class binary_archiver : public serializer {
     std::ios_base::iostate exc_restore_;
 };
 
-// True if Archive is a binary archiver or unarchiver
-template <typename Archive>
-constexpr bool is_binary = std::is_base_of_v<binary_archiver, Archive> ||
-                           std::is_base_of_v<binary_unarchiver, Archive>;
-
 }  // namespace serialization

--- a/src/serialization/json_archive.h
+++ b/src/serialization/json_archive.h
@@ -120,6 +120,9 @@ struct json_archiver : public serializer {
         serialize_blob(blobs.data(), blobs.size() * sizeof(T));
     }
 
+    // writes a literal null value; used by optional.h, only for non-binary serialization.
+    void serialize_null() { set(nullptr); }
+
     void write_variant_tag(std::string_view t) { tag(t); }
 
   private:

--- a/src/serialization/optional.h
+++ b/src/serialization/optional.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/// Serialization of std::optionals.
+
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+#include "serialization.h"
+
+namespace serialization {
+
+template <class Archive, class T>
+void serialize_value(Archive& ar, std::optional<T>& v) {
+    using I = std::remove_cv_t<T>;
+
+    bool have_value = v.has_value();
+    if constexpr (is_binary<Archive>)
+        ar.serialize_int(have_value);
+
+    if (have_value) {
+        if (Archive::is_deserializer && !v.has_value())
+            v.emplace();
+        if constexpr (std::is_same_v<I, uint32_t> || std::is_same_v<I, uint64_t>)
+            varint(ar, *v);
+        else
+            value(ar, *v);
+    } else if constexpr (Archive::is_serializer) {
+        if constexpr (!is_binary<Archive>)
+            ar.serialize_null();
+    } else {  // deserializing && !have_value
+        v.reset();
+    }
+}
+
+}  // namespace serialization

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -114,8 +114,8 @@
  *     public:
  *       template <class Archive>
  *       void serialize_object(Archive& ar) {
- *         field(ar, v1);
- *         field(ar, v2);
+ *         field(ar, "v1", v1);
+ *         field(ar, "v2", v2);
  *       }
  *     };
  *
@@ -368,5 +368,13 @@ void serialize(Archive& ar, T& v) {
     value(ar, v);
     done(ar);
 }
+
+class binary_archiver;
+class binary_unarchiver;
+
+// True if Archive is a binary archiver or unarchiver
+template <typename Archive>
+constexpr bool is_binary = std::is_base_of_v<binary_archiver, Archive> ||
+                           std::is_base_of_v<binary_unarchiver, Archive>;
 
 }  // namespace serialization


### PR DESCRIPTION
For json serialization these become either the value, or the json `null` literal.

For binary serialization these become a serialized bool (0 or 1) indicating whether the value is set and then, if (and only if) 1, the serialized value.  Deserializing loads the bool and then either clears the optional (if 0) or emplaces and loads it (if 1).

Includes unit test.