### PR TITLE
HF20 for testnet

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -142,6 +142,7 @@ static constexpr std::array testnet_hard_forks = {
         hard_fork{hf::hf19_reward_batching, 1, 254, 1653632397},     // 2022-05-27T06:19:57.000Z UTC
         hard_fork{hf::hf19_reward_batching, 2, 62885, 1661205699},   // 2022-08-22T22:01:39.000Z UTC
         hard_fork{hf::hf19_reward_batching, 3, 161000, 1673385120},  // 2023-01-10T21:12:00.000Z UTC
+        hard_fork{hf::hf20_eth_transition, 0, 629500, 1729215000},   // 2024-10-17T01:30:00.000Z UTC
 };
 
 static constexpr std::array devnet_hard_forks = {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -451,6 +451,9 @@ void validate_registration(
         uint64_t staking_requirement,
         uint64_t block_timestamp,
         const registration_details& reg) {
+    if (hf_version == feature::ETH_TRANSITION)
+        throw invalid_registration{
+                "New registrations are disabled during OXEN->SENT transition period"};
     if (reg.uses_portions) {
         if (hf_version >= hf::hf19_reward_batching)
             throw invalid_registration{"Portion-based registrations are not permitted in HF19+"};

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2344,7 +2344,16 @@ bool rpc_command_executor::prepare_registration(bool force_registration) {
     auto& hfinfo = *maybe_hf;
     auto hf_version = hfinfo["version"].get<cryptonote::hf>();
     if (hf_version < hf::hf19_reward_batching) {
-        tools::fail_msg_writer("Error: this command only supports HF19+");
+        tools::fail_msg_writer("Error: this command only supports HF19");
+        return false;
+    } else if (hf_version == cryptonote::feature::ETH_TRANSITION) {
+        tools::fail_msg_writer(
+                "Error: New SN registrations are disabled during OXEN->SENT transition");
+        return false;
+    } else if (hf_version >= cryptonote::feature::ETH_BLS) {
+        tools::fail_msg_writer(
+                "Error: New SN registrations must be initiated via the Session token; did you "
+                "meant to use the prepare_eth_registration command instead?");
         return false;
     }
 


### PR DESCRIPTION
Testnet forked to HF20 last week, running the devnet branch, though only depends on #1744 and #1734 (both separately merged now).

Edit: Also adds a commit that makes disabled OXEN registrations fail with a proper message in HF20+ (which currently applies on testnet, and substantially confused me by letting me prepare a registration and then gave a misleading error message from the wallet when I tried to submit it).