### PR TITLE
Oxen-logging, fmt, spdlog updates/fixes

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,6 +39,19 @@ endif()
 
 include(system_or_submodule)
 
+if(BUILD_STATIC_DEPS)
+  set(OXEN_LOGGING_FORCE_SUBMODULES TRUE CACHE BOOL "" FORCE)
+endif()
+
+system_or_submodule(OXENLOGGING oxen-logging liboxen-logging>=1.1.0 oxen-logging)
+if(OXENLOGGING_FOUND)
+    add_library(oxen::logging ALIAS oxen-logging::oxen-logging)
+
+    # If we load oxen-logging via system lib then we won't necessarily have fmt/spdlog targets, but
+    # this script will give us them:
+    include(oxen-logging/cmake/load_fmt_spdlog.cmake)
+endif()
+
 system_or_submodule(OXENC oxenc liboxenc>=1.1.0 oxen-encoding)
 system_or_submodule(OXENMQ oxenmq liboxenmq>=1.2.13 oxen-mq)
 
@@ -51,13 +64,6 @@ set(BN256_ENABLE_TEST OFF CACHE BOOL "" FORCE)
 set(BUILD_DOC OFF CACHE BOOL "" FORCE)
 add_subdirectory(bn256 EXCLUDE_FROM_ALL)
 oxen_install_library(bn256)
