### PR TITLE
Fix subsystem rescan edge cases

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -59,16 +59,16 @@ BlockchainSQLite::BlockchainSQLite(
     height = prepared_get<int64_t>("SELECT height FROM batch_db_info");
 
     uint64_t row_count =
-            batch_payments_accrued_row_count(PaymentTableType::Nil, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Nil, /*height*/ std::nullopt);
     uint64_t recent_count =
-            batch_payments_accrued_row_count(PaymentTableType::Recent, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Recent, /*height*/ std::nullopt);
     uint64_t recent_min_height =
             prepared_get<int>("SELECT MIN(height) FROM batched_payments_accrued_recent");
     uint64_t recent_max_height =
             prepared_get<int>("SELECT MAX(height) FROM batched_payments_accrued_recent");
 
     uint64_t archive_count =
-            batch_payments_accrued_row_count(PaymentTableType::Archive, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Archive, /*height*/ std::nullopt);
     uint64_t archive_min_height =
             prepared_get<int>("SELECT MIN(height) FROM batched_payments_accrued_archive");
     uint64_t archive_max_height =
@@ -479,7 +479,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
     // NOTE: Execute detach
     std::string detach_label = "";
     int rows_restored = 0;
-    int rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, nullptr);
+    int rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, std::nullopt);
     switch (history) {
         case PaymentTableType::Nil: {
             reset_database();
@@ -489,7 +489,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
         default: {
             std::string batched_payments_history_table = "batched_payments_accrued_{}"_format(
                     history == PaymentTableType::Archive ? "archive" : "recent");
-            rows_restored = batch_payments_accrued_row_count(history, &new_height);
+            rows_restored = batch_payments_accrued_row_count(history, new_height);
 
             db.exec(R"(DELETE FROM batched_payments_raw WHERE height_paid > {0};
                        DELETE FROM batched_payments_accrued;
@@ -572,7 +572,7 @@ void BlockchainSQLite::add_sn_rewards(const block_payments& payments) {
 }
 
 size_t BlockchainSQLite::batch_payments_accrued_row_count(
-        PaymentTableType type, const uint64_t* height) {
+        PaymentTableType type, std::optional<uint64_t> height) {
     size_t result = 0;
     switch (type) {
         case PaymentTableType::Nil:

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -68,9 +68,9 @@ class BlockchainSQLite : public db::Database {
 
     // Return the number of rows for the desired batched payments accrued table. The row count will
     // be for the 'height' specified. 'height' is ignored if type is nil as the default accrued
-    // table only stores state for the current DB's height already. If 'height' is null then the row
+    // table only stores state for the current DB's height already. If 'height' is nullopt then the row
     // count of the entire table will be returned.
-    size_t batch_payments_accrued_row_count(PaymentTableType type, const uint64_t* height);
+    size_t batch_payments_accrued_row_count(PaymentTableType type, std::optional<uint64_t> height);
 
     // Add payments to the specified addresses to the SQL rewards table. The function throws if
     // insertion into the DB fails.

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -2648,14 +2648,13 @@ bool name_system_db::prune_db(uint64_t height) {
 
         log::debug(
                 logcat,
-                "Detach request for ONS @ {} (is {}), {} to {}",
-                height,
-                this->last_processed_height,
-                result ? "detached to" : "failed to detach",
-                height - 1);
+                "Detach request for ONS (last processed is {}), {} to {}",
+                last_processed_height,
+                result ? "detached" : "failed to detach",
+                height);
 
-        if (result)
-            this->last_processed_height = (height - 1);
+        if (result && height <= last_processed_height)
+            last_processed_height = height - 1;
     }
     return result;
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 
@@ -3714,7 +3715,6 @@ void service_node_list::blockchain_detached(uint64_t height) {
     const auto& netconf = get_config(blockchain.nettype());
     uint64_t target_height = height ? height - 1 : 0;
     uint64_t archive_height = target_height - (target_height % netconf.HISTORY_ARCHIVE_INTERVAL);
-    auto history = cryptonote::BlockchainSQLite::PaymentTableType::Nil;
 
     // NOTE: Early exit if we are already detached to the desired height
     if (m_state.height == target_height) {
@@ -3722,18 +3722,36 @@ void service_node_list::blockchain_detached(uint64_t height) {
             return;
     }
 
+    // NOTE: Checks if the SQL has a backup for the existing height.
+    //
+    // If we are either pre-SQL DB then the SQL DB trivially "has" a backup, because the correct
+    // state is empty.  Otherwise, from HF19 and up, we check that it has actual rows of the given
+    // type at the requested height.
+    const auto sqlite_begins = hard_fork_begins(blockchain.nettype(), hf::hf19_reward_batching)
+                                       .value_or(std::numeric_limits<uint64_t>::max());
+    auto sql_db_has = [this, sqlite_begins](
+                              uint64_t height,
+                              cryptonote::BlockchainSQLite::PaymentTableType table_type) {
+        // NOTE: If we're below HF19 then anything is fine because the correct SQLite DB is
+        // empty:
+        if (height < sqlite_begins)
+            return true;
+
+        // NOTE: Accept if SQL has payment rows for the requested height:
+        return blockchain.sqlite_db().batch_payments_accrued_row_count(
+                       cryptonote::BlockchainSQLite::PaymentTableType::Recent, height) > 0;
+    };
+
     // NOTE: Lookup desired SNL state from recent backups
-    if (history == cryptonote::BlockchainSQLite::PaymentTableType::Nil) {
+    auto history = cryptonote::BlockchainSQLite::PaymentTableType::Nil;
+    {
         state_set& set = m_transient->state_history;
         for (auto it = set.rbegin(); it != set.rend(); it++) {
             // NOTE: Find the closest starting point
             if (it->only_loaded_quorums || it->height > target_height)
                 continue;
 
-            // NOTE: Check if the SQL DB has a backup for the requested height
-            size_t row_count = blockchain.sqlite_db().batch_payments_accrued_row_count(
-                    cryptonote::BlockchainSQLite::PaymentTableType::Recent, &it->height);
-            if (row_count) {  // NOTE: Accept if SQL has
+            if (sql_db_has(it->height, cryptonote::BlockchainSQLite::PaymentTableType::Recent)) {
                 history = cryptonote::BlockchainSQLite::PaymentTableType::Recent;
                 target_height = it->height;
                 break;
@@ -3753,11 +3771,7 @@ void service_node_list::blockchain_detached(uint64_t height) {
                 ((it->height % netconf.HISTORY_ARCHIVE_INTERVAL) != 0))
                 continue;
 
-            // NOTE: Check if the SQL DB has a backup for the requested height
-            size_t row_count = blockchain.sqlite_db().batch_payments_accrued_row_count(
-                    cryptonote::BlockchainSQLite::PaymentTableType::Archive, &it->height);
-
-            if (row_count) {  // NOTE: Accept if SQL has
+            if (sql_db_has(it->height, cryptonote::BlockchainSQLite::PaymentTableType::Archive)) {
                 history = cryptonote::BlockchainSQLite::PaymentTableType::Archive;
                 archive_height = it->height;
                 break;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -537,10 +537,6 @@ class node_server
     cryptonote::network_type m_nettype;
 };
 
-static void log_detailed_peer_stats(
-        std::unordered_map<peerid_type, peer_stats>& peer_stats_map,
-        std::mutex& peer_stats_map_mutex);
-
 extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ip;
 extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ipv6_address;
 extern const command_line::arg_descriptor<uint16_t> arg_p2p_bind_port;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -745,6 +745,16 @@ node_server<t_payload_net_handler>::get_payload_object() {
     return m_payload_handler;
 }
 //-----------------------------------------------------------------------------------
+static void log_detailed_peer_stats(std::unordered_map<peerid_type, peer_stats>& peer_stats_map, std::mutex& peer_stats_map_mutex) {
+    if (log::get_level(logcat) > log::Level::debug)
+      return;
+    std::unique_lock lock{peer_stats_map_mutex};
+    for (const auto& [peer_id, stats] : peer_stats_map) {
+        log::debug(globallogcat, "Peer ID: {}\n\tConnections: {} total, {} failed\n\tLast Connected: {}\n\tTotal Connection Time: {} seconds",
+            peer_id, stats.total_connections, stats.failed_connections, stats.last_connected_timestamp, stats.total_connection_time);
+    }
+}
+//-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::run() {
     // creating thread to log number of connections
@@ -795,16 +805,6 @@ bool node_server<t_payload_net_handler>::run() {
     log::info(logcat, "net_service loop stopped.");
     log_detailed_peer_stats(peer_stats_map, peer_stats_map_mutex);
     return true;
-}
-//-----------------------------------------------------------------------------------
-static void log_detailed_peer_stats(std::unordered_map<peerid_type, peer_stats>& peer_stats_map, std::mutex& peer_stats_map_mutex) {
-    if (log::get_level(logcat) > log::Level::debug)
-      return;
-    std::unique_lock lock{peer_stats_map_mutex};
-    for (const auto& [peer_id, stats] : peer_stats_map) {
-        log::debug(globallogcat, "Peer ID: {}\n\tConnections: {} total, {} failed\n\tLast Connected: {}\n\tTotal Connection Time: {} seconds",
-            peer_id, stats.total_connections, stats.failed_connections, stats.last_connected_timestamp, stats.total_connection_time);
-    }
 }
 //-----------------------------------------------------------------------------------
 static void update_peer_stats(


### PR DESCRIPTION
This fixes some issues I encountered with the subsystem rescanning on mainnet:

- when interrupting a rescan (e.g. by hitting ctrl-C) during a rescan oxend would shut down cleanly, but upon restarting would restart scanning from the beginning of time (i.e. block 101250).  Upon investigation it turned out that this was caused by stopping specifically before HF19 as the the recent fixes to sync status did not recognize no-payment-rows as a valid state (which it is, and is correct, for pre-HF19/batching heights).

- When removing my ons.db and restarting, the brand new ONS db ended up with its current state set to the current top block height, rather than 0.  As a result, it is missing ONS records (which is wrong on its own), and pretty soon causes block syncing to fails when it hits the first ONS update (because the tx updates a record that does not exist, which causes the block to get rejected).  This PR fixes the ONS detach function to only update the ONS height if it would actually lower it, but not allow it to be increased which resolves it and makes ONS properly rescan in such a case.

- Also fixes an unrelated warning about a static function declared in a header without a definition in net_node.h that kept complaining at me.  Fixed it by moving the declaration into net_node.inl, which is the only place the function is used.