### PR TITLE
WIP: Parse the contract ID from NewSNv2

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4994,6 +4994,15 @@ service_node_list::state_t::state_t(service_node_list& snl, state_serialized&& s
             // Nothing to do here
             info.version = version_t::v8_ethereum_address;
         }
+        if (info.version < version_t::v9_eth_sn_contract_id) {
+            // NOTE: This is only relevant in stagenet. It's fairly difficult in retrospect to
+            // populate the contract ID. The contract ID is not being used anywhere except in
+            // the sent-staking-backend. For those purposes, we can hardcode a table that patches up
+            // missing contract IDs in the oxen RPC to avoid having to retrospectively fill in the
+            // missing information in their Oxen state.
+            info.contract_id = 0;
+            info.version = version_t::v9_eth_sn_contract_id;
+        }
         // Make sure we handled any future state version upgrades:
         assert(info.version == tools::enum_top<decltype(info.version)>);
         service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -214,6 +214,7 @@ struct service_node_info  // registration information
         v6_reassign_sort_keys,
         v7_decommission_reason,
         v8_ethereum_address,
+        v9_eth_sn_contract_id,
         _count
     };
 
@@ -312,6 +313,7 @@ struct service_node_info  // registration information
     version_t version = tools::enum_top<version_t>;
     cryptonote::hf registration_hf_version = cryptonote::hf::none;
     pulse_sort_key pulse_sorter;
+    uint64_t contract_id; // Monotonic ID allocated by the smart contract for the node
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -383,6 +385,8 @@ struct service_node_info  // registration information
             field(ar, "bls_public_key", bls_public_key);
             field(ar, "operator_ethereum_address", operator_ethereum_address);
         }
+        if (version >= version_t::v9_eth_sn_contract_id)
+            field(ar, "contract_id", contract_id);
     }
 };
 

--- a/src/l2_tracker/events.h
+++ b/src/l2_tracker/events.h
@@ -72,8 +72,9 @@ struct ContributorV2 {
 };
 
 struct NewServiceNodeV2 : L2StateChange {
-    enum class Version { invalid = -1, v0, _count };
-    Version version = Version::v0;
+    enum class Version { invalid = -1, v0, v1_contract_id, _count };
+    Version version = Version::v1_contract_id;
+    uint64_t contract_id = 0;
     crypto::public_key sn_pubkey = crypto::null<crypto::public_key>;
     bls_public_key bls_pubkey = crypto::null<bls_public_key>;
     crypto::ed25519_signature ed_signature = crypto::null<crypto::ed25519_signature>;
@@ -97,6 +98,8 @@ struct NewServiceNodeV2 : L2StateChange {
         field(ar, "signature", ed_signature);
         field_varint(ar, "fee", fee);
         field(ar, "contributors", contributors);
+        if (version >= Version::v1_contract_id)
+            field(ar, "contract_id", contract_id);
     }
 
     std::strong_ordering operator<=>(const NewServiceNodeV2& o) const = default;

--- a/src/l2_tracker/rewards_contract.cpp
+++ b/src/l2_tracker/rewards_contract.cpp
@@ -266,6 +266,12 @@ event::StateChangeVariant get_log_event(const uint64_t chain_id, const ethyl::Lo
 
             auto& item = result.emplace<event::NewServiceNodeV2>(chain_id, l2_height);
 
+            // NOTE: Primitive fields that are indexed are stored in the topics array. Our SN
+            // contract ID is available here.
+            u256 sn_id256;
+            std::tie(sn_id256) = tools::split_hex_into<u256>(log.topics[1]);
+            item.contract_id = tools::decode_integer_be(sn_id256);
+
             u256 fee256, c_offset, c_len;
             std::string_view contrib_hex;
             std::tie(

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2802,6 +2802,8 @@ void core_rpc_server::fill_sn_response_entry(
             microportion(info.portions_for_operator),
             "swarm_id",
             info.swarm_id,
+            "contract_id",
+            info.contract_id,
             "swarm",
             "{:x}"_format(info.swarm_id),
             "registration_hf_version",


### PR DESCRIPTION
Not sure how to do this without a hardfork hence WIP. It's annoying to bootstrap the value because some RPC nodes may have pruned this data already. This will change the contents of NewServiceNodeV2 which contributes to the block hash.

This is useful because the 2 systems are updated asynchronously and nodes can suddenly disappear on the contract (because of user interaction, like conducting an exit) that the session-staking-backend then has to do a bunch of book keeping to persist the contract ID beyond the window of kept data in arbitrum.

As it stands currently this will break consensus because of this new field contributing to the block hash.

--

Some ideas. Is it possible, to only make this affect consensus at the next hardfork/MSNU, but, still serialize it to the disk? On mainnet/proper launch we'll just let the values contribute to the block hash but for retroactively activating it, we only need it for external tools interacting with Oxen RPC so .. it'd be nice to be able to slip it in.

Alternatively, I also had the idea to just hardcode a table  that maps the existing (SN pubkeys -> contract ID) into the backend that has the contract IDs for SN's registered prior to this change coming into effect so we can gate this change until whenever is convenient.