### PR TITLE
Use checksum formatting for eth addresses

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -35,6 +35,7 @@ oxen_add_library(cncrypto
   crypto-ops-data.c
   crypto-ops.c
   crypto.cpp
+  eth.cpp
   groestl.c
   hash-extra-blake.c
   hash-extra-groestl.c

--- a/src/crypto/eth.cpp
+++ b/src/crypto/eth.cpp
@@ -1,0 +1,27 @@
+#include "eth.h"
+
+#include <oxenc/hex.h>
+
+#include "crypto/hash.h"
+
+fmt::format_context::iterator fmt::formatter<eth::address>::default_format(
+        std::span<const unsigned char> val, fmt::format_context& ctx) const {
+    auto out = ctx.out();
+    *out++ = '0';
+    *out++ = 'x';
+
+    if (val.size() == 20) {
+        std::array<char, 40> buf;
+        oxenc::to_hex(val.begin(), val.end(), buf.begin());
+        auto csum = crypto::keccak(buf);
+        constexpr char to_uc = 'a' - 'A';
+        for (size_t i = 0; i < 20; i++) {
+            char c1 = buf[2 * i], c2 = buf[2 * i + 1];
+            *out++ = c1 - ((c1 >= 'a' && (csum[i] & 0x80)) ? to_uc : 0);
+            *out++ = c2 - ((c2 >= 'a' && (csum[i] & 0x08)) ? to_uc : 0);
+        }
+        return out;
+    } else {
+        return oxenc::to_hex(val.begin(), val.end(), out);
+    }
+};

--- a/src/crypto/eth.h
+++ b/src/crypto/eth.h
@@ -36,10 +36,5 @@ struct std::hash<eth::address> : crypto::raw_hasher<eth::address> {};
 template <>
 struct fmt::formatter<eth::address> : formattable::hex_span_formatter {
     fmt::format_context::iterator default_format(
-            std::span<const unsigned char> val, fmt::format_context& ctx) const override {
-        auto out = ctx.out();
-        *out++ = '0';
-        *out++ = 'x';
-        return oxenc::to_hex(val.begin(), val.end(), out);
-    }
+            std::span<const unsigned char> val, fmt::format_context& ctx) const override;
 };

--- a/src/rpc/common/param_parser.hpp
+++ b/src/rpc/common/param_parser.hpp
@@ -132,7 +132,7 @@ void load_value(BTConsumer& c, T& val) {
         val = c.template consume_integer<T>();
     else if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>)
         val = c.consume_string_view();
