### PR TITLE
Add configurable staking URL to register command

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -276,18 +276,22 @@ bool command_parser_executor::prepare_eth_registration(const std::vector<std::st
         tools::fail_msg_writer("Invalid arguments: no operator address given.  Usage: {}", usage);
         return false;
     }
-    if (args[0].size() != 42) {
+    eth::address operator_address;
+    if (!tools::try_load_from_hex_guts(args[0], operator_address)) {
         tools::fail_msg_writer(
                 "Invalid arguments: {} is not a valid operator address.  Usage: {}",
                 args[0],
                 usage);
         return false;
     }
-    const auto operator_address = std::string_view{args[0]};
-    std::string url = "https://ssb.oxen.observer";  // Empty implies print
+    std::string url = "";  // Empty string means use network default
     if (argc == 2) {
-        if (args[1] == "print")
-            url.clear();
+        if (args[1] == "print" || args[1] == "plaintext" || args[1] == "contract")
+            // print: normal, human-readable formatted output
+            // We also support a couple "hidden" valuesthat we leave undocumented in the usage info:
+            // plaintext: same as print, but without formatting
+            // contract: print values formatted for raw contract use
+            url = args[1];
         else if (args[1].starts_with("http://") || args[1].starts_with("https://")) {
             url = args[1];
             if (url.ends_with('/'))

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -108,13 +108,16 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
             "to the blockchain.");
 
     m_command_lookup.set_handler(
-            "prepare_eth_registration",
+            "register",
             [this](const auto& x) { return m_parser.prepare_eth_registration(x); },
-            "prepare_eth_registration <operator address> [\"print\"]",
-            "Prepare a service node registration for submission to the ethereum contract.  By "
-            "default this information is submitted to https://stake.getsession.org to make it easy "
-            "to submit your registration to the smart contract.  If you would prefer to just print "
-            "the information instead of submitting it, append the word 'print' to the command.");
+            "register <operator address> [https://URL | print]",
+            "Produce the signed service node registration information needed register and stake "
+            "this service node to the smart contract for registration.  By default this "
+            "information is submitted to https://stake.getsession.org to simplify submitting a "
+            "registration to the smart contract, but you can specify an alternative URL (beginning "
+            "with http:// or https://) to submit to a non-default staking URL.  If you specify the "
+            "word 'print' instead of a URL then the information is simply displayed without being "
+            "submitting anywhere.");
 
     m_command_lookup.set_handler(
             "print_sn",

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2766,9 +2766,9 @@ bool rpc_command_executor::prepare_eth_registration(
                 fmt::styled("L2 Contract Registration Information:", fmt::emphasis::underline));
         tools::msg_writer(
                 "{} {}\n"
-                "{} {}{}\n"
-                "{} {}{}\n"
-                "{} {}{}{}{}\n"
+                "{} {} {}\n"
+                "{} {} {}\n"
+                "{} {} {} {} {}\n"
                 "{} {}\n",
                 fmt::styled("   ed25519_pubkey:", fmt::emphasis::bold),
                 fmt::styled(snode_pubkey, fmt::fg(fmt::terminal_color::bright_green)),

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -248,7 +248,7 @@ class rpc_command_executor final {
 
     bool prepare_registration(bool force_registration = false);
 
-    bool prepare_eth_registration(std::string_view operator_address, std::string_view url);
+    bool prepare_eth_registration(const eth::address& operator_address, std::string_view url);
 
     bool print_sn(const std::vector<std::string>& args, bool self = false);
 

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -248,7 +248,7 @@ class rpc_command_executor final {
 
     bool prepare_registration(bool force_registration = false);
 
-    bool prepare_eth_registration(std::string_view operator_address, bool print = false);
+    bool prepare_eth_registration(std::string_view operator_address, std::string_view url);
 
     bool print_sn(const std::vector<std::string>& args, bool self = false);
 

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -74,5 +74,6 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
         .L2_NODE_LIST_PURGE_BLOCKS = 10min / L2_BLOCK_TIME,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = mainnet::config.L2_NODE_LIST_PURGE_MIN_OXEN_AGE,
+        .DEFAULT_STAKING_URL = ""sv,
 };
 }  // namespace cryptonote::config::devnet

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -53,5 +53,6 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
         .L2_NODE_LIST_PURGE_BLOCKS = mainnet::config.L2_NODE_LIST_PURGE_BLOCKS,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = mainnet::config.L2_NODE_LIST_PURGE_MIN_OXEN_AGE,
+        .DEFAULT_STAKING_URL = ""sv,
 };
 }  // namespace cryptonote::config::fakechain

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -80,5 +80,6 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = 1,
         .L2_NODE_LIST_PURGE_BLOCKS = 20,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = 19,
+        .DEFAULT_STAKING_URL = ""sv,
 };
 }  // namespace cryptonote::config::localdev

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -82,5 +82,6 @@ inline constexpr network_config config{
         // state having nodes that *don't* exist in the contract (or vice versa) for some reason.
         .L2_NODE_LIST_PURGE_BLOCKS = 1h / L2_BLOCK_TIME,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = 24h / TARGET_BLOCK_TIME,
+        .DEFAULT_STAKING_URL = "https://stake.getsession.org"sv,
 };
 }  // namespace cryptonote::config::mainnet

