### PR TITLE
Allow 0x prefix for binary value rpc inputs

### DIFF
--- a/src/common/json_binary_proxy.cpp
+++ b/src/common/json_binary_proxy.cpp
@@ -11,7 +11,11 @@ void load_binary_parameter_impl(
     if (allow_raw && bytes.size() == raw_size) {
         std::memcpy(val_data, bytes.data(), bytes.size());
         return;
-    } else if (bytes.size() == raw_size * 2) {
+    } else if (const auto hex_size = oxenc::to_hex_size(raw_size);
+               bytes.size() == hex_size ||
+               (bytes.size() == hex_size + 2 && bytes.starts_with("0x"))) {
+        if (bytes.size() > hex_size)
+            bytes.remove_prefix(2);
         if (oxenc::is_hex(bytes)) {
             oxenc::from_hex(bytes.begin(), bytes.end(), val_data);
             return;


### PR DESCRIPTION
Currently for things like eth::address rpc inputs we don't allow the 0x prefix on json inputs (e.g. you have to provide "888...888" for an eth::address rather than "0x888...888").  This updates the parsing of json rpc requests to accept a 0x prefix on all such encoded binary field inputs.