### PR TITLE
BLS requests: Increase fd limit & try connections to decommed nodes

### DIFF
--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -538,8 +538,7 @@ namespace {
                 ++active_connections;
 
                 oxenmq::ConnectionID connid;
-                bool is_sn_conn = core.service_node_list.is_service_node(
-                        snode.sn_pubkey, /*require_active*/ true);
+                bool is_sn_conn = core.service_node_list.is_funded_service_node(snode.sn_pubkey);
                 if (is_sn_conn) {
                     connid = tools::view_guts(snode.x_pubkey);
                 } else {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2181,7 +2181,7 @@ bool core::handle_uptime_proof(
     crypto::x25519_public_key x_pkey{};
     bool result = service_node_list.handle_uptime_proof(
             std::move(proof), my_uptime_proof_confirmation, x_pkey);
-    if (result && service_node_list.is_service_node(pubkey, true /*require_active*/) && x_pkey) {
+    if (result && service_node_list.is_active_service_node(pubkey) && x_pkey) {
         oxenmq::pubkey_set added;
         added.insert(tools::copy_guts(x_pkey));
         m_omq->update_active_sns(added, {} /*removed*/);
@@ -2446,7 +2446,7 @@ void core::do_uptime_proof_call() {
 
             auto pubkey = service_node_list.find_public_key(m_service_keys.pub_x25519);
             if (pubkey && pubkey != m_service_keys.pub &&
-                service_node_list.is_service_node(pubkey, false /*don't require active*/)) {
+                service_node_list.is_service_node(pubkey)) {
                 log::error(
                         globallogcat,
                         fg(fmt::terminal_color::red) | fmt::emphasis::bold,

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -515,7 +515,21 @@ class service_node_list {
         std::lock_guard lock{m_sn_mutex};
         return m_state.get_next_block_leader();
     }
-    bool is_service_node(const crypto::public_key& pubkey, bool require_active = true) const;
+
+    // Checks whether a service node is registered, with an optional additional check.  If the
+    // service node is *not* registered at all, this returns false.  Otherwise, if `check` is
+    // provided, returns the result of invoking it with the service_node_info record.  Otherwise
+    // (i.e. exists and no check given) returns true.
+    bool is_service_node(
+            const crypto::public_key& pubkey,
+            const std::function<bool(const service_node_info&)>& check = nullptr) const;
+    // Queries whether the given pubkey is that of a registered, fully funded service node that is
+    // not current decommissioned.
+    bool is_active_service_node(const crypto::public_key& pubkey) const;
+    // Queries whether the given pubkey is that of a registered, fully funded service node,
+    // regardless of whether the node is currently active or decommissioned.
+    bool is_funded_service_node(const crypto::public_key& pubkey) const;
+
     bool is_key_image_locked(
             crypto::key_image const& check_image,
             uint64_t* unlock_height = nullptr,

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -279,8 +279,8 @@ void quorum_cop::process_quorums(cryptonote::block const& block) {
                                                       ? REORG_SAFETY_BUFFER_BLOCKS_POST_HF12
                                                       : REORG_SAFETY_BUFFER_BLOCKS_PRE_HF12;
     const auto& my_keys = m_core.get_service_keys();
-    bool voting_enabled = m_core.service_node() && m_core.service_node_list.is_service_node(
-                                                           my_keys.pub, /*require_active=*/true);
+    bool voting_enabled =
+            m_core.service_node() && m_core.service_node_list.is_active_service_node(my_keys.pub);
 
     uint64_t const height = block.get_height();
     uint64_t const latest_height = std::max(


### PR DESCRIPTION
- Increases the FD limit during daemon initialization to avoid hitting FD limits when doing a BLS request fanout for BLS signatures.
- Changes the BLS aggregation code to attempt to connect to any funded node instead of only active nodes, so that we still try decommed nodes that may still be good for constructing a contract signature part.

Edit:
And also, since we don't have any binding FD limit, a third commit to remove the connection limiter entirely, which simplifies the code and potentially improves response time by just blasting everything out ASAP.