### PR TITLE
Allow notifications on alternative SN conns

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2654,7 +2654,7 @@ void core::do_uptime_proof_call() {
                     log::error(
                             globallogcat,
                             fg(fmt::terminal_color::red) | fmt::emphasis::bold,
-                            "Failed to submit uptime proof: the L2 RPC provider has not responsed "
+                            "Failed to submit uptime proof: the L2 RPC provider has not responded "
                             "since {}.  Make sure the L2 RPC provider configuration is correct, "
                             "and consider adding a backup provider for redundancy.",
                             l2_update_age

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -100,6 +100,10 @@ class L2Tracker {
     };
     std::vector<l2_oxend_proxy> l2_oxend_proxies;
 
+    // Called by a proxying node when it receives a notification of new L2 state.  Returns the
+    // proxy's `l2_oxen_proxy` `id` value if it matched a configured proxy, std::nullopt otherwise.
+    std::optional<std::string> find_proxy(const oxenmq::ConnectionID& conn) const;
+
     // Provider state updating: `update_state()` starts a chain of updates, each one triggering the
     // next step in the chain when its response is received.  While such an update is in progress
     // any call to `update_state()` will do nothing.

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -102,7 +102,7 @@ class L2Tracker {
 
     // Called by a proxying node when it receives a notification of new L2 state.  Returns the
     // proxy's `l2_oxen_proxy` `id` value if it matched a configured proxy, std::nullopt otherwise.
-    std::optional<std::string> find_proxy(const oxenmq::ConnectionID& conn) const;
+    std::optional<std::string_view> find_proxy(const oxenmq::ConnectionID& conn) const;
 
     // Provider state updating: `update_state()` starts a chain of updates, each one triggering the
     // next step in the chain when its response is received.  While such an update is in progress

--- a/src/l2_tracker/l2_tracker_proxy.cpp
+++ b/src/l2_tracker/l2_tracker_proxy.cpp
@@ -514,19 +514,27 @@ void L2Tracker::proxy_disconnect(oxenmq::ConnectionID conn, bool clear_only) {
     }
 }
 
-void L2Tracker::l2_notify_state(oxenmq::Message& msg, bool purge) {
-    // Only process this notification if it arrived on one of our outgoing proxy conns so that we
-    // can't be tricked into requesting state from someone other than the proxy we configured.
-    bool proxy_conn = false;
-    {
-        std::shared_lock lock{mutex};
-        for (auto& oxend : l2_oxend_proxies) {
-            if (msg.conn == oxend.connid) {
-                proxy_conn = true;
-                break;
-            }
-        }
+std::optional<std::string> L2Tracker::find_proxy(const oxenmq::ConnectionID& conn) const {
+    std::shared_lock lock{mutex};
+
+    for (auto& oxend : l2_oxend_proxies) {
+        if (conn == oxend.connid)
+            return oxend.id;
+        // When both local and remote are SNs, the remote may fire the notification by SN pubkey
+        // rather than the specific connection id, which means it is possible for it to arrive via
+        // some other connection we have with that same SN (e.g. a connection that it established to
+        // us), and so we also want to allow an incoming request with a remote pubkey that matches
+        // even if it didn't arrive on the same connection that we use to subscribe.
+        if (oxend.address.curve() && !conn.pubkey().empty() &&
+            oxend.address.pubkey == conn.pubkey())
+            return oxend.id;
     }
+
+    return std::nullopt;
+}
+
+void L2Tracker::l2_notify_state(oxenmq::Message& msg, bool purge) {
+    auto proxy_conn = find_proxy(msg.conn);
     if (!proxy_conn) {
         log::warning(
                 logcat,
@@ -543,7 +551,7 @@ void L2Tracker::l2_notify_state(oxenmq::Message& msg, bool purge) {
                 logcat,
                 "Invalid incoming {}state notification from {}: did not include a valid l2 height",
                 purge ? "purge " : "",
-                msg.remote);
+                *proxy_conn);
         return;
     }
 
@@ -553,15 +561,7 @@ void L2Tracker::l2_notify_state(oxenmq::Message& msg, bool purge) {
 }
 
 void L2Tracker::proxy_request_state(oxenmq::ConnectionID conn, bool purge_state) {
-    std::string_view id = "(unknown remote)"sv;
-    {
-        std::shared_lock lock{mutex};
-        for (const auto& oxend : l2_oxend_proxies)
-            if (oxend.connid == conn) {
-                id = oxend.id;
-                break;
-            }
-    }
+    std::string id = find_proxy(conn).value_or("(unknown remote)"s);
 
     proxy_request_generic(
             conn,

--- a/src/l2_tracker/l2_tracker_proxy.cpp
+++ b/src/l2_tracker/l2_tracker_proxy.cpp
@@ -658,6 +658,8 @@ void L2Tracker::proxy_update_state(L2State&& new_state, std::string_view from) {
     state.recent_exits.for_each(add_to_pool);
     state.recent_unlocks.for_each(add_to_pool);
     state.recent_req_changes.for_each(add_to_pool);
+
+    latest_height_ts = std::chrono::steady_clock::now();
 }
 
 void L2Tracker::proxy_update_state(L2PurgeState&& new_state, std::string_view from) {

--- a/src/l2_tracker/l2_tracker_proxy.cpp
+++ b/src/l2_tracker/l2_tracker_proxy.cpp
@@ -514,7 +514,7 @@ void L2Tracker::proxy_disconnect(oxenmq::ConnectionID conn, bool clear_only) {
     }
 }
 
-std::optional<std::string> L2Tracker::find_proxy(const oxenmq::ConnectionID& conn) const {
+std::optional<std::string_view> L2Tracker::find_proxy(const oxenmq::ConnectionID& conn) const {
     std::shared_lock lock{mutex};
 
     for (auto& oxend : l2_oxend_proxies) {
@@ -561,7 +561,7 @@ void L2Tracker::l2_notify_state(oxenmq::Message& msg, bool purge) {
 }
 
 void L2Tracker::proxy_request_state(oxenmq::ConnectionID conn, bool purge_state) {
-    std::string id = find_proxy(conn).value_or("(unknown remote)"s);
+    std::string_view id = find_proxy(conn).value_or("(unknown remote)"sv);
 
     proxy_request_generic(
             conn,

--- a/src/l2_tracker/l2_tracker_proxy.h
+++ b/src/l2_tracker/l2_tracker_proxy.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <oxenmq/oxenmq.h>
+
 #include "crypto/crypto.h"
 #include "l2_tracker.h"
 #include "l2_tracker/events.h"
-#include "oxenmq/oxenmq.h"
 #include "serialization/crypto.h"
 #include "serialization/map.h"
 #include "serialization/serialization.h"
@@ -125,8 +126,9 @@ class L2Proxy {
 
     uint64_t last_notify_height = 0, last_notify_purge_height = 0;
 
-    // Called by the other endpoints.  If the connection is allowed, return true; otherwise replies
-    // with ["FORBIDDEN"] and returns false.
+    // Called by the proxy's endpoints when a proxying node attempts to subscribe or obtain L2
+    // state.  If the connection is allowed, return true; otherwise replies with ["FORBIDDEN"] and
+    // returns false.
     bool authorize(std::string_view endpoint, oxenmq::Message& msg);
 
     // l2_proxy.state, .purge_state, and json variation handler


### PR DESCRIPTION
When both sides of the proxy are SNs, it is possible for there to be alternative connections between the two, and when sending the l2_notify the proxy ends up sending by pubkey, since the incoming connection was from a SN.

That means the state notifications to the SN could go down *any* of the connections between the two nodes, but the L2 proxy code was only allowing notifications on the same connection.

This commit fixes it by allowing notifications on either the same connection *or* a curve connection with a pubkey matching any proxy pubkey.