### PR TITLE
Optimize signature aggregation

### DIFF
--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -18,7 +18,8 @@ namespace eth {
 struct bls_aggregate_signed {
     std::vector<uint8_t> msg_to_sign;
     std::unordered_map<bls_public_key, bls_signature> signatures;  // Individual signatures
-    bls_signature signature;  // Aggregate of all the signatures in `signatures`
+    bls_public_key aggregate_pubkey;  // Aggregate pubkey of the pubkeys in `signatures`
+    bls_signature signature;          // Aggregate of all the signatures in `signatures`
 };
 
 enum class bls_exit_type {

--- a/src/bls/bls_aggregator.h
+++ b/src/bls/bls_aggregator.h
@@ -73,7 +73,7 @@ class bls_aggregator {
     void rewards_request(
             const address& addr,
             uint64_t height,
-            std::function<void(const bls_rewards_response&)> callback);
+            std::function<void(std::shared_ptr<const bls_rewards_response>)> callback);
 
     // Request the service node network to sign a request to remove the node specified by `pubkey`
     // (either SN pubkey or BLS pubkey) from the network. The nature of this exit is set by `type`.
@@ -90,7 +90,7 @@ class bls_aggregator {
     void exit_liquidation_request(
             const std::variant<crypto::public_key, eth::bls_public_key>& pubkey,
             bls_exit_type type,
-            std::function<void(const bls_exit_liquidation_response&)> callback);
+            std::function<void(std::shared_ptr<const bls_exit_liquidation_response>)> callback);
 
     bls_registration_response registration(
             const address& sender, const crypto::public_key& sn_pubkey) const;
@@ -132,10 +132,10 @@ class bls_aggregator {
     std::mutex exit_liquidation_response_cache_mutex;
 
     // Cache the aggregate signature response for updating rewards to avoid requerying the network
-    std::unordered_map<address, bls_rewards_response> rewards_response_cache;
+    std::unordered_map<address, std::shared_ptr<bls_rewards_response>> rewards_response_cache;
 
     // The cache for exits and liquidation signature aggregations. See `rewards_response_cache`
-    std::unordered_map<bls_public_key, bls_exit_liquidation_response>
+    std::unordered_map<bls_public_key, std::shared_ptr<bls_exit_liquidation_response>>
             exit_liquidation_response_cache;
 };
 }  // namespace eth

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2643,14 +2643,14 @@ uint64_t core::get_free_space() const {
 void core::bls_rewards_request(
         const eth::address& address,
         uint64_t height,
-        std::function<void(const eth::bls_rewards_response&)> callback) {
+        std::function<void(std::shared_ptr<const eth::bls_rewards_response>)> callback) {
     m_bls_aggregator->rewards_request(address, height, std::move(callback));
 }
 //-----------------------------------------------------------------------------------------------
 void core::bls_exit_liquidation_request(
         const std::variant<crypto::public_key, eth::bls_public_key>& pubkey,
         bool liquidate,
-        std::function<void(const eth::bls_exit_liquidation_response&)> callback) {
+        std::function<void(std::shared_ptr<const eth::bls_exit_liquidation_response>)> callback) {
     m_bls_aggregator->exit_liquidation_request(
             pubkey,
             liquidate ? eth::bls_exit_type::liquidate : eth::bls_exit_type::normal,

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -600,14 +600,15 @@ class core final {
     void bls_rewards_request(
             const eth::address& address,
             uint64_t height,
-            std::function<void(const eth::bls_rewards_response&)> callback);
+            std::function<void(std::shared_ptr<const eth::bls_rewards_response>)> callback);
 
     // Initiates an asynchronous exit or liquidation signing request to the network's nodes and
     // returns immediately.  `callback` gets invoked once the requests are finished.
     void bls_exit_liquidation_request(
             const std::variant<crypto::public_key, eth::bls_public_key>& pubkey,
             bool liquidate,
-            std::function<void(const eth::bls_exit_liquidation_response&)> callback);
+            std::function<void(std::shared_ptr<const eth::bls_exit_liquidation_response>)>
+                    callback);
 
     eth::bls_registration_response bls_registration(const eth::address& ethereum_address) const;
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2571,6 +2571,12 @@ void set_contract_signature(
         std::shared_ptr<responder> responder,
         std::function<void()> success_cb) {
 
+    if (!sig.signature) {
+        responder->error.emplace(
+                ERROR_BLS_SIG, "Failed to obtain a BLS signature from the network");
+        return;
+    }
+
     l2_tracker.get_non_signers(
             std::ranges::views::keys(sig.signatures),
             [&response,
@@ -2595,14 +2601,25 @@ void set_contract_signature(
                             "Found {} unwanted BLS signatures from non-contract pubkeys; "
                             "de-aggregating them",
                             unwanted.size());
-                    eth::signature_aggregator agg;
-                    agg.add(sig.signature);
-                    for (auto& remove_pk : unwanted)
-                        agg.subtract(sig.signatures.at(remove_pk));
-                    auto final_sig = agg.get();
+                    eth::pubkey_aggregator pk_agg;
+                    eth::signature_aggregator sig_agg;
+                    pk_agg.add(sig.aggregate_pubkey);
+                    sig_agg.add(sig.signature);
+                    for (auto& remove_pk : unwanted) {
+                        pk_agg.subtract(remove_pk);
+                        sig_agg.subtract(sig.signatures.at(remove_pk));
+                    }
+                    auto final_pk = pk_agg.get();
+                    auto final_sig = sig_agg.get();
+                    response_hex["aggregate_pubkey"] = final_pk;
                     response_hex["signature"] = final_sig;
-                    log::debug(logcat, "Final BLS signature: {}", final_sig);
+                    log::debug(
+                            logcat,
+                            "Final BLS aggregate pubkey: {}, signature: {}",
+                            final_pk,
+                            final_sig);
                 } else {
+                    response_hex["aggregate_pubkey"] = sig.aggregate_pubkey;
                     response_hex["signature"] = sig.signature;
                 }
                 response["non_signer_indices"] = std::move(non_signers->missing_ids);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2566,10 +2566,11 @@ void core_rpc_server::invoke(
 void set_contract_signature(
         nlohmann::json& response,
         tools::json_binary_proxy& response_hex,
-        const eth::bls_aggregate_signed& sig,
+        std::shared_ptr<const eth::bls_aggregate_signed> sig_ptr,
         eth::L2Tracker& l2_tracker,
         std::shared_ptr<responder> responder,
         std::function<void()> success_cb) {
+    auto& sig = *sig_ptr;
 
     if (!sig.signature) {
         responder->error.emplace(
@@ -2581,7 +2582,7 @@ void set_contract_signature(
             std::ranges::views::keys(sig.signatures),
             [&response,
              &response_hex,
-             &sig,
+             sig_ptr,
              responder = std::move(responder),
              success_cb = std::move(success_cb)](std::optional<eth::NonSigners> non_signers) {
                 if (!non_signers) {
@@ -2591,6 +2592,7 @@ void set_contract_signature(
                 }
 
                 response["status"] = STATUS_OK;
+                auto& sig = *sig_ptr;
                 response_hex["msg_to_sign"] = std::string_view(
                         reinterpret_cast<const char*>(sig.msg_to_sign.data()),
                         sig.msg_to_sign.size());
@@ -2644,14 +2646,15 @@ void core_rpc_server::invoke(
                 rpc.request.address,
                 static_cast<uint64_t>(rpc.request.height),
                 [&rpc, keepalive = std::move(keepalive), &l2 = m_core.l2_tracker()](
-                        const eth::bls_rewards_response& response) mutable {
+                        std::shared_ptr<const eth::bls_rewards_response> response_ptr) mutable {
+                    auto& response = *response_ptr;
                     set_contract_signature(
                             rpc.response,
                             rpc.response_hex,
-                            response,
+                            std::move(response_ptr),
                             l2,
                             std::move(keepalive),
-                            [&rpc, response] {
+                            [&rpc, &response] {
                                 rpc.response["address"] = "{}"_format(response.addr);
                                 rpc.response["amount"] = response.amount;
                                 rpc.response["height"] = response.height;
@@ -2735,14 +2738,16 @@ void core_rpc_server::invoke(
                 rpc.request.pubkey,
                 rpc.request.liquidate,
                 [&rpc, keepalive = std::move(keepalive), &l2 = m_core.l2_tracker()](
-                        const eth::bls_exit_liquidation_response& response) mutable {
+                        std::shared_ptr<const eth::bls_exit_liquidation_response>
+                                response_ptr) mutable {
+                    auto& response = *response_ptr;
                     set_contract_signature(
                             rpc.response,
                             rpc.response_hex,
-                            response,
+                            std::move(response_ptr),
                             l2,
                             std::move(keepalive),
-                            [&rpc, response] {
+                            [&rpc, &response] {
                                 rpc.response["timestamp"] = response.timestamp;
                                 rpc.response_hex["bls_pubkey"] = response.remove_pubkey;
                             });


### PR DESCRIPTION
Currently when an RPC node does a network fanout to get a reward or exit
signature, it verifies each signature as it returns before adding it to
the aggregate.

This ends up being quite slow: on my desktop machine on current
stagenet, in a release build, with 240 stagenet nodeus nodes, just these
verifications calls taking a bit more than a full second in total (while
the aggregation itself takes only a tenth of a second).  While still
reasonable on stagenet, on mainnet it's going to be 10s of CPU time per
signature request, which is too much.

This commit rewrites it to speed it up considerably in the normal (i.e.
no bad signature) case:
- the aggregator aggregates returning pubkeys and signatures without
  individual verification.
- once we have all results, we then perform a single verification of the
  aggregated signature against the aggregated pubkey.  If it succeeds
  there's no other needed checks.
- if that check *fails* then we fall back to doing a one-by-one
  verification on all the individual signatures, removing them from the
  aggregates if we find any failures.

In the normal case (where we don't get any failing signatures) this
speeds up aggregate processing by more than 10x by only needing one
signature verification.

A nice side effect of this is that because we always know the aggregate
pubkey now, we can include that in debug logs (previously it was only
available in debug logs *in debug builds*), and in the RPC result.

(This builds on top of #1751)