### PR TITLE
Simplify LMDB resize

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -730,9 +730,12 @@ class BlockchainDB {
      * If any of this cannot be done, the subclass should throw the corresponding
      * subclass of DB_EXCEPTION
      *
+     * @params bytes_required Amount of bytes that the DB must guarantee be
+     * available for storing (can be set to 0).
+     *
      * @return true if we started the batch, false if already started
      */
-    virtual bool batch_start() = 0;
+    virtual bool batch_start(uint64_t bytes_required = 0) = 0;
 
     /**
      * @brief ends a batch transaction

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -722,9 +722,7 @@ class BlockchainDB {
      *
      * If the subclass implements a batching method of caching blocks in RAM to
      * be added to a backing store in groups, it should start a batch which will
-     * end either when <batch_num_blocks> has been added or batch_stop() has
-     * been called.  In either case, it should end the batch and write to its
-     * backing store.
+     * end when batch_stop() has been called and write to its backing store.
      *
      * If a batch is already in-progress, this function must return false.
      * If a batch was started by this call, it must return true.
@@ -732,11 +730,9 @@ class BlockchainDB {
      * If any of this cannot be done, the subclass should throw the corresponding
      * subclass of DB_EXCEPTION
      *
-     * @param batch_num_blocks number of blocks to batch together
-     *
      * @return true if we started the batch, false if already started
      */
-    virtual bool batch_start(uint64_t batch_num_blocks = 0, uint64_t batch_bytes = 0) = 0;
+    virtual bool batch_start() = 0;
 
     /**
      * @brief ends a batch transaction

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -624,7 +624,7 @@ void BlockchainLMDB::check_open() const {
         throw0(DB_ERROR("DB operation attempted on a not-open DB instance"));
 }
 
-void BlockchainLMDB::do_resize() {
+void BlockchainLMDB::do_resize(uint64_t bytes_required) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     std::lock_guard lock{*this};
 
@@ -633,15 +633,15 @@ void BlockchainLMDB::do_resize() {
         batch_stop();
 
     // NOTE: Check disk capacity
-    constexpr uint64_t ADD_SIZE = 1 * 1024 /*KiB*/ * 1024 /*MiB*/ * 1024 /*GiB*/;
+    uint64_t const add_size = std::max(MIN_GROW_SIZE, bytes_required);
     try {
         auto free_space = fs::space(m_folder);
-        if (free_space.available < ADD_SIZE) {
+        if (free_space.available < add_size) {
             log::error(
                     logcat,
                     "Insufficient free disk space to grow DB: {} available, {} needed",
                     tools::get_human_readable_bytes(free_space.available),
-                    tools::get_human_readable_bytes(ADD_SIZE));
+                    tools::get_human_readable_bytes(add_size));
             return;
         }
     } catch (const std::exception& e) {
@@ -657,7 +657,7 @@ void BlockchainLMDB::do_resize() {
     mdb_env_stat(m_env, &stat);
 
     // NOTE: New map size is to add 1GiB and round it to the nearest page size
-    uint64_t new_size = static_cast<uint64_t>(info.me_mapsize) + ADD_SIZE;
+    uint64_t new_size = static_cast<uint64_t>(info.me_mapsize) + add_size;
     if (new_size % stat.ms_psize != 0)
         new_size += (stat.ms_psize - (new_size % stat.ms_psize));
 
@@ -690,7 +690,6 @@ void BlockchainLMDB::add_block(
         const crypto::hash& blk_hash) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
 
@@ -810,7 +809,6 @@ uint64_t BlockchainLMDB::add_transaction_data(
         const crypto::hash& tx_prunable_hash) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
 
@@ -980,47 +978,38 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
         throw1(DB_ERROR("Failed to add removal of tx index to db transaction"));
 }
 
-static bool need_resize(MDB_env* env) {
+static bool need_resize(MDB_env* env, uint64_t bytes_req) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
-    MDB_envinfo mei;
+    MDB_envinfo env_info;
+    mdb_env_info(env, &env_info);
 
-    mdb_env_info(env, &mei);
-
-    MDB_stat mst;
-
-    mdb_env_stat(env, &mst);
+    MDB_stat stat;
+    mdb_env_stat(env, &stat);
 
     // size_used doesn't include data yet to be committed, which can be
     // significant size during batch transactions. For that, we estimate the size
     // needed at the beginning of the batch transaction and pass in the
     // additional size needed.
-    uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
+    uint64_t size_used = stat.ms_psize * env_info.me_last_pgno;
 
-    log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(mei.me_mapsize));
+    log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(env_info.me_mapsize));
     log::debug(logcat, "Space used:      {}", tools::get_human_readable_bytes(size_used));
     log::debug(
             logcat,
             "Space remaining: {}",
-            tools::get_human_readable_bytes(mei.me_mapsize - size_used));
+            tools::get_human_readable_bytes(env_info.me_mapsize - size_used));
 
     constexpr static float RESIZE_PERCENT = 0.9f;
     log::debug(
             logcat,
             "Percent used: {}  Percent threshold: {}",
-            100 * size_used / mei.me_mapsize,
+            100 * size_used / env_info.me_mapsize,
             100 * RESIZE_PERCENT);
 