-    else if constexpr (tools::json_is_binary<T>)
+    else if constexpr (tools::json_is_binary<T> || std::is_same_v<T, eth::address>)
         tools::load_binary_parameter(c.consume_string_view(), true /*allow raw*/, val);
     else if constexpr (is_expandable_list<T>) {
         auto lc = c.consume_list_consumer();
@@ -193,7 +193,9 @@ void load_value(json_range& r, T& val) {
         val = i;
     } else if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>) {
         val = e.get<std::string_view>();
-    } else if constexpr (tools::json_is_binary<T> || is_expandable_list<T> || is_tuple_like<T>) {
+    } else if constexpr (
+            tools::json_is_binary<T> || std::is_same_v<T, eth::address> || is_expandable_list<T> ||
+            is_tuple_like<T>) {
         try {
             e.get_to(val);
         } catch (const std::exception& e) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -768,7 +768,7 @@ namespace {
             auto contributors = json::array();
             for (auto& contributor : x.contributors) {
                 auto& c = contributors.emplace_back();
-                json_binary_proxy{c["address"], format} = contributor.address;
+                c["address"] = "{}"_format(contributor.address);
                 c["amount"] = contributor.amount;
             }
             set("contributors", contributors);
@@ -2578,7 +2578,7 @@ void core_rpc_server::invoke(BLS_REWARDS_REQUEST& rpc, rpc_context) {
                 rpc.request.address, static_cast<uint64_t>(rpc.request.height));
         set_contract_signature(rpc.response, rpc.response_hex, response, m_core.l2_tracker());
         rpc.response["status"] = STATUS_OK;
-        rpc.response_hex["address"] = response.addr;
+        rpc.response["address"] = "{}"_format(response.addr);
         rpc.response["amount"] = response.amount;
         rpc.response["height"] = response.height;
     } catch (const std::exception& e) {
@@ -2668,7 +2668,7 @@ void core_rpc_server::invoke(BLS_EXIT_LIQUIDATION_REQUEST& rpc, rpc_context) {
 void core_rpc_server::invoke(BLS_REGISTRATION_REQUEST& rpc, rpc_context) {
     const auto response = m_core.bls_registration(rpc.request.address);
     rpc.response["status"] = STATUS_OK;
-    rpc.response_hex["address"] = response.addr;
+    rpc.response["address"] = "{}"_format(response.addr);
     rpc.response_hex["bls_pubkey"] = response.bls_pubkey;
     rpc.response_hex["proof_of_possession"] = response.proof_of_possession;
     rpc.response_hex["service_node_pubkey"] = response.sn_pubkey;
@@ -2798,7 +2798,7 @@ void core_rpc_server::fill_sn_response_entry(
 
     if (requested(reqed, "operator_address")) {
         if (info.operator_ethereum_address)
-            binary["operator_address"] = info.operator_ethereum_address;
+            entry["operator_address"] = "{}"_format(info.operator_ethereum_address);
         else
             entry["operator_address"] = cryptonote::get_account_address_as_str(
                     m_core.get_nettype(), false /*subaddress*/, info.operator_address);
@@ -2974,7 +2974,7 @@ void core_rpc_server::fill_sn_response_entry(
         for (const auto& contributor : info.contributors) {
             auto& c = contributors.emplace_back(json{{"amount", contributor.amount}});
             if (contributor.ethereum_address)
-                json_binary_proxy{c["address"], binary_format} = contributor.ethereum_address;
+                c["address"] = "{}"_format(contributor.ethereum_address);
             else
                 c["address"] = cryptonote::get_account_address_as_str(
                         m_core.get_nettype(), false /*subaddress*/, contributor.address);
@@ -3099,10 +3099,8 @@ void core_rpc_server::invoke(GET_PENDING_EVENTS& sns, rpc_context) {
                     res["fee"] = e.fee * 0.01;
                     res["contributors"] = json::array();
                     auto& contr = res["contributors"];
-                    auto contr_hex = res_hex["contributors"];
                     for (const auto& [addr, amt] : e.contributors) {
-                        contr.push_back(json{{"amount", amt}});
-                        contr_hex.back()["address"] = addr;
+                        contr.push_back(json{{"amount", amt}, {"address", "{}"_format(addr)}});
                     }
                 } else if constexpr (std::is_same_v<Event, eth::event::ServiceNodeExitRequest>) {
                     sns.response["unlocks"].push_back(std::move(entry));


### PR DESCRIPTION
This changes the format for eth::address values to use checksum formatting, both when formatting via fmt (such as in log statements) and when writing them as values in an RPC response.

Sample log line:
```
[2024-10-11 20:29:04] [+0.021s] [service_nodes:info|cryptonote_core/service_node_list.cpp:1695] New service node exit (op: 0xb82Cd271CE0E498e4203AC4db801698Bd720f6AF; key: decaf035871aa9d8e7da429f39711c349f380840ac4a305530b5a19c18793681; returned: 120000000000) tx (8a2dcbfd5484a59814017600a7865b6049fae28a45d447678e6803ebb06eee3c) from ethereum: decaf035871aa9d8e7da429f39711c349f380840ac4a305530b5a19c18793681 @ height: 38269; awaiting confirmations
```
and excerpt from the `get_service_nodes` rpc endpoint:
```json
{
        "contributors": [
          {
            "address": "0xb82Cd271CE0E498e4203AC4db801698Bd720f6AF",
            "amount": 120000000000,
            "locked_contributions": []
          }
        ],
        "operator_address": "0xb82Cd271CE0E498e4203AC4db801698Bd720f6AF"
}
```