### PR TITLE
Fix invalid mempool selection with conflicting ONS buys (stable backport)

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1790,6 +1790,11 @@ end:
     size_t const max_total_weight = 2 * median_weight - COINBASE_BLOB_RESERVED_SIZE;
     std::unordered_set<crypto::key_image> k_images;
 
+    // Track ONS buys because we can't put more than one for the same ONS name into the same block
+    // (otherwise the *block* will fail but validation won't, because validation here won't see the
+    // earlier tx has having taken effect, but the block addition will).
+    std::unordered_set<crypto::hash> ons_buys;
+
     LOG_PRINT_L2("Filling block template, median weight " << median_weight << ", " << m_txs_by_fee_and_receive_time.size() << " txes in the pool");
 
     LockedTXN lock(m_blockchain);
@@ -1889,6 +1894,24 @@ end:
       {
         LOG_PRINT_L2("  key images already seen");
         continue;
+      }
+      if (tx.type == txtype::oxen_name_system) {
+        // TX validation above has checked that this isn't an ONS buy for a name that is already
+        // registered, but it can't check that we don't create such a conflict from trying to
+        // put two conflicting registrations in the same block: when actually processing such a
+        // block the second one *would* be invalid because processing the first one created it.
+        //
+        // We only filter buys based on name_hash here which means technically we might
+        // over-filter (e.g. if there is both a session + wallet ONS) but that's not a big deal
+        // (one of the two will just get delayed for a block), and perfectly figuring out
+        // whether two might conflict is complicated enough that it's not worth doing here.
+        cryptonote::tx_extra_oxen_name_system ons;
+        if (cryptonote::get_field_from_tx_extra(tx.extra, ons) && ons.is_buying() &&
+          !ons_buys.emplace(ons.name_hash).second) {
+
+          LOG_PRINT_L2("  conflicting ONS buy in mempool");
+          continue;
+        }
       }
 
       bl.tx_hashes.push_back(sorted_it.second);


### PR DESCRIPTION
Block validation requires that ONS buys it processes do not conflict with currently active ONS records.  Mainnet ran into an issue where such a conflict happened *within the mempool*, and block creation was creating invalid blocks because the first ONS buy would get processed but that processing then invalidates the second one since the registration now exists.

Since mempool selection doesn't change the actual name system db in the same way as block processing, it won't catch this, and so could fill a block template with an invalid set of transactions.

This commit fixes it by filtering mempool selection to skip any ONS buy txes from the pool that have the same name_hash as any already-selected txes so that we don't create such an invalid block.