### PR TITLE
Fix a rescan dropping by 10k blocks when killed mid-scan

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -421,8 +421,7 @@ void BlockchainSQLite::reset_database() {
     log::debug(logcat, "Database reset complete");
 }
 
-void BlockchainSQLite::update_height(
-        uint64_t new_height, const std::optional<service_nodes::rescan_context>& rescan) {
+void BlockchainSQLite::update_height(uint64_t new_height) {
     ZoneScoped;
     log::trace(
             logcat,
@@ -431,18 +430,7 @@ void BlockchainSQLite::update_height(
             new_height,
             height);
     height = new_height;
-
-    bool commit = true;
-    if (rescan) {
-        const auto& netconf = get_config(m_nettype);
-        uint64_t block_count = rescan->top_block_height + 1;
-        uint64_t commit_from_height = block_count - netconf.HISTORY_RECENT_KEEP_WINDOW;
-        bool is_archive_height = height % netconf.HISTORY_ARCHIVE_INTERVAL == 0;
-        commit = is_archive_height || height >= commit_from_height;
-    }
-
-    if (commit)
-        prepared_exec("UPDATE batch_db_info SET height = ?", static_cast<int64_t>(height));
+    prepared_exec("UPDATE batch_db_info SET height = ?", static_cast<int64_t>(height));
 }
 
 void BlockchainSQLite::blockchain_detached(
@@ -879,7 +867,7 @@ bool BlockchainSQLite::add_block(
 
     auto hf_version = block.major_version;
     if (hf_version < hf::hf19_reward_batching) {
-        update_height(block_height, rescan);
+        update_height(block_height);
         return true;
     }
 
@@ -887,7 +875,7 @@ bool BlockchainSQLite::add_block(
         cryptonote::hard_fork_begins(m_nettype, hf::hf19_reward_batching).value_or(0)) {
         log::debug(logcat, "Batching of Service Node Rewards Begins");
         reset_database();
-        update_height(block_height - 1, rescan);
+        update_height(block_height - 1);
     }
 
     if (block_height != height + 1) {
@@ -926,7 +914,7 @@ bool BlockchainSQLite::add_block(
         if (!validate_batch_payment(miner_tx_vouts, calculated_rewards, block_height, rescan))
             return false;
         reward_handler(block, service_nodes_state, block_add, get_delayed_payments(block_height));
-        update_height(height + 1, rescan);
+        update_height(height + 1);
         if (transaction)
             transaction->commit();
         else {  // rescanning

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -449,38 +449,53 @@ void BlockchainSQLite::blockchain_detached(
         PaymentTableType history, uint64_t new_height, uint64_t target_height) {
     const auto& netconf = get_config(m_nettype);
 
-    // NOTE: Execute detach
     std::string detach_label = "";
     int rows_restored = 0;
-    int rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, std::nullopt);
-    switch (history) {
-        case PaymentTableType::Nil: {
-            reset_database();
-            detach_label = " (via reset)";
-        } break;
+    int rows_removed = 0;
+    if (new_height == height) {
+        detach_label = " (DB is already at requested height)";
+    } else {
+        // NOTE: Execute detach
+        rows_removed = batch_payments_accrued_row_count(PaymentTableType::Nil, std::nullopt);
+        switch (history) {
+            case PaymentTableType::Nil: {
+                reset_database();
+                detach_label = " (via reset)";
+            } break;
 
-        default: {
-            std::string batched_payments_history_table = "batched_payments_accrued_{}"_format(
-                    history == PaymentTableType::Archive ? "archive" : "recent");
-            rows_restored = batch_payments_accrued_row_count(history, new_height);
+            default: {
+                std::string batched_payments_history_table = "batched_payments_accrued_{}"_format(
+                        history == PaymentTableType::Archive ? "archive" : "recent");
+                rows_restored = batch_payments_accrued_row_count(history, new_height);
 
-            db.exec(R"(DELETE FROM batched_payments_accrued;
-                       INSERT INTO batched_payments_accrued
-                       SELECT address, amount, payout_offset
-                       FROM {1} WHERE height = {0};
-              )"_format(new_height, batched_payments_history_table));
+                db.exec(R"(DELETE FROM batched_payments_accrued;
+                           INSERT INTO batched_payments_accrued
+                           SELECT address, amount, payout_offset
+                           FROM {1} WHERE height = {0};
+                  )"_format(new_height, batched_payments_history_table));
 
-            std::string delayed_payments_history_table = "delayed_payments_{}"_format(
-                    history == PaymentTableType::Archive ? "archive" : "recent");
-            db.exec(R"(DELETE FROM delayed_payments;
-                       INSERT INTO delayed_payments
-                       SELECT *
-                       FROM {1} WHERE {0} >= height AND {0} <= payout_height;
-              )"_format(new_height, delayed_payments_history_table));
-        } break;
+                std::string delayed_payments_history_table = "delayed_payments_{}"_format(
+                        history == PaymentTableType::Archive ? "archive" : "recent");
+                db.exec(R"(DELETE FROM delayed_payments;
+                           INSERT INTO delayed_payments
+                           SELECT *
+                           FROM {1} WHERE {0} >= height AND {0} <= payout_height;
+                  )"_format(new_height, delayed_payments_history_table));
+            } break;
+        }
     }
 
     update_height(new_height);
+
+    if (height + 5000 < target_height) {
+        log::debug(logcat, "large rescan starting");
+        rescan_target = target_height;
+        rescan_start();
+    } else {
+        log::debug(
+                logcat, "not large rescan, height = {}, target_height = {}", height, target_height);
+    }
+
     log::debug(
             logcat,
             "Detach request for SQL @ {} executed to {}{} (-{} rows deleted, +{} restored)",
@@ -489,14 +504,6 @@ void BlockchainSQLite::blockchain_detached(
             detach_label,
             rows_removed,
             rows_restored);
-
-    if (height + 5000 < target_height) {
-        log::debug(logcat, "large rescan starting");
-        rescan_target = target_height;
-        rescan_start();
-    } else
-        log::debug(
-                logcat, "not large rescan, height = {}, target_height = {}", height, target_height);
 }
 
 const std::string& BlockchainSQLite::get_address_str(const cryptonote::batch_sn_payment& addr) {

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -56,9 +56,7 @@ class BlockchainSQLite : public db::Database {
 
     // Update the height stored in the SQL DB that indicates the last block height that this DB has
     // synchronised to in.
-    void update_height(
-            uint64_t new_height,
-            const std::optional<service_nodes::rescan_context>& rescan = std::nullopt);
+    void update_height(uint64_t new_height);
 
     enum class PaymentTableType {
         Nil,      // Table containing current state

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4210,8 +4210,12 @@ void service_node_list::blockchain_detached(uint64_t height) {
         if (height < sqlite_begins)
             return true;
 
+        cryptonote::BlockchainSQLite& sql_db = blockchain.sqlite_db();
+        if (sql_db.height == height)
+            return true;
+
         // NOTE: Accept if SQL has payment rows for the requested height:
-        return blockchain.sqlite_db().batch_payments_accrued_row_count(table_type, height) > 0;
+        return sql_db.batch_payments_accrued_row_count(table_type, height) > 0;
     };
 
     // NOTE: Lookup desired SNL state from recent backups


### PR DESCRIPTION
When you startup the node if the SQL and SNL are out of sync then the 2 systems will pop back to a common height. If the SQL DB pops back to a height from the recent/archive table it will delete those entries from the table.

If you then kill the scan midway, on startup again, it will search for the height it just popped to from the recent/archive table which no longer exists and so the next common height will be the previous 10k block if it's large rescan. But in actuality the SQL DB's current runtime state is already at the correct height and its tables have the correct values for that height.

We can fix that by checking the height of the SQL DB table when we go and try and lookup the common height between the two systems before looking it up in the archive and recent table.