### PR TITLE
Asychronous RPC requests

### DIFF
--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -168,13 +168,12 @@ namespace {
     // This method only does something if debug logging is enabled (and this is a debug build), and
     // runs/logs asynchronously (once the L2 request comes back).
     void debug_redo_bls_aggregation_steps_locally(
-            cryptonote::core& core, std::unordered_map<bls_public_key, bls_signature> signatures) {
+            cryptonote::core& core,
+            const std::unordered_map<bls_public_key, bls_signature>& signatures) {
 
         if (log::get_level(logcat) <= log::Level::debug)
             core.l2_tracker().get_all_service_node_ids(
-                    std::nullopt,
-                    [&core, signatures = std::move(signatures)](
-                            std::optional<ServiceNodeIDs> maybe_snids) {
+                    std::nullopt, [&core, signatures](std::optional<ServiceNodeIDs> maybe_snids) {
                         if (!maybe_snids) {
                             log::warning(
                                     logcat,

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2640,15 +2640,21 @@ uint64_t core::get_free_space() const {
     return fs::space(m_config_folder).available;
 }
 //-----------------------------------------------------------------------------------------------
-eth::bls_rewards_response core::bls_rewards_request(const eth::address& address, uint64_t height) {
-    return m_bls_aggregator->rewards_request(address, height);
+void core::bls_rewards_request(
+        const eth::address& address,
+        uint64_t height,
+        std::function<void(const eth::bls_rewards_response&)> callback) {
+    m_bls_aggregator->rewards_request(address, height, std::move(callback));
 }
 //-----------------------------------------------------------------------------------------------
-eth::bls_exit_liquidation_response core::bls_exit_liquidation_request(
-        const crypto::public_key& pubkey, bool liquidate) {
-    eth::bls_exit_type type =
-            liquidate ? eth::bls_exit_type::liquidate : eth::bls_exit_type::normal;
-    return m_bls_aggregator->exit_liquidation_request(pubkey, type);
+void core::bls_exit_liquidation_request(
+        const std::variant<crypto::public_key, eth::bls_public_key>& pubkey,
+        bool liquidate,
+        std::function<void(const eth::bls_exit_liquidation_response&)> callback) {
+    m_bls_aggregator->exit_liquidation_request(
+            pubkey,
+            liquidate ? eth::bls_exit_type::liquidate : eth::bls_exit_type::normal,
+            std::move(callback));
 }
 //-----------------------------------------------------------------------------------------------
 eth::bls_registration_response core::bls_registration(const eth::address& address) const {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -31,6 +31,7 @@
 #include "common/command_line.h"
 #include "common/exception.h"
 #include "crypto/crypto.h"
+#include "crypto/eth.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/connection_context.h"
 #include "cryptonote_basic/hardfork.h"
@@ -594,9 +595,20 @@ class core final {
      */
     bool offline() const { return m_offline; }
 
-    eth::bls_rewards_response bls_rewards_request(const eth::address& address, uint64_t height);
-    eth::bls_exit_liquidation_response bls_exit_liquidation_request(
-            const crypto::public_key& pubkey, bool liquidate);
+    // Initiates an asynchronous rewards signing request to the network's nodes and returns
+    // immediately.  `callback` gets invoked once the requests are finished.
+    void bls_rewards_request(
+            const eth::address& address,
+            uint64_t height,
+            std::function<void(const eth::bls_rewards_response&)> callback);
+
+    // Initiates an asynchronous exit or liquidation signing request to the network's nodes and
+    // returns immediately.  `callback` gets invoked once the requests are finished.
+    void bls_exit_liquidation_request(
+            const std::variant<crypto::public_key, eth::bls_public_key>& pubkey,
+            bool liquidate,
+            std::function<void(const eth::bls_exit_liquidation_response&)> callback);
+
     eth::bls_registration_response bls_registration(const eth::address& ethereum_address) const;
 
     /**

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -809,14 +809,16 @@ uint64_t L2Tracker::get_safe_height() const {
                  : latest_height - config.L2_TRACKER_SAFE_BLOCKS;
 }
 
-std::vector<uint64_t> L2Tracker::get_non_signers(
-        const std::unordered_set<bls_public_key>& bls_public_keys) {
-    return rewards_contract.get_non_signers(bls_public_keys);
+void L2Tracker::get_non_signers(
+        std::unordered_set<bls_public_key> bls_public_keys,
+        std::function<void(std::optional<NonSigners>)> callback) {
+    rewards_contract.get_non_signers(std::move(bls_public_keys), std::move(callback));
 }
 
-RewardsContract::ServiceNodeIDs L2Tracker::get_all_service_node_ids(
-        std::optional<uint64_t> height) {
-    return rewards_contract.all_service_node_ids(height);
+void L2Tracker::get_all_service_node_ids(
+        std::optional<uint64_t> height,
+        std::function<void(std::optional<ServiceNodeIDs>)> callback) {
+    rewards_contract.all_service_node_ids(height, std::move(callback));
 }
 
 std::optional<bool> L2Tracker::is_in_contract(const eth::bls_public_key& pubkey) const {

--- a/src/l2_tracker/rewards_contract.h
+++ b/src/l2_tracker/rewards_contract.h
@@ -5,6 +5,7 @@
 #include <cryptonote_config.h>
 #include <oxen_economy.h>  // oxen::MAX_CONTRIBUTORS_HF19
 
+#include <functional>
 #include <string>
 #include <unordered_set>
 
@@ -35,6 +36,17 @@ struct ContractServiceNode {
     size_t contributorsSize;
 };
 
+struct NonSigners {
+    // List of non-signer contract IDs to submit with the contract
+    std::vector<uint64_t> missing_ids;
+
+    // List of provided BLS pubkeys that are *not* in the contract and so should be removed
+    // before submitting to the contract.
+    std::unordered_set<bls_public_key> unwanted;
+};
+
+using ServiceNodeIDs = std::vector<std::pair<uint64_t, bls_public_key>>;
+
 class RewardsContract {
   public:
     // Constructor
@@ -42,25 +54,24 @@ class RewardsContract {
 
     std::string_view address() const { return contract_address; }
 
-    ContractServiceNode service_nodes(
-            uint64_t index, std::optional<uint64_t> block_number = std::nullopt);
-    std::vector<uint64_t> get_non_signers(
-            const std::unordered_set<bls_public_key>& bls_public_keys);
+    // Initiates a L2 request for all current service nodes and, when the request completes, fires
+    // the callback with two vectors: the first is the contract ID of any contract nodes not present
+    // in `bls_public_keys` (i.e. missing signatures) to be submitted as part of the contract call;
+    // the second is the set of input pubkeys that were not found in the contract (i.e. proposed
+    // signers that shouldn't be signers at all) that should be removed from the aggregate signature
+    // before submission to the contract.
+    void get_non_signers(
+            std::unordered_set<bls_public_key> bls_public_keys,
+            std::function<void(std::optional<NonSigners>)> callback);
 
-    std::vector<bls_public_key> get_all_bls_pubkeys(uint64_t block_number);
-
-    struct ServiceNodeIDs {
-        bool success;
-        std::vector<uint64_t> ids;
-        std::vector<bls_public_key> bls_pubkeys;
-    };
-
-    static std::vector<std::pair<uint64_t, bls_public_key>> parse_all_service_node_ids(
-            std::string_view call_result_hex);
+    static ServiceNodeIDs parse_all_service_node_ids(std::string_view call_result_hex);
 
     // Executes `allServiceNodeIDs` on the smart contract and retrieve all the BLS public keys and
-    // the ID allocated for each key in the contract
-    ServiceNodeIDs all_service_node_ids(std::optional<uint64_t> block_number = std::nullopt);
+    // the ID allocated for each key in the contract.  Asynchronous; invokes the given callback when
+    // the result completes (or with nullopt on error).
+    void all_service_node_ids(
+            std::optional<uint64_t> block_number,
+            std::function<void(std::optional<ServiceNodeIDs>)> callback);
 
   private:
     std::string contract_address;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2606,6 +2606,7 @@ void set_contract_signature(
                     response_hex["signature"] = sig.signature;
                 }
                 response["non_signer_indices"] = std::move(non_signers->missing_ids);
+                success_cb();
             });
 }
 

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "common/exception.h"
+#include "crypto/eth.h"
 #include "rpc/common/param_parser.hpp"
 
 namespace cryptonote::rpc {
@@ -104,7 +105,7 @@ void parse_request(GET_TRANSACTION_POOL_STATS& pstats, rpc_input in) {
 void parse_request(HARD_FORK_INFO& hfinfo, rpc_input in) {
     get_values(in, "height", hfinfo.request.height, "version", hfinfo.request.version);
     if (hfinfo.request.height && hfinfo.request.version)
-        throw oxen::traced<std::runtime_error>{
+        throw std::invalid_argument{
                 "Error: at most one of 'height'" + std::to_string(hfinfo.request.height) + "/" +
                 std::to_string(hfinfo.request.version) + " and 'version' may be specified"};
 }
@@ -133,15 +134,14 @@ void parse_request(GET_TRANSACTIONS& get, rpc_input in) {
             get.request.tx_hashes);
 
     if (get.request.memory_pool && !get.request.tx_hashes.empty())
-        throw oxen::traced<std::runtime_error>{
-                "Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
+        throw std::invalid_argument{"Error: 'memory_pool' and 'tx_hashes' are mutually exclusive"};
 }
 void parse_request(GET_TRANSACTION_POOL& get, rpc_input in) {
     // Deprecated wrapper; GET_TRANSACTION_POOL is a no-member subclass of GET_TRANSACTIONS; it
     // works identically, except that we force `memory_pool` to true.
     parse_request(static_cast<GET_TRANSACTIONS&>(get), std::move(in));
     if (!get.request.tx_hashes.empty())
-        throw oxen::traced<std::runtime_error>{
+        throw std::invalid_argument{
                 "Error: 'get_transaction_pool' does not support specifying 'tx_hashes'"};
     get.request.memory_pool = true;
 }
@@ -150,9 +150,9 @@ void parse_request(SET_LIMIT& limit, rpc_input in) {
     get_values(in, "limit_down", limit.request.limit_down, "limit_up", limit.request.limit_up);
 
     if (limit.request.limit_down < -1)
-        throw oxen::traced<std::domain_error>{"limit_down must be >= -1"};
+        throw std::domain_error{"limit_down must be >= -1"};
     if (limit.request.limit_down < -1)
-        throw oxen::traced<std::domain_error>{"limit_up must be >= -1"};
+        throw std::domain_error{"limit_up must be >= -1"};
 }
 
 void parse_request(IS_KEY_IMAGE_SPENT& spent, rpc_input in) {
@@ -169,7 +169,7 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
 
     if (tx_data.empty())  // required above will make sure it's specified, but doesn't guarantee
                           // against an empty value
-        throw oxen::traced<std::domain_error>{"Invalid 'tx' value: cannot be empty"};
+        throw std::domain_error{"Invalid 'tx' value: cannot be empty"};
 
     // tx can be specified as base64, hex, or binary, so try to figure out which one we have by
     // looking at the beginning.
@@ -211,14 +211,14 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
     }
 
     if (!good)
-        throw oxen::traced<std::domain_error>{"Invalid 'tx' value: expected hex, base64, or bytes"};
+        throw std::domain_error{"Invalid 'tx' value: expected hex, base64, or bytes"};
 }
 
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in) {
     get_values(in, "heights", bh.request.heights);
 
     if (bh.request.heights.size() > bh.MAX_HEIGHTS)
-        throw oxen::traced<std::domain_error>{"Error: too many block heights requested at once"};
+        throw std::domain_error{"Error: too many block heights requested at once"};
 }
 
 void parse_request(GET_PEER_LIST& pl, rpc_input in) {
@@ -449,7 +449,7 @@ void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {
         if (*qs.request.quorum_type == 255)  // backwards-compat magic value
             qs.request.quorum_type = std::nullopt;
         else if (*qs.request.quorum_type > tools::enum_count<service_nodes::quorum_type>)
-            throw oxen::traced<std::domain_error>{
+            throw std::domain_error{
                     "Quorum type specifies an invalid value: "_format(*qs.request.quorum_type)};
     }
 }
@@ -493,12 +493,26 @@ void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in) {
 }
 
 void parse_request(BLS_EXIT_LIQUIDATION_REQUEST& cmd, rpc_input in) {
+    crypto::public_key sn_pubkey{};
+    eth::bls_public_key bls_pubkey{};
+
     get_values(
             in,
+            "bls_pubkey",
+            bls_pubkey,
             "liquidate",
             required{cmd.request.liquidate},
             "pubkey",
-            required{cmd.request.pubkey});
+            sn_pubkey);
+
+    if (!bls_pubkey && !sn_pubkey)
+        throw std::invalid_argument{"Error: Exactly one of bls_pubkey or pubkey must be specified"};
+    if (bls_pubkey && sn_pubkey)
+        throw std::invalid_argument{"Error: only one of bls_pubkey or pubkey may be specified"};
+    if (bls_pubkey)
+        cmd.request.pubkey = bls_pubkey;
+    else
+        cmd.request.pubkey = sn_pubkey;
 }
 
 void parse_request(BLS_REGISTRATION_REQUEST& cmd, rpc_input in) {

--- a/src/rpc/core_rpc_server_error_codes.h
+++ b/src/rpc/core_rpc_server_error_codes.h
@@ -39,6 +39,6 @@ constexpr int16_t ERROR_WRONG_PARAM = -1, ERROR_TOO_BIG_HEIGHT = -2,
                   ERROR_INTERNAL = -5, ERROR_WRONG_BLOCKBLOB = -6, ERROR_BLOCK_NOT_ACCEPTED = -7,
                   ERROR_CORE_BUSY = -9, ERROR_WRONG_BLOCKBLOB_SIZE = -10,
                   ERROR_UNSUPPORTED_RPC = -11, ERROR_MINING_TO_SUBADDRESS = -12,
-                  ERROR_REGTEST_REQUIRED = -13, ERROR_BLS_SIG = -14;
+                  ERROR_REGTEST_REQUIRED = -13, ERROR_BLS_SIG = -14, ERROR_NO_L2_TRACKER = -15;
 
 }  // namespace cryptonote::rpc


### PR DESCRIPTION
This adds a generic interface for making asychronous RPC request
handlers, and applies these to the reward and exit signature endpoints.

The RPC interface adds an alternative the `invoke(...)` method to
optionally take a new, third argument of a `shared_ptr<response>`: when
such a version of the invoke method is present then response is not send
until the destruction of the shared_ptr, and so an asychronous request
uses these, keeps the shared_ptr alive until the response is available,
then lets it destruct which then triggers the response.

This then pushes the async approach through the reward and exit
signature requests, and gets everything working through asychronous
callbacks rather than blocking requests.

This also makes some small changes to signature handling:

- Allow exit/liquidation RPC requests to be made by either SN pubkey (as
  currently) or BLS pubkey (new).

- Allow liquidation of oxend-non-existent BLS pubkeys (i.e. liquidating
  a BLS pubkey that doesn't match any SNs oxen knows of); without this
  it isn't possible to remove a "bad" contract node that oxend didn't
  accept the registration of for whatever reason.

- Add code to remove unwanted node extra signatures from produced
  signatures.  Previously our concept of "non-signers" only included IDs
  to pass to the contract, but there is also a reverse failure were we
  collect a signature from a SN that isn't in the contract anymore (for
  example: a recently removed node with an incoming, but unconfirmed,
  exit event). This amends the signing code to detect any such signers
  and subtract the signatures of any such SNs from the aggregate before
  returning it.

- Removes the walk-the-snode-linked-list contract handling code as it is
  not used anymore.