### PR TITLE
extend watchdog timer during snl store

### DIFF
--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -133,9 +133,8 @@ void threadpool::waiter::wait(threadpool* tpool) {
 }
 
 bool threadpool::waiter::wait_for(const std::chrono::milliseconds& t) {
-    if (num == 0) return true;
     std::unique_lock lock{mt};
-    return cv.wait_for(lock, t) == std::cv_status::no_timeout && num == 0;
+    return cv.wait_for(lock, t, [this] { return num == 0; });
 }
 
 void threadpool::waiter::inc() {

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -132,6 +132,12 @@ void threadpool::waiter::wait(threadpool* tpool) {
         cv.wait(lock);
 }
 
+bool threadpool::waiter::wait_for(const std::chrono::milliseconds& t) {
+    if (num == 0) return true;
+    std::unique_lock lock{mt};
+    return cv.wait_for(lock, t) == std::cv_status::no_timeout && num == 0;
+}
+
 void threadpool::waiter::inc() {
     const std::unique_lock lock{mt};
     num++;

--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -60,6 +60,7 @@ class threadpool {
         void inc();
         void dec();
         void wait(threadpool* tpool);  //! Wait for a set of tasks to finish.
+        bool wait_for(const std::chrono::milliseconds& t);
         waiter() : num(0) {}
         ~waiter();
     };
@@ -77,6 +78,7 @@ class threadpool {
     ~threadpool();
     void stop();
     void start(unsigned int max_threads = 0);
+    void run(bool flush = false);
 
   private:
     threadpool(unsigned int max_threads = 0);
@@ -94,7 +96,6 @@ class threadpool {
     unsigned int active;
     unsigned int max;
     bool running;
-    void run(bool flush = false);
 };
 
 }  // namespace tools

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -157,6 +157,19 @@ Blockchain::~Blockchain() {
     } catch (const std::exception& e) { /* ignore */
     }
 }
+
+void Blockchain::extend_watchdog_timeout(uint64_t height) {
+#ifdef ENABLE_SYSTEMD
+    // Tell systemd that we're doing something so that it should let us continue starting up
+    // (giving us 120s until we have to send the next notification):
+    sd_notify(
+            0,
+            "EXTEND_TIMEOUT_USEC=120000000\nSTATUS=Recanning blockchain; height {}/{}"_format(
+                    height, m_db->height())
+                    .c_str());
+#endif
+}
+
 //------------------------------------------------------------------
 bool Blockchain::have_tx(const crypto::hash& id) const {
     log::trace(logcat, "Blockchain::{}", __func__);
@@ -601,7 +614,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(
             store_accumulator += interval_duration;
             if (store_accumulator >= 60s) {
                 store_accumulator -= 60s;
-                service_node_list.store();
+                service_node_list.store(height);
             }
 
             float blocks_per_s = static_cast<float>(work_blocks) / interval_duration.count();
@@ -619,15 +632,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems(
                     ons_interval_duration.count(),
                     blocks_per_s,
                     tools::get_human_readable_bytes(bytes_per_s));
-#ifdef ENABLE_SYSTEMD
-            // Tell systemd that we're doing something so that it should let us continue starting up
-            // (giving us 120s until we have to send the next notification):
-            sd_notify(
-                    0,
-                    "EXTEND_TIMEOUT_USEC=120000000\nSTATUS=Recanning blockchain; height {}"_format(
-                            height)
-                            .c_str());
-#endif
+            extend_watchdog_timeout(height);
             // NOTE: Accumulate stats
             ons_duration += ons_interval_duration;
             snl_duration += snl_interval_duration;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -144,6 +144,14 @@ class Blockchain {
     ~Blockchain();
 
     /**
+     * @brief Extend system watchdog timeout (for long rescans)
+     *
+     * If we're using a watchdog to monitor the process, this will tell the system
+     * watchdog (currently only systemd supported) to give us more time for startup
+     */
+    void extend_watchdog_timeout(uint64_t height = 0);
+
+    /**
      * @brief Initialize the Blockchain state.
      *
      * @param db a pointer to the backing store to use for the blockchain.

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4958,13 +4958,17 @@ bool service_node_list::store(uint64_t state_height) {
     tools::threadpool::waiter tpool_waiter = {};
 
     // NOTE: Serialize archive
+    int long_term_size = 0;
+    std::atomic<int> long_term_count = 0;
     if (m_transient->long_term_data_dirty) {
         size_t archive_index = 0;
+        long_term_size = m_transient->state_archive.size();
         for (auto& it : m_transient->state_archive) {
             std::string& dest = archive_blob_list[archive_index++];
-            tpool.submit(&tpool_waiter, [&dest, &it]() {
+            tpool.submit(&tpool_waiter, [&dest, &it, &long_term_count]() {
                 serialization::binary_string_archiver ba;
                 dest = serialize_snl_directly(ba, const_cast<state_t&>(it));
+                long_term_count++;
             });
         }
     }
@@ -4987,11 +4991,40 @@ bool service_node_list::store(uint64_t state_height) {
             curr = serialize_snl_directly(ba, m_state);
         });
     }
+
+    bool reporting_long_term = false;
     tpool.run(true);
     while (!tpool_waiter.wait_for(10s)) {
+        if (long_term_size > 0) {
+            int done = long_term_count.load();
+            if (done < long_term_size) {
+                // We are >=10s in and aren't done with long term states, so start (or continue)
+                // logging updates about it:
+                reporting_long_term = true;
+                log::info(
+                        globallogcat,
+                        "Serializing long-term SN state archive data ({}/{})",
+                        done,
+                        long_term_size);
+            } else if (reporting_long_term) {
+                // We're still waiting on something else, but we're done with the long-term
+                // data:
+                log::info(
+                        globallogcat,
+                        "Finished serializing {} long-term SN state archives",
+                        long_term_size);
+                reporting_long_term = false;
+            }
+        }
         log::debug(logcat, "SNL store, waiting on serialization");
         blockchain.extend_watchdog_timeout(state_height);
     }
+    // Print the final one if we started printing but didn't finish in the wait loop above
+    if (reporting_long_term)
+        log::info(
+                globallogcat,
+                "Finished serializing {} long-term SN state archives",
+                long_term_size);
 
     // NOTE: Store blobs to DB
     {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4937,7 +4937,7 @@ static std::string serialize_snl_directly(Archive& ar, service_node_list::state_
     return result;
 }
 
-bool service_node_list::store() {
+bool service_node_list::store(uint64_t state_height) {
     ZoneScoped;
     if (!blockchain.has_db())
         return false;  // Haven't been initialized yet
@@ -4987,7 +4987,11 @@ bool service_node_list::store() {
             curr = serialize_snl_directly(ba, m_state);
         });
     }
-    tpool_waiter.wait(&tpool);
+    tpool.run(true);
+    while (!tpool_waiter.wait_for(10s)) {
+        log::debug(logcat, "SNL store, waiting on serialization");
+        blockchain.extend_watchdog_timeout(state_height);
+    }
 
     // NOTE: Store blobs to DB
     {
@@ -5000,7 +5004,9 @@ bool service_node_list::store() {
             serialization::binary_string_archiver ar;
             std::string db_blob = serialize_db_blob(ar, archive_blob_list, nullptr);
             TracyCZoneEnd(serialize_step);
-            db.set_service_node_data(db_blob, true /*long_term*/);
+            db.set_service_node_data(db_blob, /*long_term = */ true);
+            log::debug(logcat, "SNL store, finished storing long term state");
+            blockchain.extend_watchdog_timeout(state_height);
         }
 
         {
@@ -5009,7 +5015,8 @@ bool service_node_list::store() {
             std::string db_blob =
                     serialize_db_blob(ar, history_blob_list, &m_transient->old_quorum_states);
             TracyCZoneEnd(serialize_step);
-            db.set_service_node_data(db_blob, false /*long_term*/);
+            db.set_service_node_data(db_blob, /*long_term = */ false);
+            log::debug(logcat, "SNL store, finished storing short term state");
         }
     }
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -816,7 +816,7 @@ class service_node_list {
     void set_my_service_node_keys(const service_node_keys* keys);
     void set_quorum_history_storage(
             uint64_t hist_size);  // 0 = none (default), 1 = unlimited, N = # of blocks
-    bool store();
+    bool store(uint64_t state_height = 0);
 
     uptime_proof::Proof generate_uptime_proof(
             cryptonote::hf hardfork,


### PR DESCRIPTION
If the SNL store operation takes too long during a startup rescan (can happen with lots of nodes on the same machine all needing said rescan at the same time), systemd can terminate the process because it hasn't checked in recently.  This aims to mitigate that by checking in at a few points during that store.