### PR TITLE
Boost 187 fixes

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -5,12 +5,12 @@
 
 set(LOCAL_MIRROR "" CACHE STRING "local mirror path/URL for lib downloads")
 
-set(BOOST_VERSION 1.86.0 CACHE STRING "boost version")
+set(BOOST_VERSION 1.87.0 CACHE STRING "boost version")
 set(BOOST_MIRROR ${LOCAL_MIRROR} https://archives.boost.io/release/${BOOST_VERSION}/source
     CACHE STRING "boost download mirror(s)")
 string(REPLACE "." "_" BOOST_VERSION_ ${BOOST_VERSION})
 set(BOOST_SOURCE boost_${BOOST_VERSION_}.tar.bz2)
-set(BOOST_HASH SHA256=1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
+set(BOOST_HASH SHA256=af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
     CACHE STRING "boost source hash")
 
 set(NCURSES_VERSION 6.3 CACHE STRING "ncurses version")

--- a/contrib/epee/include/epee/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/epee/net/abstract_tcp_server2.h
@@ -320,7 +320,7 @@ namespace net_utils
     template<class t_handler>
     bool async_call(t_handler t_callback)
     {
-      boost::asio::post(io_service_, std::move(t_callback), std::allocator<void>{});
+      boost::asio::post(io_service_, std::move(t_callback));
       return true;
     }
 

--- a/contrib/epee/include/epee/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/epee/net/abstract_tcp_server2.h
@@ -302,7 +302,7 @@ namespace net_utils
       {
         auto ptr = std::make_shared<idle_callback_conext<t_handler>>(io_service_, std::move(callback), timeout);
         //needed call handler here ?...
-        ptr->m_timer.expires_from_now(ptr->m_period);
+        ptr->m_timer.expires_after(ptr->m_period);
         ptr->m_timer.async_wait([this, ptr] (const boost::system::error_code&) { global_timer_handler<t_handler>(ptr); });
         return true;
       }
@@ -313,14 +313,14 @@ namespace net_utils
       //if handler return false - he don't want to be called anymore
       if(!ptr->call_handler())
         return;
-      ptr->m_timer.expires_from_now(ptr->m_period);
+      ptr->m_timer.expires_after(ptr->m_period);
       ptr->m_timer.async_wait([this, ptr] (const boost::system::error_code&) { global_timer_handler<t_handler>(ptr); });
     }
 
     template<class t_handler>
     bool async_call(t_handler t_callback)
     {
-      io_service_.post(std::move(t_callback));
+      boost::asio::post(io_service_, std::move(t_callback), std::allocator<void>{});
       return true;
     }
 
@@ -340,11 +340,11 @@ namespace net_utils
     struct worker
     {
       worker()
-        : io_service(), work(io_service)
+        : io_service(), work(io_service.get_executor())
       {}
 
       boost::asio::io_service io_service;
-      boost::asio::io_service::work work;
+      boost::asio::executor_work_guard<decltype(io_service.get_executor())> work;
     };
     std::unique_ptr<worker> m_io_service_local_instance;
     boost::asio::io_service& io_service_;    

--- a/contrib/epee/include/epee/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/epee/net/abstract_tcp_server2.inl
@@ -141,7 +141,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
         throw std::runtime_error("Only IPv4 and IPv6 are supported here");
     if (remote_ep.address().is_v4())
     {
-      const unsigned long ip_ = boost::asio::detail::socket_ops::host_to_network_long(remote_ep.address().to_v4().to_ulong());
+      const unsigned long ip_ = boost::asio::detail::socket_ops::host_to_network_long(remote_ep.address().to_v4().to_uint());
       return start(is_income, is_multithreaded, ipv4_network_address{uint32_t(ip_), remote_ep.port()});
     }
     else
@@ -214,7 +214,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     if(!self)
       return false;
 
-    strand_.post(boost::bind(&connection<t_protocol_handler>::call_back_starter, self));
+    strand_.post(boost::bind(&connection<t_protocol_handler>::call_back_starter, self), std::allocator<void>{});
     CATCH_ENTRY("connection<t_protocol_handler>::request_callback()", false);
     return true;
   }
