### PR TITLE
Avoid L2 provider requests for SN exit signing

### DIFF
--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -811,10 +811,10 @@ void bls_aggregator::get_exit_liquidation(oxenmq::Message& m, bls_exit_type type
     bool removable = false;
     switch (type) {
         case bls_exit_type::normal: {
-            removable = core.is_node_removable(request.remove_pk);
+            removable = core.blockchain.is_node_removable(request.remove_pk);
         } break;
         case bls_exit_type::liquidate: {
-            removable = core.is_node_liquidatable(request.remove_pk);
+            removable = core.blockchain.is_node_liquidatable(request.remove_pk);
         } break;
     }
 
@@ -904,11 +904,11 @@ bls_exit_liquidation_response bls_aggregator::exit_liquidation_request(
     switch (type) {
         case bls_exit_type::normal: {
             endpoint = OMQ_BLS_EXIT_ENDPOINT;
-            removable = core.is_node_removable(bls_pubkey);
+            removable = core.blockchain.is_node_removable(bls_pubkey);
         } break;
         case bls_exit_type::liquidate: {
             endpoint = OMQ_BLS_LIQUIDATE_ENDPOINT;
-            removable = core.is_node_liquidatable(bls_pubkey);
+            removable = core.blockchain.is_node_liquidatable(bls_pubkey);
         } break;
     }
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3388,12 +3388,14 @@ bool Blockchain::is_node_removable(const eth::bls_public_key& bls_pubkey, bool l
         return false;
     }
 
-    if (!m_l2_tracker)
+    if (!m_l2_tracker) {
         log::debug(
                 logcat,
                 "No L2 tracker configured; skipping in-contract-but-not-oxend removable check of "
                 "{}",
                 bls_pubkey);
+        return false;
+    }
 
     if (m_l2_tracker->is_in_contract(bls_pubkey).value_or(false)) {
         log::debug(
@@ -3429,7 +3431,7 @@ std::unordered_map<eth::bls_public_key, bool> Blockchain::get_removable_nodes() 
                 logcat,
                 "- {} @ {}:{} is {} (recently {} node @ height {})",
                 blspk,
-                node.public_ip,
+                epee::string_tools::get_ip_string_from_int32(node.public_ip),
                 node.qnet_port,
                 liquidatable ? "removable & liquidatable (since {})"_format(node.liquidation_height)
                              : "removable",

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -57,6 +57,7 @@
 #include "common/threadpool.h"
 #include "common/varint.h"
 #include "crypto/crypto.h"
+#include "crypto/eth.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
@@ -3312,118 +3313,201 @@ void Blockchain::flush_invalid_blocks() {
     std::unique_lock lock{*this};
     m_invalid_blocks.clear();
 }
-//------------------------------------------------------------------
-std::vector<eth::bls_public_key> Blockchain::get_removable_nodes() const {
-    assert(m_l2_tracker);
 
-    // TODO: Just calculate an acceleration structure on block receive.
-    std::vector<eth::bls_public_key> bls_pubkeys_in_snl;
-    std::vector<eth::bls_public_key> bls_pubkeys_in_smart_contract;
-    {
-        // NOTE: Extract all the service nodes from the Oxen work-chain _excluding_ those that have
-        // been recently removed (e.g. voluntarily exited or dereg by protocol). Recently removed
-        // nodes on the Oxen side need to be removed from the smart contract side and this and can
-        // be done by aggregating a signature (or without if the wait time has elapsed) from the
-        // network to be removed from the smart contract (which gets re-witnessed by Oxen thereby
-        // removing it from the 'recently_removed_nodes' list).
-        auto sns = service_node_list.get_service_node_list_state();
-        bls_pubkeys_in_snl.reserve(sns.size());
-        for (const auto& sni : sns)
-            bls_pubkeys_in_snl.push_back(sni.info->bls_public_key);
+bool Blockchain::is_node_removable(const eth::bls_public_key& bls_pubkey, bool liquidatable) const {
+    // Case 1: recently removed nodes
+    bool recently_removed = false;
+    uint64_t liquid_height = 0;
+    service_node_list.for_each_recently_removed_node([&](const auto& node) {
+        assert(node.info.bls_public_key &&
+               "Invalid null key got inserted into the recently removed list");
+        if (bls_pubkey == node.info.bls_public_key) {
+            recently_removed = true;
+            liquid_height = node.liquidation_height;
+            return true;
+        }
+        return false;
+    });
 
-        // NOTE: Because of vote confirmations, we have nodes that can exist in the smart contract
-        // but not the service node list for awhile until they get confirmed at which point they get
-        // added to the SNL.
-        //
-        // We assume that these nodes will be added to the SNL. If it does, it will eventually be
-        // removed from this list and show up in the 'get_service_node_list_state()' branch above.
-        //
-        // If the node gets denied, it will be removed from this list and never added to the SNL.
-        service_node_list.for_each_pending_l2_state(
-                [&bls_pubkeys_in_snl]<typename Event>(
-                        const Event& e,
-                        const service_nodes::service_node_list::unconfirmed_l2_tx&) {
-                    if constexpr (std::is_same_v<Event, eth::event::NewServiceNodeV2>) {
-                        bls_pubkeys_in_snl.push_back(e.bls_pubkey);
-                    } else {
-                        static_assert(
-                                std::is_same_v<Event, eth::event::ServiceNodeExitRequest> ||
-                                std::is_same_v<Event, eth::event::ServiceNodeExit> ||
-                                std::is_same_v<Event, eth::event::StakingRequirementUpdated> ||
-                                std::is_same_v<Event, eth::event::ServiceNodePurge>);
-                    }
-                });
+    if (recently_removed) {
+        if (liquidatable) {
+            bool is_liq = get_current_blockchain_height() >= liquid_height;
+            log::debug(
+                    logcat,
+                    "{} is removable {} liquidatable: recently removed node with liq. height {}",
+                    bls_pubkey,
+                    is_liq ? "and" : "but not",
+                    liquid_height);
+            // The only difference between liquidatable and removable is that a non-liquidatable but
+            // removal node is one that exists in recently removed nodes, and the liquidation height
+            // is not yet reached.  (If we didn't find it in recently_removed, then removable and
+            // liquidatable status are the same and so we don't have to worry about liquidatable
+            // below this).
+            return is_liq;
+        }
 
-        // NOTE: Extract all service nodes from the smart contract
-        eth::RewardsContract::ServiceNodeIDs smart_contract_ids =
-                m_l2_tracker->get_all_service_node_ids(std::nullopt);
-        if (!smart_contract_ids.success)
-            throw oxen::traced<std::runtime_error>(
-                    "Querying of service node IDs from smart contract failed");
-        bls_pubkeys_in_smart_contract = std::move(smart_contract_ids.bls_pubkeys);
+        log::debug(logcat, "{} is a removable, recently removed node", bls_pubkey);
+        return true;
     }
 
-    // NOTE: Ensure lists are sorted as required for 'set_difference'
-    std::sort(bls_pubkeys_in_snl.begin(), bls_pubkeys_in_snl.end());
-    std::sort(bls_pubkeys_in_smart_contract.begin(), bls_pubkeys_in_smart_contract.end());
-
-    // NOTE: Find BLS keys that are in the smart contract but not in the Oxen SNL.
-    std::vector<eth::bls_public_key> result;
-    std::set_difference(
-            bls_pubkeys_in_smart_contract.begin(),
-            bls_pubkeys_in_smart_contract.end(),
-            bls_pubkeys_in_snl.begin(),
-            bls_pubkeys_in_snl.end(),
-            std::back_inserter(result));
-
-    // NOTE: Print the reason that each node in the list is removable for
-    fmt::memory_buffer buffer;
-    fmt::format_to(std::back_inserter(buffer), "Found {} nodes that are removable", result.size());
-    if (oxen::log::get_level(logcat) <= oxen::log::Level::debug) {
-        if (result.size())
-            fmt::format_to(std::back_inserter(buffer), "\n");
-
-        for (size_t index = 0; index < result.size(); index++) {
-            if (index)
-                fmt::format_to(std::back_inserter(buffer), "\n");
-
-            // NOTE: Determine if the node was unlocked/deregistered or only exists in the contract
-            const eth::bls_public_key& it = result[index];
-            bool protocol_dereg = false;
-            std::optional<uint64_t> unlock_or_dereg_height = {};
-            uint32_t ip = 0;
-            uint16_t port = 0;
-            service_node_list.for_each_recently_removed_node([&](const auto& node) {
-                if (it != node.info.bls_public_key)
+    bool pending_reg = false;
+    service_node_list.for_each_pending_l2_state(
+            [&]<typename Event>(const Event& e, const auto& /*vote_info*/) {
+                if constexpr (std::is_same_v<Event, eth::event::NewServiceNodeV2>) {
+                    if (e.bls_pubkey == bls_pubkey) {
+                        pending_reg = true;
+                        return true;
+                    }
                     return false;
-                protocol_dereg =
-                        node.type ==
-                        service_nodes::service_node_list::recently_removed_node::type_t::deregister;
-                unlock_or_dereg_height = node.height;
-                ip = node.public_ip;
-                port = node.qnet_port;
-                return true;
+                } else {
+                    static_assert(
+                            std::is_same_v<Event, eth::event::ServiceNodeExitRequest> ||
+                            std::is_same_v<Event, eth::event::ServiceNodeExit> ||
+                            std::is_same_v<Event, eth::event::StakingRequirementUpdated> ||
+                            std::is_same_v<Event, eth::event::ServiceNodePurge>);
+                }
             });
 
-            // NOTE: Generate a reason string
-            std::string removable_reason;
-            if (unlock_or_dereg_height) {
-                removable_reason = "node {}; height {} {}:{}"_format(
-                        protocol_dereg ? "dereg" : "expired",
-                        *unlock_or_dereg_height,
-                        epee::string_tools::get_ip_string_from_int32(ip),
-                        port);
-            } else {
-                removable_reason = "node exists only in contract";
-            }
-
-            fmt::format_to(
-                    std::back_inserter(buffer), " {:04d} {} ({})", index, it, removable_reason);
-        }
+    // Incoming, unconfirmed registrations are not removable:
+    if (pending_reg) {
+        log::debug(
+                logcat,
+                "{} is not removable: found a pending but unconfirmed new service node event with "
+                "that BLS pubkey",
+                bls_pubkey);
+        return false;
     }
 
-    std::string log = fmt::to_string(buffer);
-    oxen::log::debug(logcat, "{}", fmt::to_string(buffer));
+    // Case 2: not in the registered SN list, recently removed, or incoming unconfirmed, but *is* in
+    // the contract: this is both removable and liquidatable.
+    if (service_node_list.find_public_key_registered(bls_pubkey)) {
+        log::debug(
+                logcat,
+                "{} is not removable: pubkey belongs to a registered service node",
+                bls_pubkey);
+        return false;
+    }
+
+    if (!m_l2_tracker)
+        log::debug(
+                logcat,
+                "No L2 tracker configured; skipping in-contract-but-not-oxend removable check of "
+                "{}",
+                bls_pubkey);
+
+    if (m_l2_tracker->is_in_contract(bls_pubkey).value_or(false)) {
+        log::debug(
+                logcat, "{} is removable: found in contract but not in oxend SN list", bls_pubkey);
+        return true;
+    }
+
+    log::debug(
+            logcat,
+            "{} is not removable: BLS pubkey is neither registered, nor found in L2 contract",
+            bls_pubkey);
+    return false;
+}
+
+std::unordered_map<eth::bls_public_key, bool> Blockchain::get_removable_nodes() const {
+    std::unordered_map<eth::bls_public_key, bool> result;
+
+    const uint64_t height = get_current_blockchain_height();
+
+    log::debug(logcat, "Looking for removable nodes @ height {}", height);
+
+    // Case 1: recently removed nodes
+    size_t liq_count = 0;
+    service_node_list.for_each_recently_removed_node([&](const auto& node) {
+        assert(node.info.bls_public_key &&
+               "Invalid null key got inserted into the recently removed list");
+        const auto& blspk = node.info.bls_public_key;
+        bool liquidatable = height >= node.liquidation_height;
+        result.emplace(blspk, liquidatable);
+        if (liquidatable)
+            ++liq_count;
+        log::trace(
+                logcat,
+                "- {} @ {}:{} is {} (recently {} node @ height {})",
+                blspk,
+                node.public_ip,
+                node.qnet_port,
+                liquidatable ? "removable & liquidatable (since {})"_format(node.liquidation_height)
+                             : "removable",
+                node.type == service_nodes::service_node_list::recently_removed_node::type_t::
+                                        deregister
+                        ? "dereg"
+                        : "expired",
+                node.height);
+    });
+
+    log::debug(
+            logcat,
+            "Found {} removable ({} liquidatable) recently removed nodes",
+            result.size(),
+            liq_count);
+
+    if (!m_l2_tracker)
+        return result;
+
+    // Case 2: missing-from-oxend SN list pubkeys
+    auto contract_extra = m_l2_tracker->all_contract_pubkeys();
+
+    const auto n_contract = contract_extra.size();
+
+    // Remove anything we found via recently removed nodes:
+    for (const auto& [blspk, _liq] : result)
+        contract_extra.erase(blspk);
+
+    // Remove registered service nodes:
+    service_node_list.for_each_service_node([&](const auto& /*snpk*/, const auto& sni) {
+        contract_extra.erase(sni.bls_public_key);
+    });
+
+    const auto n_post_reg = contract_extra.size();
+
+    // Remove unconfirmed, incoming new service nodes:
+    service_node_list.for_each_pending_l2_state(
+            [&]<typename Event>(const Event& e, const auto& /*vote_info*/) {
+                if constexpr (std::is_same_v<Event, eth::event::NewServiceNodeV2>) {
+                    contract_extra.erase(e.bls_pubkey);
+                } else {
+                    static_assert(
+                            std::is_same_v<Event, eth::event::ServiceNodeExitRequest> ||
+                            std::is_same_v<Event, eth::event::ServiceNodeExit> ||
+                            std::is_same_v<Event, eth::event::StakingRequirementUpdated> ||
+                            std::is_same_v<Event, eth::event::ServiceNodePurge>);
+                }
+            });
+
+    // Everything left is something we don't have or a recently removed node; we emplace here with
+    // true (for liquidatable), but rely on emplace failing in the case of a recently removed nodes
+    // we already recorded (so that we don't flip a non-liquidatable node's value to true).
+    for (const auto& blspk : contract_extra)
+        if (result.emplace(blspk, true).second /*inserted*/)
+            ++liq_count;
+
+    const auto n_post_unconf = contract_extra.size();
+
+    log::debug(
+            logcat,
+            "Found {}/{} removable contract nodes: {} registered or recent, {} unconfirmed "
+            "registrations",
+            n_post_unconf,
+            n_contract,
+            n_post_reg - n_contract,
+            n_post_unconf - n_post_reg);
+    log::debug(
+            logcat, "Total removable node count: {} ({} liquidatable)", result.size(), liq_count);
+
+#ifndef NDEBUG
+    for (const auto& extra : contract_extra)
+        log::trace(
+                logcat,
+                "- {} is removable (found in contract but not found in "
+                "registered/recent/unconfirmed  registrations)",
+                extra);
+#endif
+
     return result;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1203,33 +1203,6 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
     quorumnet_init(*this, m_quorumnet_state);
 }
 
-bool core::is_node_removable(const eth::bls_public_key& node_bls_pubkey) {
-    auto removable_nodes = blockchain.get_removable_nodes();
-    return std::find(removable_nodes.begin(), removable_nodes.end(), node_bls_pubkey) !=
-           removable_nodes.end();
-}
-
-bool core::is_node_liquidatable(const eth::bls_public_key& node_bls_pubkey) {
-    if (!is_node_removable(node_bls_pubkey))
-        return false;
-
-    // NOTE: Node exists in the smart contract but not the oxen service node
-    // list, it's been deregistered from _OR_ it voluntarily exited the SNL.
-    uint64_t height = blockchain.get_current_blockchain_height();
-    bool result = false;
-    service_node_list.for_each_recently_removed_node([&](const auto& node) {
-        assert(node.info.bls_public_key &&
-               "Invalid null key got inserted into the recently removed list");
-        if (node.info.bls_public_key == node_bls_pubkey) {
-            result = height >= node.liquidation_height;
-            return true;
-        }
-        return false;
-    });
-
-    return result;
-}
-
 void core::start_oxenmq() {
     update_omq_sns();  // Ensure we have SNs set for the current block before starting
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -599,10 +599,6 @@ class core final {
             const crypto::public_key& pubkey, bool liquidate);
     eth::bls_registration_response bls_registration(const eth::address& ethereum_address) const;
 
-    bool is_node_removable(const eth::bls_public_key& node_bls_pubkey);
-
-    bool is_node_liquidatable(const eth::bls_public_key& node_bls_pubkey);
-
     /**
      * @brief Add a service node vote
      *

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -814,14 +814,21 @@ std::vector<uint64_t> L2Tracker::get_non_signers(
     return rewards_contract.get_non_signers(bls_public_keys);
 }
 
-std::vector<bls_public_key> L2Tracker::get_all_bls_public_keys(uint64_t blockNumber) {
-    return rewards_contract.get_all_bls_pubkeys(blockNumber);
-}
-
 RewardsContract::ServiceNodeIDs L2Tracker::get_all_service_node_ids(
         std::optional<uint64_t> height) {
-    RewardsContract::ServiceNodeIDs result = rewards_contract.all_service_node_ids(height);
-    return result;
+    return rewards_contract.all_service_node_ids(height);
+}
+
+std::optional<bool> L2Tracker::is_in_contract(const eth::bls_public_key& pubkey) const {
+    std::shared_lock lock{mutex};
+    if (in_contract.empty())
+        return std::nullopt;
+    return in_contract.count(pubkey);
+}
+
+std::unordered_set<eth::bls_public_key> L2Tracker::all_contract_pubkeys() const {
+    std::shared_lock lock{mutex};
+    return in_contract;
 }
 
 bool L2Tracker::get_vote_for(const event::NewServiceNodeV2& reg) const {

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -79,8 +79,8 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = 70s / L2_BLOCK_TIME,
         // This relatively infrequent check is only for handling highly unusual cleanup cases where
         // a L2 disruption or bug between the contract and oxend results in oxend service nodes
-        // state having nodes that *don't* exist in the contract for some reason.
-        .L2_NODE_LIST_PURGE_BLOCKS = 2h / L2_BLOCK_TIME,
+        // state having nodes that *don't* exist in the contract (or vice versa) for some reason.
+        .L2_NODE_LIST_PURGE_BLOCKS = 1h / L2_BLOCK_TIME,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = 24h / TARGET_BLOCK_TIME,
 };
 }  // namespace cryptonote::config::mainnet

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -39,6 +39,7 @@
 #include "common/json_binary_proxy.h"
 #include "core_rpc_server_binary_commands.h"
 #include "core_rpc_server_commands_defs.h"
+#include "crypto/eth.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 #include "p2p/net_node.h"
@@ -232,7 +233,8 @@ class core_rpc_server {
             bool is_bt,
             const std::unordered_set<std::string>& requested,
             const service_nodes::service_node_pubkey_info& sn_info,
-            uint64_t top_height);
+            uint64_t top_height,
+            const std::unordered_map<eth::bls_public_key, bool>* removable);
 
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>>& m_p2p;


### PR DESCRIPTION
This replaces the handling for determining if a node is removable to avoid needing to go to the L2 tracker, and thus eliminate a potential L2 provider credit exhaustion attack where a malicious entity could request signatures over and over to make a service node exhaust its available L2 provider request credits.  This instead now uses a combination of the recently_removed_nodes list and the infrequently-updated purge list (that was added for removing not-in-contract nodes) to handle the removability determination without needing any L2 requests other than the ones already being done to maintain chain state.

This change slightly alters the definition of what we consider "removable":

- recently_removed_nodes are now instantly considered removable.

- nodes in the contract and not in oxend are considered removable, but with a lag because we now use the cached service node list collected for node purging (which is updated only once an hour or so).

This avoids any need for an L2 request when signing; "normal" signatures will be for the first case, and won't incur any delay.  The second case is mainly of a fallback for abnormal handling (for instance: a registration accepted by the smart contract that oxend rejected for some reason), where an hour or more of delay doesn't meaningfully matter.

Other related changes made here:

- shorten the mainnet purge list interval to 1h instead of 2h as it now makes sense to be moderately more up-to-date now that it's also used for missing nodes in both directions instead of just contract-missing nodes.

- for_each_pending_l2_state now allows a bool lambda to return true to short-circuit the iteration (similar to how some other for_each_... work).

- Remove unused `get_all_bls_public_keys` method; it seems everything that might have used it is using `get_all_service_node_ids` instead.

- Added a more efficient, singleton "is removable" method that doesn't need to produce to full removable list for the common case of a check for a single removable node (as is common for signing requests to SNs).

- Make get_removable_nodes return an unordered_map<pubkey, bool> instead of a vector as it simplifies both implementation and common uses (the key presence indicates removability, the bool indicates liquidatable).

- Consolidate is-removable/liquidatable functions into blockchain (removing from cryptonote_core).

- Re-enable is_removable/is_liquidatable fields in get_service_nodes rpc response.