### PR TITLE
Compatibility fix for oxen 10 wallets

### DIFF
--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -40,6 +40,15 @@ void parse_request(GET_SERVICE_NODES& sns, rpc_input in) {
                     sns.request.fields.insert(k);
                 }
             }
+            // Compatibility fix for Oxen 10 wallets: Oxen 10 did not support asking for
+            // locked_contributions at all, so never sends it, but expects to get them back, so if
+            // locked_contributions (nor the -locked_contributions negated version, for Oxen 11+
+            // aware requestors) is in the input but contributors *is* asked for then implicitly set
+            // locked_contributions.
+            if (!sns.request.fields.empty() && !fit->count("locked_contributions") &&
+                !sns.request.fields.count("-locked_contributions") &&
+                sns.request.fields.count("contributors"))
+                sns.request.fields.insert("locked_contributions");
         }
     }
     if (!fields_dict) {


### PR DESCRIPTION
Oxen 11's `get_service_nodes` rpc endpoint added a "locked_contribution" field to the requested fields, so that you can ignore them as usually no one cares about those.  But wallet2 does (and dev wallet2 requests it), but existing 10.x wallets don't and so think all funds are unlocked.

This adds a compatibility fix to default locked_contribution to enabled if contributors have been specifically requested with the sort of request an oxen 10 wallet would be making.