### PR TITLE
Wallet 10 pending rewards compatibility fix

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3856,6 +3856,19 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
         }
     }
 
+    if (rpc.request.oxen10_compat) {
+        // Oxen 10.x wallets expect `"addresses": [...], "amounts": [...]` because old Monero
+        // serialization didn't support dicts, so rewrite it if this came through the old endpoint
+        // name to maintain compatibility.
+        auto& addrs = rpc.response["addresses"];
+        auto& amts = rpc.response["amounts"];
+        for (auto& [addr, amt] : balances.items()) {
+            addrs.emplace_back(std::move(addr));
+            amts.emplace_back(std::move(amt));
+        }
+        rpc.response.erase("balances");
+    }
+
     rpc.response["status"] = STATUS_OK;
 }
 

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -434,6 +434,11 @@ void parse_request(GET_ACCRUED_REWARDS& rpc, rpc_input in) {
     get_values(in, "addresses", rpc.request.addresses);
 }
 
+void parse_request(GET_ACCRUED_BATCHED_EARNINGS& rpc, rpc_input in) {
+    rpc.request.oxen10_compat = true;
+    get_values(in, "addresses", rpc.request.addresses);
+}
+
 void parse_request(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_input in) {
     get_values(
             in,

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -19,6 +19,7 @@ void parse_request(CONTRACT_REGISTRATION& reg, rpc_input in);
 void parse_request(FLUSH_CACHE& flush_cache, rpc_input in);
 void parse_request(FLUSH_TRANSACTION_POOL& flush_transaction_pool, rpc_input in);
 void parse_request(GET_ACCRUED_REWARDS& rpc, rpc_input in);
+void parse_request(GET_ACCRUED_BATCHED_EARNINGS& rpc, rpc_input in);
 void parse_request(GET_BLOCK& get_block, rpc_input in);
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in);
 void parse_request(GET_BLOCK_HEADERS_RANGE& get_block_headers_range, rpc_input in);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2248,12 +2248,31 @@ struct GET_PENDING_EVENTS : PUBLIC {
 ///  - `balances` -- a dict where keys are the wallet addresses and values are the balance (in
 ///    atomic SENT units).
 struct GET_ACCRUED_REWARDS : PUBLIC {
-    static constexpr auto names() {
-        return NAMES("get_accrued_rewards", "get_accrued_batched_earnings");
-    }
+    static constexpr auto names() { return NAMES("get_accrued_rewards"); }
     struct request_parameters {
         std::vector<std::string> addresses;
+        bool oxen10_compat = false;
     } request;
+};
+
+/// RPC: blockchain/get_accrued_batched_earnings
+///
+/// Deprecated version of GET_ACCRUED_REWARDS that returns results as two lists where element `[i]`
+/// of the "addresses" array maps to element [i] of the "amounts" array.
+///
+/// Do not use: this is only provided for Oxen 10.x wallet compatibility, and will be removed once
+/// all supported wallets are upgraded to use the Oxen 11.x code base.
+///
+/// Inputs:
+///  - `addresses` -- a set of addresses about which to query.  If omitted/empty then all addresses
+///    with balances are returned.
+///
+/// Outputs:
+///  - `addresses` -- the resulting array of addresses.
+///  - `amounts` -- the resulting array of amounts indicating the pending (unpaid) reward amount in
+///    atomic OXEN units.
+struct GET_ACCRUED_BATCHED_EARNINGS : GET_ACCRUED_REWARDS {
+    static constexpr auto names() { return NAMES("get_accrued_batched_earnings"); }
 };
 
 /// Dev-RPC: service_node/storage_server_ping
@@ -2897,6 +2916,7 @@ using core_rpc_types = tools::type_list<
         FLUSH_CACHE,
         FLUSH_TRANSACTION_POOL,
         GET_ACCRUED_REWARDS,
+        GET_ACCRUED_BATCHED_EARNINGS,
         GET_ALTERNATE_CHAINS,
         GET_BANS,
         GET_FEE_ESTIMATE,


### PR DESCRIPTION
The `get_accrued_rewards` endpoint in oxen 11 made a very sensible change from oxen 10's `get_accrued_batched_earnings` to return a dict of `address: amount`, but the oxen 10 wallet expects two parallel arrays of addresses and amounts, and the old name was aliased to the new name.

This restores the oxen 10 output format when invoked via the old endpoint name to fix the pending balance displayed by oxen 10 wallets.