### PR TITLE
Fix l2 tracker requirement enforced too early

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2020,11 +2020,27 @@ bool Blockchain::create_block_template_internal(
     uint64_t already_generated_coins;
     uint64_t pool_cookie;
 
-    if (!m_l2_tracker)
+    // Creates the block template for next block on main chain
+    std::tie(height, b.prev_id) = get_tail_id();
+    ++height;  // Convert to the next block's height
+    std::tie(b.major_version, b.minor_version) = get_ideal_block_version(m_nettype, height);
+    auto hf_version = b.major_version;
+
+    if (!m_l2_tracker && hf_version >= cryptonote::feature::ETH_BLS)
         throw oxen::traced<std::logic_error>{
                 "Cannot create a block template without a configured L2 provider"};
 
-    auto lock = tools::shared_locks(tx_pool, *this, *m_l2_tracker);
+    std::unique_lock pool_lock{tx_pool, std::defer_lock};
+    std::unique_lock bc_lock{*this, std::defer_lock};
+    auto l2_lock = m_l2_tracker ? std::shared_lock{*m_l2_tracker, std::defer_lock}
+                                : std::shared_lock<eth::L2Tracker>{};
+
+    if (m_l2_tracker) {
+        std::lock(pool_lock, bc_lock, l2_lock);
+    } else {
+        std::lock(pool_lock, bc_lock);
+    }
+
     if (m_btc_valid) {
         // The pool cookie is atomic. The lack of locking is OK, as if it changes
         // just as we compare it, we'll just use a slightly old template, but
@@ -2053,10 +2069,6 @@ bool Blockchain::create_block_template_internal(
         invalidate_block_template_cache();
     }
 
-    // Creates the block template for next block on main chain
-    std::tie(height, b.prev_id) = get_tail_id();
-    ++height;  // Convert to the next block's height
-    std::tie(b.major_version, b.minor_version) = get_ideal_block_version(m_nettype, height);
     median_weight = m_current_block_cumul_weight_limit / 2;
     diffic = get_difficulty_for_next_block(!info.is_miner);
     already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
@@ -2069,7 +2081,6 @@ bool Blockchain::create_block_template_internal(
 
     CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
 
-    auto hf_version = b.major_version;
     size_t txs_weight;
     uint64_t fee;
 

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1575,16 +1575,26 @@ namespace {
             uint64_t height = 0;
             service_nodes::payout block_producer_payouts =
                     service_nodes::service_node_payout_portions(key.pub, *info);
-            if (!blockchain.create_next_pulse_block_template(
-                        block,
-                        block_producer_payouts,
-                        context.prepare_for_round.round,
-                        context.transient.wait_for_handshake_bitsets.best_bitset,
-                        height)) {
+
+            try {
+                if (!blockchain.create_next_pulse_block_template(
+                            block,
+                            block_producer_payouts,
+                            context.prepare_for_round.round,
+                            context.transient.wait_for_handshake_bitsets.best_bitset,
+                            height)) {
+                    log::error(
+                            logcat,
+                            "{}Failed to generate a block template, waiting until next round",
+                            log_prefix(context));
+                    return goto_preparing_for_next_round(context);
+                }
+            } catch (const std::exception& e) {
                 log::error(
                         logcat,
-                        "{}Failed to generate a block template, waiting until next round",
-                        log_prefix(context));
+                        "{}Failed to generate a block template, waiting until next round: {}",
+                        log_prefix(context),
+                        e.what());
                 return goto_preparing_for_next_round(context);
             }
 


### PR DESCRIPTION
The block template creation code was enforcing the L2 tracker requirement before it's actually required, causing nodes without it configured yet (and it's not necessary yet) to fail to produce blocks and get in a state where they couldn't participate in quorums as a validator either.