### PR TITLE
Remove left-over 'clear_archive' trigger in SQL DB

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -365,6 +365,7 @@ void BlockchainSQLite::upgrade_schema() {
         --
         -- We rename the trigger to be more apt for its new role of handling
         -- both archive and recent tables.
+        DROP   TRIGGER IF EXISTS clear_archive;
         DROP   TRIGGER IF EXISTS clear_recent;
         DROP   TRIGGER IF EXISTS clear_recent_and_archive;
         CREATE TRIGGER           clear_recent_and_archive AFTER UPDATE ON batch_db_info


### PR DESCRIPTION
This is an old trigger that was overzealously deleting an archive that should not be deleted that was yet one more bug causing a rescan to jump back 10k blocks if you kill the node mid-scan.

The 'clear_archive' trigger was deprecated for the 'clear_recent_and_archive' trigger which combined and prunes both the recent and archive table on block add.

This trigger caused the following situation:

  When the SQL DB reorgs to an older archive from 11'123 to 11'000, the 11k
  entries are imported into the main tables. `make_archive` triggers to store
  the 11k block entries into the archive table, then, `clear_archive`
  which has the following code:

  ```
  DROP TRIGGER "main"."clear_archive";
  CREATE TRIGGER clear_archive AFTER UPDATE ON batch_db_info
  FOR EACH ROW WHEN NEW.height < OLD.height BEGIN
            DELETE FROM batched_payments_accrued_archive WHERE height >= NEW.height;
  END
  ```

  Which triggers and deletes the height that we just put into the archive
  tables. If you then kill the node mid-scan, if the node needs to reorg back to
  the previous 10k entry, it will now jump back to 10k instead of 11k because
  the archive rows are missing.

Simply deleting the trigger suffices. All the other triggers work to ensure that the archives are saved correctly and pruned correctly already so this trigger is defunct and no longer needed.