### PR TITLE
Add a persistent Ed->X conversion cache

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <mutex>
 #include <stdexcept>
 
 #include "blockchain.h"
@@ -3240,15 +3241,23 @@ static void generate_other_quorums(
     }
 }
 
+static std::unordered_map<crypto::public_key, crypto::x25519_public_key> snpk_xpk_cache;
+static std::mutex snpk_mut;
+
 // Converts an Ed25519 public key to an x25519 pubkey.  Only intended for use with hf >=
 // feature::SN_PK_IS_ED25519 (because before that we don't have a guarantee that a
 // crypto::public_key is actually the correct Ed25519 pubkeys that we want to convert to get the
 // X25519 pubkey).
-crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk) {
-    crypto::x25519_public_key xpk;
-    if (0 != crypto_sign_ed25519_pk_to_curve25519(xpk.data(), snpk.data()))
-        throw oxen::traced<std::runtime_error>{
-                "Unable to convert SN Ed25519 pubkey {} to X25519 pubkey"_format(snpk)};
+crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk, bool already_locked) {
+    std::unique_lock lock{snpk_mut, std::defer_lock};
+    if (!already_locked)
+        lock.lock();
+    auto& xpk = snpk_xpk_cache[snpk];
+    if (!xpk) {
+        if (0 != crypto_sign_ed25519_pk_to_curve25519(xpk.data(), snpk.data()))
+            throw oxen::traced<std::runtime_error>{
+                    "Unable to convert SN Ed25519 pubkey {} to X25519 pubkey"_format(snpk)};
+    }
     return xpk;
 }
 
@@ -5288,13 +5297,14 @@ void service_node_list::state_t::initialize_alt_pk_maps() {
         !cryptonote::is_hard_fork_at_least(sn_list->blockchain.nettype(), feature::ETH_BLS, height))
         return;
 
+    std::lock_guard lock{snpk_mut};
     for (const auto& [snpk, info] : service_nodes_infos) {
-        x25519_map.emplace(snpk_to_xpk(snpk), snpk);
+        x25519_map.emplace(snpk_to_xpk(snpk, true), snpk);
         bls_map.emplace(info->bls_public_key, snpk);
     }
 
     for (const auto& it : recently_removed_nodes) {
-        x25519_map.emplace(snpk_to_xpk(it.service_node_pubkey), it.service_node_pubkey);
+        x25519_map.emplace(snpk_to_xpk(it.service_node_pubkey, true), it.service_node_pubkey);
         bls_map.emplace(it.info.bls_public_key, it.service_node_pubkey);
     }
 }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -465,7 +465,7 @@ struct payout {
     std::vector<payout_entry> payouts;
 };
 
-crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk);
+crypto::x25519_public_key snpk_to_xpk(const crypto::public_key& snpk, bool _already_locked = false);
 
 /// Collection of keys used by a service node
 struct service_node_keys {


### PR DESCRIPTION
We convert these values for *every* state, which means when we initially populate a few hundred recent state_t's, each one of those state_t constructions does an Ed->X conversion for every network pubkey, which is already over 100k conversions on stagenet, and will be many hundreds of thousands on mainnet.

This is visible on current stagenet, where oxend takes around 7-8s at startup just to initialize the state_ts; profiling revealed that virtually all of this time is spent in libsodium converting these keys.

This adds a persistent cache to eliminate this overhead.

The cache is never pruned, but as this conversion is only done for registered nodes there is effectively a limit on how big it will get.

With this applied, that particular block of startup code drops (on current stagenet) from 8s to 0.1s.