### PR TITLE
oxen-wallet-rpc: log to stdout by default and fix early printing

### DIFF
--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -188,13 +188,17 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
         return {std::move(vm), should_terminate};
 
     std::string log_path;
+    bool log_stdout = false;
     if (!command_line::is_arg_defaulted(vm, arg_log_file))
         log_path = command_line::get_arg(vm, arg_log_file);
     else
-        log_path = epee::string_tools::get_current_module_name() + ".log";
+        log_path = default_log_name;
+    if (log_path == "stdout" || log_path == "-") {
+        log_stdout = true;
+        log_path.clear();
+    }
 
-    oxen::logging::init(
-            log_path, command_line::get_arg(vm, arg_log_level), false /*do not log to stdout.*/);
+    oxen::logging::init(log_path, command_line::get_arg(vm, arg_log_level), log_stdout);
 
     if (notice)
         print("{}\n"_format(notice));
@@ -210,7 +214,8 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
         const char* logs = getenv("OXEN_LOGS");
         log::info(logcat, "Setting log levels = {}", (logs ? logs : "<default>"));
     }
-    print("{}{}"_format(tr("Logging to: "), log_path));
+    if (!log_path.empty())
+        print("{}{}"_format(tr("Logging to: "), log_path));
 
     const ssize_t lockable_memory = tools::get_lockable_memory();
     if (lockable_memory >= 0 &&

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3782,8 +3782,8 @@ int main(int argc, char** argv) {
             desc_params,
             hidden_params,
             po::positional_options_description(),
-            [](const std::string& s) {},
-            "oxen-wallet-rpc.log",
+            [](const std::string& s) { fmt::print("{}", s); },
+            "stdout",
             true);
     if (!vm)
         return 1;


### PR DESCRIPTION
Various things oxen-wallet-rpc was supposed to print were not being printed, and the default log-to-file meant that errors you should see (e.g. missing arguments) didn't show up because of the log-to-file default.

This changes it to print the early stuff properly, and changes the default logging to stdout (which now induces logging to stdout) instead of oxen-wallet-rpc.log, which seems a much more useful default for a daemon.