### PR TITLE
adjust log level for missing quorum

### DIFF
--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -609,11 +609,20 @@ void quorum_cop::process_quorums(cryptonote::block const& block) {
                         auto quorum = m_core.service_node_list.get_quorum(
                                 quorum_type::checkpointing, m_last_checkpointed_height);
                         if (!quorum) {
-                            // TODO(oxen): Fatal error
-                            log::error(
-                                    logcat,
-                                    "Checkpoint quorum for height: {} was not cached in daemon!",
-                                    m_last_checkpointed_height);
+                            if (height > m_last_checkpointed_height + (VOTE_LIFETIME / 2))
+                                log::debug(
+                                        logcat,
+                                        "Checkpoint quorum for height {} was not found in SNL, but "
+                                        "it is old enough our votes on it shouldn't matter anyway, "
+                                        "if we even missed voting from being offline.",
+                                        m_last_checkpointed_height);
+                            else
+                                // TODO(oxen): Fatal error
+                                log::error(
+                                        logcat,
+                                        "Checkpoint quorum for height: {} was not cached in "
+                                        "daemon!",
+                                        m_last_checkpointed_height);
                             continue;
                         }
 


### PR DESCRIPTION
When a block is added, quorum cop checks if we need to vote in a checkpoint quorum.  If it is the first block added since startup, it also "catches up" its state starting with the last checkpoint quorum up to VOTE_WINDOW (60) blocks ago.  Currently the first quorum can be missing from the SNL state, but that's not a problem and just means if we were supposed to vote that long ago *and* didn't, we just didn't vote in that quorum.

I chose the "ignore it, it's fine" threshold as > 40 blocks ago, but that number can change or be parametrized; just wasn't sure exactly what we'd want so I put something safe enough.