### PR TITLE
Fix off by one in pulse quorum gen

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5220,10 +5220,12 @@ void service_node_list::reset(bool delete_db_entry) {
 
     m_state.height = hard_fork_begins(blockchain.nettype(), hf::hf9_service_nodes).value_or(1) - 1;
 
-    // NOTE: Rescanning the SNL has side-effects on the SQL DB in particular, if we encounter any
-    // ETH exits, a 'delayed_payment' row is added to the DB. If we _don't_ reset the SQL DB then we
-    // double up on exit payments to be handed to them.
-    blockchain.sqlite_db().reset_database();
+    if (delete_db_entry) {
+        // NOTE: Rescanning the SNL has side-effects on the SQL DB in particular, if we encounter
+        // any ETH exits, a 'delayed_payment' row is added to the DB. If we _don't_ reset the SQL DB
+        // then we double up on exit payments to be handed to them.
+        blockchain.sqlite_db().reset_database();
+    }
 }
 
 size_t service_node_info::total_num_locked_contributions() const {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5121,18 +5121,17 @@ bool service_node_list::load(const uint64_t current_height) {
         return false;
     }
 
-    // NOTE: Temporary code for HF21 on Stagenet.v3, on reset we are not resetting the SQL DB which
-    // means we double count exit payments. This is causing rewards to go out of sync even after
-    // 'resetting' the SNL.
+    // NOTE: Temporary code for HF21 on Stagenet.v3. The pulse sort key of nodes
+    // we incorrectly assigning the wrong height (we neeeded 'height + 1' not
+    // 'height') which means eventually the pulse sort keys go out of sync.
     //
-    // TODO: This is because rescanning the SNL has side-effects on the SQL DB (e.g.
-    // it can cause new rows to be inserted) which is less than ideal. Originally the SNL was not
-    // meant to modify dependent state outside of the SNL because resetting the SNL != resetting
-    // another subsystem, a 'subsytem' should be able to rederive their state purely by processing
-    // blocks in isolation.
-    if (blockchain.nettype() == cryptonote::network_type::STAGENET &&
+    // By returning false here the DB will fail to load, the SQL DB will be
+    // reset as well and the sort keys will be recalculated to their correct
+    // value.
+    if ((blockchain.nettype() == cryptonote::network_type::STAGENET ||
+         blockchain.nettype() == cryptonote::network_type::DEVNET) &&
         data_in.version <
-                data_for_serialization::version_t::version_4_ensure_rescan_resets_sql_db) {
+                data_for_serialization::version_t::version_5_stagenet_devnet_regen_pulse_sorter) {
         return false;
     }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3169,7 +3169,7 @@ void service_node_list::state_t::update_from_block(
                  quorum_index++) {
                 crypto::public_key const& key = quorum->validators[quorum_index];
                 service_node_info& new_info = duplicate_info(service_nodes_infos[key]);
-                new_info.pulse_sorter.last_height_validating_in_quorum = height;
+                new_info.pulse_sorter.last_height_validating_in_quorum = height + 1;
                 new_info.pulse_sorter.quorum_index = quorum_index;
             }
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -1023,13 +1023,14 @@ class service_node_list {
             version_2_regen_recently_removed_nodes_w_sn_info,
             version_3_eth_beneficiary,
             version_4_ensure_rescan_resets_sql_db,
+            version_5_stagenet_devnet_regen_pulse_sorter,
             count,
         };
         static version_t get_version(cryptonote::hf /*hf_version*/) {
-            return version_t::version_4_ensure_rescan_resets_sql_db;
+            return version_t::version_5_stagenet_devnet_regen_pulse_sorter;
         }
 
-        version_t version{version_t::version_4_ensure_rescan_resets_sql_db};
+        version_t version{version_t::version_5_stagenet_devnet_regen_pulse_sorter};
         std::vector<quorum_for_serialization> quorum_states;
         std::vector<state_serialized> states;
         void clear() {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3012,6 +3012,12 @@ void core_rpc_server::fill_sn_response_entry(
             }
         }
     }
+
+    if (requested(reqed, "pulse_sorter")) {
+        entry["pulse_sorter"]["last_height_validating_in_quorum"] =
+                info.pulse_sorter.last_height_validating_in_quorum;
+        entry["pulse_sorter"]["quorum_index"] = info.pulse_sorter.quorum_index;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The height that is meant to be applied to the sort keys for selecting the Pulse quorum is meant to be the _height_ of the block that is being processed. When some of the code was shuffled around to implement the TX confirmation approach the incrementing of the SNL's height was done after instead of before the quorum was generated.

This the nodes to be included in a quorum to be subtly off-by-1 once the sorting goes out of sync.

This fixes the sync of dev onto a pre-existing stable DB, draft for now as I'm testing some further with different scenarios but at least mainnet seems clear. Will sync overnight.