### PR TITLE
Fix oxen-sn-keys restoring bls keys as an empty file

### DIFF
--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -471,6 +471,8 @@ int restore(key_type type, std::list<std::string_view> args) {
         auto eth_bls_pk = get_pubkey(bls_sec);
         fmt::print("{}", display_bls(eth_bls_pk));
         hex_pk = tools::hex_guts(eth_bls_pk);
+
+        sk_data = "0x{}\n"_format(skey_hex);
     }
 
     std::string cmd_instead, fn;

--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -472,7 +472,7 @@ int restore(key_type type, std::list<std::string_view> args) {
         fmt::print("{}", display_bls(eth_bls_pk));
         hex_pk = tools::hex_guts(eth_bls_pk);
 
-        sk_data = "0x{}\n"_format(skey_hex);
+        sk_data = fmt::format("0x{}\n", skey_hex);
     }
 
     std::string cmd_instead, fn;


### PR DESCRIPTION
As a workaround before this goes in: this tool isn't really needed for restoring BLS keys (they are just hex strings, not binary strings like the previous oxen keys) and so you can just write the 0x..... private key value directly as text in the key file.