### PR TITLE
Fix incorrect archive window calculations

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -372,11 +372,11 @@ void BlockchainSQLite::upgrade_schema() {
         FOR EACH ROW WHEN NEW.height > OLD.height BEGIN
             -- Batched payments
             INSERT INTO batched_payments_accrued_recent SELECT *, NEW.height FROM  batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_recent                      WHERE height < NEW.height - {0};
+            DELETE FROM batched_payments_accrued_recent                      WHERE height < (NEW.height - {0});
 
             -- Delayed payments
             INSERT INTO delayed_payments_recent SELECT *                     FROM  delayed_payments WHERE height == NEW.height;
-            DELETE FROM delayed_payments_recent                              WHERE height < NEW.height - {0};
+            DELETE FROM delayed_payments_recent                              WHERE height < (NEW.height - {0});
 
         END;
 
@@ -395,11 +395,11 @@ void BlockchainSQLite::upgrade_schema() {
 
             -- Batch payments
             INSERT INTO batched_payments_accrued_archive SELECT *, NEW.height FROM  batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_archive                      WHERE height < (NEW.height - (NEW.height % {2}));
+            DELETE FROM batched_payments_accrued_archive                      WHERE height < (NEW.height - {2});
 
             -- Delayed payments
             INSERT INTO delayed_payments_archive SELECT *                     FROM  delayed_payments;
-            DELETE FROM delayed_payments_archive                              WHERE height < (NEW.height - (NEW.height % {2}));
+            DELETE FROM delayed_payments_archive                              WHERE height < (NEW.height - {2});
 
         END;
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3703,7 +3703,7 @@ void service_node_list::blockchain_detached(uint64_t height) {
     // _should_ rejig the system back into sync.
 
     const auto& netconf = get_config(blockchain.nettype());
-    uint64_t target_height = height - 1;
+    uint64_t target_height = height ? height - 1 : 0;
     uint64_t archive_height = target_height - (target_height % netconf.HISTORY_ARCHIVE_INTERVAL);
     auto history = cryptonote::BlockchainSQLite::PaymentTableType::Nil;
 
@@ -3762,7 +3762,7 @@ void service_node_list::blockchain_detached(uint64_t height) {
         case cryptonote::BlockchainSQLite::PaymentTableType::Nil: {  // NOTE: Not found
             m_transient->state_history.clear();
             m_transient->state_archive.clear();
-            init();
+            reset(true);
             detach_label = " (via reset)";
         } break;
 

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -65,7 +65,7 @@ inline constexpr network_config config{
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
                 mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         .HISTORY_ARCHIVE_INTERVAL = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
-        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         .ETH_EXIT_BUFFER = testnet::config.ETH_EXIT_BUFFER,
         .ETHEREUM_CHAIN_ID = 421614,  // Arbitrum Sepolia

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -44,7 +44,7 @@ inline constexpr network_config config{
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
                 mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         .HISTORY_ARCHIVE_INTERVAL = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
-        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         .ETH_EXIT_BUFFER = testnet::config.ETH_EXIT_BUFFER,
         .ETHEREUM_CHAIN_ID = mainnet::config.ETHEREUM_CHAIN_ID,

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -59,7 +59,7 @@ inline constexpr network_config config{
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
                 mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         .HISTORY_ARCHIVE_INTERVAL = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
-        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         // Only permit 1 block because we're running an integration test
         // locally and pulse quorums take time to create blocks which bloat the

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -7,8 +7,6 @@ using namespace std::literals;
 namespace cryptonote::config::mainnet {
 
 inline constexpr auto TARGET_BLOCK_TIME = 2min;
-inline constexpr auto ARCHIVE_INTERVAL = 10'000;
-
 inline constexpr network_config config{
         .NETWORK_TYPE = network_type::MAINNET,
         .DEFAULT_CONFIG_SUBDIR = ""sv,
@@ -68,9 +66,9 @@ inline constexpr network_config config{
         .DEREGISTRATION_LOCK_DURATION = 30 * 24h,
         .UNLOCK_DURATION = 15 * 24h,
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD = 7 * 24h / TARGET_BLOCK_TIME,
-        .HISTORY_ARCHIVE_INTERVAL = ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_INTERVAL = 10'000,
         .HISTORY_ARCHIVE_KEEP_WINDOW =
-                2 * 365 * 24h / TARGET_BLOCK_TIME / ARCHIVE_INTERVAL,  // 2yrs worth
+                2 * 365 * 24h / TARGET_BLOCK_TIME,  // 2yrs worth
         .HISTORY_RECENT_KEEP_WINDOW = 360,
         .ETH_EXIT_BUFFER = 7 * 24h / TARGET_BLOCK_TIME,
         .ETHEREUM_CHAIN_ID = 42161,  // Arbitrum One

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -65,7 +65,7 @@ inline constexpr network_config config{
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
                 mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         .HISTORY_ARCHIVE_INTERVAL = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
-        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         // Much shorter than mainnet so that you can test this more easily.
         .ETH_EXIT_BUFFER = 2h / mainnet::config.TARGET_BLOCK_TIME,

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -64,7 +64,7 @@ inline constexpr network_config config{
         .HARDFORK_DEREGISTRATION_GRACE_PERIOD =
                 mainnet::config.HARDFORK_DEREGISTRATION_GRACE_PERIOD,
         .HISTORY_ARCHIVE_INTERVAL = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
-        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_INTERVAL,
+        .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         // Much shorter than mainnet so that you can test this more easily.
         .ETH_EXIT_BUFFER = 1h / mainnet::config.TARGET_BLOCK_TIME,


### PR DESCRIPTION
The archive window was being calculated as the interval but also additionally the mod subtraction does not calculate what we intended. This has been fixed now so that the window is the number of blocks generated in 2 years and that the SQL trigger is correctly using the 2 year window.