--- a/src/network_config/network_config.h
+++ b/src/network_config/network_config.h
@@ -167,6 +167,11 @@ struct network_config final {
                         : hf::hf10_bulletproofs;
         return GOVERNANCE_WALLET_ADDRESS[hard_fork_version >= wallet_switch ? 1 : 0];
     }
+
+    // The default URL for submission of Service Node L2 contract registration information, used by
+    // the `register 0x....` command.  This address should have the staking backend API available at
+    // DEFAULT_STAKING_URL + "/api/store/PUBKEY" for accepting registrations.
+    const std::string_view DEFAULT_STAKING_URL;
 };
 
 }  // namespace cryptonote

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -75,5 +75,8 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
         .L2_NODE_LIST_PURGE_BLOCKS = testnet::config.L2_NODE_LIST_PURGE_BLOCKS,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = testnet::config.L2_NODE_LIST_PURGE_MIN_OXEN_AGE,
+        // FIXME: once mainnet is close to launching this will move to an alternative
+        // stagenet-specific URL and stake.getsession.org will be used for mainnet staking:
+        .DEFAULT_STAKING_URL = "https://stake.getsession.org"sv,
 };
 }  // namespace cryptonote::config::stagenet

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -79,5 +79,6 @@ inline constexpr network_config config{
         // we're probably still somewhere in the 1-2 hour range:
         .L2_NODE_LIST_PURGE_BLOCKS = mainnet::config.L2_NODE_LIST_PURGE_BLOCKS / 2,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = mainnet::config.L2_NODE_LIST_PURGE_MIN_OXEN_AGE,
+        .DEFAULT_STAKING_URL = ""sv,
 };
 }  // namespace cryptonote::config::testnet

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2760,15 +2760,15 @@ void core_rpc_server::invoke(
     }
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(BLS_REGISTRATION_REQUEST& rpc, rpc_context) {
+void core_rpc_server::invoke(CONTRACT_REGISTRATION& rpc, rpc_context) {
     if (!m_core.service_node())
         throw rpc_error{ERROR_NOT_A_SERVICE_NODE, "This oxend is not running in service node mode"};
 
-    const auto response = m_core.bls_registration(rpc.request.address);
+    const auto response = m_core.bls_registration(rpc.request.operator_address);
     rpc.response["status"] = STATUS_OK;
-    rpc.response["address"] = "{}"_format(response.addr);
+    rpc.response["operator_address"] = "{}"_format(response.addr);
     rpc.response_hex["bls_pubkey"] = response.bls_pubkey;
-    rpc.response_hex["proof_of_possession"] = response.proof_of_possession;
+    rpc.response_hex["bls_signature"] = response.proof_of_possession;
     rpc.response_hex["service_node_pubkey"] = response.sn_pubkey;
     rpc.response_hex["service_node_signature"] = response.ed_signature;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2761,6 +2761,9 @@ void core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_REGISTRATION_REQUEST& rpc, rpc_context) {
+    if (!m_core.service_node())
+        throw rpc_error{ERROR_NOT_A_SERVICE_NODE, "This oxend is not running in service node mode"};
+
     const auto response = m_core.bls_registration(rpc.request.address);
     rpc.response["status"] = STATUS_OK;
     rpc.response["address"] = "{}"_format(response.addr);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -201,7 +201,7 @@ class core_rpc_server {
             BLS_EXIT_LIQUIDATION_REQUEST& rpc,
             rpc_context context,
             std::shared_ptr<responder> keepalive);
-    void invoke(BLS_REGISTRATION_REQUEST& rpc, rpc_context context);
+    void invoke(CONTRACT_REGISTRATION& rpc, rpc_context context);
     void invoke(RELAY_TX& relay_tx, rpc_context context);
     void invoke(GET_BLOCK_HEADERS_RANGE& get_block_headers_range, rpc_context context);
     void invoke(GET_BLOCK_HEADER_BY_HEIGHT& get_block_header_by_height, rpc_context context);

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -520,7 +520,7 @@ void parse_request(BLS_EXIT_LIQUIDATION_REQUEST& cmd, rpc_input in) {
         cmd.request.pubkey = sn_pubkey;
 }
 
-void parse_request(BLS_REGISTRATION_REQUEST& cmd, rpc_input in) {
-    get_values(in, "address", required{cmd.request.address});
+void parse_request(CONTRACT_REGISTRATION& cmd, rpc_input in) {
+    get_values(in, "operator_address", required{cmd.request.operator_address});
 }
 }  // namespace cryptonote::rpc

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -14,8 +14,8 @@ inline void parse_request(NO_ARGS&, rpc_input) {}
 
 void parse_request(BANNED& banned, rpc_input in);
 void parse_request(BLS_EXIT_LIQUIDATION_REQUEST& cmd, rpc_input in);
-void parse_request(BLS_REGISTRATION_REQUEST& cmd, rpc_input in);
 void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in);
+void parse_request(CONTRACT_REGISTRATION& reg, rpc_input in);
 void parse_request(FLUSH_CACHE& flush_cache, rpc_input in);
 void parse_request(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_input in);
 void parse_request(GET_ACCRUED_REWARDS& rpc, rpc_input in);

--- a/src/rpc/core_rpc_server_error_codes.h
+++ b/src/rpc/core_rpc_server_error_codes.h
@@ -39,6 +39,7 @@ constexpr int16_t ERROR_WRONG_PARAM = -1, ERROR_TOO_BIG_HEIGHT = -2,
                   ERROR_INTERNAL = -5, ERROR_WRONG_BLOCKBLOB = -6, ERROR_BLOCK_NOT_ACCEPTED = -7,
                   ERROR_CORE_BUSY = -9, ERROR_WRONG_BLOCKBLOB_SIZE = -10,
                   ERROR_UNSUPPORTED_RPC = -11, ERROR_MINING_TO_SUBADDRESS = -12,
-                  ERROR_REGTEST_REQUIRED = -13, ERROR_BLS_SIG = -14, ERROR_NO_L2_TRACKER = -15;
+                  ERROR_REGTEST_REQUIRED = -13, ERROR_BLS_SIG = -14, ERROR_NO_L2_TRACKER = -15,
+                  ERROR_NOT_A_SERVICE_NODE = -16;
 
 }  // namespace cryptonote::rpc

