### PR TITLE
fix misuse of threadpool run

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4997,7 +4997,6 @@ bool service_node_list::store(uint64_t state_height) {
     }
 
     bool reporting_long_term = false;
-    tpool.run(true);
     while (!tpool_waiter.wait_for(10s)) {
         if (long_term_size > 0) {
             int done = long_term_count.load();


### PR DESCRIPTION
threadpool::run blocks until either the threadpool stops, or if flush=true is passed, until the threadpool is empty.  Threads in the threadpool are already running and waiting for jobs, so this call to is was simply adding the current thread as a worker in the threadpool for no good reason.