### PR TITLE
Remove useless init hook for quorum_cop

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -653,7 +653,6 @@ bool core::init(
             [this](const auto& info) { blockchain.sqlite_db().blockchain_detached(info.height); });
 
     // NOTE: There is an implicit dependency on service node lists being hooked first!
-    blockchain.hook_init([this] { m_quorum_cop.init(); });
     blockchain.hook_block_add(
             [this](const auto& info) { m_quorum_cop.block_add(info.block, info.txs); });
     blockchain.hook_blockchain_detached([this](const auto& info) {

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -80,13 +80,7 @@ std::optional<std::vector<std::string_view>> service_node_test_results::why() co
     return results;
 }
 
-quorum_cop::quorum_cop(cryptonote::core& core) :
-        m_core(core), m_obligations_height(0), m_last_checkpointed_height(0) {}
-
-void quorum_cop::init() {
-    m_obligations_height = 0;
-    m_last_checkpointed_height = 0;
-}
+quorum_cop::quorum_cop(cryptonote::core& core) : m_core(core) {}
 
 // Perform service node tests -- this returns true is the server node is in a good state, that is,
 // has submitted uptime proofs, participated in required quorums, etc.

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -113,7 +113,6 @@ class quorum_cop {
   public:
     explicit quorum_cop(cryptonote::core& core);
 
-    void init();
     void block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
     void blockchain_detached(uint64_t height, bool by_pop_blocks);
 
@@ -136,8 +135,8 @@ class quorum_cop {
 
     cryptonote::core& m_core;
     voting_pool m_vote_pool;
-    uint64_t m_obligations_height;
-    uint64_t m_last_checkpointed_height;
+    uint64_t m_obligations_height = 0;
+    uint64_t m_last_checkpointed_height = 0;
     mutable std::recursive_mutex m_lock;
 };
 


### PR DESCRIPTION
It assigns '0' to some height variables which we do in the constructor already. These values only get changed in block_add which means that when the init hooks are called, those values are still going to be 0 until a block is added.