### PR TITLE
Tweak and fix dereg/unlock issues

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2021,9 +2021,10 @@ bool service_node_list::state_t::process_confirmed_event(
         return false;
     }
 
-    // NOTE: Calculate how many blocks from now the funds are still to be locked for
+    // NOTE: Calculate how many blocks from now the funds are still to be locked for, if this node
+    // did not leave voluntarily.
     uint64_t block_delay = 0;
-    if (slash_amount > 0) {
+    if (node->type != recently_removed_node::type_t::voluntary_exit) {
         // NOTE: Calculate the height at which funds are unlocked
         auto& netconf = get_config(confirm.nettype);
         uint64_t dereg_height = node->height;
@@ -5368,9 +5369,14 @@ service_nodes_infos_t::iterator service_node_list::state_t::erase_info(
                 }
             }
 
+            const auto& netconf = get_config(nettype);
+            const auto exit_buffer = exit_type == recently_removed_node::type_t::voluntary_exit
+                                           ? netconf.ETH_EXIT_BUFFER
+                                           : netconf.ETH_DEREG_BUFFER;
+
             recently_removed_nodes.emplace_back(recently_removed_node{
                     .height = height,
-                    .liquidation_height = height + get_config(nettype).ETH_EXIT_BUFFER,
+                    .liquidation_height = height + exit_buffer,
                     .type = exit_type,
                     .public_ip = public_ip,
                     .qnet_port = qnet_port,

--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -68,6 +68,7 @@ inline constexpr network_config config{
         .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         .ETH_EXIT_BUFFER = testnet::config.ETH_EXIT_BUFFER,
+        .ETH_DEREG_BUFFER = testnet::config.ETH_DEREG_BUFFER,
         .ETHEREUM_CHAIN_ID = 421614,  // Arbitrum Sepolia
         .ETHEREUM_REWARDS_CONTRACT = "0x75Dc11700b2D03902FCb5Ca7aFd6A859a1Fa25Cb",
         .ETHEREUM_POOL_CONTRACT = "0xb515C61DE12f28eE908a905b930aFb80B9bAd7cf",

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -47,6 +47,7 @@ inline constexpr network_config config{
         .HISTORY_ARCHIVE_KEEP_WINDOW = mainnet::config.HISTORY_ARCHIVE_KEEP_WINDOW,
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         .ETH_EXIT_BUFFER = testnet::config.ETH_EXIT_BUFFER,
+        .ETH_DEREG_BUFFER = testnet::config.ETH_DEREG_BUFFER,
         .ETHEREUM_CHAIN_ID = mainnet::config.ETHEREUM_CHAIN_ID,
         .ETHEREUM_REWARDS_CONTRACT = mainnet::config.ETHEREUM_REWARDS_CONTRACT,
         .ETHEREUM_POOL_CONTRACT = mainnet::config.ETHEREUM_POOL_CONTRACT,

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -65,6 +65,7 @@ inline constexpr network_config config{
         // locally and pulse quorums take time to create blocks which bloat the
         // test duration.
         .ETH_EXIT_BUFFER = 1,
+        .ETH_DEREG_BUFFER = 1,
         .ETHEREUM_CHAIN_ID = 31337,
         .ETHEREUM_REWARDS_CONTRACT = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"sv,
         .ETHEREUM_POOL_CONTRACT = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"sv,

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -70,6 +70,7 @@ inline constexpr network_config config{
         .HISTORY_ARCHIVE_KEEP_WINDOW = 2 * 365 * 24h / TARGET_BLOCK_TIME,  // 2yrs worth
         .HISTORY_RECENT_KEEP_WINDOW = 360,
         .ETH_EXIT_BUFFER = 7 * 24h / TARGET_BLOCK_TIME,
+        .ETH_DEREG_BUFFER = 7 * 24h / TARGET_BLOCK_TIME,
         .ETHEREUM_CHAIN_ID = 42161,  // Arbitrum One
         // TODO: To be set closer to mainnet TGE
         .ETHEREUM_REWARDS_CONTRACT = "",

--- a/src/network_config/network_config.h
+++ b/src/network_config/network_config.h
@@ -140,6 +140,13 @@ struct network_config final {
     /// buffer period.
     const uint64_t ETH_EXIT_BUFFER;
 
+    /// (HF21+) Number of blocks after a deregistration during which the node is protected from
+    /// liquidation-with-penalty.  Regular removals can still be submitted to remove it from the ETH
+    /// pubkey list, but *not* penalizing liquidation (which also remove it but award a penalty
+    /// reward to the liquidator) during this buffer period.  0 means liquidations will be available
+    /// immediately upon deregistration.
+    const uint64_t ETH_DEREG_BUFFER;
+
     // Details of the ethereum smart contract managing rewards and chain its kept on:
     const uint32_t ETHEREUM_CHAIN_ID;
     const std::string_view ETHEREUM_REWARDS_CONTRACT;

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -69,6 +69,7 @@ inline constexpr network_config config{
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         // Much shorter than mainnet so that you can test this more easily.
         .ETH_EXIT_BUFFER = 2h / mainnet::config.TARGET_BLOCK_TIME,
+        .ETH_DEREG_BUFFER = 2h / mainnet::config.TARGET_BLOCK_TIME,
         .ETHEREUM_CHAIN_ID = 421614,
         .ETHEREUM_REWARDS_CONTRACT = "0x9d8aB00880CBBdc2Dcd29C179779469A82E7be35"sv,
         .ETHEREUM_POOL_CONTRACT = "0xaAD853fE7091728dac0DAa7b69990ee68abFC636"sv,

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -68,6 +68,7 @@ inline constexpr network_config config{
         .HISTORY_RECENT_KEEP_WINDOW = mainnet::config.HISTORY_RECENT_KEEP_WINDOW,
         // Much shorter than mainnet so that you can test this more easily.
         .ETH_EXIT_BUFFER = 1h / mainnet::config.TARGET_BLOCK_TIME,
+        .ETH_DEREG_BUFFER = 1h / mainnet::config.TARGET_BLOCK_TIME,
         // FIXME!
         .ETHEREUM_CHAIN_ID = 421614,  // Arbitrum Sepolia
         .ETHEREUM_REWARDS_CONTRACT = "",


### PR DESCRIPTION
- Apply the dereg stake lock for deregistrations.  Previously the lock was being applied based on whether the exit was a liquidation or not, but liquidations and exits can each apply to both deregistrations and voluntary exits.  This exits submitted in the contract would end up failing to lock funds of deregistered nodes, and liquidations from the contract would lock funds of voluntary exited nodes.

- Add a separate buffer, ETH_DEREG_BUFFER, that defines how long deregistrations have to exit before liquidation applies.  Currently this is the same as the ETH_EXIT_BUFFER, but this could be set to 0 in a future release to allow instant liquidations of deregistered nodes without any other changes required here or in the contract. Also this fixes a bug in the documentation of the ETH_EXIT_BUFFER parameter, in that it says it only applies to voluntary exits but specifically not to deregistrations, but before this commit was applying to both.

There was also a suggestion that a lockup of contributor funds upon liquidation is warranted as contributors also have some responsibility of getting the node out of the contract, but I'm not sure that contributors actually are the best placed to monitor and worry about that: the person watching the node more carefully, and more familiar with staking rules etc. really is the operator.

But if we *do* want to spread that responsibility and incentive to contributors, I think it would make more sense to rework the liquidation penalty to apply to contributors instead of just the operator, rather than having both a penalty and a lockup period in effect in different ways for properly exited, but liquidated, nodes.  For instance, we could apply half the penalty against the operator, and half against the contributors (including the operator) proportional to contribution.  Or perhaps could apply it according to the fee (i.e. the operator pays FEE% of the slashing, and then contributors+operators pay the reset proportionally).  But again I'm not sure it would make much difference to node exit speed compared to targeting the operator alone.