-    if ((double)size_used / mei.me_mapsize > RESIZE_PERCENT) {
-        log::info(logcat, "Threshold met (percent-based)");
-        return true;
-    }
-    return false;
-}
-
-void BlockchainLMDB::grow_if_needed() {
-    if (need_resize(m_env)) {
-        do_resize();
-    }
+    uint64_t size_required = size_used + bytes_req;
+    float occupancy01      = size_required / static_cast<double>(env_info.me_mapsize);
+    bool result            = occupancy01 > RESIZE_PERCENT;
+    return result;
 }
 
 uint64_t BlockchainLMDB::add_output(
@@ -1031,7 +1020,6 @@ uint64_t BlockchainLMDB::add_output(
         const rct::key* commitment) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
     uint64_t m_num_outputs = num_outputs();
@@ -1093,7 +1081,6 @@ void BlockchainLMDB::add_tx_amount_output_indices(
         const uint64_t tx_id, const std::vector<uint64_t>& amount_output_indices) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     CURSOR(tx_outputs)
 
@@ -1229,7 +1216,6 @@ void BlockchainLMDB::prune_outputs(uint64_t amount) {
 void BlockchainLMDB::add_spent_key(const crypto::key_image& k_image) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(spent_keys)
@@ -1369,7 +1355,6 @@ void BlockchainLMDB::open(
         log::info(logcat, "LMDB memory map size: {}", tools::get_human_readable_bytes(cur_mapsize));
     }
 
-    grow_if_needed();
 
     int txn_flags = 0;
     if (mdb_flags & MDB_RDONLY)
@@ -1820,7 +1805,6 @@ void BlockchainLMDB::add_txpool_tx(
         throw1(DB_ERROR("Attempting to add txpool tx with empty blob"));
 
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(txpool_meta)
@@ -2816,7 +2800,6 @@ uint64_t BlockchainLMDB::get_max_block_size() {
 void BlockchainLMDB::add_max_block_size(uint64_t sz) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(properties)
@@ -3669,7 +3652,7 @@ bool BlockchainLMDB::for_all_outputs(
     return fret;
 }
 
-bool BlockchainLMDB::batch_start() {
+bool BlockchainLMDB::batch_start(uint64_t bytes_required) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     if (!m_batch_transactions)
         throw0(DB_ERROR("batch transactions not enabled"));
@@ -3680,6 +3663,12 @@ bool BlockchainLMDB::batch_start() {
     if (m_write_txn)
         throw0(DB_ERROR("batch transaction attempted, but m_write_txn already in use"));
     check_open();
+
+    // Evaluate if the DB needs to resize to accommodate the storage of `bytes_required` bytes to
+    // write to the DB. This can be set to 0 if the resize of the DB should be dictated by if the DB
+    // exceeds the threshold from its usage against its current capacity.
+    if (need_resize(m_env, bytes_required))
+        do_resize(bytes_required);
 
     m_writer = boost::this_thread::get_id();
     m_write_batch_txn = new mdb_txn_safe();
@@ -4476,7 +4465,6 @@ void BlockchainLMDB::add_output_blacklist(std::vector<uint64_t> const& blacklist
         return;
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
 
     mdb_txn_cursors* m_cursors = &m_wcursors;
     CURSOR(output_blacklist);
@@ -4499,7 +4487,6 @@ void BlockchainLMDB::add_alt_block(
         std::string const* checkpoint) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
-    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(alt_blocks)

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -695,7 +695,6 @@ void BlockchainLMDB::do_resize(uint64_t increase_size) {
 // threshold_size is used for batch transactions
 bool BlockchainLMDB::need_resize(uint64_t threshold_size) const {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
-#if defined(ENABLE_AUTO_RESIZE)
     MDB_envinfo mei;
 
     mdb_env_info(m_env, &mei);
@@ -737,9 +736,6 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const {
         return true;
     }
     return false;
-#else
-    return false;
-#endif
 }
 
 void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint64_t batch_bytes) {

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -759,11 +759,6 @@ void BlockchainLMDB::add_block(
     if (result)
         throw0(DB_ERROR("Failed to add block height by hash to db transaction: {}"_format(
                 mdb_strerror(result))));
-
-    // we use weight as a proxy for size, since we don't have size but weight is >= size
-    // and often actually equal
-    m_cum_size += block_weight;
-    m_cum_count++;
 }
 
 void BlockchainLMDB::remove_block() {
@@ -1294,9 +1289,6 @@ BlockchainLMDB::BlockchainLMDB(bool batch_transactions) : BlockchainDB() {
     m_write_txn = nullptr;
     m_write_batch_txn = nullptr;
     m_batch_active = false;
-    m_cum_size = 0;
-    m_cum_count = 0;
-
     // reset may also need changing when initialize things here
 }
 
@@ -1730,8 +1722,6 @@ void BlockchainLMDB::reset() {
         throw0(DB_ERROR("Failed to write version to database: {}"_format(mdb_strerror(result))));
 
     txn.commit();
-    m_cum_size = 0;
-    m_cum_count = 0;
 }
 
 std::vector<fs::path> BlockchainLMDB::get_filenames() const {

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1471,8 +1471,6 @@ void BlockchainLMDB::open(
         (result = mdb_env_set_maxreaders(m_env, threads + 16)))
         throw0(DB_ERROR("Failed to set max number of readers: {}"_format(mdb_strerror(result))));
 
-    size_t mapsize = DEFAULT_MAPSIZE;
-
     if (db_flags & DBF_FAST)
         mdb_flags |= MDB_NOSYNC;
     if (db_flags & DBF_FASTEST)
@@ -1492,8 +1490,9 @@ void BlockchainLMDB::open(
     mdb_env_info(m_env, &mei);
     uint64_t cur_mapsize = (uint64_t)mei.me_mapsize;
 
-    if (cur_mapsize < mapsize) {
-        if (auto result = mdb_env_set_mapsize(m_env, mapsize))
+    constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 30;
+    if (cur_mapsize < DEFAULT_MAPSIZE) {
+        if (auto result = mdb_env_set_mapsize(m_env, DEFAULT_MAPSIZE))
             throw0(DB_ERROR("Failed to set max memory map size: {}"_format(mdb_strerror(result))));
         mdb_env_info(m_env, &mei);
         cur_mapsize = (uint64_t)mei.me_mapsize;

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -980,7 +980,7 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
         throw1(DB_ERROR("Failed to add removal of tx index to db transaction"));
 }
 
-static bool need_resize(MDB_env *env) {
+static bool need_resize(MDB_env* env) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     MDB_envinfo mei;
 
@@ -1017,9 +1017,7 @@ static bool need_resize(MDB_env *env) {
     return false;
 }
 
-
-void BlockchainLMDB::grow_if_needed()
-{
+void BlockchainLMDB::grow_if_needed() {
     if (need_resize(m_env)) {
         do_resize();
     }
@@ -3932,7 +3930,6 @@ uint64_t BlockchainLMDB::add_block(
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
     uint64_t m_height = height();
-
 
     try {
         BlockchainDB::add_block(

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1007,8 +1007,8 @@ static bool need_resize(MDB_env* env, uint64_t bytes_req) {
             100 * RESIZE_PERCENT);
 
     uint64_t size_required = size_used + bytes_req;
-    float occupancy01      = size_required / static_cast<double>(env_info.me_mapsize);
-    bool result            = occupancy01 > RESIZE_PERCENT;
+    float occupancy01 = size_required / static_cast<double>(env_info.me_mapsize);
+    bool result = occupancy01 > RESIZE_PERCENT;
     return result;
 }
 
@@ -1354,7 +1354,6 @@ void BlockchainLMDB::open(
         cur_mapsize = (uint64_t)mei.me_mapsize;
         log::info(logcat, "LMDB memory map size: {}", tools::get_human_readable_bytes(cur_mapsize));
     }
-
 
     int txn_flags = 0;
     if (mdb_flags & MDB_RDONLY)

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -594,9 +594,9 @@ void lmdb_resized(MDB_env* env) {
 
     log::info(
             logcat,
-            "LMDB Mapsize increased.  Old: {}MiB, New: {}MiB",
-            old / (1024 * 1024),
-            new_mapsize / (1024 * 1024));
+            "LMDB map size increased.  Old: {}, new: {}",
+            tools::get_human_readable_bytes(old),
+            tools::get_human_readable_bytes(new_mapsize));
 
     mdb_txn_safe::allow_new_txns();
 }
@@ -624,230 +624,59 @@ void BlockchainLMDB::check_open() const {
         throw0(DB_ERROR("DB operation attempted on a not-open DB instance"));
 }
 
-void BlockchainLMDB::do_resize(uint64_t increase_size) {
+void BlockchainLMDB::do_resize() {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     std::lock_guard lock{*this};
-    const uint64_t add_size = 1LL << 30;
 
-    // check disk capacity
+    bool batch_was_active = m_batch_active;
+    if (batch_was_active)
+        batch_stop();
+
+    // NOTE: Check disk capacity
+    constexpr uint64_t ADD_SIZE = 1 * 1024 /*KiB*/ * 1024 /*MiB*/ * 1024 /*GiB*/;
     try {
-        auto si = fs::space(m_folder);
-        if (si.available < add_size) {
+        auto free_space = fs::space(m_folder);
+        if (free_space.available < ADD_SIZE) {
             log::error(
                     logcat,
-                    "!! WARNING: Insufficient free space to extend database !!: {} MB available, "
-                    "{} MB needed",
-                    (si.available >> 20L),
-                    (add_size >> 20L));
+                    "Insufficient free disk space to grow DB: {} available, {} needed",
+                    tools::get_human_readable_bytes(free_space.available),
+                    tools::get_human_readable_bytes(ADD_SIZE));
             return;
         }
-    } catch (...) {
-        // print something but proceed.
-        log::warning(logcat, "Unable to query free disk space.");
+    } catch (const std::exception& e) {
+        log::warning(logcat, "Unable to query free disk space for resizing DB: {}", e.what());
     }
 
-    MDB_envinfo mei;
+    // NOTE: Query DB size before
+    MDB_envinfo info;
+    mdb_env_info(m_env, &info);
 
-    mdb_env_info(m_env, &mei);
+    // NOTE: Query page size
+    MDB_stat stat;
+    mdb_env_stat(m_env, &stat);
 
-    MDB_stat mst;
+    // NOTE: New map size is to add 1GiB and round it to the nearest page size
+    uint64_t new_size = static_cast<uint64_t>(info.me_mapsize) + ADD_SIZE;
+    new_size += new_size % stat.ms_psize;
 
-    mdb_env_stat(m_env, &mst);
-
-    // add 1Gb per resize, instead of doing a percentage increase
-    uint64_t new_mapsize = (uint64_t)mei.me_mapsize + add_size;
-
-    // If given, use increase_size instead of above way of resizing.
-    // This is currently used for increasing by an estimated size at start of new
-    // batch txn.
-    if (increase_size > 0)
-        new_mapsize = mei.me_mapsize + increase_size;
-
-    new_mapsize += (new_mapsize % mst.ms_psize);
-
+    // NOTE: Resize the DB
     mdb_txn_safe::prevent_new_txns();
-
-    if (m_write_txn != nullptr) {
-        if (m_batch_active) {
-            throw0(DB_ERROR("lmdb resizing not yet supported when batch transactions enabled!"));
-        } else {
-            throw0(
-                    DB_ERROR("attempting resize with write transaction in progress, this should "
-                             "not happen!"));
-        }
-    }
-
     mdb_txn_safe::wait_no_active_txns();
-
-    int result = mdb_env_set_mapsize(m_env, new_mapsize);
-    if (result)
-        throw0(DB_ERROR("Failed to set new mapsize: {}"_format(mdb_strerror(result))));
-
-    log::info(
-            logcat,
-            "LMDB Mapsize increased.  Old: {}MiB, New: {}MiB",
-            mei.me_mapsize / (1024 * 1024),
-            new_mapsize / (1024 * 1024));
-
+    int result = mdb_env_set_mapsize(m_env, new_size);
     mdb_txn_safe::allow_new_txns();
-}
 
-// threshold_size is used for batch transactions
-bool BlockchainLMDB::need_resize(uint64_t threshold_size) const {
-    log::trace(logcat, "BlockchainLMDB::{}", __func__);
-    MDB_envinfo mei;
+    // NOTE: Handle outcome
+    std::string old_size_str = tools::get_human_readable_bytes(info.me_mapsize);
+    std::string new_size_str = tools::get_human_readable_bytes(new_size);
 
-    mdb_env_info(m_env, &mei);
+    if (result)
+        throw0(DB_ERROR("Failed to set resize DB from {} to {}: {}"_format(
+                old_size_str, new_size_str, mdb_strerror(result))));
 
-    MDB_stat mst;
-
-    mdb_env_stat(m_env, &mst);
-
-    // size_used doesn't include data yet to be committed, which can be
-    // significant size during batch transactions. For that, we estimate the size
-    // needed at the beginning of the batch transaction and pass in the
-    // additional size needed.
-    uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
-
-    log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(mei.me_mapsize));
-    log::debug(logcat, "Space used:      {}", tools::get_human_readable_bytes(size_used));
-    log::debug(
-            logcat,
-            "Space remaining: {}",
-            tools::get_human_readable_bytes(mei.me_mapsize - size_used));
-    log::debug(logcat, "Size threshold:  {}", tools::get_human_readable_bytes(threshold_size));
-    float resize_percent = RESIZE_PERCENT;
-    log::debug(
-            logcat,
-            "Percent used: {}  Percent threshold: {}",
-            100. * size_used / mei.me_mapsize,
-            100. * resize_percent);
-
-    if (threshold_size > 0) {
-        if (mei.me_mapsize - size_used < threshold_size) {
-            log::info(logcat, "Threshold met (size-based)");
-            return true;
-        } else
-            return false;
-    }
-
-    if ((double)size_used / mei.me_mapsize > resize_percent) {
-        log::info(logcat, "Threshold met (percent-based)");
-        return true;
-    }
-    return false;
-}
-
-void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint64_t batch_bytes) {
-    log::trace(logcat, "BlockchainLMDB::{}", __func__);
-    log::trace(logcat, "[{}] checking DB size", __func__);
-    const uint64_t min_increase_size = 512 * (1 << 20);
-    uint64_t threshold_size = 0;
-    uint64_t increase_size = 0;
-    if (batch_num_blocks > 0) {
-        threshold_size = get_estimated_batch_size(batch_num_blocks, batch_bytes);
-        log::debug(logcat, "calculated batch size: {}", threshold_size);
-
-        // The increased DB size could be a multiple of threshold_size, a fixed
-        // size increase (> threshold_size), or other variations.
-        //
-        // Currently we use the greater of threshold size and a minimum size. The
-        // minimum size increase is used to avoid frequent resizes when the batch
-        // size is set to a very small numbers of blocks.
-        increase_size = (threshold_size > min_increase_size) ? threshold_size : min_increase_size;
-        log::debug(logcat, "increase size: {}", increase_size);
-    }
-
-    // if threshold_size is 0 (i.e. number of blocks for batch not passed in), it
-    // will fall back to the percent-based threshold check instead of the
-    // size-based check
-    if (need_resize(threshold_size)) {
-        log::info(logcat, "[batch] DB resize needed");
-        do_resize(increase_size);
-    }
-}
-
-uint64_t BlockchainLMDB::get_estimated_batch_size(
-        uint64_t batch_num_blocks, uint64_t batch_bytes) const {
-    log::trace(logcat, "BlockchainLMDB::{}", __func__);
-    uint64_t threshold_size = 0;
-
-    // batch size estimate * batch safety factor = final size estimate
-    // Takes into account "reasonable" block size increases in batch.
-    float batch_safety_factor = 1.7f;
-    float batch_fudge_factor = batch_safety_factor * batch_num_blocks;
-    // estimate of stored block expanded from raw block, including denormalization and db overhead.
-    // Note that this probably doesn't grow linearly with block size.
-    float db_expand_factor = 4.5f;
-    uint64_t num_prev_blocks = 500;
-    // For resizing purposes, allow for at least 4k average block size.
-    uint64_t min_block_size = 4 * 1024;
-
-    uint64_t block_stop = 0;
-    uint64_t m_height = height();
-    if (m_height > 1)
-        block_stop = m_height - 1;
-    uint64_t block_start = 0;
-    if (block_stop >= num_prev_blocks)
-        block_start = block_stop - num_prev_blocks + 1;
-    uint32_t num_blocks_used = 0;
-    uint64_t total_block_size = 0;
-    log::debug(
-            logcat,
-            "[{}] m_height: {}  block_start: {}  block_stop: {}",
-            __func__,
-            m_height,
-            block_start,
-            block_stop);
-    size_t avg_block_size = 0;
-    if (batch_bytes) {
-        avg_block_size = batch_bytes / batch_num_blocks;
-        goto estim;
-    }
-    if (m_height == 0) {
-        log::debug(logcat, "No existing blocks to check for average block size");
-    } else if (m_cum_count >= num_prev_blocks) {
-        avg_block_size = m_cum_size / m_cum_count;
-        log::debug(
-                logcat,
-                "average block size across recent {} blocks: {}",
-                m_cum_count,
-                avg_block_size);
-        m_cum_size = 0;
-        m_cum_count = 0;
-    } else {
-        MDB_txn* rtxn;
-        mdb_txn_cursors* rcurs;
-        bool my_rtxn = block_rtxn_start(&rtxn, &rcurs);
-        for (uint64_t block_num = block_start; block_num <= block_stop; ++block_num) {
-            // we have access to block weight, which will be greater or equal to block size,
-            // so use this as a proxy. If it's too much off, we might have to check actual size,
-            // which involves reading more data, so is not really wanted
-            size_t block_weight = get_block_weight(block_num);
-            total_block_size += block_weight;
-            // Track number of blocks being totalled here instead of assuming, in case
-            // some blocks were to be skipped for being outliers.
-            ++num_blocks_used;
-        }
-        if (my_rtxn)
-            block_rtxn_stop();
-        avg_block_size = total_block_size / (num_blocks_used ? num_blocks_used : 1);
-        log::debug(
-                logcat,
-                "average block size across recent {} blocks: {}",
-                num_blocks_used,
-                avg_block_size);
-    }
-estim:
-    if (avg_block_size < min_block_size)
-        avg_block_size = min_block_size;
-    log::debug(logcat, "estimated average block size for batch: {}", avg_block_size);
-
-    // bigger safety margin on smaller block sizes
-    if (batch_fudge_factor < 5000.0)
-        batch_fudge_factor = 5000.0;
-    threshold_size = avg_block_size * db_expand_factor * batch_fudge_factor;
-    return threshold_size;
+    log::info(logcat, "LMDB map size increased.  Old: {}, new: {}", old_size_str, new_size_str);
+    if (batch_was_active)
+        batch_start();
 }
 
 void BlockchainLMDB::add_block(
@@ -860,6 +689,7 @@ void BlockchainLMDB::add_block(
         const crypto::hash& blk_hash) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
 
@@ -984,6 +814,7 @@ uint64_t BlockchainLMDB::add_transaction_data(
         const crypto::hash& tx_prunable_hash) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
 
@@ -1153,6 +984,51 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
         throw1(DB_ERROR("Failed to add removal of tx index to db transaction"));
 }
 
+static bool need_resize(MDB_env *env) {
+    log::trace(logcat, "BlockchainLMDB::{}", __func__);
+    MDB_envinfo mei;
+
+    mdb_env_info(env, &mei);
+
+    MDB_stat mst;
+
+    mdb_env_stat(env, &mst);
+
+    // size_used doesn't include data yet to be committed, which can be
+    // significant size during batch transactions. For that, we estimate the size
+    // needed at the beginning of the batch transaction and pass in the
+    // additional size needed.
+    uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
+
+    log::debug(logcat, "DB map size:     {}", tools::get_human_readable_bytes(mei.me_mapsize));
+    log::debug(logcat, "Space used:      {}", tools::get_human_readable_bytes(size_used));
+    log::debug(
+            logcat,
+            "Space remaining: {}",
+            tools::get_human_readable_bytes(mei.me_mapsize - size_used));
+
+    constexpr static float RESIZE_PERCENT = 0.9f;
+    log::debug(
+            logcat,
+            "Percent used: {}  Percent threshold: {}",
+            100 * size_used / mei.me_mapsize,
+            100 * RESIZE_PERCENT);
+
+    if ((double)size_used / mei.me_mapsize > RESIZE_PERCENT) {
+        log::info(logcat, "Threshold met (percent-based)");
+        return true;
+    }
+    return false;
+}
+
+
+void BlockchainLMDB::grow_if_needed()
+{
+    if (need_resize(m_env)) {
+        do_resize();
+    }
+}
+
 uint64_t BlockchainLMDB::add_output(
         const crypto::hash& tx_hash,
         const tx_out& tx_output,
@@ -1161,6 +1037,7 @@ uint64_t BlockchainLMDB::add_output(
         const rct::key* commitment) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     uint64_t m_height = height();
     uint64_t m_num_outputs = num_outputs();
@@ -1222,6 +1099,7 @@ void BlockchainLMDB::add_tx_amount_output_indices(
         const uint64_t tx_id, const std::vector<uint64_t>& amount_output_indices) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
     CURSOR(tx_outputs)
 
@@ -1357,6 +1235,7 @@ void BlockchainLMDB::prune_outputs(uint64_t amount) {
 void BlockchainLMDB::add_spent_key(const crypto::key_image& k_image) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(spent_keys)
@@ -1499,10 +1378,7 @@ void BlockchainLMDB::open(
         log::info(logcat, "LMDB memory map size: {}", tools::get_human_readable_bytes(cur_mapsize));
     }
 
-    if (need_resize()) {
-        log::warning(logcat, "LMDB memory map needs to be resized, doing that now.");
-        do_resize();
-    }
+    grow_if_needed();
 
     int txn_flags = 0;
     if (mdb_flags & MDB_RDONLY)
@@ -1955,6 +1831,7 @@ void BlockchainLMDB::add_txpool_tx(
         throw1(DB_ERROR("Attempting to add txpool tx with empty blob"));
 
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(txpool_meta)
@@ -2950,6 +2827,7 @@ uint64_t BlockchainLMDB::get_max_block_size() {
 void BlockchainLMDB::add_max_block_size(uint64_t sz) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(properties)
@@ -3802,8 +3680,7 @@ bool BlockchainLMDB::for_all_outputs(
     return fret;
 }
 
-// batch_num_blocks: (optional) Used to check if resize needed before batch transaction starts.
-bool BlockchainLMDB::batch_start(uint64_t batch_num_blocks, uint64_t batch_bytes) {
+bool BlockchainLMDB::batch_start() {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     if (!m_batch_transactions)
         throw0(DB_ERROR("batch transactions not enabled"));
@@ -3816,8 +3693,6 @@ bool BlockchainLMDB::batch_start(uint64_t batch_num_blocks, uint64_t batch_bytes
     check_open();
 
     m_writer = boost::this_thread::get_id();
-    check_and_resize_for_batch(batch_num_blocks, batch_bytes);
-
     m_write_batch_txn = new mdb_txn_safe();
 
     // NOTE: need to make sure it's destroyed properly when done
@@ -4067,13 +3942,6 @@ uint64_t BlockchainLMDB::add_block(
     check_open();
     uint64_t m_height = height();
 
-    if (m_height % 1024 == 0) {
-        // for batch mode, DB resize check is done at start of batch transaction
-        if (!m_batch_active && need_resize()) {
-            log::warning(logcat, "LMDB memory map needs to be resized, doing that now.");
-            do_resize();
-        }
-    }
 
     try {
         BlockchainDB::add_block(
@@ -4618,9 +4486,9 @@ void BlockchainLMDB::get_output_blacklist(std::vector<uint64_t>& blacklist) cons
 void BlockchainLMDB::add_output_blacklist(std::vector<uint64_t> const& blacklist) {
     if (blacklist.size() == 0)
         return;
-
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
 
     mdb_txn_cursors* m_cursors = &m_wcursors;
     CURSOR(output_blacklist);
@@ -4643,6 +4511,7 @@ void BlockchainLMDB::add_alt_block(
         std::string const* checkpoint) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     check_open();
+    grow_if_needed();
     mdb_txn_cursors* m_cursors = &m_wcursors;
 
     CURSOR(alt_blocks)
@@ -5459,7 +5328,7 @@ void BlockchainLMDB::migrate_0_1() {
 
         hk.mv_size = sizeof(crypto::hash);
         set_batch_transactions(true);
-        batch_start(1000);
+        batch_start();
         txn.m_txn = m_write_txn->m_txn;
         m_height = 0;
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -658,7 +658,8 @@ void BlockchainLMDB::do_resize() {
 
     // NOTE: New map size is to add 1GiB and round it to the nearest page size
     uint64_t new_size = static_cast<uint64_t>(info.me_mapsize) + ADD_SIZE;
-    new_size += new_size % stat.ms_psize;
+    if (new_size % stat.ms_psize != 0)
+        new_size += (stat.ms_psize - (new_size % stat.ms_psize));
 
     // NOTE: Resize the DB
     mdb_txn_safe::prevent_new_txns();

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -404,7 +404,7 @@ class BlockchainLMDB : public BlockchainDB {
 
   private:
     // The minimum amount the DB should grow by
-    constexpr static uint64_t MIN_GROW_SIZE = 1 * 1024 * 1024 * 1024; // 1 GiB
+    constexpr static uint64_t MIN_GROW_SIZE = 1 * 1024 * 1024 * 1024;  // 1 GiB
 
     // Resize the DB by `max(MIN_GROW_SIZE, bytes_required)`
     void do_resize(uint64_t bytes_required);

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -547,13 +547,6 @@ class BlockchainLMDB : public BlockchainDB {
     mdb_txn_cursors m_wcursors;
     mutable boost::thread_specific_ptr<mdb_threadinfo> m_tinfo;
 
-#if defined(__arm__)
-    // force a value so it can compile with 32-bit ARM
-    constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 31;
-#else
-    constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 30;
-#endif
-
     // Guards LMDB resize
     std::mutex m_synchronization_lock;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -36,8 +36,6 @@
 #include "common/fs.h"
 #include "ringct/rctTypes.h"
 
-#define ENABLE_AUTO_RESIZE
-
 namespace cryptonote {
 
 struct mdb_block_info;
@@ -553,11 +551,7 @@ class BlockchainLMDB : public BlockchainDB {
     // force a value so it can compile with 32-bit ARM
     constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 31;
 #else
-#if defined(ENABLE_AUTO_RESIZE)
     constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 30;
-#else
-    constexpr static uint64_t DEFAULT_MAPSIZE = 1LL << 33;
-#endif
 #endif
 
     // Guards LMDB resize

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -354,7 +354,7 @@ class BlockchainLMDB : public BlockchainDB {
             size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const override;
 
     void set_batch_transactions(bool batch_transactions) override;
-    bool batch_start() override;
+    bool batch_start(uint64_t bytes_required = 0) override;
     void batch_commit();
     void batch_stop() override;
     void batch_abort() override;
@@ -403,9 +403,11 @@ class BlockchainLMDB : public BlockchainDB {
     static int compare_string(const MDB_val* a, const MDB_val* b);
 
   private:
-    void grow_if_needed();
+    // The minimum amount the DB should grow by
+    constexpr static uint64_t MIN_GROW_SIZE = 1 * 1024 * 1024 * 1024; // 1 GiB
 
-    void do_resize();
+    // Resize the DB by `max(MIN_GROW_SIZE, bytes_required)`
+    void do_resize(uint64_t bytes_required);
 
     void add_block(
             const block& blk,

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -354,7 +354,7 @@ class BlockchainLMDB : public BlockchainDB {
             size_t num_desired_checkpoints = GET_ALL_CHECKPOINTS) const override;
 
     void set_batch_transactions(bool batch_transactions) override;
-    bool batch_start(uint64_t batch_num_blocks = 0, uint64_t batch_bytes = 0) override;
+    bool batch_start() override;
     void batch_commit();
     void batch_stop() override;
     void batch_abort() override;
@@ -403,11 +403,9 @@ class BlockchainLMDB : public BlockchainDB {
     static int compare_string(const MDB_val* a, const MDB_val* b);
 
   private:
-    void do_resize(uint64_t size_increase = 0);
+    void grow_if_needed();
 
-    bool need_resize(uint64_t threshold_size = 0) const;
-    void check_and_resize_for_batch(uint64_t batch_num_blocks, uint64_t batch_bytes);
-    uint64_t get_estimated_batch_size(uint64_t batch_num_blocks, uint64_t batch_bytes) const;
+    void do_resize();
 
     void add_block(
             const block& blk,
@@ -549,8 +547,6 @@ class BlockchainLMDB : public BlockchainDB {
 
     // Guards LMDB resize
     std::mutex m_synchronization_lock;
-
-    constexpr static float RESIZE_PERCENT = 0.9f;
 };
 
 }  // namespace cryptonote

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -532,8 +532,6 @@ class BlockchainLMDB : public BlockchainDB {
 
     MDB_dbi m_properties;
 
-    mutable uint64_t m_cum_size;  // used in batch size estimation
-    mutable unsigned int m_cum_count;
     fs::path m_folder;
     mdb_txn_safe* m_write_txn;        // may point to either a short-lived txn or a batch txn
     mdb_txn_safe* m_write_batch_txn;  // persist batch txn outside of BlockchainLMDB

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -57,7 +57,7 @@ class BaseTestDB : public cryptonote::BlockchainDB {
     virtual void lock() override {}
     virtual bool try_lock() override { return true; }
     virtual void unlock() override {}
-    virtual bool batch_start(uint64_t batch_num_blocks = 0, uint64_t batch_bytes = 0) override {
+    virtual bool batch_start() override {
         return true;
     }
     virtual void batch_stop() override {}

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -57,7 +57,7 @@ class BaseTestDB : public cryptonote::BlockchainDB {
     virtual void lock() override {}
     virtual bool try_lock() override { return true; }
     virtual void unlock() override {}
-    virtual bool batch_start() override { return true; }
+    virtual bool batch_start(uint64_t) override { return true; }
     virtual void batch_stop() override {}
     virtual void batch_abort() override {}
     virtual void set_batch_transactions(bool) override {}

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -57,9 +57,7 @@ class BaseTestDB : public cryptonote::BlockchainDB {
     virtual void lock() override {}
     virtual bool try_lock() override { return true; }
     virtual void unlock() override {}
-    virtual bool batch_start() override {
-        return true;
-    }
+    virtual bool batch_start() override { return true; }
     virtual void batch_stop() override {}
     virtual void batch_abort() override {}
     virtual void set_batch_transactions(bool) override {}

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -281,14 +281,14 @@ int import_from_file(
     }
 
     if (use_batch) {
-        uint64_t bytes, h2;
+        uint64_t h2;
         bool q2;
         pos = import_file.tellg();
-        bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
+        bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
         if (import_file.eof())
             import_file.clear();
         import_file.seekg(pos);
-        core.blockchain.db().batch_start(db_batch_size, bytes);
+        core.blockchain.db().batch_start();
     }
     while (!quit) {
         uint32_t chunk_size;
@@ -443,16 +443,16 @@ int import_from_file(
 
                     if (use_batch) {
                         if ((h - 1) % db_batch_size == 0) {
-                            uint64_t bytes, h2;
+                            uint64_t h2;
                             bool q2;
                             std::cout << refresh_string;
                             // zero-based height
                             std::cout << "\n[- batch commit at height " << h - 1 << " -]\n";
                             core.blockchain.db().batch_stop();
                             pos = import_file.tellg();
-                            bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
+                            bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
                             import_file.seekg(pos);
-                            core.blockchain.db().batch_start(db_batch_size, bytes);
+                            core.blockchain.db().batch_start();
                             std::cout << "\n";
                             core.blockchain.db().show_stats();
                         }

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -281,14 +281,14 @@ int import_from_file(
     }
 
     if (use_batch) {
-        uint64_t h2;
+        uint64_t bytes, h2;
         bool q2;
         pos = import_file.tellg();
-        bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
+        bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
         if (import_file.eof())
             import_file.clear();
         import_file.seekg(pos);
-        core.blockchain.db().batch_start();
+        core.blockchain.db().batch_start(bytes);
     }
     while (!quit) {
         uint32_t chunk_size;
@@ -443,16 +443,16 @@ int import_from_file(
 
                     if (use_batch) {
                         if ((h - 1) % db_batch_size == 0) {
-                            uint64_t h2;
+                            uint64_t bytes, h2;
                             bool q2;
                             std::cout << refresh_string;
                             // zero-based height
                             std::cout << "\n[- batch commit at height " << h - 1 << " -]\n";
                             core.blockchain.db().batch_stop();
                             pos = import_file.tellg();
-                            bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
+                            bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
                             import_file.seekg(pos);
-                            core.blockchain.db().batch_start();
+                            core.blockchain.db().batch_start(bytes);
                             std::cout << "\n";
                             core.blockchain.db().show_stats();
                         }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -6316,8 +6316,6 @@ bool Blockchain::prepare_handle_incoming_blocks(
     ZoneScoped;
     log::trace(logcat, "Blockchain::{}", __func__);
     auto prepare = std::chrono::steady_clock::now();
-    uint64_t bytes = 0;
-    size_t total_txs = 0;
     blocks.clear();
 
     // Order of locking must be:
@@ -6339,16 +6337,17 @@ bool Blockchain::prepare_handle_incoming_blocks(
     if (blocks_entry.size() == 0)
         return false;
 
+    size_t total_txs = 0;
+    uint64_t bytes = 0;
     for (const auto& entry : blocks_entry) {
         bytes += entry.block.size();
         bytes += entry.checkpoint.size();
-        for (const auto& tx_blob : entry.txs) {
+        for (const auto& tx_blob : entry.txs)
             bytes += tx_blob.size();
-        }
         total_txs += entry.txs.size();
     }
     m_bytes_to_sync += bytes;
-    while (!m_db->batch_start()) {
+    while (!m_db->batch_start(bytes)) {
         unlock();
         tx_pool.unlock();
         std::this_thread::sleep_for(100ms);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -6348,7 +6348,7 @@ bool Blockchain::prepare_handle_incoming_blocks(
         total_txs += entry.txs.size();
     }
     m_bytes_to_sync += bytes;
-    while (!m_db->batch_start(blocks_entry.size(), bytes)) {
+    while (!m_db->batch_start()) {
         unlock();
         tx_pool.unlock();
         std::this_thread::sleep_for(100ms);

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -43,8 +43,6 @@
 
 extern "C" {
 #include "crypto/crypto-ops.h"
-#include "crypto/keccak.h"
-#include "crypto/random.h"
 }
 #include "common/util.h"
 #include "crypto/crypto.h"

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -58,15 +58,10 @@ extern "C" {
 // atomic units of moneros
 #define ATOMS 64
 
-// for printing large ints
-
 // Namespace specifically for ring ct code
 namespace rct {
 
 using namespace std::literals;
-
-// basic ops containers
-typedef unsigned char* Bytes;
 
 // Can contain a secret or public key
 //  similar to secret_key / public_key of crypto-ops,


### PR DESCRIPTION
Removing of some unused headers. Enforcing the code defined by ENABLE_AUTO_RESIZE (that macro has been defined for 10 years and isn't ever going away) and also replacing the previous LMDB resize logic with something simpler resembling more like dynamic array growth (grow by 1GiB when 90% full _always_ vs maybe check the last 100 blocks to estimate the size of a batch of blocks being written to the DB or use this other heuristic to grow the DB).

The meat of the changes:

```
The resize logic before this change was quite intricate with it reading
the previous window of blocks for the average size, then, applying some
fudge-factor ontop of it to try and overshoot the expected number of
bytes required so writing the objects to the DB doesn't fail.

It's actually still possible for this to fail if you had a batch of
blocks that were larger than the remaining space in the DB because
inherently the DB was unable to resize in the middle of a batch.

This is all-nice machinery that we don't necessarily need with some
sensible resizing logic:

1. We always increase the size of the DB by 1 GiB. Before this, we'd
enumerate the size of the payload and check if we overflowed, and then,
do some logic to choose a reasonable size.

Since we now only increase in 1 GiB increments, to ensure this doesn't break
we need to ensure that any blockchain payload cannot exceed 1 GiB. The
current default syncing window is 100 blocks per payload (and increasing
it above this is quite dicey as the node actually can't support much
higher than this without encountering some internal errors) and so for
1 GiB to be reasonable it must not be possible for a 100 block payload
to exceed 1 GiB. It's reasonable to assume that we won't have a window
of 100, 10MiB blocks without hitting some block weight limit or some
fatal exploit to bloat up the blocks.

Even if this were possible however, I've added an additional change which
ensures that in practice writing to the DB will always work as follows.

2. Allow a batch to be paused mid-write to resize the DB before continuing the
batch. This was as simple as stopping the batch before resize and
restarting the batch afterwards.

This now means that the _only_ way to break a write to the DB is to insert a
_single_ object that is larger than 1 GiB. The only individual item even
remotely close to this is the SNL blob. As of current with at most
2 years worth of 10k intervals and the last 60 SNL states, that consumes
~140 MiB which has plenty of leeway to grow.

As a result, assuming these assumptions we can drop the complicated
resize logic for a simpler resizing scheme.
```

--

Currently letting the node resync the chain from scratch to see if there are any issues. Will update when that is done successfully.