### PR TITLE
prepare_eth_registration: remove multi-contributor address

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -269,8 +269,7 @@ bool command_parser_executor::prepare_registration(const std::vector<std::string
 }
 
 bool command_parser_executor::prepare_eth_registration(const std::vector<std::string>& args) {
-    constexpr auto usage =
-            "Eth registration args: <operator address> [multi-contributor address] [\"print\"]"sv;
+    constexpr auto usage = "Eth registration args: <operator address> [\"print\"]"sv;
 
     auto argc = args.size();
     if (argc < 1) {
@@ -282,33 +281,14 @@ bool command_parser_executor::prepare_eth_registration(const std::vector<std::st
         return false;
     }
     const auto operator_address = std::string_view{args[0]};
-    auto contract_address = ""sv;
     bool print = false;
-    if (argc == 2) {
-        if (args[1] != "print") {
-            if (args[1].size() != 42) {
-                log::error(logcat, usage);
-                return false;
-            }
-            contract_address = std::string_view{args[1]};
-        } else
-            print = true;
-    } else if (argc == 3) {
-        if (args[2] != "print") {
-            log::error(logcat, usage);
-            return false;
-        }
+    if (argc == 2 && args[1] == "print") {
         print = true;
-        if (args[1].size() != 42) {
-            log::error(logcat, usage);
-            return false;
-        }
-        contract_address = std::string_view{args[1]};
     } else if (argc != 1) {
         log::error(logcat, usage);
         return false;
     }
-    return m_executor.prepare_eth_registration(operator_address, contract_address, print);
+    return m_executor.prepare_eth_registration(operator_address, print);
 }
 
 bool command_parser_executor::print_sn(const std::vector<std::string>& args) {

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -110,11 +110,11 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
     m_command_lookup.set_handler(
             "prepare_eth_registration",
             [this](const auto& x) { return m_parser.prepare_eth_registration(x); },
-            "prepare_eth_registration <operator address> [multi-contributor address] [\"print\"]",
+            "prepare_eth_registration <operator address> [\"print\"]",
             "Prepare a service node registration for submission to the ethereum contract.  By "
             "default this information is submitted to https://stake.getsession.org to make it easy "
-            "to submit your registration.  If you would prefer to just print the information with "
-            "submitting it instead, add the word 'print' as the final argument.");
+            "to submit your registration to the smart contract.  If you would prefer to just print "
+            "the information instead of submitting it, append the word 'print' to the command.");
 
     m_command_lookup.set_handler(
             "print_sn",

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -248,10 +248,7 @@ class rpc_command_executor final {
 
     bool prepare_registration(bool force_registration = false);
 
-    bool prepare_eth_registration(
-            std::string_view operator_address,
-            std::string_view contract_address,
-            bool print = false);
+    bool prepare_eth_registration(std::string_view operator_address, bool print = false);
 
     bool print_sn(const std::vector<std::string>& args, bool self = false);
 


### PR DESCRIPTION
This extra address is no longer used (and wasn't really usable anyway because there can't be a contribution contract until after you run this command).

The POP now always signs the operator address, and so this drops the extra address both from the command, and from submission to the staking website.

("Ignore whitespace" highly recommended for reviewing this one)