### PR TITLE
Avoid std::char_traits<unsigned char> for libc++-19+

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -324,7 +324,7 @@ local gui_wallet_step_darwin = {
   // Various debian builds
   debian_pipeline('Debian sid (w/ tests) (amd64)', docker_base + 'debian-sid', lto=true, run_tests=true, build_everything=true),
   debian_pipeline('Debian sid Debug (amd64)', docker_base + 'debian-sid', build_type='Debug', build_everything=true, cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
-  clang(18),
+  clang(19),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386', cmake_extra='-DDOWNLOAD_SODIUM=ON -DARCH_ID=i386 -DARCH=i686'),
   debian_pipeline('Debian bullseye (amd64)', docker_base + 'debian-bullseye'),
   debian_pipeline('Ubuntu LTS (amd64)', docker_base + 'ubuntu-lts'),

--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <list>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -85,10 +86,9 @@ restore-legacy [--overwrite] FILENAME
     return exit_code;
 }
 
-using ustring = std::basic_string<unsigned char>;
-using ustring_view = std::basic_string_view<unsigned char>;
-
-crypto::ed25519_public_key pubkey_from_privkey(ustring_view privkey) {
+crypto::ed25519_public_key pubkey_from_privkey(std::span<const unsigned char> privkey) {
+    if (privkey.size() < 32)
+        throw std::logic_error{"invalid key: too small for privkey"};
     crypto::ed25519_public_key pubkey;
     // noclamp because Monero keys are not clamped at all, and because sodium keys are pre-clamped.
     crypto_scalarmult_ed25519_base_noclamp(pubkey.data(), privkey.data());
@@ -97,7 +97,7 @@ crypto::ed25519_public_key pubkey_from_privkey(ustring_view privkey) {
 template <size_t N>
     requires(N >= 32)
 crypto::ed25519_public_key pubkey_from_privkey(const std::array<unsigned char, N>& privkey) {
-    return pubkey_from_privkey(ustring_view{privkey.data(), 32});
+    return pubkey_from_privkey(std::span{privkey}.template first<N>());
 }
 
 std::string display_ed(
@@ -170,7 +170,7 @@ int generate(key_type type, std::list<std::string_view> args) {
         privkey_signhash[31] &= 63;
         privkey_signhash[31] |= 64;
 
-        ustring_view privkey{privkey_signhash.data(), 32};
+        auto privkey = std::span{privkey_signhash}.first<32>();
 
         // Double-check that we did it properly:
         if (pubkey_from_privkey(privkey) != pubkey)
@@ -304,7 +304,7 @@ int show(std::list<std::string_view> args) {
     if (bls && key_data.size() != 32)
         return error(2, fmt::format("File size ({} bytes) is invalid for a BLS secret key", size));
 
-    ustring_view seckey{reinterpret_cast<const unsigned char*>(key_data.data()), key_data.size()};
+    std::span seckey{reinterpret_cast<const unsigned char*>(key_data.data()), key_data.size()};
 
     if (legacy) {
         auto pubkey = pubkey_from_privkey(seckey);
@@ -330,10 +330,9 @@ Public key:  {}
         privkey_signhash[31] &= 63;
         privkey_signhash[31] |= 64;
 
-        ustring_view privkey{privkey_signhash.data(), 32};
+        auto privkey = std::span{privkey_signhash}.first<32>();
         auto pubkey = pubkey_from_privkey(privkey);
-        if (size >= 64 &&
-            ustring_view{pubkey.data(), pubkey.size()} != ustring_view{seckey.data() + 32, 32})
+        if (size >= 64 && !std::equal(pubkey.begin(), pubkey.end(), seckey.begin() + 32))
             return error(
                     13,
                     "Error: derived pubkey (" + oxenc::to_hex(pubkey.begin(), pubkey.end()) +

--- a/src/common/fs.h
+++ b/src/common/fs.h
@@ -3,14 +3,17 @@
 #include <filesystem>
 #include <string_view>
 
-#include "string_util.h"
-
 namespace fs = std::filesystem;
 
 namespace tools {
 
 inline fs::path utf8_path(std::string_view p) {
-    return fs::path{convert_sv<char8_t>(p)};
+    return fs::path{std::u8string_view{reinterpret_cast<const char8_t*>(p.data()), p.size()}};
+}
+
+inline std::string path_to_str(const fs::path& p) {
+    auto u8path = p.u8string();
+    return {reinterpret_cast<const char*>(u8path.data()), u8path.size()};
 }
 
 }  // namespace tools

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -28,19 +28,20 @@ concept byte_spannable = std::convertible_to<T, std::span<const typename T::valu
 /// do unless the struct is specifically design to be used this way.  The value must be a standard
 /// layout type; it should really require is_trivial, too, but we have classes (like crypto keys)
 /// that aren't C++-trivial but are still designed to be accessed this way.
-template <oxenc::basic_char Char = char, safe_to_memcpy T>
-std::basic_string_view<Char> view_guts(const T& val) {
-    return {reinterpret_cast<const Char*>(&val), sizeof(val)};
+template <safe_to_memcpy T>
+std::string_view view_guts(const T& val) {
+    return {reinterpret_cast<const char*>(&val), sizeof(val)};
 }
 
 /// Convenience wrapper around the above that also copies the result into a new string
-template <oxenc::basic_char Char = char, safe_to_memcpy T>
-std::basic_string<Char> copy_guts(const T& val) {
-    return std::basic_string<Char>{view_guts<Char>(val)};
+template <safe_to_memcpy T>
+std::string copy_guts(const T& val) {
+    return std::string{view_guts(val)};
 }
 
 /// Multi-input version of copy/view_guts that returns an std::array with all of the `view_guts()`
-/// values of the given inputs concatenated together into the returned array.
+/// values of the given inputs concatenated together into the returned array, and optionally
+/// reinterpreted as a different 1-byte type.
 template <oxenc::basic_char Char = char, safe_to_memcpy... T>
 std::array<Char, (0 + ... + sizeof(T))> concat_guts(const T&... vals) {
     std::array<Char, (0 + ... + sizeof(T))> result;
@@ -153,9 +154,11 @@ namespace detail {
     constexpr bool is_skip<skip<N>> = true;
 
     template <typename T>
-    constexpr bool is_basic_sv = false;
+    constexpr bool is_basic_view = false;
+    template <>
+    inline constexpr bool is_basic_view<std::string_view> = true;
     template <oxenc::basic_char Char>
-    constexpr bool is_basic_sv<std::basic_string_view<Char>> = true;
+    constexpr bool is_basic_view<std::span<const Char>> = true;
 
     template <size_t I, typename Next, typename... More, typename Tuple>
     void load_split_tuple(Tuple& t, std::string_view from) {
@@ -165,7 +168,7 @@ namespace detail {
             from = {};
         } else {
             auto& e = std::get<I>(t);
-            if constexpr (is_basic_sv<Next>) {
+            if constexpr (is_basic_view<Next>) {
                 static_assert(I == std::tuple_size_v<Tuple> - 1);
                 e = {reinterpret_cast<Next::const_pointer>(from.data()), from.size()};
                 from = {};
@@ -187,7 +190,7 @@ namespace detail {
             from = {};
         } else {
             auto& e = std::get<I>(t);
-            if constexpr (is_basic_sv<Next>) {
+            if constexpr (is_basic_view<Next>) {
                 static_assert(I == std::tuple_size_v<Tuple> - 1);
                 e = {reinterpret_cast<Next::const_pointer>(from.data()), from.size()};
                 from = {};
@@ -212,18 +215,20 @@ namespace detail {
     constexpr size_t split_guts_piece_size() {
         if constexpr (is_skip<T>)
             return T::size;
-        else if constexpr (is_basic_sv<T>)
+        else if constexpr (is_basic_view<T>)
             return 0;
         else
             return sizeof(T);
     }
 
     template <typename... More>
-    constexpr bool final_is_string_view = false;
+    constexpr bool final_is_view = false;
+    template <>
+    inline constexpr bool final_is_view<std::string_view> = true;
     template <oxenc::basic_char Char>
-    constexpr bool final_is_string_view<std::basic_string_view<Char>> = true;
+    constexpr bool final_is_view<std::span<const Char>> = true;
     template <typename T1, typename T2, typename... More>
-    constexpr bool final_is_string_view<T1, T2, More...> = final_is_string_view<T2, More...>;
+    constexpr bool final_is_view<T1, T2, More...> = final_is_view<T2, More...>;
 
     template <typename... More>
     constexpr bool final_is_ignore = false;
@@ -232,11 +237,11 @@ namespace detail {
     template <typename T1, typename T2, typename... More>
     constexpr bool final_is_ignore<T1, T2, More...> = final_is_ignore<T2, More...>;
 
-    // Used below to check that either no string view is supplied at all, or exactly one is supplied
-    // as the very last argument.
+    // Used below to check that either no string view or span is supplied at all, or exactly one is
+    // supplied as the very last argument.
     template <typename... T>
-    constexpr bool valid_sv_arg = (is_basic_sv<T> + ...) == 0 ||
-                                  ((is_basic_sv<T> + ...) == 1 && final_is_string_view<T...>);
+    constexpr bool valid_view_arg =
+            (is_basic_view<T> + ...) == 0 || ((is_basic_view<T> + ...) == 1 && final_is_view<T...>);
 
     // Used below to check that either no ignore is supplied at all, or exactly one is supplied as
     // the very last argument.
@@ -253,15 +258,15 @@ namespace detail {
 }  // namespace detail
 
 template <typename T>
-concept splittable_into = safe_to_memcpy<T> || detail::is_skip<T> || detail::is_basic_sv<T>;
+concept splittable_into = safe_to_memcpy<T> || detail::is_skip<T> || detail::is_basic_view<T>;
 
 // Splits bytes into a tuple of primitive types, copying the size of each primitive object from
 // consecutive locations in the string.  The given string must exactly match the sum of the sizes of
 // the primitive inputs.  You may also include `skip<N>` (or `skip_t<T>`) as a type, in which case
 // `N` bytes (for skip_t: N=sizeof(T)) will be skipped (the `skip<N>` type is not included in the
-// returned tuple).  The *final* type may optionally be a basic_string_view<Char>, in which case the
-// final element of the tuple will be such a string view containing any unconsumed characters, or
-// `ignore` which simply ignores any unconsumed trailing data.
+// returned tuple).  The *final* type may optionally be a std::string_view or std::span<const Char>,
+// in which case the final element of the tuple will be such a string view containing any unconsumed
+// characters, or `ignore` which simply ignores any unconsumed trailing data.
 //
 // For example:
 //
@@ -281,14 +286,13 @@ concept splittable_into = safe_to_memcpy<T> || detail::is_skip<T> || detail::is_
 //     e == "omg"sv
 //
 template <splittable_into... T, byte_spannable Spannable>
-    requires(sizeof...(T) > 0 && detail::valid_sv_arg<T...> && detail::valid_ignore_arg<T...>)
+    requires(sizeof...(T) > 0 && detail::valid_view_arg<T...> && detail::valid_ignore_arg<T...>)
 constexpr detail::tuple_without_skips<T...> split_guts_into(const Spannable& s) {
     using Char = typename Spannable::value_type;
     std::span<const Char> span{s};
     constexpr auto min_size = (detail::split_guts_piece_size<T>() + ...);
-    if ((detail::final_is_string_view<T...> || detail::final_is_ignore<T...>)
-                ? span.size() < min_size
-                : span.size() != min_size)
+    if ((detail::final_is_view<T...> || detail::final_is_ignore<T...>) ? span.size() < min_size
+                                                                       : span.size() != min_size)
         throw oxen::traced<std::runtime_error>{"Invalid split_guts_into string size"};
 
     detail::tuple_without_skips<T...> result;
@@ -301,17 +305,16 @@ constexpr detail::tuple_without_skips<T...> split_guts_into(const Spannable& s) 
 // prefix.  If using a `skip<N>` type the `N` refers to bytes skipped, not hex characters (i.e.
 // skip<2> skips 4 hex characters of input).
 //
-// If a trailing std::basic_string_view type is specified then that string view will contain all
-// unconsumed *hex* digits, not *byte* values.
+// If a trailing std::string_view or std::span<const Char> type is specified then that view will
+// contain all unconsumed *hex* digits, not *byte* values.
 template <splittable_into... T>
-    requires(sizeof...(T) > 0 && detail::valid_sv_arg<T...> && detail::valid_ignore_arg<T...>)
+    requires(sizeof...(T) > 0 && detail::valid_view_arg<T...> && detail::valid_ignore_arg<T...>)
 constexpr detail::tuple_without_skips<T...> split_hex_into(std::string_view hex_in) {
     if (hex_in.starts_with("0x") || hex_in.starts_with("0X"))
         hex_in.remove_prefix(2);
 
     constexpr auto min_size = 2 * (detail::split_guts_piece_size<T>() + ...);
-    if ((detail::final_is_string_view<T...> ? hex_in.size() < min_size
-                                            : hex_in.size() != min_size)) {
+    if ((detail::final_is_view<T...> ? hex_in.size() < min_size : hex_in.size() != min_size)) {
         throw oxen::traced<std::runtime_error>{
                 "Invalid split_hex_into string input: incorrect hex string size (hex_in {}, min_size {})"_format(
                         hex_in.size(), min_size)};

--- a/src/common/json_binary_proxy.h
+++ b/src/common/json_binary_proxy.h
@@ -107,11 +107,12 @@ class json_binary_proxy {
     /// Assigns binary data from a string_view/string/etc.
     nlohmann::json& operator=(std::string_view binary_data);
 
-    /// Assigns binary data from a string_view over a 1-byte, non-char type (e.g. unsigned char or
-    /// uint8_t).
-    template <oxenc::basic_char Char>
-        requires(!std::same_as<Char, char>)
-    nlohmann::json& operator=(std::basic_string_view<Char> binary_data) {
+    /// Assigns binary data from an unsigned char or std::byte buffer spannable type.
+    nlohmann::json& operator=(std::span<const unsigned char> binary_data) {
+        return *this = std::string_view{
+                       reinterpret_cast<const char*>(binary_data.data()), binary_data.size()};
+    }
+    nlohmann::json& operator=(std::span<const std::byte> binary_data) {
         return *this = std::string_view{
                        reinterpret_cast<const char*>(binary_data.data()), binary_data.size()};
     }

--- a/src/common/sha256sum.cpp
+++ b/src/common/sha256sum.cpp
@@ -10,10 +10,15 @@
 
 namespace tools {
 
-bool sha256sum_str(std::string_view data, crypto::hash& hash) {
-    crypto_hash_sha256(
-            hash.data(), reinterpret_cast<const unsigned char*>(data.data()), data.size());
+bool sha256sum_str(std::span<const unsigned char> data, crypto::hash& hash) {
+    crypto_hash_sha256(hash.data(), data.data(), data.size());
     return true;
+}
+bool sha256sum_str(std::span<const char> data, crypto::hash& hash) {
+    return sha256sum_str({reinterpret_cast<const unsigned char*>(data.data()), data.size()}, hash);
+}
+bool sha256sum_str(std::span<const std::byte> data, crypto::hash& hash) {
+    return sha256sum_str({reinterpret_cast<const unsigned char*>(data.data()), data.size()}, hash);
 }
 
 bool sha256sum_file(const fs::path& filename, crypto::hash& hash) {

--- a/src/common/sha256sum.h
+++ b/src/common/sha256sum.h
@@ -14,23 +14,9 @@ struct hash;
 namespace tools {
 
 // Calculates sha256 checksum of the given data
-bool sha256sum_str(std::string_view str, crypto::hash& hash);
-
-// Calculates sha256 checksum of the given data, for non-char string_view (e.g.
-// basic_string_view<unsigned char> or basic_string_view<uint8_t>).
-template <oxenc::basic_char Char>
-    requires(!std::same_as<Char, char>)
-bool sha256sum_str(std::basic_string_view<Char> str, crypto::hash& hash) {
-    return sha256sum_str(
-            std::string_view{reinterpret_cast<const char*>(str.data()), str.size()}, hash);
-}
-
-// Calculates sha256 checksum of the given byte data given any arbitrary size-1 value pointer and
-// byte length.
-template <oxenc::basic_char Char>
-bool sha256sum_str(const Char* data, size_t len, crypto::hash& hash) {
-    return sha256sum_str(std::string_view{reinterpret_cast<const char*>(data), len}, hash);
-}
+bool sha256sum_str(std::span<const unsigned char> data, crypto::hash& hash);
+bool sha256sum_str(std::span<const char> data, crypto::hash& hash);
+bool sha256sum_str(std::span<const std::byte> data, crypto::hash& hash);
 
 // Opens the given file and calculates a sha256sum of its contents
 bool sha256sum_file(const fs::path& filename, crypto::hash& hash);

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -128,28 +128,6 @@ bool parse_int(const std::string_view str, T& value, int base = 10) {
 std::string lowercase_ascii_string(std::string_view src);
 std::string uppercase_ascii_string(std::string_view src);
 
-// Converts between basic_string_view<T> for different 1-byte T values
-template <oxenc::basic_char To, oxenc::basic_char From>
-std::basic_string_view<To> convert_sv(std::basic_string_view<From> from) {
-    return {reinterpret_cast<const To*>(from.data()), from.size()};
-}
-// Same as above, but converting from a string rather than view.
-template <oxenc::basic_char To, oxenc::basic_char From>
-std::basic_string_view<To> convert_sv(const std::basic_string<From>& from) {
-    return {reinterpret_cast<const To*>(from.data()), from.size()};
-}
-
-// Same as above, but makes a copy into a basic_string
-template <oxenc::basic_char To, oxenc::basic_char From>
-std::basic_string<To> convert_str(std::basic_string_view<From> from) {
-    return {reinterpret_cast<const To*>(from.data()), from.size()};
-}
-// Same as above, but converting from a string rather than view.
-template <oxenc::basic_char To, oxenc::basic_char From>
-std::basic_string<To> convert_str(const std::basic_string<From>& from) {
-    return {reinterpret_cast<const To*>(from.data()), from.size()};
-}
-
 namespace detail {
     template <size_t N>
     struct usv_literal {
@@ -161,17 +139,6 @@ namespace detail {
         using size = std::integral_constant<size_t, N - 1>;
     };
 }  // namespace detail
-
-namespace literals {
-    // unsigned char string literals
-    inline std::basic_string<unsigned char> operator""_us(const char* str, size_t len) noexcept {
-        return {reinterpret_cast<const unsigned char*>(str), len};
-    }
-    template <detail::usv_literal UStr>
-    constexpr std::basic_string_view<unsigned char> operator""_usv() {
-        return {UStr.str, decltype(UStr)::size::value};
-    }
-}  // namespace literals
 
 /// Converts a duration into a human friendlier string, such as "3d7d47m12s" or "347µs"
 std::string friendly_duration(std::chrono::nanoseconds dur);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -100,7 +100,7 @@ const command_line::arg_descriptor<std::string> arg_data_dir{
             fs::path base = tools::get_default_data_dir();
             if (auto subdir = cryptonote::network_config_subdir(nettype); !subdir.empty())
                 base /= subdir;
-            return tools::convert_str<char>(base.u8string());
+            return tools::path_to_str(base);
         }};
 const command_line::arg_flag arg_offline = {
         "offline", "Do not listen for peers, nor connect to any"};

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -88,9 +88,9 @@ enum struct mapping_record_column {
 };
 
 static constexpr unsigned char OLD_ENCRYPTION_NONCE[crypto_secretbox_NONCEBYTES] = {};
-std::pair<std::basic_string_view<unsigned char>, std::basic_string_view<unsigned char>>
+std::pair<std::span<const unsigned char>, std::span<const unsigned char>>
 ons::mapping_value::value_nonce(mapping_type type) const {
-    std::pair<std::basic_string_view<unsigned char>, std::basic_string_view<unsigned char>> result;
+    std::pair<std::span<const unsigned char>, std::span<const unsigned char>> result;
     auto& [head, tail] = result;
     head = {buffer.data(), len};
     if ((type == mapping_type::session &&
@@ -99,8 +99,8 @@ ons::mapping_value::value_nonce(mapping_type type) const {
         len < crypto_aead_xchacha20poly1305_ietf_NPUBBYTES /* shouldn't occur, but just in case */)
         tail = {OLD_ENCRYPTION_NONCE, sizeof(OLD_ENCRYPTION_NONCE)};
     else {
-        tail = head.substr(len - crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
-        head.remove_suffix(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+        tail = head.last(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+        head = head.first(len - crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
     }
     return result;
 }
@@ -637,7 +637,7 @@ sqlite3* init_oxen_name_system(const fs::path& file_path, bool read_only) {
     }
 
     int const flags = read_only ? SQLITE_OPEN_READONLY : SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE;
-    auto utf8_path = tools::convert_str<char>(file_path.u8string());
+    auto utf8_path = tools::path_to_str(file_path);
     int sql_open = sqlite3_open_v2(utf8_path.c_str(), &result, flags, nullptr);
     if (sql_open != SQLITE_OK) {
         log::error(

--- a/src/cryptonote_core/oxen_name_system.h
+++ b/src/cryptonote_core/oxen_name_system.h
@@ -72,8 +72,8 @@ struct mapping_value {
     // older session values the nonce will be all 0 bytes *if* the encrypted value is not the proper
     // length for an including-the-nonce value.  For newer session and all others the nonce is
     // always present.
-    std::pair<std::basic_string_view<unsigned char>, std::basic_string_view<unsigned char>>
-    value_nonce(mapping_type type) const;
+    std::pair<std::span<const unsigned char>, std::span<const unsigned char>> value_nonce(
+            mapping_type type) const;
     bool operator==(mapping_value const& other) const {
         return encrypted == other.encrypted && other.to_view() == to_view();
     }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -41,6 +41,7 @@
 #include <limits>
 #include <mutex>
 #include <stdexcept>
+#include <type_traits>
 
 #include "blockchain.h"
 #include "blockchain_db/sqlite/db_sqlite.h"
@@ -733,32 +734,35 @@ void validate_registration(
                 "Registration expired ({} < {})"_format(reg.hf, block_timestamp)};
 }
 
+static void append(std::vector<unsigned char>& buf, std::span<const unsigned char> val) {
+    std::copy(val.begin(), val.end(), std::back_inserter(buf));
+}
+
 // For ETH_BLS+:
-std::basic_string<unsigned char> get_eth_registration_message_for_signing(
+std::vector<unsigned char> get_eth_registration_message_for_signing(
         const registration_details& registration) {
-    std::basic_string<unsigned char> buffer;
+    std::vector<unsigned char> buffer;
     size_t size = sizeof(crypto::ed25519_public_key) + sizeof(eth::bls_public_key);
-    buffer.reserve(size);
-    buffer += tools::view_guts<unsigned char>(registration.service_node_pubkey);
-    buffer += tools::view_guts<unsigned char>(registration.bls_pubkey);
+    append(buffer, registration.service_node_pubkey);
+    append(buffer, registration.bls_pubkey);
     assert(buffer.size() == size);
     return buffer;
 }
 
 // For pre-ETH_BLS:
 crypto::hash get_registration_hash(const registration_details& registration) {
-    std::basic_string<unsigned char> buffer;
+    std::vector<unsigned char> buffer;
     size_t size = sizeof(uint64_t) +  // fee
                   registration.reserved.size() * (sizeof(cryptonote::account_public_address) +
                                                   sizeof(uint64_t)) +  // addr+amount for each
                   sizeof(uint64_t);                                    // expiration timestamp
     buffer.reserve(size);
-    buffer += tools::view_guts<unsigned char>(oxenc::host_to_little(registration.fee));
+    append(buffer, tools::span_guts<unsigned char>(oxenc::host_to_little(registration.fee)));
     for (const auto& [addr, amount] : registration.reserved) {
-        buffer += tools::view_guts<unsigned char>(addr);
-        buffer += tools::view_guts<unsigned char>(oxenc::host_to_little(amount));
+        append(buffer, tools::span_guts<unsigned char>(addr));
+        append(buffer, tools::span_guts<unsigned char>(oxenc::host_to_little(amount)));
     }
-    buffer += tools::view_guts<unsigned char>(oxenc::host_to_little(registration.hf));
+    append(buffer, tools::span_guts<unsigned char>(oxenc::host_to_little(registration.hf)));
     assert(buffer.size() == size);
     return crypto::cn_fast_hash(buffer.data(), buffer.size());
 }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -1405,7 +1405,7 @@ void validate_registration(
 void validate_registration_signature(const registration_details& registration);
 crypto::hash get_registration_hash(const registration_details& registration);
 
-std::basic_string<unsigned char> get_eth_registration_message_for_signing(
+std::vector<unsigned char> get_eth_registration_message_for_signing(
         const registration_details& registration);
 
 bool make_registration_cmd(

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -39,12 +39,12 @@ namespace daemon_args {
 const command_line::arg_descriptor<std::string> arg_config_file = {
         "config-file",
         "Specify configuration file",
-        "<data-dir>/" + tools::convert_str<char>(cryptonote::CONF_FILENAME.u8string())};
+        "<data-dir>/" + tools::path_to_str(cryptonote::CONF_FILENAME)};
 
 const command_line::arg_descriptor<std::string> arg_log_file = {
         "log-file",
         "Specify log file",
-        "<data-dir>/" + tools::convert_str<char>(cryptonote::LOG_FILENAME.u8string())};
+        "<data-dir>/" + tools::path_to_str(cryptonote::LOG_FILENAME)};
 const command_line::arg_descriptor<std::size_t> arg_max_log_file_size = {
         "max-log-file-size", "Specify maximum log file size [B]", 104850000};
 const command_line::arg_descriptor<std::size_t> arg_max_log_files = {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -627,8 +627,7 @@ bool node_server<t_payload_net_handler>::init(const boost::program_options::vari
 
     static_cast<std::array<unsigned char, 16>&>(m_network_id) = get_config(m_nettype).NETWORK_ID;
 
-    m_config_folder = fs::path{
-            tools::convert_sv<char8_t>(command_line::get_arg(vm, cryptonote::arg_data_dir))};
+    m_config_folder = tools::utf8_path(command_line::get_arg(vm, cryptonote::arg_data_dir));
     network_zone& public_zone = m_network_zones.at(epee::net_utils::zone::public_);
 
     if (public_zone.m_port != std::to_string(cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT))

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2791,11 +2791,11 @@ void core_rpc_server::invoke(GET_SERVICE_PRIVKEYS& get_service_privkeys, rpc_con
     const auto& keys = m_core.get_service_keys();
     if (keys.key)
         get_service_privkeys.response_hex["service_node_privkey"] =
-                tools::view_guts<std::byte>(keys.key);
+                tools::span_guts<const std::byte>(keys.key);
     get_service_privkeys.response_hex["service_node_ed25519_privkey"] =
-            tools::view_guts<std::byte>(keys.key_ed25519);
+            tools::span_guts<const std::byte>(keys.key_ed25519);
     get_service_privkeys.response_hex["service_node_x25519_privkey"] =
-            tools::view_guts<std::byte>(keys.key_x25519);
+            tools::span_guts<const std::byte>(keys.key_x25519);
     get_service_privkeys.response["status"] = STATUS_OK;
 }
 

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -161,14 +161,12 @@ omq_rpc::omq_rpc(
         // Push default .oxen/oxend.sock
         locals.push_back(
                 "ipc://" +
-                tools::convert_str<char>(
-                        (core.get_config_directory() / cryptonote::SOCKET_FILENAME).u8string()));
+                tools::path_to_str(core.get_config_directory() / cryptonote::SOCKET_FILENAME));
         // Pushing old default lokid.sock onto the list. A symlink from .loki -> .oxen so the
         // user should be able to communicate via the old .loki/lokid.sock
         locals.push_back(
-                "ipc://" + tools::convert_str<char>(
-                                   (core.get_config_directory() / cryptonote::old::SOCKET_FILENAME)
-                                           .u8string()));
+                "ipc://" +
+                tools::path_to_str(core.get_config_directory() / cryptonote::old::SOCKET_FILENAME));
 #endif
     } else if (locals.size() == 1 && locals[0] == "none") {
         locals.clear();

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -85,8 +85,8 @@ bool PendingTransactionImpl::commit(std::string_view filename_, bool overwrite, 
                 m_status = {
                         Status_Error,
                         "Attempting to save transaction to file, but specified file(s) exist. "
-                        "Exiting to not risk overwriting. File:" +
-                                tools::convert_str<char>(filename.u8string())};
+                        "Exiting to not risk overwriting. File: " +
+                                tools::path_to_str(filename)};
                 log::error(logcat, "{}", m_status.second);
                 return false;
             }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -941,7 +941,7 @@ std::string WalletImpl::publicMultisigSignerKey() const {
 
 EXPORT
 std::string WalletImpl::path() const {
-    return tools::convert_str<char>(wallet()->path().u8string());
+    return tools::path_to_str(wallet()->path());
 }
 
 EXPORT
@@ -965,12 +965,12 @@ bool WalletImpl::store(std::string_view path_) {
 
 EXPORT
 std::string WalletImpl::filename() const {
-    return tools::convert_str<char>(wallet()->get_wallet_file().u8string());
+    return tools::path_to_str(wallet()->get_wallet_file());
 }
 
 EXPORT
 std::string WalletImpl::keysFilename() const {
-    return tools::convert_str<char>(wallet()->get_keys_file().u8string());
+    return tools::path_to_str(wallet()->get_keys_file());
 }
 
 EXPORT

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -211,7 +211,7 @@ std::vector<std::string> WalletManagerImpl::findWallets(std::string_view path_) 
             filename.replace_extension();
             if (fs::exists(filename)) {
                 log::trace(logcat, "Found wallet: {}", filename.string());
-                result.push_back(tools::convert_str<char>(filename.u8string()));
+                result.push_back(tools::path_to_str(filename));
             }
         }
     }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -386,7 +386,7 @@ namespace {
                     auto dir = get_default_ringdb_path();
                     if (auto subdir = network_config_subdir(nettype); !subdir.empty())
                         dir /= subdir;
-                    return tools::convert_str<char>(dir.u8string());
+                    return tools::path_to_str(dir);
                 }};
         const command_line::arg_descriptor<uint64_t> kdf_rounds = {
                 "kdf-rounds",
@@ -690,8 +690,9 @@ namespace {
             if (!tools::slurp_file(json_file, buf)) {
                 THROW_WALLET_EXCEPTION(
                         tools::error::wallet_internal_error,
-                        std::string(tools::wallet2::tr("Failed to load file ")) +
-                                tools::convert_str<char>(json_file.u8string()));
+                        "{}{}"_format(
+                                tools::wallet2::tr("Failed to load file "),
+                                tools::path_to_str(json_file)));
                 return false;
             }
 
@@ -15640,8 +15641,7 @@ uint64_t wallet2::import_key_images_from_file(
     THROW_WALLET_EXCEPTION_IF(
             !r,
             error::wallet_internal_error,
-            std::string(tr("failed to read file ")) +
-                    tools::convert_str<char>(filename.u8string()));
+            "{}{}"_format(tr("failed to read file "), tools::path_to_str(filename)));
 
     if (!data.starts_with(KEY_IMAGE_EXPORT_FILE_MAGIC)) {
         THROW_WALLET_EXCEPTION(

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -165,7 +165,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
         }
 
         if (!command_line::is_arg_defaulted(vm, arg_config_file)) {
-            fs::path config{tools::convert_sv<char8_t>(command_line::get_arg(vm, arg_config_file))};
+            auto config = tools::utf8_path(command_line::get_arg(vm, arg_config_file));
             if (std::error_code ec; fs::exists(config, ec)) {
                 std::ifstream cfg{config};
                 if (!cfg.is_open())

--- a/tests/unit_tests/blockchain_db.cpp
+++ b/tests/unit_tests/blockchain_db.cpp
@@ -221,7 +221,7 @@ protected:
 
   void set_prefix(std::string_view prefix)
   {
-    m_prefix = fs::path(tools::convert_sv<char8_t>(prefix));
+    m_prefix = tools::utf8_path(prefix);
   }
 };
 


### PR DESCRIPTION
Our use of ustring/ustring_view implicitly requires `std::char_traits<unsigned char>`, but v19 of libc++ has stopped providing that as the C++ standard doesn't require that it be available.

This replaces all such use of ustring with std::vector<unsigned char>, replaces ustring_view with std::span<const unsigned char>, and gets rid of the functions that allowed converting between
std::basic_string_view<Char> types.

This will affect compilation on Apple soon -- XCode 16.3 (currently in beta) has updated LLVM from 17 to 19.

(I tried also doing a full libc++19 build on Linux, and got all the way up to linking the final binaries, but then it fails as neither fmt nor boost will link properly with a `-stdlib=libc++` binary)