### PR TITLE
Remove deprecated SQL tables (batched accrued raw and paid)

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -710,10 +710,10 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const {
     // additional size needed.
     uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
 
-    log::debug(logcat, "DB map size:     {}", mei.me_mapsize);
-    log::debug(logcat, "Space used:      {}", size_used);
-    log::debug(logcat, "Space remaining: {}", mei.me_mapsize - size_used);
-    log::debug(logcat, "Size threshold:  {}", threshold_size);
+    log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(mei.me_mapsize));
+    log::debug(logcat, "Space used:      {}", tools::get_human_readable_bytes(size_used));
+    log::debug(logcat, "Space remaining: {}", tools::get_human_readable_bytes(mei.me_mapsize - size_used));
+    log::debug(logcat, "Size threshold:  {}", tools::get_human_readable_bytes(threshold_size));
     float resize_percent = RESIZE_PERCENT;
     log::debug(
             logcat,
@@ -1498,7 +1498,7 @@ void BlockchainLMDB::open(
             throw0(DB_ERROR("Failed to set max memory map size: {}"_format(mdb_strerror(result))));
         mdb_env_info(m_env, &mei);
         cur_mapsize = (uint64_t)mei.me_mapsize;
-        log::info(logcat, "LMDB memory map size: {}", cur_mapsize);
+        log::info(logcat, "LMDB memory map size: {}", tools::get_human_readable_bytes(cur_mapsize));
     }
 
     if (need_resize()) {

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -712,7 +712,10 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const {
 
     log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(mei.me_mapsize));
     log::debug(logcat, "Space used:      {}", tools::get_human_readable_bytes(size_used));
-    log::debug(logcat, "Space remaining: {}", tools::get_human_readable_bytes(mei.me_mapsize - size_used));
+    log::debug(
+            logcat,
+            "Space remaining: {}",
+            tools::get_human_readable_bytes(mei.me_mapsize - size_used));
     log::debug(logcat, "Size threshold:  {}", tools::get_human_readable_bytes(threshold_size));
     float resize_percent = RESIZE_PERCENT;
     log::debug(

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -796,7 +796,7 @@ void BlockchainSQLite::reward_handler(
     std::lock_guard a_s_lock{address_str_cache_mutex};
 
     if (block.major_version < feature::ETH_BLS) {
-        // Step 1 (pre-ETH only): Pay out the block producer their tx fees (note that, unlike the
+        // Step 1: Pay out the block producer their tx fees (note that, unlike the
         // below, this applies even if the SN isn't currently payable).
         constexpr uint64_t base_sn_reward = oxen::SN_REWARD_HF15 * BATCH_REWARD_FACTOR;
         if (block_reward < base_sn_reward)
@@ -819,9 +819,26 @@ void BlockchainSQLite::reward_handler(
                         payments);
         }
         block_reward = base_sn_reward;
+
+        // Step 2: Add Governance reward to the list
+        if (m_nettype != cryptonote::network_type::FAKECHAIN) {
+            if (parsed_governance_addr.first != block.major_version) {
+                cryptonote::get_account_address_from_str(
+                        parsed_governance_addr.second,
+                        m_nettype,
+                        cryptonote::get_config(m_nettype).governance_wallet_address(
+                                block.major_version));
+                parsed_governance_addr.first = block.major_version;
+            }
+
+            uint64_t foundation_reward =
+                    cryptonote::governance_reward_formula(block.major_version) *
+                    BATCH_REWARD_FACTOR;
+            payments[parsed_governance_addr.second.address] += foundation_reward;
+        }
     }
 
-    // Step 2: Iterate over the payable (active for >=24h) N service nodes and pay each node 1/N
+    // Step 3: Iterate over the payable (active for >=24h) N service nodes and pay each node 1/N
     // fraction of the total block reward.
     const auto payable_service_nodes =
             service_nodes_state.payable_service_nodes_infos(block.get_height(), m_nettype);
@@ -829,21 +846,6 @@ void BlockchainSQLite::reward_handler(
     for (const auto& [node_pubkey, node_info] : payable_service_nodes)
         add_rewards(block.major_version, block_reward / N, *node_info, payments);
 
-    // Step 3: Add Governance reward to the list
-    if (m_nettype != cryptonote::network_type::FAKECHAIN &&
-        block.major_version < feature::ETH_BLS) {
-        if (parsed_governance_addr.first != block.major_version) {
-            cryptonote::get_account_address_from_str(
-                    parsed_governance_addr.second,
-                    m_nettype,
-                    cryptonote::get_config(m_nettype).governance_wallet_address(
-                            block.major_version));
-            parsed_governance_addr.first = block.major_version;
-        }
-        uint64_t foundation_reward =
-                cryptonote::governance_reward_formula(block.major_version) * BATCH_REWARD_FACTOR;
-        payments[parsed_governance_addr.second.address] += foundation_reward;
-    }
     add_sn_rewards(payments);
 }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -476,8 +476,6 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
 
 // Must be called with the address_str_cache_mutex held!
 std::string BlockchainSQLite::get_address_str(const cryptonote::batch_sn_payment& addr) {
-    if (addr.eth_address)
-        return "0x{:x}"_format(addr.eth_address);
     auto& address_str = address_str_cache[addr.address_info.address];
     if (address_str.empty())
         address_str =

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -49,11 +49,8 @@ BlockchainSQLite::BlockchainSQLite(
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
     height = 0;
 
-    if (!db.tableExists("batched_payments_accrued") || !db.tableExists("batched_payments_raw") ||
-        !db.tableExists("batch_db_info")) {
+    if (!table_exists("batched_payments_accrued"))
         create_schema();
-    }
-
     upgrade_schema();
 
     height = prepared_get<int64_t>("SELECT height FROM batch_db_info");
@@ -92,61 +89,31 @@ void BlockchainSQLite::create_schema() {
 
     auto& netconf = cryptonote::get_config(m_nettype);
 
-    db.exec(fmt::format(
-            R"(
-      CREATE TABLE batched_payments_accrued(
-        address VARCHAR NOT NULL,
-        amount BIGINT NOT NULL,
-        payout_offset INTEGER NOT NULL,
-        PRIMARY KEY(address),
-        CHECK(amount >= 0)
-      );
+    db.exec(R"(CREATE TABLE IF NOT EXISTS batched_payments_accrued(
+                 address VARCHAR NOT NULL,
+                 amount BIGINT NOT NULL,
+                 payout_offset INTEGER NOT NULL,
+                 PRIMARY KEY(address),
+                 CHECK(amount >= 0)
+               );
 
-      CREATE INDEX batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
+               CREATE INDEX IF NOT EXISTS batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
 
-      CREATE TRIGGER batch_payments_delete_empty AFTER UPDATE ON batched_payments_accrued
-      FOR EACH ROW WHEN NEW.amount = 0 BEGIN
-          DELETE FROM batched_payments_accrued WHERE address = NEW.address;
-      END;
+               -- For pre-ETH hardfork. Oxen SN's were paid and the amount paid was subtracted
+               -- from the accumulated amount in the DB. After the ETH hardfork the DB tracks
+               -- the lifetime rewards and instead the smart contract tracks how much has been paid
+               -- out. The delta in how much the DB has allocated and how much the smart contract
+               -- has paid is the amount owed.
+               --
+               -- In other words after hardforking, rewards amounts are strictly accumulative which
+               -- means this condition will never trigger.
+               CREATE TRIGGER IF NOT EXISTS batch_payments_delete_empty AFTER UPDATE ON batched_payments_accrued
+               FOR EACH ROW WHEN NEW.amount = 0 BEGIN
+                   DELETE FROM batched_payments_accrued WHERE address = NEW.address;
+               END;
 
-      CREATE TABLE batched_payments_raw(
-        address VARCHAR NOT NULL,
-        amount BIGINT NOT NULL,
-        height_paid BIGINT NOT NULL,
-        PRIMARY KEY(address, height_paid),
-        CHECK(amount >= 0)
-      );
-
-      CREATE INDEX batched_payments_raw_height_idx ON batched_payments_raw(height_paid);
-
-      CREATE TABLE batch_db_info(
-        height BIGINT NOT NULL
-      );
-
-      INSERT INTO batch_db_info(height) VALUES(0);
-
-      CREATE TRIGGER batch_payments_prune AFTER UPDATE ON batch_db_info
-      FOR EACH ROW BEGIN
-          DELETE FROM batched_payments_raw WHERE height_paid < (NEW.height - 10000);
-      END;
-
-      CREATE VIEW batched_payments_paid AS SELECT * FROM batched_payments_raw;
-
-      CREATE TRIGGER make_payment INSTEAD OF INSERT ON batched_payments_paid
-      FOR EACH ROW BEGIN
-          UPDATE batched_payments_accrued SET amount = (amount - NEW.amount) WHERE address = NEW.address;
-          SELECT RAISE(ABORT, 'Address not found') WHERE changes() = 0;
-          INSERT INTO batched_payments_raw(address, amount, height_paid) VALUES(NEW.address, NEW.amount, NEW.height_paid);
-      END;
-
-      CREATE TRIGGER rollback_payment INSTEAD OF DELETE ON batched_payments_paid
-      FOR EACH ROW BEGIN
-          DELETE FROM batched_payments_raw WHERE address = OLD.address AND height_paid = OLD.height_paid;
-          INSERT INTO batched_payments_accrued(address, payout_offset, amount) VALUES(OLD.address, OLD.height_paid % {}, OLD.amount)
-              ON CONFLICT(address) DO UPDATE SET amount = (amount + excluded.amount);
-      END;
-    )",
-            netconf.BATCHING_INTERVAL));
+               CREATE TABLE IF NOT EXISTS batch_db_info(height BIGINT NOT NULL);
+               INSERT INTO  batch_db_info(height) VALUES(0);)");
 
     log::debug(logcat, "Database setup complete");
 }
@@ -196,21 +163,8 @@ void BlockchainSQLite::upgrade_schema() {
         log::debug(logcat, "Adding payout_offset to batching db");
         auto& netconf = get_config(m_nettype);
 
-        db.exec(fmt::format(
-                R"(
-        ALTER TABLE batched_payments_accrued ADD COLUMN payout_offset INTEGER NOT NULL DEFAULT -1;
-
-        CREATE INDEX batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
-
-        DROP TRIGGER IF EXISTS rollback_payment;
-        CREATE TRIGGER rollback_payment INSTEAD OF DELETE ON batched_payments_paid
-        FOR EACH ROW BEGIN
-            DELETE FROM batched_payments_raw WHERE address = OLD.address AND height_paid = OLD.height_paid;
-            INSERT INTO batched_payments_accrued(address, payout_offset, amount) VALUES(OLD.address, OLD.height_paid % {}, OLD.amount)
-                ON CONFLICT(address) DO UPDATE SET amount = (amount + excluded.amount);
-        END;
-        )",
-                netconf.BATCHING_INTERVAL));
+        db.exec(R"(ALTER TABLE batched_payments_accrued ADD COLUMN payout_offset INTEGER NOT NULL DEFAULT -1;
+                   CREATE INDEX batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);)");
 
         auto st = prepared_st(
                 "UPDATE batched_payments_accrued SET payout_offset = ? WHERE address = ?");
@@ -442,17 +396,9 @@ void BlockchainSQLite::reset_database() {
 
     db.exec(R"(
       DROP TABLE IF EXISTS delayed_payments;
-
       DROP TABLE IF EXISTS batched_payments_accrued;
-
       DROP TABLE IF EXISTS batched_payments_accrued_archive;
-
       DROP TABLE IF EXISTS batched_payments_accrued_recent;
-
-      DROP VIEW IF EXISTS batched_payments_paid;
-
-      DROP TABLE IF EXISTS batched_payments_raw;
-
       DROP TABLE IF EXISTS batch_db_info;
     )");
 
@@ -491,8 +437,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
                     history == PaymentTableType::Archive ? "archive" : "recent");
             rows_restored = batch_payments_accrued_row_count(history, new_height);
 
-            db.exec(R"(DELETE FROM batched_payments_raw WHERE height_paid > {0};
-                       DELETE FROM batched_payments_accrued;
+            db.exec(R"(DELETE FROM batched_payments_accrued;
                        INSERT INTO batched_payments_accrued
                        SELECT address, amount, payout_offset
                        FROM {1} WHERE height = {0};
@@ -1038,14 +983,13 @@ bool BlockchainSQLite::save_payments(
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
     auto select_sum = prepared_st("SELECT amount from batched_payments_accrued WHERE address = ?");
-
     auto update_paid = prepared_st(
-            "INSERT INTO batched_payments_paid (address, amount, height_paid) VALUES (?,?,?)");
+            "UPDATE batched_payments_accrued SET amount = (amount - ?) WHERE address = ?");
 
-    std::lock_guard a_s_lock{address_str_cache_mutex};
-
+    std::lock_guard lock{address_str_cache_mutex};
     for (const auto& payment : paid_amounts) {
         const auto address_str = get_address_str(payment);
+
         if (auto maybe_amount = db::exec_and_maybe_get<int64_t>(select_sum, address_str)) {
             // Truncate the thousanths amount to an atomic OXEN:
             auto amount = static_cast<uint64_t>(*maybe_amount) / BATCH_REWARD_FACTOR *
@@ -1063,11 +1007,7 @@ bool BlockchainSQLite::save_payments(
                 return false;
             }
 
-            db::exec_query(
-                    update_paid,
-                    address_str,
-                    static_cast<int64_t>(amount),
-                    static_cast<int64_t>(block_height));
+            db::exec_query(update_paid, static_cast<int64_t>(payment.amount.to_db()), address_str);
             update_paid->reset();
         } else {
             // This shouldn't occur: we validate payout addresses much earlier in the block
@@ -1079,18 +1019,7 @@ bool BlockchainSQLite::save_payments(
                     address_str);
             return false;
         }
-
-        select_sum->reset();
     }
     return true;
 }
-
-bool BlockchainSQLite::delete_block_payments(uint64_t block_height) {
-    log::trace(logcat, "BlockchainDB_SQLITE::{} Called with height: {}", __func__, block_height);
-    prepared_exec(
-            "DELETE FROM batched_payments_paid WHERE height_paid >= ?",
-            static_cast<int64_t>(block_height));
-    return true;
-}
-
 }  // namespace cryptonote

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -540,8 +540,7 @@ std::pair<int, std::string> BlockchainSQLite::get_address_str(
     } else {
         auto* oxen_addr = std::get_if<cryptonote::account_public_address>(&addr);
         assert(oxen_addr);
-        offset = batching_interval == 0 ? 0
-                                        : static_cast<int>(oxen_addr->modulus(batching_interval));
+        offset = static_cast<int>(oxen_addr->modulus(batching_interval));
         auto& cached = address_str_cache[*oxen_addr];
         if (cached.empty())
             cached = cryptonote::get_account_address_as_str(m_nettype, 0, *oxen_addr);

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -388,6 +388,11 @@ void BlockchainSQLite::upgrade_schema() {
                   netconf.HISTORY_ARCHIVE_KEEP_WINDOW));
     }
 
+    // NOTE: Remove deprecated tables, this can be removed post HF21 as everyone
+    // will have upgraded.
+    db.exec(R"(DROP TABLE IF EXISTS batched_payments_accrued_raw;
+               DROP VIEW  IF EXISTS batched_payments_accrued_paid;)");
+
     transaction.commit();
 }
 
