### PR TITLE
Subsystem rescan parallel loading

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -59,16 +59,16 @@ BlockchainSQLite::BlockchainSQLite(
     height = prepared_get<int64_t>("SELECT height FROM batch_db_info");
 
     uint64_t row_count =
-            batch_payments_accrued_row_count(PaymentTableType::Nil, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Nil, /*height*/ std::nullopt);
     uint64_t recent_count =
-            batch_payments_accrued_row_count(PaymentTableType::Recent, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Recent, /*height*/ std::nullopt);
     uint64_t recent_min_height =
             prepared_get<int>("SELECT MIN(height) FROM batched_payments_accrued_recent");
     uint64_t recent_max_height =
             prepared_get<int>("SELECT MAX(height) FROM batched_payments_accrued_recent");
 
     uint64_t archive_count =
-            batch_payments_accrued_row_count(PaymentTableType::Archive, /*height*/ nullptr);
+            batch_payments_accrued_row_count(PaymentTableType::Archive, /*height*/ std::nullopt);
     uint64_t archive_min_height =
             prepared_get<int>("SELECT MIN(height) FROM batched_payments_accrued_archive");
     uint64_t archive_max_height =
@@ -479,7 +479,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
     // NOTE: Execute detach
     std::string detach_label = "";
     int rows_restored = 0;
-    int rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, nullptr);
+    int rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, std::nullopt);
     switch (history) {
         case PaymentTableType::Nil: {
             reset_database();
@@ -489,7 +489,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
         default: {
             std::string batched_payments_history_table = "batched_payments_accrued_{}"_format(
                     history == PaymentTableType::Archive ? "archive" : "recent");
-            rows_restored = batch_payments_accrued_row_count(history, &new_height);
+            rows_restored = batch_payments_accrued_row_count(history, new_height);
 
             db.exec(R"(DELETE FROM batched_payments_raw WHERE height_paid > {0};
                        DELETE FROM batched_payments_accrued;
@@ -572,7 +572,7 @@ void BlockchainSQLite::add_sn_rewards(const block_payments& payments) {
 }
 
 size_t BlockchainSQLite::batch_payments_accrued_row_count(
-        PaymentTableType type, const uint64_t* height) {
+        PaymentTableType type, std::optional<uint64_t> height) {
     size_t result = 0;
     switch (type) {
         case PaymentTableType::Nil:

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -68,8 +68,8 @@ class BlockchainSQLite : public db::Database {
 
     // Return the number of rows for the desired batched payments accrued table. The row count will
     // be for the 'height' specified. 'height' is ignored if type is nil as the default accrued
-    // table only stores state for the current DB's height already. If 'height' is nullopt then the row
-    // count of the entire table will be returned.
+    // table only stores state for the current DB's height already. If 'height' is nullopt then the
+    // row count of the entire table will be returned.
     size_t batch_payments_accrued_row_count(PaymentTableType type, std::optional<uint64_t> height);
 
     // Add payments to the specified addresses to the SQL rewards table. The function throws if

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -68,9 +68,9 @@ class BlockchainSQLite : public db::Database {
 
     // Return the number of rows for the desired batched payments accrued table. The row count will
     // be for the 'height' specified. 'height' is ignored if type is nil as the default accrued
-    // table only stores state for the current DB's height already. If 'height' is null then the row
+    // table only stores state for the current DB's height already. If 'height' is nullopt then the row
     // count of the entire table will be returned.
-    size_t batch_payments_accrued_row_count(PaymentTableType type, const uint64_t* height);
+    size_t batch_payments_accrued_row_count(PaymentTableType type, std::optional<uint64_t> height);
 
     // Add payments to the specified addresses to the SQL rewards table. The function throws if
     // insertion into the DB fails.

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -316,7 +316,36 @@ uint64_t Blockchain::get_current_blockchain_height() const {
     return m_db->height();
 }
 //------------------------------------------------------------------
-bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool>* abort) {
+struct block_data {
+    uint64_t height;  // Height of blocks[0] and txs[0]
+    std::vector<cryptonote::block> blocks;
+    std::vector<std::vector<cryptonote::transaction>> txs;
+    size_t size;  // Total block + tx sizes of all the blocks/txs contained here.
+};
+
+// Optional loading of block and tx blobs from the DB with a thread for
+// subsystem rescan. Only used on startup scan. Beware using it at any other
+// point as `Blockchain` has a batching mechanism to defer writes to the DB
+// which are not observable on other threads until a commit has ensued.
+struct block_load_context {
+    // We do the loading here with two threads: a block loader that preloads the next chunks (up
+    // to MAX_QUEUE_SIZE * CHUNK_SIZE blocks preloaded) from the database, and then the current
+    // thread processes those chunks, so that the next load of blocks (which can be I/O bound,
+    // and has parallelizable parsing of the blocks and transactions) happens in parallel with
+    // processing the current set of blocks (which is CPU limited).
+    static constexpr uint64_t CHUNK_SIZE = 50;
+    static constexpr size_t MAX_QUEUE_SIZE = 5;
+
+    std::queue<block_data> next_blocks;
+    std::condition_variable block_cv;
+    std::mutex block_mut;
+    bool failed{false}, finished{false};
+    std::thread thread;
+    uint64_t height;
+};
+
+bool Blockchain::load_missing_blocks_into_oxen_subsystems(
+        const std::atomic<bool>* abort, bool use_threaded_load) {
     constexpr auto no_hf_height = std::numeric_limits<uint64_t>::max();
     const uint64_t hf15_height = hard_fork_begins(m_nettype, hf::hf15_ons).value_or(no_hf_height);
 
@@ -354,132 +383,133 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
     uint64_t work_blocks = 0;
     uint64_t total_bytes = 0, work_bytes = 0;
 
-    // We do the loading here with two threads: a block loader that preloads the next chunks (up to
-    // MAX_QUEUE_SIZE * CHUNK_SIZE blocks preloaded) from the database, and then the current thread
-    // processes those chunks, so that the next load of blocks (which can be I/O bound, and has
-    // parallelizable parsing of the blocks and transactions) happens in parallel with processing
-    // the current set of blocks (which is CPU limited).
-    uint64_t constexpr CHUNK_SIZE = 50;
-    constexpr size_t MAX_QUEUE_SIZE = 5;
+    block_load_context load_context = {};
+    load_context.height = start_height;
 
-    struct block_data {
-        uint64_t height;  // Height of blocks[0] and txs[0]
-        std::vector<cryptonote::block> blocks;
-        std::vector<std::vector<cryptonote::transaction>> txs;
-        size_t size;  // Total block + tx sizes of all the blocks/txs contained here.
-    };
+    auto get_block_data = [&](uint64_t height, uint64_t end_height) -> block_data {
+        block_data next_chunk{};
+        next_chunk.height = height;
+        size_t blocks_size;
+        // We call the internal non-locking version of _get_blocks here because our companion
+        // thread already holds a lock on this, and does not call anything that can change the
+        // LMDB, which is all the lock in get_blocks is meant to achieve.
+        if (!_get_blocks(height, block_load_context::CHUNK_SIZE, next_chunk.blocks, &blocks_size)) {
+            log::critical(
+                    logcat,
+                    "Unable to get checkpointed historical blocks [{}-{}] for updating oxen "
+                    "subsystems",
+                    height,
+                    std::min(height + block_load_context::CHUNK_SIZE - 1, end_height));
+            next_chunk = {};
+            return next_chunk;
+        }
+        next_chunk.size += blocks_size;
 
-    std::queue<block_data> next_blocks;
-    std::condition_variable block_cv;
-    std::mutex block_mut;
-    dseconds load_duration;
-
-    bool load_failed{false}, load_finished{false};
-
-    std::thread block_loader{[&] {
-        // Deferred callback that gets fired if we return early (or throw) that makes sure the
-        // processing thread gets notified about the failure.
-        auto failure_propagator = oxen::defer([&] {
-            std::unique_lock<std::mutex> lock{block_mut};
-            load_failed = true;
-            block_cv.notify_all();
-        });
-
-        for (uint64_t height = start_height; height < end_height; height += CHUNK_SIZE) {
-            {
-                std::unique_lock lock{block_mut};
-                block_cv.wait(lock, [&] {
-                    return load_failed || (abort && *abort) || next_blocks.size() < MAX_QUEUE_SIZE;
-                });
-
-                if (load_failed || (abort && *abort))
-                    return;
-
-                assert(next_blocks.size() < MAX_QUEUE_SIZE);
-            }
-
-            block_data next_chunk{};
-            next_chunk.height = height;
-            size_t blocks_size;
-            // We call the internal non-locking version of _get_blocks here because our companion
-            // thread already holds a lock on this, and does not call anything that can change the
-            // LMDB, which is all the lock in get_blocks is meant to achieve.
-            if (!_get_blocks(height, CHUNK_SIZE, next_chunk.blocks, &blocks_size)) {
+        next_chunk.txs.resize(next_chunk.blocks.size());
+        for (size_t i = 0; i < next_chunk.blocks.size(); i++) {
+            const auto& blk = next_chunk.blocks[i];
+            size_t txs_size;
+            std::unordered_set<crypto::hash> missed_txs;
+            // Non-locking version; see comment about _get_blocks, above, re: safety.
+            if (!_get_transactions(blk.tx_hashes, next_chunk.txs[i], &missed_txs, &txs_size) ||
+                !missed_txs.empty()) {
                 log::critical(
                         logcat,
-                        "Unable to get checkpointed historical blocks [{}-{}] for updating oxen "
-                        "subsystems",
-                        height,
-                        std::min(height + CHUNK_SIZE - 1, end_height));
-                return;
+                        "Unable to get all transactions for subsystem updating from block: {}",
+                        cryptonote::get_block_hash(blk));
+                next_chunk = {};
+                return next_chunk;
             }
-            next_chunk.size += blocks_size;
+            next_chunk.size += txs_size;
+        }
+        return next_chunk;
+    };
 
-            next_chunk.txs.resize(next_chunk.blocks.size());
-            for (size_t i = 0; i < next_chunk.blocks.size(); i++) {
-                const auto& blk = next_chunk.blocks[i];
-                size_t txs_size;
-                std::unordered_set<crypto::hash> missed_txs;
-                // Non-locking version; see comment about _get_blocks, above, re: safety.
-                if (!_get_transactions(blk.tx_hashes, next_chunk.txs[i], &missed_txs, &txs_size) ||
-                    !missed_txs.empty()) {
-                    log::critical(
-                            logcat,
-                            "Unable to get all transactions for subsystem updating from block: {}",
-                            cryptonote::get_block_hash(blk));
-                    return;
+    if (use_threaded_load) {
+        load_context.thread = std::thread{[&] {
+            // Deferred callback that gets fired if we return early (or throw) that makes sure the
+            // processing thread gets notified about the failure.
+            auto failure_propagator = oxen::defer([&] {
+                std::unique_lock<std::mutex> lock{load_context.block_mut};
+                load_context.failed = true;
+                load_context.block_cv.notify_all();
+            });
+
+            for (; load_context.height < end_height;
+                 load_context.height += block_load_context::CHUNK_SIZE) {
+                {
+                    std::unique_lock lock{load_context.block_mut};
+                    load_context.block_cv.wait(lock, [&] {
+                        return load_context.failed || (abort && *abort) ||
+                               load_context.next_blocks.size() < block_load_context::MAX_QUEUE_SIZE;
+                    });
+
+                    if (load_context.failed || (abort && *abort))
+                        return;
+
+                    assert(load_context.next_blocks.size() < block_load_context::MAX_QUEUE_SIZE);
                 }
-                next_chunk.size += txs_size;
+
+                block_data next_chunk = get_block_data(load_context.height, end_height);
+                {
+                    std::unique_lock lock{load_context.block_mut};
+                    load_context.next_blocks.push(std::move(next_chunk));
+                }
+                load_context.block_cv.notify_all();
             }
+
+            // Disarm the failure transmitter, then signal the processing thread that we finished
+            // loading everything.
+            failure_propagator.cancel();
 
             {
-                std::unique_lock lock{block_mut};
-                next_blocks.push(std::move(next_chunk));
+                std::unique_lock lock{load_context.block_mut};
+                load_context.finished = true;
             }
-            block_cv.notify_all();
-        }
-
-        // Disarm the failure transmitter, then signal the processing thread that we finished
-        // loading everything.
-        failure_propagator.cancel();
-
-        {
-            std::unique_lock lock{block_mut};
-            load_finished = true;
-        }
-        block_cv.notify_all();
-    }};
+            load_context.block_cv.notify_all();
+        }};
+    }
 
     // If we bail out of this function in any way before the very end successful `return true` (just
     // before which we cancel this deferred call) then make sure we signal the loader thread and
     // rejoin the thread on our way out.
     auto failure_rejoiner = oxen::defer([&] {
-        {
-            std::unique_lock<std::mutex> lock{block_mut};
-            load_failed = true;
+        if (use_threaded_load) {
+            {
+                std::unique_lock<std::mutex> lock{load_context.block_mut};
+                load_context.failed = true;
+            }
+            load_context.block_cv.notify_all();
+            load_context.thread.join();
         }
-        block_cv.notify_all();
-        block_loader.join();
     });
 
     while (true) {
         block_data chunk;
-        {
-            std::unique_lock lock{block_mut};
-            block_cv.wait(lock, [&] {
-                return load_failed || (abort && *abort) || load_finished || !next_blocks.empty();
-            });
+        if (use_threaded_load) {
+            {
+                std::unique_lock lock{load_context.block_mut};
+                load_context.block_cv.wait(lock, [&] {
+                    return load_context.failed || (abort && *abort) || load_context.finished ||
+                           !load_context.next_blocks.empty();
+                });
 
-            if (load_failed || (abort && *abort))
-                return false;
+                if (load_context.failed || (abort && *abort))
+                    return false;
 
-            if (load_finished && next_blocks.empty())
+                if (load_context.finished && load_context.next_blocks.empty())
+                    break;
+
+                chunk = std::move(load_context.next_blocks.front());
+                load_context.next_blocks.pop();
+            }
+            load_context.block_cv.notify_all();  // Notify the loader that we've removed a block
+        } else {
+            chunk = get_block_data(load_context.height, end_height);
+            if (load_context.height >= end_height || chunk.blocks.empty() || (abort && *abort))
                 break;
-
-            chunk = std::move(next_blocks.front());
-            next_blocks.pop();
+            load_context.height += block_load_context::CHUNK_SIZE;
         }
-        block_cv.notify_all();  // Notify the loader that we've removed a block
 
         uint64_t height = chunk.height;
 
@@ -610,9 +640,11 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
         service_node_list.store();
     }
 
-    failure_rejoiner.cancel();
-    assert(load_finished);
-    block_loader.join();
+    if (use_threaded_load) {
+        failure_rejoiner.cancel();
+        assert(load_context.finished);
+        load_context.thread.join();
+    }
     return true;
 }
 
@@ -622,7 +654,8 @@ static bool exec_detach_hooks(
         std::span<BlockchainDetachedHook> hooks,
         bool by_pop_blocks,
         bool load_missing_blocks = true,
-        const std::atomic<bool>* abort = nullptr) {
+        const std::atomic<bool>* abort = nullptr,
+        bool use_threaded_load = false) {
 
     detached_info hook_data{detach_height, by_pop_blocks};
     for (const auto& hook : hooks)
@@ -630,7 +663,7 @@ static bool exec_detach_hooks(
 
     bool result = true;
     if (load_missing_blocks)
-        result = blockchain.load_missing_blocks_into_oxen_subsystems(abort);
+        result = blockchain.load_missing_blocks_into_oxen_subsystems(abort, use_threaded_load);
     return result;
 }
 
@@ -842,7 +875,8 @@ bool Blockchain::init(
                     m_blockchain_detached_hooks,
                     /*by_pop_blocks*/ false,
                     /*load_missing_blocks_into_oxen_subsystems*/ true,
-                    abort)) {
+                    abort,
+                    /*use_threaded_load*/ true)) {
             return false;
         }
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -41,6 +41,7 @@
 #include <chrono>
 #include <cstdio>
 #include <limits>
+#include <mutex>
 #include <stdexcept>
 
 #include "blockchain_db/blockchain_db.h"
@@ -342,8 +343,6 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
                 ons_height);
     }
 
-    uint64_t constexpr CHUNK_SIZE = 100;
-
     // NOTE: Timers
     using clock = std::chrono::steady_clock;
     using dseconds = std::chrono::duration<double>;
@@ -355,16 +354,141 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
     uint64_t work_blocks = 0;
     uint64_t total_bytes = 0, work_bytes = 0;
 
-    for (uint64_t height = start_height; height < end_height; height += CHUNK_SIZE) {
-        if (abort && *abort)
-            return false;
+    // We do the loading here with two threads: a block loader that preloads the next chunks (up to
+    // MAX_QUEUE_SIZE * CHUNK_SIZE blocks preloaded) from the database, and then the current thread
+    // processes those chunks, so that the next load of blocks (which can be I/O bound, and has
+    // parallelizable parsing of the blocks and transactions) happens in parallel with processing
+    // the current set of blocks (which is CPU limited).
+    uint64_t constexpr CHUNK_SIZE = 50;
+    constexpr size_t MAX_QUEUE_SIZE = 5;
+
+    struct block_data {
+        uint64_t height;  // Height of blocks[0] and txs[0]
+        std::vector<cryptonote::block> blocks;
+        std::vector<std::vector<cryptonote::transaction>> txs;
+        size_t size;  // Total block + tx sizes of all the blocks/txs contained here.
+    };
+
+    std::queue<block_data> next_blocks;
+    std::condition_variable block_cv;
+    std::mutex block_mut;
+    dseconds load_duration;
+
+    bool load_failed{false}, load_finished{false};
+
+    std::thread block_loader{[&] {
+        // Deferred callback that gets fired if we return early (or throw) that makes sure the
+        // processing thread gets notified about the failure.
+        auto failure_propagator = oxen::defer([&] {
+            std::unique_lock<std::mutex> lock{block_mut};
+            load_failed = true;
+            block_cv.notify_all();
+        });
+
+        for (uint64_t height = start_height; height < end_height; height += CHUNK_SIZE) {
+            {
+                std::unique_lock lock{block_mut};
+                block_cv.wait(lock, [&] {
+                    return load_failed || (abort && *abort) || next_blocks.size() < MAX_QUEUE_SIZE;
+                });
+
+                if (load_failed || (abort && *abort))
+                    return;
+
+                assert(next_blocks.size() < MAX_QUEUE_SIZE);
+            }
+
+            block_data next_chunk{};
+            next_chunk.height = height;
+            size_t blocks_size;
+            // We call the internal non-locking version of _get_blocks here because our companion
+            // thread already holds a lock on this, and does not call anything that can change the
+            // LMDB, which is all the lock in get_blocks is meant to achieve.
+            if (!_get_blocks(height, CHUNK_SIZE, next_chunk.blocks, &blocks_size)) {
+                log::critical(
+                        logcat,
+                        "Unable to get checkpointed historical blocks [{}-{}] for updating oxen "
+                        "subsystems",
+                        height,
+                        std::min(height + CHUNK_SIZE - 1, end_height));
+                return;
+            }
+            next_chunk.size += blocks_size;
+
+            next_chunk.txs.resize(next_chunk.blocks.size());
+            for (size_t i = 0; i < next_chunk.blocks.size(); i++) {
+                const auto& blk = next_chunk.blocks[i];
+                size_t txs_size;
+                std::unordered_set<crypto::hash> missed_txs;
+                // Non-locking version; see comment about _get_blocks, above, re: safety.
+                if (!_get_transactions(blk.tx_hashes, next_chunk.txs[i], &missed_txs, &txs_size) ||
+                    !missed_txs.empty()) {
+                    log::critical(
+                            logcat,
+                            "Unable to get all transactions for subsystem updating from block: {}",
+                            cryptonote::get_block_hash(blk));
+                    return;
+                }
+                next_chunk.size += txs_size;
+            }
+
+            {
+                std::unique_lock lock{block_mut};
+                next_blocks.push(std::move(next_chunk));
+            }
+            block_cv.notify_all();
+        }
+
+        // Disarm the failure transmitter, then signal the processing thread that we finished
+        // loading everything.
+        failure_propagator.cancel();
+
+        {
+            std::unique_lock lock{block_mut};
+            load_finished = true;
+        }
+        block_cv.notify_all();
+    }};
+
+    // If we bail out of this function in any way before the very end successful `return true` (just
+    // before which we cancel this deferred call) then make sure we signal the loader thread and
+    // rejoin the thread on our way out.
+    auto failure_rejoiner = oxen::defer([&] {
+        {
+            std::unique_lock<std::mutex> lock{block_mut};
+            load_failed = true;
+        }
+        block_cv.notify_all();
+        block_loader.join();
+    });
+
+    while (true) {
+        block_data chunk;
+        {
+            std::unique_lock lock{block_mut};
+            block_cv.wait(lock, [&] {
+                return load_failed || (abort && *abort) || load_finished || !next_blocks.empty();
+            });
+
+            if (load_failed || (abort && *abort))
+                return false;
+
+            if (load_finished && next_blocks.empty())
+                break;
+
+            chunk = std::move(next_blocks.front());
+            next_blocks.pop();
+        }
+        block_cv.notify_all();  // Notify the loader that we've removed a block
+
+        uint64_t height = chunk.height;
 
         // NOTE: Log progress every 10s
         auto now = clock::now();
         dseconds duration{now - work_start};
         bool every_10s = duration >= 10s;
 
-        if ((height + CHUNK_SIZE) >= end_height || every_10s) {
+        if (height + chunk.blocks.size() >= end_height || every_10s) {
             service_node_list.store();
 
             float blocks_per_s = work_blocks / duration.count();
@@ -372,9 +496,10 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
 
             log::info(
                     globallogcat,
-                    "... scanning height {} ({:.2f}s) (snl: {:.2f}s; ons: {:.2f}s; {:.1f} blks/s; "
-                    "{}/s)",
+                    "... scanning height {}/{} ({:.2f}s) (snl: {:.2f}s; ons: {:.2f}s; {:.1f} "
+                    "blks/s; {}/s)",
                     height,
+                    end_height,
                     duration.count(),
                     snl_iteration_duration.count(),
                     ons_iteration_duration.count(),
@@ -401,41 +526,17 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
             }
         }
 
-        // NOTE: Grab blocks
-        std::vector<cryptonote::block> blocks;
-        size_t blocks_size;
-        if (!get_blocks(height, CHUNK_SIZE, blocks, nullptr, &blocks_size)) {
-            log::critical(
-                    logcat,
-                    "Unable to get checkpointed historical blocks [{}-{}] for updating oxen "
-                    "subsystems",
-                    height,
-                    std::min(height + CHUNK_SIZE - 1, end_height));
-            return false;
-        }
-
         // NOTE: Load blocks into subsystems
-        work_blocks += blocks.size();
-        work_bytes += blocks_size;
+        work_blocks += chunk.blocks.size();
+        work_bytes += chunk.size;
 
         std::vector<cryptonote::transaction> txs;
         std::unordered_set<crypto::hash> missed_txs;
 
-        for (cryptonote::block const& blk : blocks) {
+        for (size_t i = 0; i < chunk.blocks.size(); i++) {
+            const auto& blk = chunk.blocks[i];
             uint64_t block_height = blk.get_height();
-
-            txs.clear();
-            size_t txs_size;
-            if (!get_transactions(blk.tx_hashes, txs, &missed_txs, &txs_size) ||
-                !missed_txs.empty()) {
-                log::critical(
-                        logcat,
-                        "Unable to get all transactions for subsystem updating from block: {}",
-                        cryptonote::get_block_hash(blk));
-                return false;
-            }
-
-            work_bytes += txs_size;
+            const auto& txs = chunk.txs[i];
 
             if (block_height >= snl_height) {
                 auto snl_start = clock::now();
@@ -509,6 +610,9 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(const std::atomic<bool
         service_node_list.store();
     }
 
+    failure_rejoiner.cancel();
+    assert(load_finished);
+    block_loader.join();
     return true;
 }
 
@@ -2613,15 +2717,12 @@ bool Blockchain::handle_alternative_block(
 
     return true;
 }
-//------------------------------------------------------------------
-bool Blockchain::get_blocks(
+bool Blockchain::_get_blocks(
         uint64_t start_offset,
         size_t count,
         std::vector<block>& blocks,
-        std::vector<std::string>* txs,
         size_t* size_loaded) const {
-    log::trace(logcat, "Blockchain::{}", __func__);
-    std::unique_lock lock{*this};
+
     const uint64_t height = m_db->height();
     if (size_loaded)
         *size_loaded = 0;
@@ -2642,6 +2743,22 @@ bool Blockchain::get_blocks(
             return false;
         }
     }
+
+    return true;
+}
+
+//------------------------------------------------------------------
+bool Blockchain::get_blocks(
+        uint64_t start_offset,
+        size_t count,
+        std::vector<block>& blocks,
+        std::vector<std::string>* txs,
+        size_t* size_loaded) const {
+    log::trace(logcat, "Blockchain::{}", __func__);
+    std::unique_lock lock{*this};
+
+    if (!_get_blocks(start_offset, count, blocks, size_loaded))
+        return false;
 
     if (txs) {
         for (const auto& blk : blocks) {
@@ -3169,14 +3286,12 @@ bool Blockchain::get_split_transactions_blobs(
     return true;
 }
 //------------------------------------------------------------------
-bool Blockchain::get_transactions(
+bool Blockchain::_get_transactions(
         const std::vector<crypto::hash>& txs_ids,
         std::vector<transaction>& txs,
         std::unordered_set<crypto::hash>* missed_txs,
         size_t* total_size) const {
     log::trace(logcat, "Blockchain::{}", __func__);
-    std::unique_lock lock{*this};
-
     txs.reserve(txs_ids.size());
     std::string tx;
     if (total_size)
@@ -3200,6 +3315,15 @@ bool Blockchain::get_transactions(
         }
     }
     return true;
+}
+bool Blockchain::get_transactions(
+        const std::vector<crypto::hash>& txs_ids,
+        std::vector<transaction>& txs,
+        std::unordered_set<crypto::hash>* missed_txs,
+        size_t* total_size) const {
+    log::trace(logcat, "Blockchain::{}", __func__);
+    std::unique_lock lock{*this};
+    return _get_transactions(txs_ids, txs, missed_txs, total_size);
 }
 //------------------------------------------------------------------
 // Find the split point between us and foreign blockchain and return

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1262,7 +1262,8 @@ class Blockchain {
 
     tx_memory_pool& tx_pool;
 
-    bool load_missing_blocks_into_oxen_subsystems(const std::atomic<bool>* abort = nullptr);
+    bool load_missing_blocks_into_oxen_subsystems(
+            const std::atomic<bool>* abort = nullptr, bool use_threaded_load = false);
 
 #ifndef IN_UNIT_TESTS
   private:

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -897,7 +897,6 @@ class Blockchain {
             size_t* total_size) const;
 
   public:
-
     /**
      * @brief looks up transactions based on a list of transaction hashes and returns the block
      * height in which they were mined, or 0 if not found on the blockchain.

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -212,6 +212,17 @@ class Blockchain {
             std::vector<std::string>* txs = nullptr,
             size_t* blocks_size = nullptr) const;
 
+  private:
+    /// Private implementation used by the above public get_blocks; this does *not* take a lock and
+    /// must only be used where the lock is already held or safety against LMDB changes is otherwise
+    /// guaranteed.
+    bool _get_blocks(
+            uint64_t start_offset,
+            size_t count,
+            std::vector<block>& blocks,
+            size_t* blocks_size) const;
+
+  public:
     /**
      * @brief get blocks and transactions from blocks based on start height and count
      *
@@ -876,6 +887,16 @@ class Blockchain {
             std::vector<transaction>& txs,
             std::unordered_set<crypto::hash>* missed_txs = nullptr,
             size_t* total_size = nullptr) const;
+
+  private:
+    // Private, non-lock-obtaining implementing code of get_transactions()
+    bool _get_transactions(
+            const std::vector<crypto::hash>& txs_ids,
+            std::vector<transaction>& txs,
+            std::unordered_set<crypto::hash>* missed_txs,
+            size_t* total_size) const;
+
+  public:
 
     /**
      * @brief looks up transactions based on a list of transaction hashes and returns the block

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -2648,14 +2648,13 @@ bool name_system_db::prune_db(uint64_t height) {
 
         log::debug(
                 logcat,
-                "Detach request for ONS @ {} (is {}), {} to {}",
-                height,
-                this->last_processed_height,
-                result ? "detached to" : "failed to detach",
-                height - 1);
+                "Detach request for ONS (last processed is {}), {} to {}",
+                last_processed_height,
+                result ? "detached" : "failed to detach",
+                height);
 
-        if (result)
-            this->last_processed_height = (height - 1);
+        if (result && height <= last_processed_height)
+            last_processed_height = height - 1;
     }
     return result;
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 
@@ -3715,7 +3716,6 @@ void service_node_list::blockchain_detached(uint64_t height) {
     const auto& netconf = get_config(blockchain.nettype());
     uint64_t target_height = height ? height - 1 : 0;
     uint64_t archive_height = target_height - (target_height % netconf.HISTORY_ARCHIVE_INTERVAL);
-    auto history = cryptonote::BlockchainSQLite::PaymentTableType::Nil;
 
     // NOTE: Early exit if we are already detached to the desired height
     if (m_state.height == target_height) {
@@ -3723,18 +3723,36 @@ void service_node_list::blockchain_detached(uint64_t height) {
             return;
     }
 
+    // NOTE: Checks if the SQL has a backup for the existing height.
+    //
+    // If we are either pre-SQL DB then the SQL DB trivially "has" a backup, because the correct
+    // state is empty.  Otherwise, from HF19 and up, we check that it has actual rows of the given
+    // type at the requested height.
+    const auto sqlite_begins = hard_fork_begins(blockchain.nettype(), hf::hf19_reward_batching)
+                                       .value_or(std::numeric_limits<uint64_t>::max());
+    auto sql_db_has = [this, sqlite_begins](
+                              uint64_t height,
+                              cryptonote::BlockchainSQLite::PaymentTableType table_type) {
+        // NOTE: If we're below HF19 then anything is fine because the correct SQLite DB is
+        // empty:
+        if (height < sqlite_begins)
+            return true;
+
+        // NOTE: Accept if SQL has payment rows for the requested height:
+        return blockchain.sqlite_db().batch_payments_accrued_row_count(
+                       cryptonote::BlockchainSQLite::PaymentTableType::Recent, height) > 0;
+    };
+
     // NOTE: Lookup desired SNL state from recent backups
-    if (history == cryptonote::BlockchainSQLite::PaymentTableType::Nil) {
+    auto history = cryptonote::BlockchainSQLite::PaymentTableType::Nil;
+    {
         state_set& set = m_transient->state_history;
         for (auto it = set.rbegin(); it != set.rend(); it++) {
             // NOTE: Find the closest starting point
             if (it->only_loaded_quorums || it->height > target_height)
                 continue;
 
-            // NOTE: Check if the SQL DB has a backup for the requested height
-            size_t row_count = blockchain.sqlite_db().batch_payments_accrued_row_count(
-                    cryptonote::BlockchainSQLite::PaymentTableType::Recent, &it->height);
-            if (row_count) {  // NOTE: Accept if SQL has
+            if (sql_db_has(it->height, cryptonote::BlockchainSQLite::PaymentTableType::Recent)) {
                 history = cryptonote::BlockchainSQLite::PaymentTableType::Recent;
                 target_height = it->height;
                 break;
@@ -3754,11 +3772,7 @@ void service_node_list::blockchain_detached(uint64_t height) {
                 ((it->height % netconf.HISTORY_ARCHIVE_INTERVAL) != 0))
                 continue;
 
-            // NOTE: Check if the SQL DB has a backup for the requested height
-            size_t row_count = blockchain.sqlite_db().batch_payments_accrued_row_count(
-                    cryptonote::BlockchainSQLite::PaymentTableType::Archive, &it->height);
-
-            if (row_count) {  // NOTE: Accept if SQL has
+            if (sql_db_has(it->height, cryptonote::BlockchainSQLite::PaymentTableType::Archive)) {
                 history = cryptonote::BlockchainSQLite::PaymentTableType::Archive;
                 archive_height = it->height;
                 break;


### PR DESCRIPTION
This PR (built on top of #1784 -- ignore those changes here) parallelizes subsystem rescanning into two threads: one that preloads blocks from the LMDB, and the other that does the actual subsystem processing of those blocks.

The effect here is particularly noticeable on my desktop system early in the chain (before bulletproofs, when blocks and transactions were much larger), but this also manages to shave a good 15% or so off later block processing times as well.

This should also helps (probably more) on servers/VPSes with slower storage, where the loading process can spend quite a bit of time being I/O-bound.