--- a/utils/local-devnet/daemons.py
+++ b/utils/local-devnet/daemons.py
@@ -282,7 +282,7 @@ class Daemon(RPCDaemon):
         return result
 
     def get_ethereum_registration_args(self, address):
-        return self.json_rpc("bls_registration_request", {"address": address}).json()["result"]
+        return self.json_rpc("contract_registration", {"operator_address": address}).json()["result"]
 
     def get_bls_rewards(self, address):
         return self.json_rpc("bls_rewards_request", {"address": address}, timeout=1000).json()

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -395,10 +395,10 @@ class SNNetwork:
             )
 
             sig = BLSSignatureParams(
-                sigs0=int(reg_json["proof_of_possession"][:64], 16),
-                sigs1=int(reg_json["proof_of_possession"][64:128], 16),
-                sigs2=int(reg_json["proof_of_possession"][128:192], 16),
-                sigs3=int(reg_json["proof_of_possession"][192:256], 16),
+                sigs0=int(reg_json["bls_signature"][:64], 16),
+                sigs1=int(reg_json["bls_signature"][64:128], 16),
+                sigs2=int(reg_json["bls_signature"][128:192], 16),
+                sigs3=int(reg_json["bls_signature"][192:256], 16),
             )
 
             params = ServiceNodeParams(


### PR DESCRIPTION
Fixes #1741 

(NB: this is on top of #1753, but only the last two commits here are relevant).

- rename overly verbose `prepare_eth_registration` to just `register`

- `register` now takes an optional URL to submit to, usage is:
    - `register 0xabc... https://example.com`/
    - This submits to https://example.com/api/store/PUBKEY, and then
      prints a message to visit https://example.com/register/PUBKEY

- `register` now defaults to stake.getsession.org, rather than
  ssb.oxen.observer, and the stake.getsession.org is now unified for
  both backend and frontend.  (Previously it submitted to ssb, but
  printed misleadingly that it was submitting to stake.getsession.org).

- added colored formatting for the "register ... print" output, in
  particular using alternating regular/bright colours for each
  64-hex-digit segment to make it a lot easier to split it up into
  multiple u256 values as the contracts require.

- fixed the register command not giving an error if oxend is not a
  service node.  Previously it was outputting 0 pubkeys.

- fixed the BLS_REGISTRATION_REQUEST endpoint returning zero pubkeys
  when not a service node instead of producing an error.

- fixed `register` error output to be a bright red error message rather
  than a error log line.
  
Edit: added in last commit:
- makes the default staking URL a network-dependent option.

- renames `bls_registration_request` endpoint to `contract_registration` as the former name was misleading, along with tweaking the returned parameters to be more similar to related endpoints.

- adds mostly-internal-user `plaintext` and `contract` print modes for the `register` command (specified instead of `print`, but deliberately omitted from the public usage info): `plaintext` is like `print` but without formatting; `contract` splits up and formats values as needed by the contract, for easier direct contract interactions.