### PR TITLE
Subsystem rescan statistics and logging fixes

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -35,15 +35,10 @@
 #include <fmt/color.h>
 
 #include <chrono>
-#include <iomanip>
 #include <string>
 #include <thread>
 
-#include "crypto/crypto.h"
-#include "epee/misc_log_ex.h"
-#include "epee/readline_buffer.h"
 #include "epee/string_tools.h"
-#include "epee/wipeable_string.h"
 #include "i18n.h"
 #include "logging/oxen_logger.h"
 #include "string_util.h"
@@ -199,32 +194,29 @@ std::string get_human_readable_timestamp(std::time_t t) {
 std::string get_human_readable_timespan(std::chrono::seconds seconds) {
     uint64_t ts = seconds.count();
     if (ts < 60)
-        return std::to_string(ts) + tr(" seconds");
+        return "{}{}"_format(ts, tr(" seconds"));
     if (ts < 3600)
-        return std::to_string((uint64_t)(ts / 60)) + tr(" minutes");
+        return "{:.1f}{}"_format(ts / 60.0, tr(" minutes"));
     if (ts < 3600 * 24)
-        return std::to_string((uint64_t)(ts / 3600)) + tr(" hours");
+        return "{:.1f}{}"_format(ts / 3600.0, tr(" hours"));
     if (ts < 3600 * 24 * 30.5)
-        return std::to_string((uint64_t)(ts / (3600 * 24))) + tr(" days");
-    if (ts < 3600 * 24 * 365.25)
-        return std::to_string((uint64_t)(ts / (3600 * 24 * 30.5))) + tr(" months");
-    return tr("a long time");
+        return "{:.1f}{}"_format(ts / (24 * 3600.0), tr(" days"));
+    if (ts < 3600 * 24 * 365.2425)
+        return "{:.1f}{}"_format(ts / (3600 * 24 * 30.5), tr(" months"));
+    return "{:.1f}{}"_format(ts / (3600 * 24 * 365.2425), tr(" years"));
 }
 
 std::string get_human_readable_bytes(uint64_t bytes) {
     if (bytes < 1000)
-        return std::to_string(bytes) + " B";
-    constexpr std::array units{" kB", " MB", " GB", " TB"};
+        return "{} B"_format(bytes);
+    constexpr std::array prefixes{'k', 'M', 'G', 'T'};
     double b = bytes;
-    for (const auto& suffix : units) {
+    for (const auto& prefix : prefixes) {
         b /= 1000.;
-        if (b < 1000.) {
-            std::ostringstream o;
-            o << std::fixed << std::setprecision(2) << b;
-            return o.str() + suffix;
-        }
+        if (b < 1000.)
+            return "{:.2f} {}B"_format(b, prefix);
     }
-    return std::to_string(std::lround(b)) + units.back();
+    return "{:.0f} {}B"_format(b, prefixes.back());
 }
 
 // Calculate a "sync weight" over ranges of blocks in the blockchain, suitable for

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -34,12 +34,11 @@
 
 #include <chrono>
 #include <concepts>
-#include <memory>
 #include <optional>
 #include <string>
 #include <type_traits>
 
-#include "crypto/hash.h"
+#include "crypto/base.h"
 #include "cryptonote_config.h"
 
 /*! \brief Dumping ground for random functions.  Please think long and hard before you add anything

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -55,6 +55,7 @@
 #include "common/sha256sum.h"
 #include "common/string_util.h"
 #include "common/threadpool.h"
+#include "common/util.h"
 #include "common/varint.h"
 #include "crypto/crypto.h"
 #include "crypto/eth.h"
@@ -351,34 +352,34 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
     dseconds ons_duration{}, snl_duration{}, ons_iteration_duration{}, snl_iteration_duration{};
 
     // NOTE: Stats
-    uint64_t blocks_per_iteration = 0;
+    uint64_t work_blocks = 0;
+    uint64_t total_bytes = 0, work_bytes = 0;
+
     for (uint64_t height = start_height; height < end_height; height += CHUNK_SIZE) {
         if (abort && *abort)
             return false;
 
         // NOTE: Log progress every 10s
         auto now = clock::now();
-        auto duration = dseconds{now - work_start};
+        dseconds duration{now - work_start};
         bool every_10s = duration >= 10s;
 
         if ((height + CHUNK_SIZE) >= end_height || every_10s) {
             service_node_list.store();
 
-            auto duration_ms =
-                    std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-            float blocks_per_s = blocks_per_iteration / static_cast<float>(duration_ms) / 1000.f;
-            float gb_per_s = sizeof(cryptonote::block) * blocks_per_s / 1024.f / 1024.f;
+            float blocks_per_s = work_blocks / duration.count();
+            float bytes_per_s = work_bytes / duration.count();
 
             log::info(
                     globallogcat,
-                    "... scanning height {} ({:.3f}s) (snl: {:.3f}s; ons: {:.3f}s; {:.1f} blks/s; "
-                    "{} MiB/s)",
+                    "... scanning height {} ({:.2f}s) (snl: {:.2f}s; ons: {:.2f}s; {:.1f} blks/s; "
+                    "{}/s)",
                     height,
                     duration.count(),
                     snl_iteration_duration.count(),
                     ons_iteration_duration.count(),
                     blocks_per_s,
-                    gb_per_s);
+                    tools::get_human_readable_bytes(bytes_per_s));
 #ifdef ENABLE_SYSTEMD
             // Tell systemd that we're doing something so that it should let us continue starting up
             // (giving us 120s until we have to send the next notification):
@@ -394,14 +395,17 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
             ons_iteration_duration = 0s;
             snl_iteration_duration = 0s;
 
-            if (every_10s)  // NOTE: Reset block load counter
-                blocks_per_iteration = 0;
+            if (every_10s) {  // NOTE: Reset iteration stats
+                total_bytes += work_bytes;
+                work_blocks = work_bytes = 0;
+            }
         }
 
         // NOTE: Grab blocks
         std::vector<cryptonote::block> blocks;
-        if (!get_blocks(height, CHUNK_SIZE, blocks)) {
-            log::error(
+        size_t blocks_size;
+        if (!get_blocks(height, CHUNK_SIZE, blocks, nullptr, &blocks_size)) {
+            log::critical(
                     logcat,
                     "Unable to get checkpointed historical blocks [{}-{}] for updating oxen "
                     "subsystems",
@@ -411,18 +415,27 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
         }
 
         // NOTE: Load blocks into subsystems
-        blocks_per_iteration += blocks.size();
+        work_blocks += blocks.size();
+        work_bytes += blocks_size;
+
+        std::vector<cryptonote::transaction> txs;
+        std::unordered_set<crypto::hash> missed_txs;
+
         for (cryptonote::block const& blk : blocks) {
             uint64_t block_height = blk.get_height();
 
-            std::vector<cryptonote::transaction> txs;
-            if (!get_transactions(blk.tx_hashes, txs)) {
-                log::error(
+            txs.clear();
+            size_t txs_size;
+            if (!get_transactions(blk.tx_hashes, txs, &missed_txs, &txs_size) ||
+                !missed_txs.empty()) {
+                log::critical(
                         logcat,
-                        "Unable to get transactions for block for updating ONS DB: {}",
+                        "Unable to get all transactions for subsystem updating from block: {}",
                         cryptonote::get_block_hash(blk));
                 return false;
             }
+
+            work_bytes += txs_size;
 
             if (block_height >= snl_height) {
                 auto snl_start = clock::now();
@@ -439,7 +452,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
                     constexpr bool skip_verify = true;
                     service_node_list.block_add(blk, txs, checkpoint_ptr, skip_verify);
                 } catch (const std::exception& e) {
-                    log::error(
+                    log::critical(
                             logcat,
                             "Unable to process block for updating service node list: {}",
                             e.what());
@@ -451,7 +464,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
             if (m_ons_db.db && (block_height >= ons_height)) {
                 auto ons_start = clock::now();
                 if (!m_ons_db.add_block(blk, txs)) {
-                    log::error(
+                    log::critical(
                             logcat,
                             "Unable to process block for updating ONS DB: {}",
                             cryptonote::get_block_hash(blk));
@@ -465,25 +478,34 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
 
     if (total_blocks > 0) {
         // NOTE: Check that all subsystems ended up synchronised to the same height
-        assert(service_node_list.height() == m_ons_db.height());
-        if (m_sqlite_db)
-            assert(m_ons_db.height() == m_sqlite_db->height);
-        assert(service_node_list.height() == end_height - 1);
+        if (service_node_list.height() != m_ons_db.height() ||
+            (m_sqlite_db && m_ons_db.height() != m_sqlite_db->height) ||
+            service_node_list.height() != end_height - 1) {
+            log::critical(
+                    logcat,
+                    "Mismatched subsystem height after subsystem refresh: "
+                    "blockchain ({}), SN ({}), ONS ({}){}",
+                    end_height - 1,
+                    service_node_list.height(),
+                    m_ons_db.height(),
+                    m_sqlite_db ? ", rewards ({})"_format(m_sqlite_db->height) : "");
+            return false;
+        }
 
-        auto duration = end - scan_start;
-        auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-        float blocks_per_s = blocks_per_iteration / static_cast<float>(duration_ms) / 1000.f;
-        float gb_per_s = sizeof(cryptonote::block) * blocks_per_s / 1024.f / 1024.f;
+        total_bytes += work_bytes;
+
+        dseconds duration{end - scan_start};
+        float blocks_per_s = total_blocks / duration.count();
+        float bytes_per_s = total_bytes / duration.count();
 
         log::info(
                 globallogcat,
-                "Loading subsystems done in {:.2f}s ({:.2f}s snl; {:.2f}s ons; {:.1f} "
-                "blks/s; {} MiB/s)",
-                dseconds{duration}.count(),
+                "Loaded subsystems in {:.2f}s (snl: {:.2f}s; ons: {:.2f}s; {:.1f} blks/s; {}/s)",
+                duration.count(),
                 snl_duration.count(),
                 ons_duration.count(),
                 blocks_per_s,
-                gb_per_s);
+                tools::get_human_readable_bytes(bytes_per_s));
         service_node_list.store();
     }
 
@@ -2596,10 +2618,14 @@ bool Blockchain::get_blocks(
         uint64_t start_offset,
         size_t count,
         std::vector<block>& blocks,
-        std::vector<std::string>* txs) const {
+        std::vector<std::string>* txs,
+        size_t* size_loaded) const {
     log::trace(logcat, "Blockchain::{}", __func__);
     std::unique_lock lock{*this};
     const uint64_t height = m_db->height();
+    if (size_loaded)
+        *size_loaded = 0;
+
     if (start_offset >= height)
         return false;
 
@@ -2607,7 +2633,10 @@ bool Blockchain::get_blocks(
     blocks.reserve(blocks.size() + num_blocks);
     for (size_t i = 0; i < num_blocks; i++) {
         try {
-            blocks.emplace_back(m_db->get_block_from_height(start_offset + i));
+            size_t size;
+            blocks.emplace_back(m_db->get_block_from_height(start_offset + i, &size));
+            if (size_loaded)
+                *size_loaded += size;
         } catch (std::exception const& e) {
             log::error(logcat, "Invalid block at height {}. {}", start_offset + i, e.what());
             return false;
@@ -3143,16 +3172,22 @@ bool Blockchain::get_split_transactions_blobs(
 bool Blockchain::get_transactions(
         const std::vector<crypto::hash>& txs_ids,
         std::vector<transaction>& txs,
-        std::unordered_set<crypto::hash>* missed_txs) const {
+        std::unordered_set<crypto::hash>* missed_txs,
+        size_t* total_size) const {
     log::trace(logcat, "Blockchain::{}", __func__);
     std::unique_lock lock{*this};
 
     txs.reserve(txs_ids.size());
     std::string tx;
+    if (total_size)
+        *total_size = 0;
+
     for (const auto& tx_hash : txs_ids) {
         tx.clear();
         try {
             if (m_db->get_tx_blob(tx_hash, tx)) {
+                if (total_size)
+                    *total_size += tx.size();
                 txs.emplace_back();
                 if (!parse_and_validate_tx_from_blob(tx, txs.back())) {
                     log::error(logcat, "Invalid transaction");

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -202,11 +202,16 @@ class Blockchain {
      */
     bool deinit();
 
+    /// Loads `count` blocks (optionally including transaction data within those blocks), starting
+    /// at height `start_offset`.  The total amount of block data consumed (not including
+    /// transactions) will be set in `blocks_size`, if provided.
     bool get_blocks(
             uint64_t start_offset,
             size_t count,
             std::vector<block>& blocks,
-            std::vector<std::string>* txs = nullptr) const;
+            std::vector<std::string>* txs = nullptr,
+            size_t* blocks_size = nullptr) const;
+
     /**
      * @brief get blocks and transactions from blocks based on start height and count
      *
@@ -869,7 +874,8 @@ class Blockchain {
     bool get_transactions(
             const std::vector<crypto::hash>& txs_ids,
             std::vector<transaction>& txs,
-            std::unordered_set<crypto::hash>* missed_txs = nullptr) const;
+            std::unordered_set<crypto::hash>* missed_txs = nullptr,
+            size_t* total_size = nullptr) const;
 
     /**
      * @brief looks up transactions based on a list of transaction hashes and returns the block


### PR DESCRIPTION
- Simplify some unnecessary chrono size casts by just using a floating point seconds type.

- The reported "blks/s" value was always reporting 0.0 (because of a ÷ 1000 that should have been a × 1000).  This wasn't fixed directly but rather got resolved by the above point removing the need for s <-> ms conversion.

- The MiB/s value was being calculated using sizeof(cryptonote::block) instead of the actual sizes of blocks and transactions that we process.  This fixes it, adding a couple of optional arguments into the block/tx fetching methods to expose the size retrieval already available deeper in the LMDB API.

- Lower the time precision to two decimal places instead of 3, to slightly shorten the line (and because 2 decimal digits of precision on a 10s+ value seems like more than enough).

- Switches to tools::get_human_readable_bytes for auto-ranging prefix rather than a fixed MiB/s calculation.  The reported MiB/s value for mainnet nodes, at least, was tiny, e.g. 4.1679375e-08 MiB/s; part of this was the 1e6 correction above, but even after that would still be something like 0.04167...  MiB/s instead of the 41.68 kB/s that get_human_readable_bytes produces.

- Upgrade some of the subsystem error logs (which will always be fatal) to critical instead of error severity.

- Added a check for no missing transactions to the subsystem transaction fetch.  If we fail to retrieve any of a block's transactions (e.g. because of some lmdb inconsistency) we need to fail, but were previously not noticing (and thus could potentially not process required transactinos).

- Change the asserts on the final subsystem heights checks into always-checked values, with a critical log and failure return if they don't match.  This code only runs once, and it seems a worthwhile consistency check.

Before:

    Loading blocks into oxen subsystems, scanning blockchain from height: 1750001 to: 1762613 (snl: 1750001, sql: 1750001, ons: 1760000)
    ... scanning height 1750801 (12.166s) (snl: 12.079s; ons: 0.000s; 0.0 blks/s; 4.7162388e-08 MiB/s)
    ... scanning height 1751101 (11.502s) (snl: 10.179s; ons: 0.000s; 0.0 blks/s; 1.8706976e-08 MiB/s)
    ... scanning height 1751701 (10.534s) (snl: 9.293s; ons: 0.000s; 0.0 blks/s; 4.0848477e-08 MiB/s)
    ... scanning height 1752301 (10.511s) (snl: 9.349s; ons: 0.000s; 0.0 blks/s; 4.093786e-08 MiB/s)
    ... scanning height 1752901 (12.073s) (snl: 10.894s; ons: 0.000s; 0.0 blks/s; 3.5641335e-08 MiB/s)
    ... scanning height 1753501 (10.098s) (snl: 8.887s; ons: 0.000s; 0.0 blks/s; 4.2616406e-08 MiB/s)
    ... scanning height 1754001 (11.171s) (snl: 9.990s; ons: 0.000s; 0.0 blks/s; 3.2099326e-08 MiB/s)
    ... scanning height 1754101 (12.045s) (snl: 7.646s; ons: 0.000s; 0.0 blks/s; 5.954031e-09 MiB/s)
    ... scanning height 1754801 (11.513s) (snl: 10.362s; ons: 0.000s; 0.0 blks/s; 4.3604114e-08 MiB/s)
    ... scanning height 1755401 (20.159s) (snl: 19.010s; ons: 0.000s; 0.0 blks/s; 2.1346256e-08 MiB/s)
    ... scanning height 1756001 (10.325s) (snl: 9.156s; ons: 0.000s; 0.0 blks/s; 4.1679375e-08 MiB/s)
    ... scanning height 1756601 (10.956s) (snl: 9.741s; ons: 0.000s; 0.0 blks/s; 3.927867e-08 MiB/s)
    ... scanning height 1757201 (10.950s) (snl: 9.787s; ons: 0.000s; 0.0 blks/s; 3.929661e-08 MiB/s)
    ... scanning height 1757701 (11.511s) (snl: 10.174s; ons: 0.000s; 0.0 blks/s; 3.1153913e-08 MiB/s)
    ... scanning height 1758301 (10.623s) (snl: 9.443s; ons: 0.000s; 0.0 blks/s; 4.051006e-08 MiB/s)
    ... scanning height 1758801 (11.879s) (snl: 10.740s; ons: 0.000s; 0.0 blks/s; 3.0186175e-08 MiB/s)
    ... scanning height 1758901 (11.456s) (snl: 10.264s; ons: 0.000s; 0.0 blks/s; 6.2601524e-09 MiB/s)
    ... scanning height 1759401 (10.202s) (snl: 8.997s; ons: 0.000s; 0.0 blks/s; 3.5151608e-08 MiB/s)
    ... scanning height 1760001 (11.287s) (snl: 10.118s; ons: 0.000s; 0.0 blks/s; 3.8123314e-08 MiB/s)
    ... scanning height 1760601 (12.886s) (snl: 11.545s; ons: 0.004s; 0.0 blks/s; 3.3395256e-08 MiB/s)
    ... scanning height 1761101 (11.010s) (snl: 9.584s; ons: 0.003s; 0.0 blks/s; 3.2568714e-08 MiB/s)
    ... scanning height 1761701 (11.056s) (snl: 9.852s; ons: 0.004s; 0.0 blks/s; 3.892337e-08 MiB/s)
    ... scanning height 1762101 (14.732s) (snl: 13.526s; ons: 0.003s; 0.0 blks/s; 1.9472253e-08 MiB/s)
    ... scanning height 1762301 (10.224s) (snl: 9.001s; ons: 0.001s; 0.0 blks/s; 1.4030385e-08 MiB/s)
    ... scanning height 1762601 (8.320s) (snl: 7.138s; ons: 0.002s; 0.0 blks/s; 2.5862356e-08 MiB/s)
    Loading subsystems done in 290.56s (256.76s snl; 0.02s ons; 0.0 blks/s; 7.700762e-10 MiB/s)

After:

    Loading blocks into oxen subsystems, scanning blockchain from height: 1750001 to: 1762669 (snl: 1750001, sql: 1750001, ons: 1760000)
    ... scanning height 1750801 (10.57s) (snl: 10.51s; ons: 0.00s; 75.7 blks/s; 63.25 kB/s)
    ... scanning height 1751501 (10.60s) (snl: 9.18s; ons: 0.00s; 66.0 blks/s; 57.14 kB/s)
    ... scanning height 1752101 (15.19s) (snl: 13.98s; ons: 0.00s; 39.5 blks/s; 33.77 kB/s)
    ... scanning height 1752201 (12.14s) (snl: 10.86s; ons: 0.00s; 8.2 blks/s; 7.74 kB/s)
    ... scanning height 1752501 (10.04s) (snl: 8.79s; ons: 0.00s; 29.9 blks/s; 24.35 kB/s)
    ... scanning height 1753001 (10.14s) (snl: 8.84s; ons: 0.00s; 49.3 blks/s; 57.63 kB/s)
    ... scanning height 1753501 (11.39s) (snl: 10.21s; ons: 0.00s; 43.9 blks/s; 42.16 kB/s)
    ... scanning height 1754101 (10.44s) (snl: 9.19s; ons: 0.00s; 57.5 blks/s; 48.90 kB/s)
    ... scanning height 1754801 (11.51s) (snl: 10.31s; ons: 0.00s; 60.8 blks/s; 46.54 kB/s)
    ... scanning height 1755401 (10.94s) (snl: 9.68s; ons: 0.00s; 54.8 blks/s; 54.80 kB/s)
    ... scanning height 1755501 (17.91s) (snl: 16.66s; ons: 0.00s; 5.6 blks/s; 4.13 kB/s)
    ... scanning height 1756101 (10.91s) (snl: 9.66s; ons: 0.00s; 55.0 blks/s; 48.37 kB/s)
    ... scanning height 1756701 (11.73s) (snl: 10.53s; ons: 0.00s; 51.2 blks/s; 51.76 kB/s)
    ... scanning height 1757201 (12.94s) (snl: 11.71s; ons: 0.00s; 38.6 blks/s; 39.18 kB/s)
    ... scanning height 1757801 (10.79s) (snl: 9.54s; ons: 0.00s; 55.6 blks/s; 41.81 kB/s)
    ... scanning height 1758301 (11.05s) (snl: 9.84s; ons: 0.00s; 45.3 blks/s; 46.87 kB/s)
    ... scanning height 1758801 (11.64s) (snl: 10.41s; ons: 0.00s; 43.0 blks/s; 32.68 kB/s)
    ... scanning height 1759301 (10.78s) (snl: 8.85s; ons: 0.00s; 46.4 blks/s; 38.76 kB/s)
    ... scanning height 1759901 (11.68s) (snl: 10.46s; ons: 0.00s; 51.4 blks/s; 39.21 kB/s)
    ... scanning height 1760401 (11.42s) (snl: 10.20s; ons: 0.00s; 43.8 blks/s; 32.16 kB/s)
    ... scanning height 1760901 (11.00s) (snl: 9.56s; ons: 0.00s; 45.5 blks/s; 34.23 kB/s)
    ... scanning height 1761401 (10.02s) (snl: 8.75s; ons: 0.00s; 49.9 blks/s; 35.55 kB/s)
    ... scanning height 1761901 (10.32s) (snl: 9.12s; ons: 0.00s; 48.5 blks/s; 35.40 kB/s)
    ... scanning height 1762301 (12.60s) (snl: 11.24s; ons: 0.00s; 31.7 blks/s; 30.35 kB/s)
    ... scanning height 1762601 (8.10s) (snl: 6.75s; ons: 0.00s; 37.1 blks/s; 30.05 kB/s)
    Loaded subsystems in 288.36s (snl: 254.81s; ons: 0.02s; 43.9 blks/s; 37.95 kB/s)