@@ -566,7 +566,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   std::chrono::milliseconds connection<t_protocol_handler>::get_timeout_from_bytes_read(size_t bytes)
   {
     std::chrono::milliseconds ms{(unsigned)(bytes * TIMEOUT_EXTRA_MS_PER_BYTE)};
-    if (auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(m_timer.expires_at() - std::chrono::steady_clock::now());
+    if (auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(m_timer.expiry() - std::chrono::steady_clock::now());
         remaining > 0ms)
       ms += remaining;
     if (ms > get_default_timeout())
@@ -605,11 +605,11 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     }
     if (add)
     {
-      if (const auto cur = std::chrono::duration_cast<std::chrono::milliseconds>(m_timer.expires_at() - std::chrono::steady_clock::now());
+      if (const auto cur = std::chrono::duration_cast<std::chrono::milliseconds>(m_timer.expiry() - std::chrono::steady_clock::now());
           cur > 0s)
         ms += cur;
     }
-    m_timer.expires_from_now(ms);
+    m_timer.expires_after(ms);
     m_timer.async_wait([=](const boost::system::error_code& ec)
     {
       if(ec == boost::asio::error::operation_aborted)
@@ -818,8 +818,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     try
     {
       boost::asio::ip::tcp::resolver resolver(io_service_);
-      boost::asio::ip::tcp::resolver::query query(address, boost::lexical_cast<std::string>(port), boost::asio::ip::tcp::resolver::query::canonical_name);
-      boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
+      boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, boost::lexical_cast<std::string>(port), boost::asio::ip::tcp::resolver::canonical_name).begin();
       acceptor_.open(endpoint.protocol());
 #if !defined(_WIN32)
       acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
@@ -852,8 +851,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       {
         if (port_ipv6 == 0) port_ipv6 = port; // default arg means bind to same port as ipv4
         boost::asio::ip::tcp::resolver resolver(io_service_);
-        boost::asio::ip::tcp::resolver::query query(address_ipv6, boost::lexical_cast<std::string>(port_ipv6), boost::asio::ip::tcp::resolver::query::canonical_name);
-        boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
+        boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(address_ipv6, boost::lexical_cast<std::string>(port_ipv6), boost::asio::ip::tcp::resolver::canonical_name).begin();
         acceptor_ipv6.open(endpoint.protocol());
 #if !defined(_WIN32)
         acceptor_ipv6.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
@@ -1129,7 +1127,7 @@ POP_WARNINGS
     sock_.open(remote_endpoint.protocol());
     if(bind_ip != "0.0.0.0" && bind_ip != "0" && bind_ip != "" )
     {
-      boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::address::from_string(bind_ip.c_str()), 0);
+      boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::make_address_v4(bind_ip.c_str()), 0);
       boost::system::error_code ec;
       sock_.bind(local_endpoint, ec);
       if (ec)
@@ -1212,13 +1210,12 @@ POP_WARNINGS
     bool try_ipv6 = false;
 
     boost::asio::ip::tcp::resolver resolver(io_service_);
-    boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), adr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
     boost::system::error_code resolve_error;
-    boost::asio::ip::tcp::resolver::iterator iterator;
+    boost::asio::ip::tcp::resolver::results_type results;
     try
     {
       //resolving ipv4 address as ipv6 throws, catch here and move on
-      iterator = resolver.resolve(query, resolve_error);
+      results = resolver.resolve(boost::asio::ip::tcp::v4(), adr, port, boost::asio::ip::tcp::resolver::canonical_name, resolve_error);
     }
     catch (const boost::system::system_error& e)
     {
@@ -1236,8 +1233,7 @@ POP_WARNINGS
 
     std::string bind_ip_to_use;
 
-    boost::asio::ip::tcp::resolver::iterator end;
-    if(iterator == end)
+    if(!results.size())
     {
       if (!m_use_ipv6)
       {
@@ -1255,11 +1251,9 @@ POP_WARNINGS
 
     if (try_ipv6)
     {
-      boost::asio::ip::tcp::resolver::query query6(boost::asio::ip::tcp::v6(), adr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
+      results = resolver.resolve(boost::asio::ip::tcp::v6(), adr, port, boost::asio::ip::tcp::resolver::canonical_name, resolve_error);
 
-      iterator = resolver.resolve(query6, resolve_error);
-
-      if(iterator == end)
+      if(!results.size())
       {
         return false;
       }
@@ -1278,7 +1272,7 @@ POP_WARNINGS
 
     }
 
-    boost::asio::ip::tcp::endpoint remote_endpoint(*iterator);
+    boost::asio::ip::tcp::endpoint remote_endpoint(*(results.begin()));
 
     auto try_connect_result = try_connect(new_connection_l, adr, port, sock_, remote_endpoint, bind_ip_to_use, conn_timeout);
     if (try_connect_result == CONNECT_FAILURE)
@@ -1322,13 +1316,12 @@ POP_WARNINGS
     bool try_ipv6 = false;
 
     boost::asio::ip::tcp::resolver resolver(io_service_);
-    boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), adr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
     boost::system::error_code resolve_error;
-    boost::asio::ip::tcp::resolver::iterator iterator;
+    boost::asio::ip::tcp::resolver::results_type results;
     try
     {
       //resolving ipv4 address as ipv6 throws, catch here and move on
-      iterator = resolver.resolve(query, resolve_error);
+      results = resolver.resolve(boost::asio::ip::tcp::v4(), adr, port, boost::asio::ip::tcp::resolver::canonical_name, resolve_error);
     }
     catch (const boost::system::system_error& e)
     {
@@ -1344,9 +1337,7 @@ POP_WARNINGS
       throw;
     }
 
-    boost::asio::ip::tcp::resolver::iterator end;
-
-    if(iterator == end)
+    if(!results.size())
     {
       if (!try_ipv6)
       {
@@ -1356,23 +1347,21 @@ POP_WARNINGS
 
     if (try_ipv6)
     {
-      boost::asio::ip::tcp::resolver::query query6(boost::asio::ip::tcp::v6(), adr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
+      results = resolver.resolve(boost::asio::ip::tcp::v6(), adr, port, boost::asio::ip::tcp::resolver::canonical_name, resolve_error);
 
-      iterator = resolver.resolve(query6, resolve_error);
-
-      if(iterator == end)
+      if(!results.size())
       {
         return false;
       }
     }
 
 
-    boost::asio::ip::tcp::endpoint remote_endpoint(*iterator);
+    boost::asio::ip::tcp::endpoint remote_endpoint(*(results.begin()));
      
     sock_.open(remote_endpoint.protocol());
     if(bind_ip != "0.0.0.0" && bind_ip != "0" && bind_ip != "" )
     {
-      boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::address::from_string(bind_ip.c_str()), 0);
+      boost::asio::ip::tcp::endpoint local_endpoint(boost::asio::ip::make_address(bind_ip.c_str()), 0);
       boost::system::error_code ec;
       sock_.bind(local_endpoint, ec);
       if (ec)
@@ -1385,7 +1374,7 @@ POP_WARNINGS
     
     std::shared_ptr<boost::asio::steady_timer> sh_deadline(new boost::asio::steady_timer(io_service_));
     //start deadline
-    sh_deadline->expires_from_now(std::chrono::milliseconds(conn_timeout));
+    sh_deadline->expires_after(std::chrono::milliseconds(conn_timeout));
     sh_deadline->async_wait([=](const boost::system::error_code& error)
       {
           if(error != boost::asio::error::operation_aborted) 

--- a/contrib/epee/include/epee/net/connection_basic.hpp
+++ b/contrib/epee/include/epee/net/connection_basic.hpp
@@ -50,6 +50,11 @@
 #include <utility>
 
 #include <boost/asio.hpp>
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+  typedef io_context io_service;
+}
+#endif
 
 #include "../shared_sv.h"
 

--- a/contrib/epee/include/epee/net/connection_basic.hpp
+++ b/contrib/epee/include/epee/net/connection_basic.hpp
@@ -52,7 +52,7 @@
 #include <boost/asio.hpp>
 #if BOOST_VERSION >= 108700
 namespace boost::asio {
-  typedef io_context io_service;
+  using io_service = io_context;
 }
 #endif
 

--- a/contrib/epee/include/epee/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/epee/net/levin_protocol_handler_async.h
@@ -179,7 +179,7 @@ public:
     {
       if(m_con.start_outer_call())
       {
-        m_timer.expires_from_now(std::chrono::milliseconds(timeout));
+        m_timer.expires_after(std::chrono::milliseconds(timeout));
         m_timer.async_wait([&con, cb](const boost::system::error_code& ec)
         {
           if(ec == boost::asio::error::operation_aborted)
@@ -228,19 +228,17 @@ public:
       if(!m_cancel_timer_called)
       {
         m_cancel_timer_called = true;
-        boost::system::error_code ignored_ec;
-        m_timer_cancelled = 1 == m_timer.cancel(ignored_ec);
+        m_timer_cancelled = 1 == m_timer.cancel();
       }
       return m_timer_cancelled;
     }
     virtual void reset_timer()
     {
-      boost::system::error_code ignored_ec;
-      if (!m_cancel_timer_called && m_timer.cancel(ignored_ec) > 0)
+      if (!m_cancel_timer_called && m_timer.cancel() > 0)
       {
         callback_t& cb = m_cb;
         async_protocol_handler& con = m_con;
-        m_timer.expires_from_now(m_timeout);
+        m_timer.expires_after(m_timeout);
         m_timer.async_wait([&con, cb](const boost::system::error_code& ec)
         {
           if(ec == boost::asio::error::operation_aborted)

--- a/contrib/epee/include/epee/net/local_ip.h
+++ b/contrib/epee/include/epee/net/local_ip.h
@@ -61,7 +61,11 @@ namespace epee
     bool is_ipv6_loopback(const std::string& ip)
     {
       // ipv6 loopback is ::1
+#if BOOST_VERSION >= 106600
+      return boost::asio::ip::make_address_v6(ip).is_loopback();
+#else
       return boost::asio::ip::address_v6::from_string(ip).is_loopback();
+#endif
     }
 
     inline

--- a/contrib/epee/include/epee/net/net_utils_base.h
+++ b/contrib/epee/include/epee/net/net_utils_base.h
@@ -47,11 +47,9 @@
 #define MAKE_IP( a1, a2, a3, a4 )	(a1|(a2<<8)|(a3<<16)|(((uint32_t)a4)<<24))
 #endif
 
-#if BOOST_VERSION >= 108700
 namespace boost::asio {
   typedef io_context io_service;
 }
-#endif
 
 #if BOOST_VERSION >= 107000
 #define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())

--- a/contrib/epee/include/epee/net/net_utils_base.h
+++ b/contrib/epee/include/epee/net/net_utils_base.h
@@ -29,7 +29,7 @@
 #ifndef _NET_UTILS_BASE_H_
 #define _NET_UTILS_BASE_H_
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/address_v6.hpp>
 #include <typeinfo>
 #include <type_traits>
@@ -45,6 +45,12 @@
 
 #ifndef MAKE_IP
 #define MAKE_IP( a1, a2, a3, a4 )	(a1|(a2<<8)|(a3<<16)|(((uint32_t)a4)<<24))
+#endif
+
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+  typedef io_context io_service;
+}
 #endif
 
 #if BOOST_VERSION >= 107000

--- a/contrib/epee/include/epee/net/net_utils_base.h
+++ b/contrib/epee/include/epee/net/net_utils_base.h
@@ -48,7 +48,7 @@
 #endif
 
 namespace boost::asio {
-  typedef io_context io_service;
+  using io_service = io_context;
 }
 
 #if BOOST_VERSION >= 107000

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -851,8 +851,8 @@ bool Blockchain::init(
 
     // create general purpose async service queue
 
-    m_async_work_idle = std::unique_ptr<boost::asio::io_service::work>(
-            new boost::asio::io_service::work(m_async_service));
+    m_async_work_idle = std::make_unique<work_type>(m_async_service.get_executor());
+
     m_async_thread = std::thread{[this] { m_async_service.run(); }};
 
 #if defined(PER_BLOCK_CHECKPOINT)
@@ -6112,7 +6112,7 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync) {
             if (m_db_sync_mode == db_async) {
                 m_sync_counter = 0;
                 m_bytes_to_sync = 0;
-                m_async_service.dispatch([this] { return store_blockchain(); });
+                m_async_service.get_executor().dispatch([this] { return store_blockchain(); }, std::allocator<void>{});
             } else if (m_db_sync_mode == db_sync) {
                 store_blockchain();
             } else  // db_nosync

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -6112,7 +6112,8 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync) {
             if (m_db_sync_mode == db_async) {
                 m_sync_counter = 0;
                 m_bytes_to_sync = 0;
-                m_async_service.get_executor().dispatch([this] { return store_blockchain(); }, std::allocator<void>{});
+                m_async_service.get_executor().dispatch(
+                        [this] { return store_blockchain(); }, std::allocator<void>{});
             } else if (m_db_sync_mode == db_sync) {
                 store_blockchain();
             } else  // db_nosync

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -32,6 +32,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/version.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 
 // Workaround for boost::serialization issue #219
 #include <boost/version.hpp>

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -29,7 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/version.hpp>
 
@@ -38,6 +38,12 @@
 #include <type_traits>
 #if BOOST_VERSION == 107400
 #include <boost/serialization/library_version_type.hpp>
+#endif
+
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+  typedef io_context io_service;
+}
 #endif
 
 #include <atomic>
@@ -1376,7 +1382,8 @@ class Blockchain {
 
     boost::asio::io_service m_async_service;
     std::thread m_async_thread;
-    std::unique_ptr<boost::asio::io_service::work> m_async_work_idle;
+    using work_type = boost::asio::executor_work_guard<decltype(m_async_service.get_executor())>;
+    std::unique_ptr<work_type> m_async_work_idle;
 
     // some invalid blocks
     std::set<crypto::hash> m_invalid_blocks;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -40,11 +40,9 @@
 #include <boost/serialization/library_version_type.hpp>
 #endif
 
-#if BOOST_VERSION >= 108700
 namespace boost::asio {
   typedef io_context io_service;
 }
-#endif
 
 #include <atomic>
 #include <boost/multi_index/global_fun.hpp>

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -41,7 +41,7 @@
 #endif
 
 namespace boost::asio {
-  typedef io_context io_service;
+typedef io_context io_service;
 }
 
 #include <atomic>

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -29,10 +29,10 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/version.hpp>
-#include <boost/asio/executor_work_guard.hpp>
 
 // Workaround for boost::serialization issue #219
 #include <boost/version.hpp>

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -42,7 +42,7 @@
 #endif
 
 namespace boost::asio {
-typedef io_context io_service;
+using io_service = io_context;
 }
 
 #include <atomic>

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -330,7 +330,7 @@ namespace {
             zone->connection_count = zone->map.size();
             for (auto id = zone->map.begin(); id != zone->map.end(); ++id) {
                 const std::size_t i = id - zone->map.begin();
-                zone->channels[i].strand.post(update_channel{zone, i, *id});
+                zone->channels[i].strand.post(update_channel{zone, i, *id}, std::allocator<void>{});
             }
         }
 
@@ -426,7 +426,7 @@ namespace {
                                 "Lost all outbound connections to anonymity network - currently "
                                 "unable to send transaction(s)");
 
-                    zone_->strand.post(update_channels{zone_, std::move(connections)});
+                    zone_->strand.post(update_channels{zone_, std::move(connections)}, std::allocator<void>{});
                 }
             }
 
@@ -453,7 +453,7 @@ namespace {
             const auto start = std::chrono::steady_clock::now();
             zone_->strand.dispatch(change_channels{
                     zone_,
-                    net::dandelionpp::connection_map{get_out_connections(*(zone_->p2p)), count_}});
+                    net::dandelionpp::connection_map{get_out_connections(*(zone_->p2p)), count_}}, std::allocator<void>{});
 
             detail::zone& alias = *zone_;
             alias.next_epoch.expires_at(start + min_epoch_ + random_duration(epoch_range_));
@@ -494,7 +494,7 @@ void notify::new_out_connection() {
     if (!zone_ || zone_->noise.view.empty() || NOISE_CHANNELS <= zone_->connection_count)
         return;
 
-    zone_->strand.dispatch(update_channels{zone_, get_out_connections(*(zone_->p2p))});
+    zone_->strand.dispatch(update_channels{zone_, get_out_connections(*(zone_->p2p))}, std::allocator<void>{});
 }
 
 void notify::run_epoch() {
@@ -537,7 +537,7 @@ bool notify::send_txs(
         }
 
         for (std::size_t channel = 0; channel < zone_->channels.size(); ++channel) {
-            zone_->channels[channel].strand.dispatch(queue_covert_notify{zone_, message, channel});
+            zone_->channels[channel].strand.dispatch(queue_covert_notify{zone_, message, channel}, std::allocator<void>{});
         }
     } else {
         const std::string payload = make_tx_payload(std::move(txs), pad_txs);
@@ -545,7 +545,7 @@ bool notify::send_txs(
                 NOTIFY_NEW_TRANSACTIONS::ID, epee::strspan<std::uint8_t>(payload))};
 
         // traditional monero send technique
-        zone_->strand.dispatch(flood_notify{zone_, std::move(message), source});
+        zone_->strand.dispatch(flood_notify{zone_, std::move(message), source}, std::allocator<void>{});
     }
 
     return true;

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -426,7 +426,8 @@ namespace {
                                 "Lost all outbound connections to anonymity network - currently "
                                 "unable to send transaction(s)");
 
-                    zone_->strand.post(update_channels{zone_, std::move(connections)}, std::allocator<void>{});
+                    zone_->strand.post(
+                            update_channels{zone_, std::move(connections)}, std::allocator<void>{});
                 }
             }
 
@@ -451,9 +452,12 @@ namespace {
                 throw boost::system::system_error{error, "start_epoch timer failed"};
 
             const auto start = std::chrono::steady_clock::now();
-            zone_->strand.dispatch(change_channels{
-                    zone_,
-                    net::dandelionpp::connection_map{get_out_connections(*(zone_->p2p)), count_}}, std::allocator<void>{});
+            zone_->strand.dispatch(
+                    change_channels{
+                            zone_,
+                            net::dandelionpp::connection_map{
+                                    get_out_connections(*(zone_->p2p)), count_}},
+                    std::allocator<void>{});
 
             detail::zone& alias = *zone_;
             alias.next_epoch.expires_at(start + min_epoch_ + random_duration(epoch_range_));
@@ -494,7 +498,8 @@ void notify::new_out_connection() {
     if (!zone_ || zone_->noise.view.empty() || NOISE_CHANNELS <= zone_->connection_count)
         return;
 
-    zone_->strand.dispatch(update_channels{zone_, get_out_connections(*(zone_->p2p))}, std::allocator<void>{});
+    zone_->strand.dispatch(
+            update_channels{zone_, get_out_connections(*(zone_->p2p))}, std::allocator<void>{});
 }
 
 void notify::run_epoch() {
@@ -537,7 +542,8 @@ bool notify::send_txs(
         }
 
         for (std::size_t channel = 0; channel < zone_->channels.size(); ++channel) {
-            zone_->channels[channel].strand.dispatch(queue_covert_notify{zone_, message, channel}, std::allocator<void>{});
+            zone_->channels[channel].strand.dispatch(
+                    queue_covert_notify{zone_, message, channel}, std::allocator<void>{});
         }
     } else {
         const std::string payload = make_tx_payload(std::move(txs), pad_txs);
@@ -545,7 +551,8 @@ bool notify::send_txs(
                 NOTIFY_NEW_TRANSACTIONS::ID, epee::strspan<std::uint8_t>(payload))};
 
         // traditional monero send technique
-        zone_->strand.dispatch(flood_notify{zone_, std::move(message), source}, std::allocator<void>{});
+        zone_->strand.dispatch(
+                flood_notify{zone_, std::move(message), source}, std::allocator<void>{});
     }
 
     return true;

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -38,7 +38,7 @@
 #include "epee/span.h"
 
 namespace boost::asio {
-  typedef io_context io_service;
+typedef io_context io_service;
 }
 
 namespace epee::levin {

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -37,11 +37,9 @@
 #include "epee/shared_sv.h"
 #include "epee/span.h"
 
-#if BOOST_VERSION >= 108700
 namespace boost::asio {
   typedef io_context io_service;
 }
-#endif
 
 namespace epee::levin {
 template <typename>

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <memory>
 #include <vector>
 
@@ -36,6 +36,12 @@
 #include "epee/net/net_utils_base.h"
 #include "epee/shared_sv.h"
 #include "epee/span.h"
+
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+  typedef io_context io_service;
+}
+#endif
 
 namespace epee::levin {
 template <typename>

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -38,7 +38,7 @@
 #include "epee/span.h"
 
 namespace boost::asio {
-typedef io_context io_service;
+using io_service = io_context;
 }
 
 namespace epee::levin {

--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -159,7 +159,7 @@ struct client::completed {
 struct client::read {
     std::shared_ptr<client> self_;
 
-    static boost::asio::mutable_buffers_1 get_buffer(client& self) noexcept {
+    static boost::asio::mutable_buffer get_buffer(client& self) noexcept {
         static_assert(
                 sizeof(v4_header) <= sizeof(self.buffer_), "buffer too small for v4 response");
         return boost::asio::buffer(self.buffer_, sizeof(v4_header));
@@ -184,7 +184,7 @@ struct client::read {
 struct client::write {
     std::shared_ptr<client> self_;
 
-    static boost::asio::const_buffers_1 get_buffer(client const& self) noexcept {
+    static boost::asio::const_buffer get_buffer(client const& self) noexcept {
         return boost::asio::buffer(self.buffer_, self.buffer_size_);
     }
 
@@ -295,7 +295,7 @@ void client::async_close::operator()(boost::system::error_code error) {
                 self->proxy_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
                 self->proxy_.close();
             }
-        });
+        }, std::allocator<void>{});
     }
 }
 }  // namespace net::socks

--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -290,12 +290,14 @@ bool client::send(std::shared_ptr<client> self) {
 void client::async_close::operator()(boost::system::error_code error) {
     if (self_ && error != boost::system::errc::operation_canceled) {
         const std::shared_ptr<client> self = std::move(self_);
-        self->strand_.dispatch([self]() {
-            if (self && self->proxy_.is_open()) {
-                self->proxy_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
-                self->proxy_.close();
-            }
-        }, std::allocator<void>{});
+        self->strand_.dispatch(
+                [self]() {
+                    if (self && self->proxy_.is_open()) {
+                        self->proxy_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+                        self->proxy_.close();
+                    }
+                },
+                std::allocator<void>{});
     }
 }
 }  // namespace net::socks

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/system/error_code.hpp>
@@ -40,6 +40,12 @@
 
 #include "epee/span.h"
 #include "net/fwd.h"
+
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+typedef io_context io_service;
+}
+#endif
 
 namespace epee::net_utils {
 class ipv4_network_address;

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -41,11 +41,9 @@
 #include "epee/span.h"
 #include "net/fwd.h"
 
-#if BOOST_VERSION >= 108700
 namespace boost::asio {
 typedef io_context io_service;
 }
-#endif
 
 namespace epee::net_utils {
 class ipv4_network_address;

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -42,7 +42,7 @@
 #include "net/fwd.h"
 
 namespace boost::asio {
-typedef io_context io_service;
+using io_service = io_context;
 }
 
 namespace epee::net_utils {

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -65,7 +65,7 @@ PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
 namespace boost::asio {
-  typedef io_context io_service;
+typedef io_context io_service;
 }
 
 namespace nodetool {

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -64,11 +64,9 @@
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
-#if BOOST_VERSION >= 108700
 namespace boost::asio {
   typedef io_context io_service;
 }
-#endif
 
 namespace nodetool {
 struct proxy {

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -33,7 +33,7 @@
 
 #include <array>
 #include <atomic>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
@@ -63,6 +63,12 @@
 
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
+
+#if BOOST_VERSION >= 108700
+namespace boost::asio {
+  typedef io_context io_service;
+}
+#endif
 
 namespace nodetool {
 struct proxy {

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -65,7 +65,7 @@ PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
 namespace boost::asio {
-typedef io_context io_service;
+using io_service = io_context;
 }
 
 namespace nodetool {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -547,20 +547,19 @@ inline bool append_net_address(
 
     io_service io_srv;
     ip::tcp::resolver resolver(io_srv);
-    ip::tcp::resolver::query query(
-            host, port, boost::asio::ip::tcp::resolver::query::canonical_name);
     boost::system::error_code ec;
-    ip::tcp::resolver::iterator i = resolver.resolve(query, ec);
+    ip::tcp::resolver::results_type result = resolver.resolve(host, port, boost::asio::ip::tcp::resolver::canonical_name, ec);
     CHECK_AND_ASSERT_MES(
             !ec, false, "Failed to resolve host name '{}': {}:{}", host, ec.message(), ec.value());
 
-    ip::tcp::resolver::iterator iend;
+    auto i = result.begin();
+    auto iend = result.end();
     for (; i != iend; ++i) {
         ip::tcp::endpoint endpoint = *i;
         if (endpoint.address().is_v4()) {
             epee::net_utils::network_address na{epee::net_utils::ipv4_network_address{
                     boost::asio::detail::socket_ops::host_to_network_long(
-                            endpoint.address().to_v4().to_ulong()),
+                            endpoint.address().to_v4().to_uint()),
                     endpoint.port()}};
             seed_nodes.push_back(na);
             log::info(logcat, "Added node: {}", na.str());


### PR DESCRIPTION
Boost removed some (long-deprecated) typedefs and methods in 1.87, some which we are still using.