@@ -1023,6 +1028,7 @@ bool BlockchainSQLite::save_payments(
                     address_str);
             return false;
         }
+        select_sum->reset();
     }
     return true;
 }

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -396,9 +396,13 @@ void BlockchainSQLite::reset_database() {
 
     db.exec(R"(
       DROP TABLE IF EXISTS delayed_payments;
+      DROP TABLE IF EXISTS delayed_payments_archive;
+      DROP TABLE IF EXISTS delayed_payments_recent;
+
       DROP TABLE IF EXISTS batched_payments_accrued;
       DROP TABLE IF EXISTS batched_payments_accrued_archive;
       DROP TABLE IF EXISTS batched_payments_accrued_recent;
+
       DROP TABLE IF EXISTS batch_db_info;
     )");
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -413,11 +413,11 @@ void BlockchainSQLite::reset_database() {
 
     create_schema();
     upgrade_schema();
-    update_height(0);
+    update_height(0, /*commit*/ false);
     log::debug(logcat, "Database reset complete");
 }
 
-void BlockchainSQLite::update_height(uint64_t new_height) {
+void BlockchainSQLite::update_height(uint64_t new_height, bool commit) {
     log::trace(
             logcat,
             "BlockchainDB_SQLITE::{} Changing to height: {}, prev: {}",
@@ -425,7 +425,8 @@ void BlockchainSQLite::update_height(uint64_t new_height) {
             new_height,
             height);
     height = new_height;
-    prepared_exec("UPDATE batch_db_info SET height = ?", static_cast<int64_t>(height));
+    if (commit)
+        prepared_exec("UPDATE batch_db_info SET height = ?", static_cast<int64_t>(height));
 }
 
 void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t new_height) {
@@ -462,7 +463,7 @@ void BlockchainSQLite::blockchain_detached(PaymentTableType history, uint64_t ne
         } break;
     }
 
-    update_height(new_height);
+    update_height(new_height, true /*commit*/);
     log::debug(
             logcat,
             "Detach request for SQL @ {} executed to {}{} (-{} rows deleted, +{} restored)",
@@ -820,7 +821,7 @@ bool BlockchainSQLite::add_block(
 
     auto hf_version = block.major_version;
     if (hf_version < hf::hf19_reward_batching) {
-        update_height(block_height);
+        update_height(block_height, false /*commit*/);
         return true;
     }
 
@@ -828,7 +829,7 @@ bool BlockchainSQLite::add_block(
         cryptonote::hard_fork_begins(m_nettype, hf::hf19_reward_batching).value_or(0)) {
         log::debug(logcat, "Batching of Service Node Rewards Begins");
         reset_database();
-        update_height(block_height - 1);
+        update_height(block_height - 1, true /*commit*/);
     }
 
     if (block_height != height + 1) {
@@ -864,7 +865,7 @@ bool BlockchainSQLite::add_block(
         if (!validate_batch_payment(miner_tx_vouts, calculated_rewards, block_height))
             return false;
         reward_handler(block, service_nodes_state, get_delayed_payments(block_height));
-        update_height(height + 1);
+        update_height(height + 1, true /*commit*/);
         transaction.commit();
     } catch (std::exception& e) {
         log::error(logcat, "Error adding reward payments: {}", e.what());
@@ -991,7 +992,7 @@ bool BlockchainSQLite::save_payments(
         uint64_t block_height, const std::vector<batch_sn_payment>& paid_amounts) {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
-    auto select_sum = prepared_st("SELECT amount from batched_payments_accrued WHERE address = ?");
+    auto select_sum = prepared_st("SELECT amount FROM batched_payments_accrued WHERE address = ?");
     auto update_paid = prepared_st(
             "UPDATE batched_payments_accrued SET amount = (amount - ?) WHERE address = ?");
 

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -53,7 +53,7 @@ class BlockchainSQLite : public db::Database {
 
     // Update the height stored in the SQL DB that indicates the last block height that this DB has
     // synchronised to in.
-    void update_height(uint64_t new_height);
+    void update_height(uint64_t new_height, bool commit);
 
     enum class PaymentTableType {
         Nil,      // Table containing current state

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -181,7 +181,6 @@ class BlockchainSQLite : public db::Database {
     // to be marked as paid in the paid_amounts vector. Block height will be added to the
     // batched_payments_paid database as height_paid.
     bool save_payments(uint64_t block_height, const std::vector<batch_sn_payment>& paid_amounts);
-    bool delete_block_payments(uint64_t block_height);
 
     uint64_t height;
 

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -150,6 +150,8 @@ void block::set_hash_valid(bool v) const {
 // it does this by taking the first 64 bits of the public_view_key and converting to an integer
 // This is used to determine when an address gets paid their batching reward.
 uint64_t account_public_address::modulus(uint64_t interval) const {
+    if (interval == 0)
+        return 0;
     uint64_t address_as_integer = 0;
     std::memcpy(&address_as_integer, m_view_public_key.data(), sizeof(address_as_integer));
     oxenc::host_to_little_inplace(address_as_integer);

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -116,7 +116,6 @@ struct reward_money {
 
 struct batch_sn_payment {
     cryptonote::address_parse_info address_info{};
-    eth::address eth_address{};
     reward_money amount;
 
     batch_sn_payment() = default;
@@ -124,8 +123,6 @@ struct batch_sn_payment {
             address_info{addr_info}, amount{amt} {}
     batch_sn_payment(const cryptonote::account_public_address& addr, reward_money amt) :
             address_info{addr, 0}, amount{amt} {}
-    batch_sn_payment(const eth::address& addr, reward_money amt) : eth_address{addr}, amount{amt} {}
-
     uint64_t coin_amount() const { return amount.to_coin(); }
 };
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -592,7 +592,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(
                 snl_iteration_duration += clock::now() - snl_start;
             }
 
-            if (m_ons_db.db && (block_height >= ons_height)) {
+            if (m_ons_db.db) {
                 auto ons_start = clock::now();
                 if (!m_ons_db.add_block(blk, txs)) {
                     log::critical(

--- a/tests/blockchain_sqlite_test.h
+++ b/tests/blockchain_sqlite_test.h
@@ -21,21 +21,11 @@ public:
     : BlockchainSQLiteTest(other.m_nettype, check_if_copy_filename(other.filename)) {
     auto all_payments_accrued = db::get_all<std::string, int, int64_t>(
             other.prepared_st("SELECT address, payout_offset, amount FROM batched_payments_accrued"));
-    auto all_payments_paid = db::get_all<std::string, int64_t, int64_t>(
-            other.prepared_st("SELECT address, amount, height_paid FROM batched_payments_raw"));
 
     SQLite::Transaction transaction {
       db,
       SQLite::TransactionBehavior::IMMEDIATE
     };
-
-    auto insert_payment_paid = prepared_st(
-      "INSERT INTO batched_payments_raw (address, amount, height_paid) VALUES (?, ?, ?)");
-
-    for (auto& [address, amount, height_paid]: all_payments_paid) {
-      db::exec_query(insert_payment_paid, address, amount, height_paid);
-      insert_payment_paid->reset();
-    }
 
     auto insert_payment_accrued = prepared_st(
       "INSERT INTO batched_payments_accrued (address, payout_offset, amount) VALUES (?, ?, ?)");

--- a/tests/blockchain_sqlite_test.h
+++ b/tests/blockchain_sqlite_test.h
@@ -47,7 +47,7 @@ public:
 
     transaction.commit();
 
-    update_height(other.height);
+    update_height(other.height, true /*commit*/);
   }
 
   // Helper functions, used in testing to assess the state of the database


### PR DESCRIPTION
For the raw and paid table removal:

```
The raw table from my understanding is for pop_blocks. Pop blocks was removed
when we redid the SQL DB to support blockchain detach. This was done to unify
the SNL and SQL DB in that the system has a hard requirement that they
need to pop to the same height and update in lock-step because updating
the SNL has side-effects on the SQL. So if one pops and the other
doesn't then it causes the SNL rewards to go out of sync.

Hence the raw table is actually unused. This was discovered when investigating
the origins of delete block payments in the SQL DB which used to be executed
on pop blocks.

It has an accompanying table, the paid table which was a SQL view of the
accrued rewards that, from my understanding, subtracts the amount each
SN was paid from the accrued table. This had unnecessary levels of indirection,
first a view was created, then a trigger was created to hijack when we insert
into the table such that it subtracted the rewards paid out in the
accrued table.

It's possible to skip this busy-work and layers by just subtracting the amount
directly from the accrued table when the payments are "saved".
```

For removing `eth_address` from `batch_sn_payment`:

```
Batch SN payment code path is only used in <=HF20 which is prior to ETH
addresses start getting written to the DB. Hence it only needs to handle Oxen
addresses so we can remove the eth address.

For eth addresses we use block_payments which is a
variant<eth_address,oxen_address>.
```