### PR TITLE
Windows build fixes on a Windows host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,11 +156,11 @@ release-static-linux-i686:
 
 release-static-win64:
 	mkdir -p $(builddir)/release
-	cd $(builddir)/release && cmake -G "MSYS Makefiles" -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) $(topdir) && $(MAKE)
+	cd $(builddir)/release && cmake -G "MSYS Makefiles" -D STATIC=ON -D BUILD_STATIC_DEPS=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) $(topdir) && $(MAKE)
 
 release-static-win32:
 	mkdir -p $(builddir)/release
-	cd $(builddir)/release && cmake -G "MSYS Makefiles" -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x32" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/32-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) $(topdir) && $(MAKE)
+	cd $(builddir)/release && cmake -G "MSYS Makefiles" -D STATIC=ON -D BUILD_STATIC_DEPS=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x32" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/32-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) $(topdir) && $(MAKE)
 
 fuzz:
 	mkdir -p $(builddir)/fuzz

--- a/README.md
+++ b/README.md
@@ -163,93 +163,45 @@ application.
 
 **Preparing the build environment**
 
-* Download and install the [MSYS2 installer](https://www.msys2.org), either the 64-bit (x86_64) or the 32-bit (i686) package, depending on your system.
-* Note: Installation must be on the C drive and root directory as result of [Monero issue 3167](https://github.com/monero-project/monero/issues/3167).
-* Open the MSYS shell via the `MSYS2 MSYS` shortcut in the Start Menu or "C:\msys64\msys2_shell.cmd -msys"
-* Update packages using pacman:  
+* Download and install the [MSYS2 installer 64-bit
+  (x86_64)](https://www.msys2.org).
+
+* Note: On Windows it's recommended to setup MSYS and the repository at the root
+  of `C:/` due to path-length limitations. Dependencies like Boost will fail to
+  build because of long file name paths that exceed `PATH_MAX` on Windows. Long
+  file name path support requires the toolchain to be built aware of these
+  limitations and enabled which is not always enforceable.
+
+  It's highly recommended to also export the variable `USE_SINGLE_BUILDDIR=1` to
+  reduce the build path length(s) for similar reasons.
+
+* Open the MSYS MinGW64 shell by opening `mingw64.exe` in the MSYS installation
+  directory
+
+* Update the base packages and install the dependencies by running the commands:
 
     ```bash
     pacman -Syu
-    ```
-
-* Exit the MSYS shell using Alt+F4 when you get a warning stating: "terminate MSYS2 without returning to shell and check for updates again/for example close your terminal window instead of calling exit"
-
-    ```bash
-    pacman -Syu
-    ```
-
-* Update packages again using pacman: 
-
-        pacman -Syu  
-
-* Install dependencies:
-
-    To build for 64-bit Windows:
-
-    ```bash
-    pacman -S git mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-sqlite3
-    ```
-
-    To build for 32-bit Windows:
-
-    ```bash
-    pacman -S git mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-zeromq mingw-w64-i686-libsodium mingw-w64-i686-hidapi mingw-w64-i686-sqlite3
-    ```
-
-* Close and reopen the MSYS MinGW shell via `MSYS2 MinGW 64-bit` shortcut on
-  64-bit Windows or `MSYS2 MinGW 32-bit` shortcut on 32-bit Windows. Note 
-  that if you are running 64-bit Windows, you will have both 64-bit and
-  32-bit MinGW shells.
-
-**Cloning**
-
-* To git clone, run:
-
-    ```bash
-    git clone --recursive https://github.com/oxen-io/oxen-core.git
+    pacman -S autoconf automake git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-libtool
     ```
 
 **Building**
 
-* Change to the cloned directory, run:
-	
+- Clone and build the program by running the commands:
+
     ```bash
+    git clone --recursive https://github.com/oxen-io/oxen-core.git
     cd oxen-core
+    USE_SINGLE_BUILDDIR=1 make release-static-win64
     ```
 
-* If you would like a specific [version/tag](https://github.com/oxen-io/oxen-core/tags), do a git checkout for that version. eg. 'v5.1.2'. If you don't care about the version and just want binaries from master, skip this step:
-	
-    ```bash
-    git checkout v5.1.2
-    ```
+* The resulting executables can be found in `./build/release/bin`
 
-* If you are on a 64-bit system, run:
-
-    ```bash
-    make release-static-win64
-    ```
-
-* If you are on a 32-bit system, run:
-
-    ```bash
-    make release-static-win32
-    ```
-
-* The resulting executables can be found in `build/<MinGW version>/<oxen version>/release/bin`
-
-* **Optional**: to build Windows binaries suitable for debugging on a 64-bit system, run:
+* **Optional**: to build Windows binaries suitable for debugging run:
 
     ```bash
     make debug-static-win64
     ```
-
-* **Optional**: to build Windows binaries suitable for debugging on a 32-bit system, run:
-
-    ```bash
-    make debug-static-win32
-    ```
-
-* The resulting executables can be found in `build/<MinGW version>/<oxen version>/debug/bin`
 
 ### On FreeBSD:
 

--- a/cmake/64-bit-toolchain.cmake
+++ b/cmake/64-bit-toolchain.cmake
@@ -26,14 +26,22 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-if (NOT CMAKE_HOST_WIN32)
+if (CMAKE_HOST_WIN32)
+  # Building w/ MSYS MinGW as recommended by the readme only ships MinGW with
+  # the posix threading API as confirmed by 'x86_64-w64-mingw32-gcc.exe -v'
+  #  > Thread model: posix
+  set (CMAKE_C_COMPILER ${ARCH_TRIPLET}-gcc)
+  set (CMAKE_CXX_COMPILER ${ARCH_TRIPLET}-g++)
+else()
+  # Our cross-compiler ships MinGW GCC with a 'posix' suffix to indicate a build
+  # with the posix threading model.
   set (CMAKE_SYSTEM_NAME Windows)
+  set (CMAKE_C_COMPILER ${ARCH_TRIPLET}-gcc-posix)
+  set (CMAKE_CXX_COMPILER ${ARCH_TRIPLET}-g++-posix)
 endif()
 
 set (ARCH_TRIPLET x86_64-w64-mingw32)
 set (CMAKE_SYSTEM_PROCESSOR x86_64)
-set (CMAKE_C_COMPILER ${ARCH_TRIPLET}-gcc-posix)
-set (CMAKE_CXX_COMPILER ${ARCH_TRIPLET}-g++-posix)
 set (CMAKE_AR ar CACHE FILEPATH "" FORCE)
 set (CMAKE_NM nm CACHE FILEPATH "" FORCE)
 set (CMAKE_LINKER ld CACHE FILEPATH "" FORCE)

--- a/cmake/64-bit-toolchain.cmake
+++ b/cmake/64-bit-toolchain.cmake
@@ -26,6 +26,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+set (ARCH_TRIPLET x86_64-w64-mingw32)
 if (CMAKE_HOST_WIN32)
   # Building w/ MSYS MinGW as recommended by the readme only ships MinGW with
   # the posix threading API as confirmed by 'x86_64-w64-mingw32-gcc.exe -v'
@@ -40,7 +41,6 @@ else()
   set (CMAKE_CXX_COMPILER ${ARCH_TRIPLET}-g++-posix)
 endif()
 
-set (ARCH_TRIPLET x86_64-w64-mingw32)
 set (CMAKE_SYSTEM_PROCESSOR x86_64)
 set (CMAKE_AR ar CACHE FILEPATH "" FORCE)
 set (CMAKE_NM nm CACHE FILEPATH "" FORCE)

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -348,17 +348,21 @@ add_static_target(zlib zlib_external libz.a)
 
 
 
-set(boost_threadapi "pthread")
+if(ARCH_TRIPLET MATCHES mingw)
+  set(boost_threadapi "win32")
+else()
+  set(boost_threadapi "pthread")
+endif()
 set(boost_bootstrap_cxx "--cxx=${deps_cxx}")
 set(boost_toolset "")
 set(boost_extra "")
 if(USE_LTO)
   list(APPEND boost_extra "lto=on")
 endif()
+
 if(CMAKE_CROSSCOMPILING)
   set(boost_bootstrap_cxx "") # need to use our native compiler to bootstrap
   if(ARCH_TRIPLET MATCHES mingw)
-    set(boost_threadapi win32)
     list(APPEND boost_extra "target-os=windows")
     if(ARCH_TRIPLET MATCHES x86_64)
       list(APPEND boost_extra "address-model=64")

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -339,7 +339,7 @@ endfunction()
 
 
 build_external(zlib
-  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS} -fPIC" ${cross_extra} ./configure --prefix=${DEPS_DESTDIR} --static
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS} -fPIC" ${cross_extra} env ./configure --prefix=${DEPS_DESTDIR} --static
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libz.a
     ${DEPS_DESTDIR}/include/zlib.h

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -536,7 +536,19 @@ else()
   endif()
   set(hidapi_cmake_toolchain)
   if(CMAKE_TOOLCHAIN_FILE)
-    set(hidapi_cmake_toolchain "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+    # If the toolchain is passed as a relative path, the toolchain is _relative_
+    # to the original directory that CMake was invoked in. At this step we are
+    # currently deep in the 'static-deps' directory for this dependency.
+    #
+    # The relative path used here from CMAKE_TOOLCHAIN_FILE will not resolve to
+    # the correct path, e.g:
+    #
+    #   cd /ox/build/release/static-deps-sources/src/hidapi_external && mkdir -p build && cd build && cmake .. -DCMAKE_TOOLCHAIN_FILE=../../cmake/64-bit-toolchain.cmake ..
+    #
+    # Resolves to the wrong path, to amend that we take the absolute path. Note
+    # if the path is already absolute, this is a no-op.
+    get_filename_component(cmake_toolchain_file_abs_path "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE BASE_DIR $ENV{PWD})
+    set(hidapi_cmake_toolchain "-DCMAKE_TOOLCHAIN_FILE=${cmake_toolchain_file_abs_path}")
   endif()
   build_external(hidapi
     DEPENDS ${maybe_eudev} libusb_external

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -418,7 +418,7 @@ build_external(boost
       threading=multi threadapi=${boost_threadapi} ${boost_buildflags} cxxstd=17 visibility=global
       --disable-icu --user-config=${CMAKE_CURRENT_BINARY_DIR}/user-config.bjam
       --prefix=${DEPS_DESTDIR} --exec-prefix=${DEPS_DESTDIR} --libdir=${DEPS_DESTDIR}/lib --includedir=${DEPS_DESTDIR}/include
-      --with-program_options --with-system --with-thread --with-serialization
+      --with-program_options --with-system --with-thread --with-serialization --layout=system
       install
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libboost_program_options.a

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -711,8 +711,9 @@ namespace {
                 T&&... args) {
             if (agg_log_lister) {
                 std::lock_guard lock{agg_log_lister->mutex};
-                agg_log_lister->success.emplace_back(
-                        addr, fmt::format(format, std::forward<T>(args)...));
+                agg_log& log = agg_log_lister->success.emplace_back();
+                log.addr = addr;
+                log.msg = fmt::format(format, std::forward<T>(args)...);
             }
         }
         template <typename... T>
@@ -722,8 +723,9 @@ namespace {
                 T&&... args) {
             if (agg_log_lister) {
                 std::lock_guard lock{agg_log_lister->mutex};
-                agg_log_lister->error.emplace_back(
-                        addr, fmt::format(format, std::forward<T>(args)...));
+                agg_log& log = agg_log_lister->error.emplace_back();
+                log.addr = addr;
+                log.msg = fmt::format(format, std::forward<T>(args)...);
             }
         }
     };

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3378,7 +3378,8 @@ void service_node_list::state_t::update_from_block(
         auto unconf_it = unconfirmed_l2_txes.begin();
         for (uint32_t i = 0; i < block.l2_votes.size(); i++) {
             bool vote = block.l2_votes[i];
-            auto& [txhash, unconf] = *unconf_it;
+            auto& txhash = unconf_it->first;
+            auto& unconf = unconf_it->second;
             (vote ? unconf.confirmations : unconf.denials) += vote_weight;
 
             if (auto done = unconf.confirmed(height)) {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2046,12 +2046,12 @@ bool service_node_list::state_t::process_confirmed_event(
         // This leads us to storing a cryptonote address in the delayed payments which causes the
         // network to stall as code tries to deserialise that address into an eth address and fails.
         if (contributor.ethereum_address) {
-            returned_stakes.emplace_back(
-                    contributor.ethereum_address,
-                    cryptonote::reward_money::coin_amount(contributor.amount),
-                    confirm.height,
-                    confirm.tx_index,
-                    contrib_index);
+            auto& item = returned_stakes.emplace_back();
+            item.addr = contributor.ethereum_address;
+            item.amount = cryptonote::reward_money::coin_amount(contributor.amount);
+            item.block_height = confirm.height;
+            item.tx_index = confirm.tx_index;
+            item.contributor_index = contrib_index;
         }
     }
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -537,10 +537,6 @@ class node_server
     cryptonote::network_type m_nettype;
 };
 
-static void log_detailed_peer_stats(
-        std::unordered_map<peerid_type, peer_stats>& peer_stats_map,
-        std::mutex& peer_stats_map_mutex);
-
 extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ip;
 extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ipv6_address;
 extern const command_line::arg_descriptor<uint16_t> arg_p2p_bind_port;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -745,6 +745,16 @@ node_server<t_payload_net_handler>::get_payload_object() {
     return m_payload_handler;
 }
 //-----------------------------------------------------------------------------------
+static void log_detailed_peer_stats(std::unordered_map<peerid_type, peer_stats>& peer_stats_map, std::mutex& peer_stats_map_mutex) {
+    if (log::get_level(logcat) > log::Level::debug)
+      return;
+    std::unique_lock lock{peer_stats_map_mutex};
+    for (const auto& [peer_id, stats] : peer_stats_map) {
+        log::debug(globallogcat, "Peer ID: {}\n\tConnections: {} total, {} failed\n\tLast Connected: {}\n\tTotal Connection Time: {} seconds",
+            peer_id, stats.total_connections, stats.failed_connections, stats.last_connected_timestamp, stats.total_connection_time);
+    }
+}
+//-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::run() {
     // creating thread to log number of connections
@@ -795,16 +805,6 @@ bool node_server<t_payload_net_handler>::run() {
     log::info(logcat, "net_service loop stopped.");
     log_detailed_peer_stats(peer_stats_map, peer_stats_map_mutex);
     return true;
-}
-//-----------------------------------------------------------------------------------
-static void log_detailed_peer_stats(std::unordered_map<peerid_type, peer_stats>& peer_stats_map, std::mutex& peer_stats_map_mutex) {
-    if (log::get_level(logcat) > log::Level::debug)
-      return;
-    std::unique_lock lock{peer_stats_map_mutex};
-    for (const auto& [peer_id, stats] : peer_stats_map) {
-        log::debug(globallogcat, "Peer ID: {}\n\tConnections: {} total, {} failed\n\tLast Connected: {}\n\tTotal Connection Time: {} seconds",
-            peer_id, stats.total_connections, stats.failed_connections, stats.last_connected_timestamp, stats.total_connection_time);
-    }
 }
 //-----------------------------------------------------------------------------------
 static void update_peer_stats(

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -392,8 +392,10 @@ GET_BLOCKS_BIN::response core_rpc_server::invoke(GET_BLOCKS_BIN::request&& req, 
                 res.status = "Failed";
                 return res;
             }
-            for (size_t i = 0; i < indices.size(); ++i)
-                out_ind.emplace_back(std::move(indices[i]));
+            for (size_t i = 0; i < indices.size(); ++i) {
+                auto& dest = out_ind.emplace_back();
+                dest.indices = std::move(indices[i]);
+            }
         }
     }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2937,7 +2937,9 @@ void core_rpc_server::fill_sn_response_entry(
     }
 
     auto& netconf = m_core.get_net_config();
-    auto [hf, snode_rev] = get_network_version_revision(nettype(), top_height);
+    std::pair<hf, uint8_t> network_rev = get_network_version_revision(nettype(), top_height);
+    hf hf = network_rev.first;
+    uint8_t snode_rev = network_rev.second;
 
     if (hf >= feature::SN_PK_IS_ED25519) {
         set_if_requested(reqed, binary, "pubkey_ed25519", sn_pubkey);


### PR DESCRIPTION
Each of the changes are documented in each commit as to reasons why. This _still_ does not fix a Windows build on a Windows host for reasons that are still beyond me at this point, but it gets all the way to the linking step instead of crashing and burning much earlier.

On a Windows host, the build fails when trying to create the final executables with the following error excerpts:

```
[ 96%] Linking CXX executable ../../bin/oxen-wallet-rpc.exe

cd /C/ox/build/release/src/wallet && /C/msys/mingw64/bin/cmake.exe -E rm -f CMakeFiles/wallet_rpc_server.dir/objects.a
cd /C/ox/build/release/src/wallet && ar qc CMakeFiles/wallet_rpc_server.dir/objects.a "CMakeFiles/wallet_rpc_server.dir/wallet_rpc_server.cpp.obj" "CMakeFiles/wallet_rpc_server.dir/wallet_rpc_server_commands_defs.cpp.obj"
cd /C/ox/build/release/src/wallet &&
/C/msys/mingw64/bin/x86_64-w64-mingw32-g++.exe  -march=x86-64 -D_GNU_SOURCE
-DWIN32_LEAN_AND_MEAN -Wall -Wextra -Wpointer-arith -Wvla -Wwrite-strings
-Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-parameter
-Wno-unused-variable -Wno-error=unused-variable -Wno-error=uninitialized
-Wlogical-op -Wno-error=maybe-uninitialized -Wno-error=cpp -Wno-error=logical-op
-Wno-error=unused-value -Wno-error=unused-but-set-variable -Wno-reorder
-Wno-missing-field-initializers -Wno-stringop-overflow   -U_FORTIFY_SOURCE
-D_FORTIFY_SOURCE=1 -Wformat -Wformat-security -fstack-protector
-fstack-protector-strong -fcf-protection=full -ftemplate-depth=900 -O3 -DNDEBUG
-Wl,--stack,10485760  -Wl,--dynamicbase -Wl,--nxcompat -Wl,--high-entropy-va
-static  -Wl,--whole-archive CMakeFiles/wallet_rpc_server.dir/objects.a
-Wl,--no-whole-archive -o ../../bin/oxen-wallet-rpc.exe
-Wl,--out-implib,liboxen-wallet-rpc.dll.a
-Wl,--major-image-version,0,--minor-image-version,0
../rpc/common/librpc_common.a libwallet.a ../daemonizer/libdaemonizer.a
../logging/liblogging.a ../../static-deps/lib/libboost_serialization.a
../../static-deps/lib/libboost_program_options.a ../rpc/librpc_commands.a
../rpc/common/librpc_common.a ../../external/libuSockets.a
../../external/libuv/libuv_a.a -lpsapi -luser32 -ladvapi32 -luserenv
../cryptonote_protocol/libcryptonote_protocol.a ../p2p/libp2p.a
../cryptonote_core/libcryptonote_core.a ../multisig/libmultisig.a
../blockchain_db/libblockchain_db.a ../ringct/libringct.a
../sqlitedb/libsqlitedb.a ../checkpoints/libcheckpoints.a
../bls/libbls_aggregator.a ../l2_tracker/libl2_tracker.a
../cryptonote_basic/libcryptonote_basic.a ../device/libdevice.a ../libversion.a
../ringct/libringct_basic.a ../../static-deps/lib/libhidapi.a
../../static-deps/lib/libusb-1.0.a ../bls/libbls_crypto.a
../../external/bn256/src/libbn256.a ../../lib/Release/libethyl.a
../../static-deps/lib/libgmp.a ../../static-deps/lib/libtasn1.a
../../external/SQLiteCpp/libSQLiteCpp.a ../../static-deps/lib/libsqlite3.a
../blocks/libblocks.a ../mnemonics/libmnemonics.a ../net/libnet.a
../../external/db_drivers/liblmdb/liblmdb.a ../rpc/librpc_http_client.a
../../external/ethyl/external/cpr/cpr/libcpr.a ../../static-deps/lib/libcurl.a
../../static-deps/lib/libz.a ../../static-deps/lib/libidn2.a
../../static-deps/lib/libunistring.a ../../static-deps/lib/libiconv.a
../common/libcommon.a ../../static-deps/lib/libboost_serialization.a
../../static-deps/lib/libboost_program_options.a ../crypto/libcncrypto.a
../logging/liblogging.a ../../contrib/epee/src/libepee.a -lmswsock -lws2_32
-liphlpapi -lcrypt32 -lbcrypt -lsetupapi ../../external/oxen-mq/liboxenmq.a
../../static-deps/lib/libzmq.a ../../static-deps/lib/libboost_thread.a
../../external/oxen-logging/liboxen-logging.a
../../external/oxen-logging/spdlog/libspdlog.a
../../external/oxen-logging/fmt/libfmt.a ../../external/randomx/librandomx.a
../../static-deps/lib/libsodium.a -lkernel32 -luser32 -lgdi32 -lwinspool
-lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32

C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x28f9): undefined reference to `boost::serialization::extended_type_info::key_unregister() const'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2901): undefined reference to `boost::serialization::typeid_system::extended_type_info_typeid_0::type_unregister()'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2949): undefined reference to `boost::serialization::extended_type_info::key_unregister() const'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2951): undefined reference to `boost::serialization::typeid_system::extended_type_info_typeid_0::type_unregister()'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2999): undefined reference to `boost::serialization::extended_type_info::key_unregister() const'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x29a1): undefined reference to `boost::serialization::typeid_system::extended_type_info_typeid_0::type_unregister()'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x29e9): undefined reference to `boost::serialization::extended_type_info::key_unregister() const'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x29f1): undefined reference to `boost::serialization::typeid_system::extended_type_info_typeid_0::type_unregister()'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2a39): undefined reference to `boost::serialization::extended_type_info::key_unregister() const'
C:/msys/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/wallet_rpc_server.dir/objects.a(wallet_rpc_server.cpp.obj):wallet_rpc_server.cpp:(.text+0x2a41): undefined reference to `boost::serialization::typeid_system::extended_type_info_typeid_0::type_unregister()'
```
The missing symbols are being linked in the linking invocation i.e: `../../static-deps/lib/libboost_serialization.a` and a `nm` dump of the object reveals the exact symbols that the linker is looking for in for example, the text section of the static library. I've pulled down the command that the CI machine cross compiles with and executed the exact same command with failures.

My assessment of the build situation is some platform specific issue regarding `binutils` is breaking on a Windows machine but doesn't on a Linux machine that is cross-compiling a Windows binary (for example the long file name paths as a platform difference is suspect). 

I've tried shuffling linking library order around as `ld` is sensitive to the order that it's listed on the command line to no success. Potentially something also to do with `ld` on Windows struggling with a lot of linking libraries. I've had one instance where a build actually succeeded and produced a usable `oxend.exe` but I was unable to reproduce this. In that build there were no changes to the build script it just intermittently worked somehow.

Unfortunately I don't have a clue what that is for the time being so I'm shipping all the other fixes I've had to make and leave this in a close-to-working but still broken state.

The build had to be updated to using `StaticBuild.cmake` because MSYS's package manager now ships Boost 1.87 which is incompatible with the codebase (because of legacy epee networking utils that use a deprecated class `io_service` vs `io_context`). Since MSYS is constantly updating and deprecating packages and they do not provide a reliable way to access older versioned packages, having a constantly moving target will make the Windows build difficult to maintain, so I've locked it down by forcing a static build.