-
-if(BUILD_STATIC_DEPS)
-  set(OXEN_LOGGING_FORCE_SUBMODULES TRUE CACHE BOOL "" FORCE)
-endif()
-add_subdirectory(oxen-logging)
-oxen_logging_add_source_dir("${PROJECT_SOURCE_DIR}")
-oxen_logging_add_source_dir("${PROJECT_SOURCE_DIR}/src")
 
 install(
     DIRECTORY boost

--- a/src/common/format.h
+++ b/src/common/format.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <fmt/ranges.h>  // for fmt::join
+
 #include <oxen/log/format.hpp>
 
 // Make ""_format available globally:

--- a/src/common/formattable.h
+++ b/src/common/formattable.h
@@ -51,8 +51,7 @@ namespace detail {
 
 template <typename T>
 struct to_string_formatter : fmt::formatter<std::string_view> {
-    template <typename FormatContext>
-    auto format(const T& val, FormatContext& ctx) const {
+    auto format(const T& val, fmt::format_context& ctx) const {
         if constexpr (::formattable::detail::callable_to_string_method<T>)
             return formatter<std::string_view>::format(val.to_string(), ctx);
         else
@@ -171,8 +170,7 @@ struct underlying_t_formatter : fmt::formatter<std::underlying_type_t<T>> {
             std::is_enum_v<T> && !std::is_convertible_v<T, std::underlying_type_t<T>>,
             "formattable::via_underlying<T> type is not a scoped enum");
 #endif
-    template <typename FormatContext>
-    auto format(const T& val, FormatContext& ctx) const {
+    auto format(const T& val, fmt::format_context& ctx) const {
         using Underlying = std::underlying_type_t<T>;
         return fmt::formatter<Underlying>::format(static_cast<Underlying>(val), ctx);
     }

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <oxenc/common.h>
 
 #include <algorithm>

--- a/src/crypto/base.h
+++ b/src/crypto/base.h
@@ -72,3 +72,9 @@ struct raw_hasher {
 
 template <crypto::hash_hex_comparable T>
 struct fmt::formatter<T> : formattable::hex_span_formatter {};
+
+// Define this so that the above does not conflict with fmt's build in range overload:
+template <crypto::hash_hex_comparable T, typename Char>
+struct fmt::is_range<T, Char> {
+    static constexpr bool value = false;
+};

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1153,17 +1153,20 @@ oxenmq::AuthLevel core::omq_allow(
         if (user_auth >= AuthLevel::basic) {
             if (user_auth > auth)
                 auth = user_auth;
-            log::info(log::Cat("omq"), "Incoming {}-authenticated connection", auth);
+            log::info(
+                    log::Cat("omq"),
+                    "Incoming {}-authenticated connection",
+                    oxenmq::to_string(auth));
         }
 
         log::debug(
                 log::Cat("omq"),
                 "Incoming [{}] curve connection from {}/{}",
-                auth,
+                to_string(auth),
                 ip,
                 x25519_pubkey);
     } else {
-        log::info(log::Cat("omq"), "Incoming [{}] plain connection from {}", auth, ip);
+        log::info(log::Cat("omq"), "Incoming [{}] plain connection from {}", to_string(auth), ip);
     }
     return auth;
 }
@@ -1187,7 +1190,7 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
     // ping.ping: a simple debugging target for pinging the omq listener
     m_omq->add_category("ping", Access{AuthLevel::none})
             .add_request_command("ping", [](Message& m) {
-                log::info(log::Cat("omq"), "Received ping from {}", m.conn);
+                log::info(log::Cat("omq"), "Received ping from {}", m.conn.to_string());
                 m.send_reply("pong");
             });
 

--- a/src/cryptonote_core/oxen_name_system.h
+++ b/src/cryptonote_core/oxen_name_system.h
@@ -430,13 +430,13 @@ struct name_system_db {
 
 template <>
 struct fmt::formatter<ons::mapping_value> : fmt::formatter<std::string> {
-    auto format(const ons::mapping_value& v, format_context& ctx) {
+    auto format(const ons::mapping_value& v, format_context& ctx) const {
         return formatter<std::string>::format(oxenc::to_hex(v.to_view()), ctx);
     }
 };
 template <>
 struct fmt::formatter<ons::mapping_type> : fmt::formatter<std::string_view> {
-    auto format(const ons::mapping_type& t, format_context& ctx) {
+    auto format(const ons::mapping_type& t, format_context& ctx) const {
         return formatter<std::string_view>::format(ons::mapping_type_str(t), ctx);
     }
 };

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -386,7 +386,7 @@ static void send_notifies(Mutex& mutex, Subs& subs, const char* desc, Call call)
             log::debug(
                     logcat,
                     "Removing {} from {} subscriptions: subscription timed out",
-                    conn,
+                    conn.to_string(),
                     desc);
             subs.erase(it);
         }
@@ -622,7 +622,7 @@ void omq_rpc::on_mempool_sub_request(oxenmq::Message& m) {
                 log::trace(
                         logcat,
                         "Renewed mempool subscription request from conn id {}@{}",
-                        m.conn,
+                        m.conn.to_string(),
                         m.remote);
                 m.send_reply("ALREADY");
                 return;
@@ -633,7 +633,7 @@ void omq_rpc::on_mempool_sub_request(oxenmq::Message& m) {
                 logcat,
                 "New {} mempool subscription request from conn {}@{}",
                 (sub_type == mempool_sub_type::blink ? "blink" : "all"),
-                m.conn,
+                m.conn.to_string(),
                 m.remote);
         m.send_reply("OK");
     }
@@ -657,10 +657,17 @@ void omq_rpc::on_block_sub_request(oxenmq::Message& m) {
     if (!result.second) {
         result.first->second.expiry = expiry;
         log::trace(
-                logcat, "Renewed block subscription request from conn id {}@{}", m.conn, m.remote);
+                logcat,
+                "Renewed block subscription request from conn id {}@{}",
+                m.conn.to_string(),
+                m.remote);
         m.send_reply("ALREADY");
     } else {
-        log::debug(logcat, "New block subscription request from conn {}@{}", m.conn, m.remote);
+        log::debug(
+                logcat,
+                "New block subscription request from conn {}@{}",
+                m.conn.to_string(),
+                m.remote);
         m.send_reply("OK");
     }
 }


### PR DESCRIPTION
Update to the latest oxen-logging with updated fmt, spdlog, and fixes for some of the weird logging bugs that have been showing up (such as logs level not being set properly).

One of the issues with oxen-logging was that its stripped paths was a compile-time constant, but different compilation units having different strip paths meant that multiple things linking to it (e.g. oxen-storage-server linking to libquic) would be getting one or the other applied randomly.  The quick and moderately dirty solution was to change it to strip out *all* paths and leave just the filename, so that we now get logs such as:

    [2025-02-27 01:11:07] [+2m41.551s] [cn:error|cryptonote_core.cpp:762] Failed to initialize blockchain storage

rather than:

    [2025-02-27 01:11:07] [+2m41.551s] [cn:error|cryptonote_core/cryptonote_core.cpp:762] Failed to initialize blockchain storage

We can investigate run-time path stripping at some point if we want to, but for now I'm fine to move ahead with this as the category + filename is almost always enough information, and the shorter log lines are nicer as well.