### PR TITLE
Use null contract address in HF20 uptime proof BLS sigs

### DIFF
--- a/src/bls/bls_crypto.h
+++ b/src/bls/bls_crypto.h
@@ -22,8 +22,14 @@ bls_public_key get_pubkey(const bls_secret_key& seckey);
 /// Gets a signature (G2 point) from the given secret key signing a message.  The `nettype` gives
 /// the network type (e.g. cryptonote::network_type::MAINNET) as the network type is used in the
 /// signature tag so that testnet signatures aren't usable on mainnet and vice versa.
+/// The contract address is also used in the signature; omitting (or passing nullptr) uses the
+/// ServiceNodeRewards contract address, which is usually what you want (HF20 uptime proofs
+/// excepted).
 bls_signature sign(
-        cryptonote::network_type nettype, const bls_secret_key& key, std::span<const uint8_t> msg);
+        cryptonote::network_type nettype,
+        const bls_secret_key& key,
+        std::span<const uint8_t> msg,
+        const eth::address* contract_addr = nullptr);
 
 /// Obtains a proof-of-possession signature of an operator address, BLS pubkey, and service node
 /// pubkey.  This is used when submitting a new BLS key for a service node to the smart contract.
@@ -40,12 +46,19 @@ bool verify(
         cryptonote::network_type nettype,
         const bls_signature& signature,
         const bls_public_key& pubkey,
-        std::span<const uint8_t> msg);
+        std::span<const uint8_t> msg,
+        const eth::address* contract_addr = nullptr);
 
 /// Constructs a keccak 32-byte hash of `baseTag` on network `nettype`.  This tag is used for domain
 /// separation of different signature types and networks, and typically is called automatically by
-/// the above functions.
-crypto::hash build_tag_hash(std::string_view base_tag, cryptonote::network_type nettype);
+/// the above functions.  The pointer to the contract address can be used to override the contract
+/// address that gets used in the signature, if non-nullptr (this is used, in particular, by HF20
+/// uptime proofs to use a null eth address because HF20 nodes will be deployed before the contract
+/// address is known).
+crypto::hash build_tag_hash(
+        std::string_view base_tag,
+        cryptonote::network_type nettype,
+        const eth::address* contract_addr = nullptr);
 
 /// Help class that aggregates pubkeys.  Construct it, then call it repeatedly with all the pubkeys
 /// to be aggregated, then retrieve the aggregate.

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4419,7 +4419,12 @@ bool service_node_list::handle_uptime_proof(
         }
 
         auto pop = tools::concat_guts<uint8_t>(proof->pubkey_bls, proof->pubkey);
-        if (!eth::verify(blockchain.nettype(), proof->pop_bls, proof->pubkey_bls, pop)) {
+        if (!eth::verify(
+                    blockchain.nettype(),
+                    proof->pop_bls,
+                    proof->pubkey_bls,
+                    pop,
+                    &crypto::null<eth::address>)) {
             log::debug(
                     logcat,
                     "Rejecting uptime proof from {}: BLS proof of possession verification "

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -49,7 +49,10 @@ Proof::Proof(
     if (hardfork == feature::ETH_TRANSITION) {
         assert(keys.pub_bls);
         pop_bls = eth::sign(
-                nettype, keys.key_bls, tools::concat_guts<uint8_t>(keys.pub_bls, keys.pub));
+                nettype,
+                keys.key_bls,
+                tools::concat_guts<uint8_t>(keys.pub_bls, keys.pub),
+                &crypto::null<eth::address>);
     }
 
     serialized_proof = bt_encode_uptime_proof(hardfork);


### PR DESCRIPTION
Testnet HF20 uptime proofs failed to send because the testnet contract address was empty, and so the BLS signature would fail because the tag hash would fail to parse the empty hex contract address into an eth::address.

This changes the HF20 uptime proof BLS signature to use a null eth address instead of the contract address for these signatures.

This bug was caused by a recent change that changed the "TODO FIXME" 0x0000... null address in the network_config to an empty string, but in doing so exposed a more serious problem: because that network_config value is going to change between the initial HF20 and final HF21 releases, uptime proofs generated *during HF20* by the HF20 release and the HF21-ready release would not have been compatible because they would have used a different contract address in the signature.

This forces the use of the null address always during HF20 (regardless of the actual network_config contract address) to solve both problems.