### PR TITLE
Add address rewards metadata

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -613,11 +613,11 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
         eth::address eth_addr = {};
         bool is_eth = tools::try_load_from_hex_guts(address, eth_addr);
 
-        int64_t amount = std::get<0>(*metadata);
-        int64_t lifetime_locked_stakes = std::get<1>(*metadata);
-        int64_t lifetime_unlocked_stakes = std::get<2>(*metadata);
-        int64_t lifetime_liquidated_stakes = std::get<3>(*metadata);
-        int64_t lifetime_rewards = std::get<4>(*metadata);
+        auto [amount,
+              lifetime_locked_stakes,
+              lifetime_unlocked_stakes,
+              lifetime_liquidated_stakes,
+              lifetime_rewards] = *metadata;
         assert(amount >= 0);
 
         result.found = true;

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -85,25 +85,46 @@ BlockchainSQLite::BlockchainSQLite(
             height);
 }
 
+constexpr std::string_view BATCHED_PAYMENTS_SCHEMA = R"(address TEXT NOT NULL,
+   amount                     INTEGER NOT NULL DEFAULT 0, -- Lifetime rewards and unlocked stakes
+   payout_offset              INTEGER NOT NULL DEFAULT 0,
+   lifetime_locked_stakes     INTEGER NOT NULL DEFAULT 0,
+   lifetime_unlocked_stakes   INTEGER NOT NULL DEFAULT 0,
+   lifetime_liquidated_stakes INTEGER NOT NULL DEFAULT 0,
+   lifetime_rewards           INTEGER NOT NULL DEFAULT 0, -- Lifetime accumulated rewards (e.g: not including unlocked stakes)
+   PRIMARY KEY(address)
+   CHECK(amount                    >= 0)
+   CHECK(lifetime_locked_stakes    >= 0)
+   CHECK(lifetime_unlocked_stakes  >= 0)
+   CHECK(lifetime_unlocked_stakes  <= lifetime_locked_stakes)
+   CHECK(lifetime_rewards          >= 0))";
+
+constexpr std::string_view BATCHED_PAYMENTS_SCHEMA_WITH_HEIGHT = R"(address TEXT NOT NULL,
+   amount                     INTEGER NOT NULL DEFAULT 0, -- Lifetime rewards and unlocked stakes
+   payout_offset              INTEGER NOT NULL DEFAULT 0,
+   height                     INTEGER NOT NULL DEFAULT 0, -- Height at which the row was recorded at
+   lifetime_locked_stakes     INTEGER NOT NULL DEFAULT 0,
+   lifetime_unlocked_stakes   INTEGER NOT NULL DEFAULT 0,
+   lifetime_liquidated_stakes INTEGER NOT NULL DEFAULT 0,
+   lifetime_rewards           INTEGER NOT NULL DEFAULT 0, -- Lifetime accumulated rewards (e.g: not including unlocked stakes)
+   UNIQUE(address, height)
+   CHECK(amount                    >= 0)
+   CHECK(lifetime_locked_stakes    >= 0)
+   CHECK(lifetime_unlocked_stakes  >= 0)
+   CHECK(lifetime_unlocked_stakes  <= lifetime_locked_stakes)
+   CHECK(lifetime_rewards          >= 0))";
+
+
 void BlockchainSQLite::create_schema() {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
-
     auto& netconf = cryptonote::get_config(m_nettype);
 
     db.exec(R"(CREATE TABLE IF NOT EXISTS batched_payments_accrued(
-                 address VARCHAR NOT NULL,
-                 amount BIGINT NOT NULL,
-                 payout_offset INTEGER NOT NULL,
-                 stakes BIGINT NOT NULL DEFAULT 0,
-                 PRIMARY KEY(address),
-                 CHECK(amount >= 0)
-                 CHECK(stakes >= 0)
+                  {}
                );
-
                CREATE INDEX IF NOT EXISTS batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
-               CREATE TABLE IF NOT EXISTS batch_db_info(height BIGINT NOT NULL);
-               INSERT INTO  batch_db_info(height) VALUES(0);)");
-
+               CREATE TABLE IF NOT EXISTS batch_db_info(height INTEGER NOT NULL);
+               INSERT INTO  batch_db_info(height) VALUES(0);)"_format(BATCHED_PAYMENTS_SCHEMA));
     log::debug(logcat, "Database setup complete");
 }
 
@@ -183,14 +204,15 @@ void BlockchainSQLite::upgrade_schema() {
     }
 
     std::string_view const DELAYED_PAYMENTS_SCHEMA = R"(
-          eth_address       VARCHAR NOT NULL,
-          amount            BIGINT  NOT NULL,
-          payout_height     BIGINT  NOT NULL, -- Height that the payment was given to 'eth_address' and removed from this table
-          height            INT     NOT NULL, -- Height that the payment was added to the DB
-          block_height      INT     NOT NULL, -- Height that the TX with the SN exit event was mined in
-          block_tx_index    INT     NOT NULL, -- Index of the TX in the block at 'block_height'
-          contributor_index INT     NOT NULL, -- Index of the contributor in a multi-contributor SN's stake
-          UNIQUE            (block_height, block_tx_index, contributor_index)
+          eth_address        TEXT    NOT NULL,
+          amount             INTEGER NOT NULL,           -- Original amount the 'eth_address' staked
+          payout_height      INTEGER NOT NULL,           -- Height that the payment was given to 'eth_address' and removed from this table
+          height             INTEGER NOT NULL,           -- Height that the payment was added to the DB
+          block_height       INTEGER NOT NULL,           -- Height that the TX with the SN exit event was mined in
+          block_tx_index     INTEGER NOT NULL,           -- Index of the TX in the block at 'block_height'
+          contributor_index  INTEGER NOT NULL,           -- Index of the contributor in a multi-contributor SN's stake
+          liquidation_amount INTEGER NOT NULL DEFAULT 0, -- Liquidation penalty (if applicable), 0 otherwise
+          UNIQUE(block_height, block_tx_index, contributor_index)
           CHECK(amount            >= 0)
           CHECK(payout_height     >= 0)
           CHECK(height            >= 0)
@@ -210,7 +232,7 @@ void BlockchainSQLite::upgrade_schema() {
         log::debug(logcat, "Adding delayed payments table to batching db");
         db.exec(R"(
         CREATE TABLE delayed_payments(
-          {}
+            {}
         );
         CREATE INDEX delayed_payments_payout_height_idx ON delayed_payments(payout_height);
         )"_format(DELAYED_PAYMENTS_SCHEMA));
@@ -226,7 +248,7 @@ void BlockchainSQLite::upgrade_schema() {
         -- Create archive table that stores the delayed payment rows every 'HISTORY_ARCHIVE_INTERVAL'
         -- blocks
         CREATE TABLE delayed_payments_archive(
-          {}
+            {}
         );
         CREATE INDEX delayed_payments_archive_height_idx ON delayed_payments_archive(height);
         )"_format(DELAYED_PAYMENTS_SCHEMA));
@@ -239,7 +261,7 @@ void BlockchainSQLite::upgrade_schema() {
         auto& netconf = get_config(m_nettype);
         db.exec(R"(
         CREATE TABLE delayed_payments_recent(
-          {}
+            {}
         );
         CREATE INDEX delayed_payments_recent_height_idx ON delayed_payments_recent(height);
         )"_format(DELAYED_PAYMENTS_SCHEMA));
@@ -255,18 +277,10 @@ void BlockchainSQLite::upgrade_schema() {
         -- Create archive table that stores the current accrued rows every 'HISTORY_ARCHIVE_INTERVAL'
         -- blocks
         CREATE TABLE batched_payments_accrued_archive(
-          address VARCHAR NOT NULL,
-          amount BIGINT NOT NULL,
-          payout_offset INTEGER NOT NULL,
-          height BIGINT NOT NULL, -- Height that the row was generated on
-          stakes BIGINT NOT NULL DEFAULT 0,
-          CHECK(amount >= 0),
-          CHECK(height >= 0)
-          CHECK(stakes >= 0)
+            {}
         );
-
         CREATE INDEX batched_payments_accrued_archive_height_idx ON batched_payments_accrued_archive(height);
-        )");
+        )"_format(BATCHED_PAYMENTS_SCHEMA_WITH_HEIGHT));
     }
 
     // NOTE: The recent table stores copies of 'batch_payments_accrued' rows at
@@ -279,20 +293,9 @@ void BlockchainSQLite::upgrade_schema() {
         // long-term archive rows.
         log::debug(logcat, "Adding recent rewards to batching db");
         auto& netconf = get_config(m_nettype);
-        db.exec(R"(
-        CREATE TABLE batched_payments_accrued_recent(
-          address VARCHAR NOT NULL,
-          amount BIGINT NOT NULL,
-          payout_offset INTEGER NOT NULL,
-          height BIGINT NOT NULL,
-          stakes BIGINT NOT NULL DEFAULT 0,
-          CHECK(amount >= 0),
-          CHECK(height >= 0)
-          CHECK(stakes >= 0)
-        );
-
-        CREATE INDEX batched_payments_accrued_recent_height_idx ON batched_payments_accrued_recent(height);
-        )");
+        db.exec("CREATE TABLE batched_payments_accrued_recent({});"
+                "CREATE INDEX batched_payments_accrued_recent_height_idx ON batched_payments_accrued_recent(height);"_format(
+                        BATCHED_PAYMENTS_SCHEMA_WITH_HEIGHT));
     }
 
     // TODO: Code block can be removed after HF20 on mainnet as everyone's
@@ -321,8 +324,8 @@ void BlockchainSQLite::upgrade_schema() {
         CREATE TRIGGER           make_recent AFTER UPDATE ON batch_db_info
         FOR EACH ROW WHEN NEW.height > OLD.height BEGIN
             -- Batched payments
-            INSERT INTO batched_payments_accrued_recent SELECT address, amount, payout_offset, NEW.height, stakes FROM  batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_recent                                                           WHERE height < (NEW.height - {0});
+            INSERT INTO batched_payments_accrued_recent SELECT address, amount, payout_offset, NEW.height, lifetime_locked_stakes, lifetime_unlocked_stakes, lifetime_liquidated_stakes, lifetime_rewards FROM  batched_payments_accrued;
+            DELETE FROM batched_payments_accrued_recent                                                                                                                                                   WHERE height < (NEW.height - {0});
 
             -- Delayed payments
             INSERT INTO delayed_payments_recent SELECT * FROM  delayed_payments WHERE height == NEW.height;
@@ -344,8 +347,8 @@ void BlockchainSQLite::upgrade_schema() {
         FOR EACH ROW WHEN (NEW.height % {1}) = 0 AND NEW.height > OLD.height BEGIN
 
             -- Batch payments
-            INSERT INTO batched_payments_accrued_archive SELECT address, amount, payout_offset, NEW.height, stakes FROM batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_archive                                                           WHERE height < (NEW.height - {2});
+            INSERT INTO batched_payments_accrued_archive SELECT address, amount, payout_offset, NEW.height, lifetime_locked_stakes, lifetime_unlocked_stakes, lifetime_liquidated_stakes, lifetime_rewards FROM  batched_payments_accrued;
+            DELETE FROM batched_payments_accrued_archive                                                                                                                                                   WHERE height < (NEW.height - {2});
 
             -- Delayed payments
             INSERT INTO delayed_payments_archive SELECT * FROM delayed_payments;
@@ -389,7 +392,7 @@ void BlockchainSQLite::upgrade_schema() {
                   netconf.HISTORY_ARCHIVE_KEEP_WINDOW));
     }
 
-    // NOTE: Add new stakes fields to DB row for tracking user stakes
+    // NOTE: Add new stakes fields to batch accrued table row for tracking
     {
         std::string_view tables[] = {
             "batched_payments_accrued",
@@ -397,19 +400,53 @@ void BlockchainSQLite::upgrade_schema() {
             "batched_payments_accrued_recent",
         };
 
+        std::string_view fields[] = {
+            "lifetime_locked_stakes",
+            "lifetime_unlocked_stakes",
+            "lifetime_liquidated_stakes",
+            "lifetime_rewards",
+        };
+
+        for (auto it : tables) {
+            for (auto field : fields) {
+                bool has_field = false;
+                SQLite::Statement msg_cols{db, "PRAGMA main.table_info({})"_format(it)};
+                while (msg_cols.executeStep()) {
+                    auto [cid, name] = db::get<int64_t, std::string>(msg_cols);
+                    if (name == field) {
+                        has_field = true;
+                        break;
+                    }
+                }
+
+                if (!has_field)
+                    db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(it, field));
+            }
+        }
+    }
+
+    // NOTE: Add new liquidation field to delayed payment table
+    {
+        std::string_view tables[] = {
+            "delayed_payments",
+            "delayed_payments_archive",
+            "delayed_payments_recent",
+        };
+
+        constexpr std::string_view field = "liquidation_amount";
         for (auto it : tables) {
             bool has_field = false;
             SQLite::Statement msg_cols{db, "PRAGMA main.table_info({})"_format(it)};
             while (msg_cols.executeStep()) {
                 auto [cid, name] = db::get<int64_t, std::string>(msg_cols);
-                if (name == "stakes") {
+                if (name == field) {
                     has_field = true;
                     break;
                 }
             }
 
             if (!has_field)
-                db.exec("ALTER TABLE {} ADD COLUMN stakes INTEGER NOT NULL DEFAULT 0;"_format(it));
+                db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(it, field));
         }
     }
 
@@ -480,7 +517,7 @@ void BlockchainSQLite::blockchain_detached(
 
                 db.exec(R"(DELETE FROM batched_payments_accrued;
                            INSERT INTO batched_payments_accrued
-                           SELECT address, amount, payout_offset, stakes
+                           SELECT address, amount, payout_offset, lifetime_locked_stakes, lifetime_unlocked_stakes, lifetime_liquidated_stakes, lifetime_rewards
                            FROM {1} WHERE height = {0};
                   )"_format(new_height, batched_payments_history_table));
 
@@ -525,6 +562,18 @@ const std::string& BlockchainSQLite::get_address_str(const cryptonote::batch_sn_
     return address_str;
 }
 
+// Format an ETH address to the representation that is used in the DB.
+//
+// TODO: This should be changed to a binary blob instead of a string. Note that the native
+// formatting of an ETH address is now the checksum address. This was changed _after_ we started
+// using lowercase ETH addresses in the DB. We should at some point just migrate entirely to byte
+// addresses.
+static std::string eth_address_to_sql_address(const eth::address& addr)
+{
+    std::string result = "0x{:x}"_format(addr);
+    return result;
+}
+
 std::pair<int, std::string> BlockchainSQLite::get_address_str(
         const std::variant<eth::address, cryptonote::account_public_address>& addr,
         uint64_t batching_interval) {
@@ -533,7 +582,7 @@ std::pair<int, std::string> BlockchainSQLite::get_address_str(
     auto& [offset, address_str] = result;
     if (auto* eth_addr = std::get_if<eth::address>(&addr)) {
         offset = 0;  // ignored for SENT
-        address_str = "0x{:x}"_format(*eth_addr);
+        address_str = eth_address_to_sql_address(*eth_addr);
     } else {
         auto* oxen_addr = std::get_if<cryptonote::account_public_address>(&addr);
         assert(oxen_addr);
@@ -546,24 +595,51 @@ std::pair<int, std::string> BlockchainSQLite::get_address_str(
     return result;
 }
 
-void BlockchainSQLite::add_sn_rewards(const block_payments& payments) {
+void BlockchainSQLite::add_sn_rewards(const block_payments& payments, bool rewards_payment) {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
-    auto insert_payment = prepared_st(
-            "INSERT INTO batched_payments_accrued (address, payout_offset, amount) "
-            "VALUES (?, ?, ?)"
-            "ON CONFLICT (address) DO UPDATE SET amount = amount + excluded.amount;");
 
+    std::string query;
+    if (rewards_payment) {
+        query = "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
+                " VALUES (?, ?, ?)"
+                " ON CONFLICT (address) DO UPDATE SET"
+                "   amount           = amount           + excluded.amount,"
+                "   lifetime_rewards = lifetime_rewards + excluded.amount;";
+    } else {
+        query = "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
+                " VALUES (?, ?, ?)"
+                " ON CONFLICT (address) DO UPDATE SET"
+                "   amount                     = amount + excluded.amount,"
+                "   lifetime_unlocked_stakes   = lifetime_unlocked_stakes + ?,"
+                "   lifetime_liquidated_stakes = lifetime_liquidated_stakes + ?;";
+    }
+
+    auto insert_payment = prepared_st(query);
     const auto& netconf = get_config(m_nettype);
 
-    for (auto& [addr, amount] : payments) {
-        auto [offset, address_str] = get_address_str(addr, netconf.BATCHING_INTERVAL);
+    for (auto& it : payments) {
+        const sql_payment& payment = it.second;
+        auto [offset, address_str] = get_address_str(it.first, netconf.BATCHING_INTERVAL);
+        cryptonote::reward_money amount = payment.amount - payment.liquidation;
         log::trace(
                 logcat,
                 "Adding record for SN reward contributor {} to database with amount {}",
                 address_str,
                 amount.to_db());
-        db::exec_query(insert_payment, address_str, offset, static_cast<int64_t>(amount.to_db()));
+
+        if (rewards_payment) {
+            db::exec_query(
+                    insert_payment, address_str, offset, static_cast<int64_t>(amount.to_db()));
+        } else {
+            db::exec_query(
+                    insert_payment,
+                    address_str,
+                    offset,
+                    static_cast<int64_t>(amount.to_db()),
+                    static_cast<int64_t>(payment.amount.to_db()),
+                    static_cast<int64_t>(payment.liquidation.to_db()));
+        }
         insert_payment->reset();
     }
 }
@@ -690,28 +766,74 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     return payments;
 }
 
-static BlockchainSQLite::wallet_info rewards_stake_pair_to_wallet_info(std::optional<std::tuple<int64_t, int64_t>> pair, uint64_t height)
-{
+static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
+        BlockchainSQLite& db,
+        std::string_view address,
+        std::optional<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>> metadata,
+        uint64_t height) {
     BlockchainSQLite::wallet_info result = {};
     result.height = height;
-    if (pair) {
-        int64_t total_rewards_db = std::get<0>(*pair);
-        int64_t locked_stakes_db = std::get<1>(*pair);
-        assert(total_rewards_db >= 0);
-        assert(locked_stakes_db >= 0);
+    if (metadata) {
+        int64_t amount_db = std::get<0>(*metadata);
+        int64_t lifetime_locked_stakes_db = std::get<1>(*metadata);
+        int64_t lifetime_unlocked_stakes_db = std::get<2>(*metadata);
+        int64_t lifetime_liquidated_stakes_db = std::get<3>(*metadata);
+        int64_t lifetime_rewards_db = std::get<4>(*metadata);
+        assert(amount_db >= 0);
+        assert(lifetime_locked_stakes_db >= 0);
+        assert(lifetime_unlocked_stakes_db >= 0);
+        assert(lifetime_rewards_db >= 0);
+        assert(amount_db ==
+               (lifetime_unlocked_stakes_db + lifetime_rewards_db - lifetime_liquidated_stakes_db));
 
         result.found = true;
-        result.total_rewards = cryptonote::reward_money::db_amount(total_rewards_db);
-        result.locked_stakes = cryptonote::reward_money::db_amount(locked_stakes_db);
+        result.amount = cryptonote::reward_money::db_amount(amount_db);
+        result.lifetime_locked_stakes =
+                cryptonote::reward_money::db_amount(lifetime_locked_stakes_db);
+        result.lifetime_unlocked_stakes =
+                cryptonote::reward_money::db_amount(lifetime_unlocked_stakes_db);
+        result.lifetime_liquidated_stakes =
+                cryptonote::reward_money::db_amount(lifetime_liquidated_stakes_db);
+        result.lifetime_rewards = cryptonote::reward_money::db_amount(lifetime_rewards_db);
+        result.locked_stakes = result.lifetime_locked_stakes - result.lifetime_unlocked_stakes;
+        result.rewards = result.amount -
+                         (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
+
+        // NOTE: Delayed payments is only supported on ETH addresses
+        if (eth::address eth_addr; tools::try_load_from_hex_guts(address, eth_addr)) {
+            cryptonote::BlockchainSQLite::delayed_payments_request request = {};
+            request.type = cryptonote::BlockchainSQLite::delayed_payments_type::address;
+            request.address = eth_addr;
+
+            block_payments delayed_payments = db.get_delayed_payments(request);
+            for (auto it : delayed_payments) {
+                const cryptonote::sql_payment& payment = it.second;
+                assert(payment.amount.to_coin() >= payment.liquidation.to_coin());
+                result.timelocked_stakes += payment.amount - payment.liquidation;
+            }
+        }
     }
     return result;
 }
 
+constexpr std::string_view WALLET_METADATA_FIELDS =
+        " amount,"
+        " lifetime_locked_stakes,"
+        " lifetime_unlocked_stakes,"
+        " lifetime_liquidated_stakes,"
+        " lifetime_rewards";
+
 static BlockchainSQLite::wallet_info get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address) {
     log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
-    auto pair = db.prepared_maybe_get<int64_t, int64_t>(
-            "SELECT amount, stakes FROM batched_payments_accrued WHERE address = ?", address);
-    BlockchainSQLite::wallet_info result = rewards_stake_pair_to_wallet_info(pair, db.height);
+    auto tuple = db.prepared_maybe_get<int64_t, int64_t, int64_t, int64_t, int64_t>(
+            "SELECT"
+            " {}"
+            " FROM batched_payments_accrued"
+            " WHERE address = ?"_format(WALLET_METADATA_FIELDS),
+            address);
+
+    BlockchainSQLite::wallet_info result =
+            wallet_metadata_tuple_to_wallet_info(db, address, tuple, db.height);
     return result;
 }
 
@@ -727,14 +849,17 @@ static BlockchainSQLite::wallet_info get_accrued_rewards_at_impl(
     if (at_height == curr_top_height)
         return get_accrued_rewards_impl(db, address);
 
-    auto pair = db.prepared_maybe_get<int64_t, int64_t>(
-            "SELECT amount, stakes FROM batched_payments_accrued_recent WHERE address = ? AND "
-            "height = ?",
+    auto tuple = db.prepared_maybe_get<int64_t, int64_t, int64_t, int64_t, int64_t>(
+            "SELECT"
+            " {}"
+            " FROM "
+            " batched_payments_accrued"
+            " WHERE address = ? AND height = ?"_format(WALLET_METADATA_FIELDS),
             address,
             static_cast<int64_t>(at_height));
 
-    if (pair)
-        return rewards_stake_pair_to_wallet_info(pair, db.height);
+    if (tuple)
+        return wallet_metadata_tuple_to_wallet_info(db, address, tuple, db.height);
 
     // No rewards found; check to see if we actually have any recent records for that height and
     // if not, return a "don't know" nullopt value.  Otherwise we fall through and return an
@@ -751,7 +876,7 @@ static BlockchainSQLite::wallet_info get_accrued_rewards_at_impl(
 }
 
 BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(const eth::address& address) {
-    std::string address_string = fmt::format("0x{:x}", address);
+    std::string address_string = eth_address_to_sql_address(address);
     wallet_info result = get_accrued_rewards_impl(*this, address_string);
     return result;
 }
@@ -766,7 +891,7 @@ BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
 
 BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
         const eth::address& address, uint64_t at_height) {
-    std::string address_string = fmt::format("0x{:x}", address);
+    std::string address_string = eth_address_to_sql_address(address);
     wallet_info result = get_accrued_rewards_at_impl(*this, address_string, at_height, height);
     return result;
 }
@@ -828,9 +953,9 @@ void BlockchainSQLite::add_rewards(
             eth::address fee_recipient = sn_info.contributors.size()
                                                ? sn_info.contributors[0].ethereum_beneficiary
                                                : sn_info.operator_ethereum_address;
-            payments[fee_recipient] += operator_fee;
+            payments[fee_recipient].amount += cryptonote::reward_money::db_amount(operator_fee);
         } else {
-            payments[sn_info.operator_address] += operator_fee;
+            payments[sn_info.operator_address].amount += cryptonote::reward_money::db_amount(operator_fee);
         }
     }
 
@@ -855,7 +980,7 @@ void BlockchainSQLite::add_rewards(
             // be assigned to the ethereum address by default.
             auto& balance = use_eth_address ? payments[contributor.ethereum_beneficiary]
                                             : payments[contributor.address];
-            balance += c_reward;
+            balance.amount += cryptonote::reward_money::db_amount(c_reward);
         }
     }
 }
@@ -863,8 +988,7 @@ void BlockchainSQLite::add_rewards(
 void BlockchainSQLite::reward_handler(
         const cryptonote::block& block,
         const service_nodes::service_node_list::state_t& sn_state,
-        const service_nodes::block_add_result& block_add,
-        block_payments payments) {
+        const service_nodes::block_add_result& block_add) {
     ZoneScoped;
     assert(block.major_version >= hf::hf19_reward_batching);
 
@@ -876,6 +1000,7 @@ void BlockchainSQLite::reward_handler(
     auto block_reward = cryptonote::reward_money::coin_amount(block.reward);
     std::lock_guard a_s_lock{address_str_cache_mutex};
 
+    block_payments payments;
     if (block.major_version < feature::ETH_BLS) {
         // Step 1: Pay out the block producer their tx fees (note that, unlike the
         // below, this applies even if the SN isn't currently payable).
@@ -931,45 +1056,95 @@ void BlockchainSQLite::reward_handler(
         add_rewards(block.major_version, per_sn_reward, *node_info, payments);
     }
 
-    add_sn_rewards(payments);
+    delayed_payments_request request = {};
+    request.type = delayed_payments_type::height;
+    request.height = block.get_height();
+
+    add_sn_rewards(get_delayed_payments(request), false /*rewards_payment*/);
+    add_sn_rewards(payments, true /*rewards_payment*/);
+
 }
 
-block_payments BlockchainSQLite::get_delayed_payments(uint64_t height) {
+block_payments BlockchainSQLite::get_delayed_payments(const delayed_payments_request& request) {
     ZoneScoped;
-    block_payments payments;
-    auto delayed_payments_st = prepared_results<std::string_view, int64_t>(
-            "SELECT eth_address, amount FROM delayed_payments WHERE payout_height = ?",
-            static_cast<int64_t>(height));
-    for (auto [addr_str, amount] : delayed_payments_st) {
-        payments[tools::make_from_hex_guts<eth::address>(addr_str)] +=
-                cryptonote::reward_money::db_amount(amount);
+
+    std::string_view preamble =
+            "SELECT"
+            " eth_address, amount, liquidation_amount"
+            " FROM"
+            " delayed_payments";
+
+    std::string query;
+    switch (request.type) {
+        case delayed_payments_type::all: {
+            query = preamble;
+        } break;
+
+        case delayed_payments_type::height: {
+            query = "{}"
+                    " WHERE"
+                    " payout_height = ?"_format(preamble);
+        } break;
+
+        case delayed_payments_type::address: {
+            query = "{}"
+                    " WHERE"
+                    " eth_address = ?"_format(preamble);
+        } break;
     }
-    return payments;
+
+    auto stmt = SQLite::Statement(db, query);
+    switch (request.type) {
+        case delayed_payments_type::all: {
+        } break;
+
+        case delayed_payments_type::height: {
+            stmt.bind(1, static_cast<int64_t>(request.height));
+        } break;
+
+        case delayed_payments_type::address: {
+            stmt.bind(1, eth_address_to_sql_address(request.address));
+        } break;
+    }
+
+    block_payments result;
+    while (stmt.executeStep()) {
+        auto [addr_str, amount, liquidation_amount] = db::get<std::string, int64_t, int64_t>(stmt);
+        auto eth_addr = tools::make_from_hex_guts<eth::address>(addr_str);
+        auto& it = result[eth_addr];
+        it.amount += cryptonote::reward_money::db_amount(amount);
+        it.liquidation += cryptonote::reward_money::db_amount(liquidation_amount);
+    }
+
+    return result;
 }
 
 static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::block_add_result& block_add)
 {
     // NOTE: Submit (locked) stakes information
-    // New ETH addresses that are staking may not exist in the table yet if it's their first time so
-    // the adding of locked stakes has to account for if it doesn't exist, hence we use a INSERT
-    // INTO instead of just using UPDATE as we do in the subtraction query below.
-    auto add_stakes = db.prepared_st(
-            "INSERT INTO batched_payments_accrued (stakes, address, amount, payout_offset) "
-            "VALUES (?, ?, 0, 0)"
-            "ON CONFLICT(address) DO UPDATE SET"
-            "  stakes = stakes + excluded.stakes;");
+    // New ETH addresses that are staking may not exist in the table yet if it's their first time
+    // because they haven't received rewards yet. The adding of locked stakes has to account for
+    // if it doesn't exist, hence we use a INSERT INTO instead of just using UPDATE as we do in the
+    // subtraction query below.
+    //
+    // NOTE: We specify amount and payout_offset because older DBs don't have the 'DEFAULT 0' clause
+    // applied to those rows.
+    auto lifetime_locked_stakes = db.prepared_st(
+            "INSERT INTO batched_payments_accrued (lifetime_locked_stakes, address, amount, payout_offset)"
+            " VALUES (?, ?, 0, 0)"
+            " ON CONFLICT(address) DO UPDATE SET"
+            "  lifetime_locked_stakes = lifetime_locked_stakes + excluded.lifetime_locked_stakes;");
 
     // NOTE: Submit locked stakes
     for (auto it : block_add.locked_stakes) {
         assert(it.amount.to_db() > 0);
 
-        // NOTE: Avoid get_address_str as we only use ETH addresses which does not have a cache.
-        std::string address = "0x{:x}"_format(it.addr);
+        std::string address = eth_address_to_sql_address(it.addr);
         BlockchainSQLite::wallet_info wallet_info_before = get_accrued_rewards_impl(db, address);
 
         // NOTE: Add the locked SESH
-        int rows_changed = exec_query(add_stakes, static_cast<int64_t>(it.amount.to_db()), address);
-        add_stakes->reset();
+        int rows_changed = exec_query(lifetime_locked_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        lifetime_locked_stakes->reset();
         assert(rows_changed == 1);
 
         // NOTE: Verify the DB operations did what we expected
@@ -981,45 +1156,49 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
                 address,
                 db.height + 1,
                 cryptonote::print_money(it.amount.to_coin()),
-                cryptonote::print_money(wallet_info_before.locked_stakes.to_coin()),
-                cryptonote::print_money(wallet_info_after.locked_stakes.to_coin()),
+                cryptonote::print_money(wallet_info_before.lifetime_locked_stakes.to_coin()),
+                cryptonote::print_money(wallet_info_after.lifetime_locked_stakes.to_coin()),
                 it.sn);
-        assert(wallet_info_before.locked_stakes.to_coin() + it.amount.to_coin() == wallet_info_after.locked_stakes.to_coin());
+        assert(wallet_info_before.locked_stakes.to_coin() + it.amount.to_coin() ==
+               wallet_info_after.locked_stakes.to_coin());
     }
 
-    // NOTE: Submit unlocked stakes
-    auto sub_stakes = db.prepared_st(
-            "UPDATE batched_payments_accrued SET stakes = (stakes - ?) WHERE address = ?");
-    for (auto it : block_add.unlocked_stakes) {
+    // NOTE: Submit purge stakes
+    auto purged_stakes = db.prepared_st("UPDATE batched_payments_accrued "
+                    "SET "
+                    "  lifetime_unlocked_stakes   = (lifetime_unlocked_stakes   + ?),"
+                    "  lifetime_liquidated_stakes = (lifetime_liquidated_stakes + ?)"
+                    "WHERE address = ?");
+
+    for (const auto& it : block_add.purged_stakes) {
         assert(it.amount.to_db() > 0);
 
         // NOTE: Verify remaining locked stakes don't go below 0
-        std::string address = "0x{:x}"_format(it.addr);
+        std::string address = eth_address_to_sql_address(it.addr);
         BlockchainSQLite::wallet_info wallet_info_before = get_accrued_rewards_impl(db, address);
         assert(wallet_info_before.found);
         if (wallet_info_before.locked_stakes.to_db() < it.amount.to_db()) {
             log::error(
                     logcat,
-                    "Internal error: SN contributor ({}) unlocked more stake ({} SESH) than is "
+                    "Internal error: SN contributor ({}) purged more stake ({} SESH) than is "
                     "available in their locked balance ({} SESH)",
                     address,
                     cryptonote::print_money(it.amount.to_coin()),
-                    cryptonote::print_money(wallet_info_before.locked_stakes.to_coin()));
+                    cryptonote::print_money(wallet_info_before.lifetime_locked_stakes.to_coin()));
             assert(wallet_info_before.locked_stakes.to_db() >= it.amount.to_db());
         }
 
-        // NOTE: Add the unlocked SESH
-        int rows_changed =
-                db::exec_query(sub_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        // NOTE: Add the purged SESH
+        int rows_changed = db::exec_query(purged_stakes, static_cast<int64_t>(it.amount.to_db()), address);
         assert(rows_changed == 1);
-        sub_stakes->reset();
+        purged_stakes->reset();
 
         // NOTE: Verify the DB operations did what we expected
         BlockchainSQLite::wallet_info wallet_info_after = get_accrued_rewards_impl(db, address);
         assert(wallet_info_after.found);
         log::error(
                 logcat,
-                "SN contributor ({}) at height {} unlocked {} SESH ({} => {} total) into SN {}",
+                "SN contributor ({}) at height {} purged {} SESH ({} => {} total) into SN {}",
                 address,
                 db.height + 1,
                 cryptonote::print_money(it.amount.to_coin()),
@@ -1087,7 +1266,7 @@ bool BlockchainSQLite::add_block(
         if (!validate_batch_payment(miner_tx_vouts, calculated_rewards, block_height, rescan))
             return false;
 
-        reward_handler(block, service_nodes_state, block_add, get_delayed_payments(block_height));
+        reward_handler(block, service_nodes_state, block_add);
         submit_stakes_metadata(*this, block_add);
         update_height(height + 1); // NOTE: Update height which synchronises the archive/recent tables
 
@@ -1129,13 +1308,21 @@ bool BlockchainSQLite::add_delayed_payments(
 
         int64_t payout_height = at_height + (delay_blocks > 0 ? delay_blocks : 1);
         auto insert_payment = prepared_st(
-                "INSERT INTO delayed_payments (eth_address, amount, payout_height, height, "
-                "block_height, block_tx_index, contributor_index) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)");
+                "INSERT INTO delayed_payments("
+                "  eth_address,"
+                "  amount,"
+                "  payout_height,"
+                "  height,"
+                "  block_height,"
+                "  block_tx_index,"
+                "  contributor_index,"
+                "  liquidation_amount"
+                ")"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
 
         for (auto& payment : payments) {
             const auto amount = static_cast<int64_t>(payment.amount.to_db());
-            const auto eth_address = "0x{:x}"_format(payment.addr);
+            const auto eth_address = eth_address_to_sql_address(payment.addr);
             log::trace(
                     logcat,
                     "Adding delayed payment for SN reward contributor {} to database with amount "
@@ -1147,12 +1334,13 @@ bool BlockchainSQLite::add_delayed_payments(
             db::exec_query(
                     insert_payment,
                     eth_address,
-                    amount,
+                    static_cast<int64_t>(payment.amount.to_db()),
                     payout_height,
                     static_cast<int64_t>(at_height),
                     payment.block_height,
                     payment.tx_index,
-                    payment.contributor_index);
+                    payment.contributor_index,
+                    static_cast<int64_t>(payment.liquidation.to_db()));
             insert_payment->reset();
         }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -114,7 +114,6 @@ constexpr std::string_view BATCHED_PAYMENTS_SCHEMA_WITH_HEIGHT = R"(address TEXT
    CHECK(lifetime_unlocked_stakes  <= lifetime_locked_stakes)
    CHECK(lifetime_rewards          >= 0))";
 
-
 void BlockchainSQLite::create_schema() {
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
     auto& netconf = cryptonote::get_config(m_nettype);
@@ -395,16 +394,16 @@ void BlockchainSQLite::upgrade_schema() {
     // NOTE: Add new stakes fields to batch accrued table row for tracking
     {
         std::string_view tables[] = {
-            "batched_payments_accrued",
-            "batched_payments_accrued_archive",
-            "batched_payments_accrued_recent",
+                "batched_payments_accrued",
+                "batched_payments_accrued_archive",
+                "batched_payments_accrued_recent",
         };
 
         std::string_view fields[] = {
-            "lifetime_locked_stakes",
-            "lifetime_unlocked_stakes",
-            "lifetime_liquidated_stakes",
-            "lifetime_rewards",
+                "lifetime_locked_stakes",
+                "lifetime_unlocked_stakes",
+                "lifetime_liquidated_stakes",
+                "lifetime_rewards",
         };
 
         for (auto it : tables) {
@@ -420,7 +419,8 @@ void BlockchainSQLite::upgrade_schema() {
                 }
 
                 if (!has_field)
-                    db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(it, field));
+                    db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(
+                            it, field));
             }
         }
     }
@@ -428,9 +428,9 @@ void BlockchainSQLite::upgrade_schema() {
     // NOTE: Add new liquidation field to delayed payment table
     {
         std::string_view tables[] = {
-            "delayed_payments",
-            "delayed_payments_archive",
-            "delayed_payments_recent",
+                "delayed_payments",
+                "delayed_payments_archive",
+                "delayed_payments_recent",
         };
 
         constexpr std::string_view field = "liquidation_amount";
@@ -446,7 +446,8 @@ void BlockchainSQLite::upgrade_schema() {
             }
 
             if (!has_field)
-                db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(it, field));
+                db.exec("ALTER TABLE {} ADD COLUMN {} INTEGER NOT NULL DEFAULT 0;"_format(
+                        it, field));
         }
     }
 
@@ -568,8 +569,7 @@ const std::string& BlockchainSQLite::get_address_str(const cryptonote::batch_sn_
 // formatting of an ETH address is now the checksum address. This was changed _after_ we started
 // using lowercase ETH addresses in the DB. We should at some point just migrate entirely to byte
 // addresses.
-static std::string eth_address_to_sql_address(const eth::address& addr)
-{
+static std::string eth_address_to_sql_address(const eth::address& addr) {
     std::string result = "0x{:x}"_format(addr);
     return result;
 }
@@ -610,42 +610,19 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
     BlockchainSQLite::wallet_info result = {};
     result.height = height;
     if (metadata) {
+        eth::address eth_addr = {};
+        bool is_eth = tools::try_load_from_hex_guts(address, eth_addr);
+
         int64_t amount = std::get<0>(*metadata);
         int64_t lifetime_locked_stakes = std::get<1>(*metadata);
         int64_t lifetime_unlocked_stakes = std::get<2>(*metadata);
         int64_t lifetime_liquidated_stakes = std::get<3>(*metadata);
         int64_t lifetime_rewards = std::get<4>(*metadata);
         assert(amount >= 0);
-        assert(lifetime_locked_stakes >= 0);
-        assert(lifetime_unlocked_stakes >= 0);
-        assert(lifetime_rewards >= 0);
-
-        int64_t rederived_amount = lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes;
-        if (amount != rederived_amount) {
-            log::error(
-                    logcat,
-                    "Internal error: SN contributor {} at height {} lifetime claimable amount "
-                    "does not match the sum of the unlocked stakes, rewards and liquidated stakes\n"
-                    "  lifetime claimable  {}\n"
-                    "  lifetime rewards    {}\n"
-                    "  lifetime unlocked   {}\n"
-                    "  lifetime liquidated {}\n"
-                    "Final calculated values were (claimable vs rederived claimable): {} != {}",
-                    address,
-                    height,
-                    cryptonote::print_money(amount,                     false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                    cryptonote::print_money(lifetime_unlocked_stakes,   false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                    cryptonote::print_money(lifetime_rewards,           false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                    cryptonote::print_money(lifetime_liquidated_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                    cryptonote::print_money(amount,                     false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                    cryptonote::print_money(rederived_amount,           false, oxen::DISPLAY_DECIMAL_POINT + 3));
-            assert(amount == rederived_amount);
-        }
 
         result.found = true;
         result.amount = cryptonote::reward_money::db_amount(amount);
-        result.lifetime_locked_stakes =
-                cryptonote::reward_money::db_amount(lifetime_locked_stakes);
+        result.lifetime_locked_stakes = cryptonote::reward_money::db_amount(lifetime_locked_stakes);
         result.lifetime_unlocked_stakes =
                 cryptonote::reward_money::db_amount(lifetime_unlocked_stakes);
         result.lifetime_liquidated_stakes =
@@ -653,13 +630,47 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
         result.lifetime_rewards = cryptonote::reward_money::db_amount(lifetime_rewards);
         result.locked_stakes = result.lifetime_locked_stakes - result.lifetime_unlocked_stakes;
 
-        cryptonote::reward_money rederived_lifetime_rewards =
-                result.amount -
-                (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
-        assert(rederived_lifetime_rewards == result.lifetime_rewards);
+        // NOTE: Some of these fields are only enumerated on ETH addresses so gate error checking
+        // behind said flag.
+        if (is_eth) {
+            assert(lifetime_locked_stakes >= 0);
+            assert(lifetime_unlocked_stakes >= 0);
+            assert(lifetime_rewards >= 0);
 
-        // NOTE: Delayed payments is only supported on ETH addresses
-        if (eth::address eth_addr; tools::try_load_from_hex_guts(address, eth_addr)) {
+            int64_t rederived_amount =
+                    lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes;
+            if (amount != rederived_amount) {
+                log::error(
+                        logcat,
+                        "Internal error: SN contributor {} at height {} lifetime claimable amount "
+                        "does not match the sum of the unlocked stakes, rewards and liquidated "
+                        "stakes\n"
+                        "  lifetime claimable  {}\n"
+                        "  lifetime rewards    {}\n"
+                        "  lifetime unlocked   {}\n"
+                        "  lifetime liquidated {}\n"
+                        "Final calculated values were (claimable vs rederived claimable): {} != {}",
+                        address,
+                        height,
+                        cryptonote::print_money(amount, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                lifetime_unlocked_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                lifetime_rewards, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                lifetime_liquidated_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(amount, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                rederived_amount, false, oxen::DISPLAY_DECIMAL_POINT + 3));
+                assert(amount == rederived_amount);
+            }
+
+            cryptonote::reward_money rederived_lifetime_rewards =
+                    result.amount -
+                    (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
+            assert(rederived_lifetime_rewards == result.lifetime_rewards);
+
+            // NOTE: Delayed payments is only supported on ETH addresses
             cryptonote::BlockchainSQLite::delayed_payments_request request = {};
             request.type = cryptonote::BlockchainSQLite::delayed_payments_type::address;
             request.address = eth_addr;
@@ -671,11 +682,13 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
                 result.timelocked_stakes += payment.amount - payment.liquidation;
             }
         }
+
     }
     return result;
 }
 
-static BlockchainSQLite::wallet_info get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address) {
+static BlockchainSQLite::wallet_info get_accrued_rewards_impl(
+        BlockchainSQLite& db, const std::string& address) {
     log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
     auto tuple = db.prepared_maybe_get<int64_t, int64_t, int64_t, int64_t, int64_t>(
             "SELECT"
@@ -988,7 +1001,8 @@ void BlockchainSQLite::add_rewards(
                                                : sn_info.operator_ethereum_address;
             payments[fee_recipient].amount += cryptonote::reward_money::db_amount(operator_fee);
         } else {
-            payments[sn_info.operator_address].amount += cryptonote::reward_money::db_amount(operator_fee);
+            payments[sn_info.operator_address].amount +=
+                    cryptonote::reward_money::db_amount(operator_fee);
         }
     }
 
@@ -1095,7 +1109,6 @@ void BlockchainSQLite::reward_handler(
 
     add_sn_rewards(get_delayed_payments(request), false /*rewards_payment*/);
     add_sn_rewards(payments, true /*rewards_payment*/);
-
 }
 
 block_payments BlockchainSQLite::get_delayed_payments(const delayed_payments_request& request) {
@@ -1152,8 +1165,8 @@ block_payments BlockchainSQLite::get_delayed_payments(const delayed_payments_req
     return result;
 }
 
-static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::block_add_result& block_add)
-{
+static void submit_stakes_metadata(
+        BlockchainSQLite& db, const service_nodes::block_add_result& block_add) {
     // NOTE: Submit (locked) stakes information
     // New ETH addresses that are staking may not exist in the table yet if it's their first time
     // because they haven't received rewards yet. The adding of locked stakes has to account for
@@ -1163,7 +1176,8 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
     // NOTE: We specify amount and payout_offset because older DBs don't have the 'DEFAULT 0' clause
     // applied to those rows.
     auto lifetime_locked_stakes = db.prepared_st(
-            "INSERT INTO batched_payments_accrued (lifetime_locked_stakes, address, amount, payout_offset)"
+            "INSERT INTO batched_payments_accrued (lifetime_locked_stakes, address, amount, "
+            "payout_offset)"
             " VALUES (?, ?, 0, 0)"
             " ON CONFLICT(address) DO UPDATE SET"
             "  lifetime_locked_stakes = lifetime_locked_stakes + excluded.lifetime_locked_stakes;");
@@ -1176,7 +1190,8 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
         BlockchainSQLite::wallet_info wallet_info_before = get_accrued_rewards_impl(db, address);
 
         // NOTE: Add the locked SESH
-        int rows_changed = exec_query(lifetime_locked_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        int rows_changed = exec_query(
+                lifetime_locked_stakes, static_cast<int64_t>(it.amount.to_db()), address);
         lifetime_locked_stakes->reset();
         assert(rows_changed == 1);
 
@@ -1224,7 +1239,8 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
         }
 
         // NOTE: Add the purged SESH
-        int rows_changed = db::exec_query(purged_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        int rows_changed =
+                db::exec_query(purged_stakes, static_cast<int64_t>(it.amount.to_db()), address);
         assert(rows_changed == 1);
         purged_stakes->reset();
 
@@ -1302,8 +1318,10 @@ bool BlockchainSQLite::add_block(
             return false;
 
         reward_handler(block, service_nodes_state, block_add);
-        submit_stakes_metadata(*this, block_add);
-        update_height(height + 1); // NOTE: Update height which synchronises the archive/recent tables
+        if (hf_version >= hf::hf21_eth)
+            submit_stakes_metadata(*this, block_add);
+        update_height(
+                height + 1);  // NOTE: Update height which synchronises the archive/recent tables
 
         if (transaction) {
             transaction->commit();
@@ -1316,7 +1334,11 @@ bool BlockchainSQLite::add_block(
         }
 
     } catch (std::exception& e) {
-        log::error(logcat, "Error adding reward payments at block {}: {}", block.get_height(), e.what());
+        log::error(
+                logcat,
+                "Error adding reward payments at block {}: {}",
+                block.get_height(),
+                e.what());
         return false;
     }
     return true;

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -665,7 +665,7 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
                 assert(amount == rederived_amount);
             }
 
-            cryptonote::reward_money rederived_lifetime_rewards =
+            [[maybe_unused]] cryptonote::reward_money rederived_lifetime_rewards =
                     result.amount -
                     (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
             assert(rederived_lifetime_rewards == result.lifetime_rewards);
@@ -1540,30 +1540,5 @@ bool BlockchainSQLite::save_payments(
         exec_query(cleanup_st);
     }
     return true;
-}
-
-void BlockchainSQLite::set_rewards_hf21(const std::unordered_map<eth::address, uint64_t>& rewards) {
-    log::trace(
-            logcat, "BlockchainSQLite::{} removing OXEN rewards and adding SENT rewards", __func__);
-
-    // values in `rewards` represent converted OXEN -> SENT rewards,
-    // any unconverted are dropped (but were paid out last block anyway).
-    db.exec("DELETE FROM batched_payments_accrued");
-
-    auto insert_payment = prepared_st(
-            "INSERT INTO batched_payments_accrued (address, payout_offset, amount) VALUES (?, ?, "
-            "?)");
-
-    for (auto& [addr, amt] : rewards) {
-        auto address_str = "0x{:x}"_format(addr);
-        auto amount = static_cast<int64_t>(amt * BATCH_REWARD_FACTOR);
-        log::trace(
-                logcat,
-                "Adding converted OXEN as SENT for contributor {} to database with amount {}",
-                address_str,
-                amt);
-        db::exec_query(insert_payment, address_str, 0, amount);
-        insert_payment->reset();
-    }
 }
 }  // namespace cryptonote

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -903,21 +903,24 @@ BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
     return get_accrued_rewards_at_impl(*this, address_string, at_height, height);
 }
 
-std::pair<std::vector<std::string>, std::vector<cryptonote::reward_money>>
+std::pair<std::vector<std::string>, std::vector<BlockchainSQLite::wallet_info>>
 BlockchainSQLite::get_all_accrued_rewards() {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
-    std::pair<std::vector<std::string>, std::vector<cryptonote::reward_money>> result;
-    auto& [addresses, amounts] = result;
+    std::pair<std::vector<std::string>, std::vector<wallet_info>> result;
+    auto& [addresses, wallets] = result;
 
-    for (auto [addr, amt] : prepared_results<std::string, int64_t>("SELECT address, amount FROM "
-                                                                   "batched_payments_accrued")) {
-        cryptonote::reward_money amount = cryptonote::reward_money::db_amount(amt);
-        if (amount.to_coin() > 0) {
-            addresses.push_back(std::move(addr));
-            amounts.push_back(amount);
-        }
+    // NOTE: Reserve
+    size_t row_count = batch_payments_accrued_row_count(PaymentTableType::Nil, std::nullopt);
+    addresses.reserve(row_count);
+    wallets.reserve(row_count);
+
+    // NOTE: Build
+    for (auto it : prepared_results<std::string>("SELECT address FROM batched_payments_accrued")) {
+        wallet_info info = get_accrued_rewards_impl(*this, it);
+        addresses.push_back(it);
+        wallets.push_back(std::move(info));
     }
 
     return result;

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -652,16 +652,30 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
                         "Final calculated values were (claimable vs rederived claimable): {} != {}",
                         address,
                         height,
-                        cryptonote::print_money(amount, false, oxen::DISPLAY_DECIMAL_POINT + 3),
                         cryptonote::print_money(
-                                lifetime_unlocked_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                                amount,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3),
                         cryptonote::print_money(
-                                lifetime_rewards, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                                lifetime_unlocked_stakes,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3),
                         cryptonote::print_money(
-                                lifetime_liquidated_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
-                        cryptonote::print_money(amount, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                                lifetime_rewards,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3),
                         cryptonote::print_money(
-                                rederived_amount, false, oxen::DISPLAY_DECIMAL_POINT + 3));
+                                lifetime_liquidated_stakes,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                amount,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3),
+                        cryptonote::print_money(
+                                rederived_amount,
+                                cryptonote::strip_zeros::no,
+                                oxen::DISPLAY_DECIMAL_POINT + 3));
                 assert(amount == rederived_amount);
             }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -1000,10 +1000,9 @@ void BlockchainSQLite::add_rewards(
             eth::address fee_recipient = sn_info.contributors.size()
                                                ? sn_info.contributors[0].ethereum_beneficiary
                                                : sn_info.operator_ethereum_address;
-            payments[fee_recipient].amount += cryptonote::reward_money::db_amount(operator_fee);
+            payments[fee_recipient].amount += operator_fee;
         } else {
-            payments[sn_info.operator_address].amount +=
-                    cryptonote::reward_money::db_amount(operator_fee);
+            payments[sn_info.operator_address].amount += operator_fee;
         }
     }
 
@@ -1028,7 +1027,7 @@ void BlockchainSQLite::add_rewards(
             // be assigned to the ethereum address by default.
             auto& balance = use_eth_address ? payments[contributor.ethereum_beneficiary]
                                             : payments[contributor.address];
-            balance.amount += cryptonote::reward_money::db_amount(c_reward);
+            balance.amount += c_reward;
         }
     }
 }
@@ -1088,7 +1087,7 @@ void BlockchainSQLite::reward_handler(
 
             auto foundation_reward = cryptonote::reward_money::coin_amount(
                     cryptonote::governance_reward_formula(block.major_version));
-            payments[parsed_governance_addr.second.address] += foundation_reward;
+            payments[parsed_governance_addr.second.address].amount += foundation_reward;
         }
     }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -682,7 +682,6 @@ static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
                 result.timelocked_stakes += payment.amount - payment.liquidation;
             }
         }
-
     }
     return result;
 }
@@ -702,7 +701,8 @@ static BlockchainSQLite::wallet_info get_accrued_rewards_impl(
     return result;
 }
 
-void BlockchainSQLite::add_sn_rewards(hf hf_version, const block_payments& payments, bool rewards_payment) {
+void BlockchainSQLite::add_sn_rewards(
+        hf hf_version, const block_payments& payments, bool rewards_payment) {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -702,7 +702,7 @@ static BlockchainSQLite::wallet_info get_accrued_rewards_impl(
     return result;
 }
 
-void BlockchainSQLite::add_sn_rewards(const block_payments& payments, bool rewards_payment) {
+void BlockchainSQLite::add_sn_rewards(hf hf_version, const block_payments& payments, bool rewards_payment) {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
@@ -743,7 +743,8 @@ void BlockchainSQLite::add_sn_rewards(const block_payments& payments, bool rewar
 
         if (rewards_payment) {
             exec_query(insert_payment, address_str, offset, amount_i64);
-            exec_query(update_lifetime_rewards, amount_i64, address_str);
+            if (hf_version >= hf::hf21_eth)
+                exec_query(update_lifetime_rewards, amount_i64, address_str);
         } else {
             db::exec_query(
                     insert_payment,
@@ -1107,8 +1108,8 @@ void BlockchainSQLite::reward_handler(
     request.type = delayed_payments_type::height;
     request.height = block.get_height();
 
-    add_sn_rewards(get_delayed_payments(request), false /*rewards_payment*/);
-    add_sn_rewards(payments, true /*rewards_payment*/);
+    add_sn_rewards(block.major_version, get_delayed_payments(request), false /*rewards_payment*/);
+    add_sn_rewards(block.major_version, payments, true /*rewards_payment*/);
 }
 
 block_payments BlockchainSQLite::get_delayed_payments(const delayed_payments_request& request) {

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -94,25 +94,13 @@ void BlockchainSQLite::create_schema() {
                  address VARCHAR NOT NULL,
                  amount BIGINT NOT NULL,
                  payout_offset INTEGER NOT NULL,
+                 stakes BIGINT NOT NULL DEFAULT 0,
                  PRIMARY KEY(address),
                  CHECK(amount >= 0)
+                 CHECK(stakes >= 0)
                );
 
                CREATE INDEX IF NOT EXISTS batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
-
-               -- For pre-ETH hardfork. Oxen SN's were paid and the amount paid was subtracted
-               -- from the accumulated amount in the DB. After the ETH hardfork the DB tracks
-               -- the lifetime rewards and instead the smart contract tracks how much has been paid
-               -- out. The delta in how much the DB has allocated and how much the smart contract
-               -- has paid is the amount owed.
-               --
-               -- In other words after hardforking, rewards amounts are strictly accumulative which
-               -- means this condition will never trigger.
-               CREATE TRIGGER IF NOT EXISTS batch_payments_delete_empty AFTER UPDATE ON batched_payments_accrued
-               FOR EACH ROW WHEN NEW.amount = 0 BEGIN
-                   DELETE FROM batched_payments_accrued WHERE address = NEW.address;
-               END;
-
                CREATE TABLE IF NOT EXISTS batch_db_info(height BIGINT NOT NULL);
                INSERT INTO  batch_db_info(height) VALUES(0);)");
 
@@ -271,8 +259,10 @@ void BlockchainSQLite::upgrade_schema() {
           amount BIGINT NOT NULL,
           payout_offset INTEGER NOT NULL,
           height BIGINT NOT NULL, -- Height that the row was generated on
+          stakes BIGINT NOT NULL DEFAULT 0,
           CHECK(amount >= 0),
           CHECK(height >= 0)
+          CHECK(stakes >= 0)
         );
 
         CREATE INDEX batched_payments_accrued_archive_height_idx ON batched_payments_accrued_archive(height);
@@ -295,8 +285,10 @@ void BlockchainSQLite::upgrade_schema() {
           amount BIGINT NOT NULL,
           payout_offset INTEGER NOT NULL,
           height BIGINT NOT NULL,
+          stakes BIGINT NOT NULL DEFAULT 0,
           CHECK(amount >= 0),
           CHECK(height >= 0)
+          CHECK(stakes >= 0)
         );
 
         CREATE INDEX batched_payments_accrued_recent_height_idx ON batched_payments_accrued_recent(height);
@@ -329,12 +321,12 @@ void BlockchainSQLite::upgrade_schema() {
         CREATE TRIGGER           make_recent AFTER UPDATE ON batch_db_info
         FOR EACH ROW WHEN NEW.height > OLD.height BEGIN
             -- Batched payments
-            INSERT INTO batched_payments_accrued_recent SELECT *, NEW.height FROM  batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_recent                      WHERE height < (NEW.height - {0});
+            INSERT INTO batched_payments_accrued_recent SELECT address, amount, payout_offset, NEW.height, stakes FROM  batched_payments_accrued;
+            DELETE FROM batched_payments_accrued_recent                                                           WHERE height < (NEW.height - {0});
 
             -- Delayed payments
-            INSERT INTO delayed_payments_recent SELECT *                     FROM  delayed_payments WHERE height == NEW.height;
-            DELETE FROM delayed_payments_recent                              WHERE height < (NEW.height - {0});
+            INSERT INTO delayed_payments_recent SELECT * FROM  delayed_payments WHERE height == NEW.height;
+            DELETE FROM delayed_payments_recent          WHERE height < (NEW.height - {0});
 
         END;
 
@@ -352,12 +344,12 @@ void BlockchainSQLite::upgrade_schema() {
         FOR EACH ROW WHEN (NEW.height % {1}) = 0 AND NEW.height > OLD.height BEGIN
 
             -- Batch payments
-            INSERT INTO batched_payments_accrued_archive SELECT *, NEW.height FROM  batched_payments_accrued;
-            DELETE FROM batched_payments_accrued_archive                      WHERE height < (NEW.height - {2});
+            INSERT INTO batched_payments_accrued_archive SELECT address, amount, payout_offset, NEW.height, stakes FROM batched_payments_accrued;
+            DELETE FROM batched_payments_accrued_archive                                                           WHERE height < (NEW.height - {2});
 
             -- Delayed payments
-            INSERT INTO delayed_payments_archive SELECT *                     FROM  delayed_payments;
-            DELETE FROM delayed_payments_archive                              WHERE height < (NEW.height - {2});
+            INSERT INTO delayed_payments_archive SELECT * FROM delayed_payments;
+            DELETE FROM delayed_payments_archive          WHERE height < (NEW.height - {2});
 
         END;
 
@@ -388,9 +380,37 @@ void BlockchainSQLite::upgrade_schema() {
         FOR EACH ROW WHEN NEW.height > OLD.height BEGIN
             DELETE FROM delayed_payments WHERE payout_height <= NEW.height;
         END;
+
+        -- Remove old trigger from pre-ETH hardfork. It is replaced with a manual delete of rows
+        -- when the correct conditions are met.
+        DROP TRIGGER IF EXISTS batch_payments_delete_empty;
         )"_format(netconf.HISTORY_RECENT_KEEP_WINDOW,
                   netconf.HISTORY_ARCHIVE_INTERVAL,
                   netconf.HISTORY_ARCHIVE_KEEP_WINDOW));
+    }
+
+    // NOTE: Add new stakes fields to DB row for tracking user stakes
+    {
+        std::string_view tables[] = {
+            "batched_payments_accrued",
+            "batched_payments_accrued_archive",
+            "batched_payments_accrued_recent",
+        };
+
+        for (auto it : tables) {
+            bool has_field = false;
+            SQLite::Statement msg_cols{db, "PRAGMA main.table_info({})"_format(it)};
+            while (msg_cols.executeStep()) {
+                auto [cid, name] = db::get<int64_t, std::string>(msg_cols);
+                if (name == "stakes") {
+                    has_field = true;
+                    break;
+                }
+            }
+
+            if (!has_field)
+                db.exec("ALTER TABLE {} ADD COLUMN stakes INTEGER NOT NULL DEFAULT 0;"_format(it));
+        }
     }
 
     // NOTE: Remove deprecated tables, this can be removed post HF21 as everyone
@@ -460,7 +480,7 @@ void BlockchainSQLite::blockchain_detached(
 
                 db.exec(R"(DELETE FROM batched_payments_accrued;
                            INSERT INTO batched_payments_accrued
-                           SELECT address, amount, payout_offset
+                           SELECT address, amount, payout_offset, stakes
                            FROM {1} WHERE height = {0};
                   )"_format(new_height, batched_payments_history_table));
 
@@ -530,8 +550,9 @@ void BlockchainSQLite::add_sn_rewards(const block_payments& payments) {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
     auto insert_payment = prepared_st(
-            "INSERT INTO batched_payments_accrued (address, payout_offset, amount) VALUES (?, ?, ?)"
-            " ON CONFLICT (address) DO UPDATE SET amount = amount + excluded.amount");
+            "INSERT INTO batched_payments_accrued (address, payout_offset, amount) "
+            "VALUES (?, ?, ?)"
+            "ON CONFLICT (address) DO UPDATE SET amount = amount + excluded.amount;");
 
     const auto& netconf = get_config(m_nettype);
 
@@ -669,71 +690,88 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     return payments;
 }
 
-static cryptonote::reward_money get_accrued_rewards_impl(
-        BlockchainSQLite& db, const std::string& address) {
-    log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
-    auto rewards = db.prepared_maybe_get<int64_t>(
-            R"(
-        SELECT amount
-        FROM batched_payments_accrued
-        WHERE address = ?
-    )",
-            address);
-    return cryptonote::reward_money::db_amount(rewards.value_or(0));
+static BlockchainSQLite::wallet_info rewards_stake_pair_to_wallet_info(std::optional<std::tuple<int64_t, int64_t>> pair, uint64_t height)
+{
+    BlockchainSQLite::wallet_info result = {};
+    result.height = height;
+    if (pair) {
+        int64_t total_rewards_db = std::get<0>(*pair);
+        int64_t locked_stakes_db = std::get<1>(*pair);
+        assert(total_rewards_db >= 0);
+        assert(locked_stakes_db >= 0);
+
+        result.found = true;
+        result.total_rewards = cryptonote::reward_money::db_amount(total_rewards_db);
+        result.locked_stakes = cryptonote::reward_money::db_amount(locked_stakes_db);
+    }
+    return result;
 }
 
-static std::optional<cryptonote::reward_money> get_accrued_rewards_at_impl(
+static BlockchainSQLite::wallet_info get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address) {
+    log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
+    auto pair = db.prepared_maybe_get<int64_t, int64_t>(
+            "SELECT amount, stakes FROM batched_payments_accrued WHERE address = ?", address);
+    BlockchainSQLite::wallet_info result = rewards_stake_pair_to_wallet_info(pair, db.height);
+    return result;
+}
+
+static BlockchainSQLite::wallet_info get_accrued_rewards_at_impl(
         BlockchainSQLite& db,
         const std::string& address,
         uint64_t at_height,
         uint64_t curr_top_height) {
     log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
-
     if (at_height > curr_top_height)
-        return std::nullopt;
+        return {};
+
     if (at_height == curr_top_height)
         return get_accrued_rewards_impl(db, address);
 
-    auto rewards = db.prepared_maybe_get<int64_t>(
-            R"(
-        SELECT amount
-        FROM batched_payments_accrued_recent
-        WHERE address = ? AND height = ?
-    )",
+    auto pair = db.prepared_maybe_get<int64_t, int64_t>(
+            "SELECT amount, stakes FROM batched_payments_accrued_recent WHERE address = ? AND "
+            "height = ?",
             address,
             static_cast<int64_t>(at_height));
-    if (!rewards) {
-        // No rewards found; check to see if we actually have any recent records for that height and
-        // if not, return a "don't know" nullopt value.  Otherwise we fall through and return an
-        // authoritive 0 value.
-        auto min_height = db.prepared_get<int64_t>(
-                "SELECT COALESCE(MIN(height), 0) FROM batched_payments_accrued_recent");
-        if (at_height < static_cast<uint64_t>(min_height))
-            return std::nullopt;
-    }
-    return cryptonote::reward_money::db_amount(rewards.value_or(0));
+
+    if (pair)
+        return rewards_stake_pair_to_wallet_info(pair, db.height);
+
+    // No rewards found; check to see if we actually have any recent records for that height and
+    // if not, return a "don't know" nullopt value.  Otherwise we fall through and return an
+    // authoritive 0 value.
+    auto min_height = db.prepared_get<int64_t>(
+            "SELECT COALESCE(MIN(height), 0) FROM batched_payments_accrued_recent");
+    if (at_height < static_cast<uint64_t>(min_height))
+        return {};
+
+    BlockchainSQLite::wallet_info result = {};
+    result.height = min_height;
+    result.found = true;
+    return result;
 }
 
-std::pair<uint64_t, cryptonote::reward_money> BlockchainSQLite::get_accrued_rewards(
-        const eth::address& address) {
+BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(const eth::address& address) {
     std::string address_string = fmt::format("0x{:x}", address);
-    return {height, get_accrued_rewards_impl(*this, address_string)};
+    wallet_info result = get_accrued_rewards_impl(*this, address_string);
+    return result;
 }
 
-std::pair<uint64_t, cryptonote::reward_money> BlockchainSQLite::get_accrued_rewards(
+BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
         const account_public_address& address) {
     std::string address_string =
             get_account_address_as_str(m_nettype, false /*subaddress*/, address);
-    return {height, get_accrued_rewards_impl(*this, address_string)};
+    wallet_info result = get_accrued_rewards_impl(*this, address_string);
+    return result;
 }
 
-std::optional<cryptonote::reward_money> BlockchainSQLite::get_accrued_rewards(
+BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
         const eth::address& address, uint64_t at_height) {
     std::string address_string = fmt::format("0x{:x}", address);
-    return get_accrued_rewards_at_impl(*this, address_string, at_height, height);
+    wallet_info result = get_accrued_rewards_at_impl(*this, address_string, at_height, height);
+    return result;
 }
 
-std::optional<cryptonote::reward_money> BlockchainSQLite::get_accrued_rewards(
+BlockchainSQLite::wallet_info BlockchainSQLite::get_accrued_rewards(
         const account_public_address& address, uint64_t at_height) {
     std::string address_string =
             get_account_address_as_str(m_nettype, false /*subaddress*/, address);
@@ -909,6 +947,88 @@ block_payments BlockchainSQLite::get_delayed_payments(uint64_t height) {
     return payments;
 }
 
+static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::block_add_result& block_add)
+{
+    // NOTE: Submit (locked) stakes information
+    // New ETH addresses that are staking may not exist in the table yet if it's their first time so
+    // the adding of locked stakes has to account for if it doesn't exist, hence we use a INSERT
+    // INTO instead of just using UPDATE as we do in the subtraction query below.
+    auto add_stakes = db.prepared_st(
+            "INSERT INTO batched_payments_accrued (stakes, address, amount, payout_offset) "
+            "VALUES (?, ?, 0, 0)"
+            "ON CONFLICT(address) DO UPDATE SET"
+            "  stakes = stakes + excluded.stakes;");
+
+    // NOTE: Submit locked stakes
+    for (auto it : block_add.locked_stakes) {
+        assert(it.amount.to_db() > 0);
+
+        // NOTE: Avoid get_address_str as we only use ETH addresses which does not have a cache.
+        std::string address = "0x{:x}"_format(it.addr);
+        BlockchainSQLite::wallet_info wallet_info_before = get_accrued_rewards_impl(db, address);
+
+        // NOTE: Add the locked SESH
+        int rows_changed = exec_query(add_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        add_stakes->reset();
+        assert(rows_changed == 1);
+
+        // NOTE: Verify the DB operations did what we expected
+        BlockchainSQLite::wallet_info wallet_info_after = get_accrued_rewards_impl(db, address);
+        assert(wallet_info_after.found);
+        log::error(
+                logcat,
+                "SN contributor ({}) at height {} locked {} SESH ({} => {} total) into SN {}",
+                address,
+                db.height + 1,
+                cryptonote::print_money(it.amount.to_coin()),
+                cryptonote::print_money(wallet_info_before.locked_stakes.to_coin()),
+                cryptonote::print_money(wallet_info_after.locked_stakes.to_coin()),
+                it.sn);
+        assert(wallet_info_before.locked_stakes.to_coin() + it.amount.to_coin() == wallet_info_after.locked_stakes.to_coin());
+    }
+
+    // NOTE: Submit unlocked stakes
+    auto sub_stakes = db.prepared_st(
+            "UPDATE batched_payments_accrued SET stakes = (stakes - ?) WHERE address = ?");
+    for (auto it : block_add.unlocked_stakes) {
+        assert(it.amount.to_db() > 0);
+
+        // NOTE: Verify remaining locked stakes don't go below 0
+        std::string address = "0x{:x}"_format(it.addr);
+        BlockchainSQLite::wallet_info wallet_info_before = get_accrued_rewards_impl(db, address);
+        assert(wallet_info_before.found);
+        if (wallet_info_before.locked_stakes.to_db() < it.amount.to_db()) {
+            log::error(
+                    logcat,
+                    "Internal error: SN contributor ({}) unlocked more stake ({} SESH) than is "
+                    "available in their locked balance ({} SESH)",
+                    address,
+                    cryptonote::print_money(it.amount.to_coin()),
+                    cryptonote::print_money(wallet_info_before.locked_stakes.to_coin()));
+            assert(wallet_info_before.locked_stakes.to_db() >= it.amount.to_db());
+        }
+
+        // NOTE: Add the unlocked SESH
+        int rows_changed =
+                db::exec_query(sub_stakes, static_cast<int64_t>(it.amount.to_db()), address);
+        assert(rows_changed == 1);
+        sub_stakes->reset();
+
+        // NOTE: Verify the DB operations did what we expected
+        BlockchainSQLite::wallet_info wallet_info_after = get_accrued_rewards_impl(db, address);
+        assert(wallet_info_after.found);
+        log::error(
+                logcat,
+                "SN contributor ({}) at height {} unlocked {} SESH ({} => {} total) into SN {}",
+                address,
+                db.height + 1,
+                cryptonote::print_money(it.amount.to_coin()),
+                cryptonote::print_money(wallet_info_before.locked_stakes.to_coin()),
+                cryptonote::print_money(wallet_info_after.locked_stakes.to_coin()),
+                it.sn);
+    }
+}
+
 bool BlockchainSQLite::add_block(
         const cryptonote::block& block,
         const service_nodes::service_node_list::state_t& service_nodes_state,
@@ -959,33 +1079,39 @@ bool BlockchainSQLite::add_block(
 
     try {
         std::optional<SQLite::Transaction> transaction{std::nullopt};
-        if (!rescan_tx) {
+        if (!rescan_tx)
             transaction.emplace(db, SQLite::TransactionBehavior::IMMEDIATE);
-        }
+
         // Goes through the miner transactions vouts checks they are right and marks them as paid in
         // the database
         if (!validate_batch_payment(miner_tx_vouts, calculated_rewards, block_height, rescan))
             return false;
+
         reward_handler(block, service_nodes_state, block_add, get_delayed_payments(block_height));
-        update_height(height + 1);
-        if (transaction)
+        submit_stakes_metadata(*this, block_add);
+        update_height(height + 1); // NOTE: Update height which synchronises the archive/recent tables
+
+        if (transaction) {
             transaction->commit();
-        else {  // rescanning
+        } else {  // rescanning
             if (++rescan_count >= 100 || height >= rescan_target) {
                 rescan_stop();
                 if (height < rescan_target)
                     rescan_start();
             }
         }
+
     } catch (std::exception& e) {
-        log::error(logcat, "Error adding reward payments: {}", e.what());
+        log::error(logcat, "Error adding reward payments at block {}: {}", block.get_height(), e.what());
         return false;
     }
     return true;
 }
 
 bool BlockchainSQLite::add_delayed_payments(
-        std::span<const exit_stake> payments, uint64_t at_height, uint64_t delay_blocks) {
+        std::span<const service_nodes::eth_stake> payments,
+        uint64_t at_height,
+        uint64_t delay_blocks) {
     ZoneScoped;
     log::trace(logcat, "BlockchainSQLite::{} called", __func__);
     try {
@@ -1151,6 +1277,22 @@ bool BlockchainSQLite::save_payments(
             return false;
         }
         select_sum->reset();
+    }
+
+    // NOTE: For pre-ETH hardfork. Oxen SN's were paid and the amount paid was subtracted
+    // from the accumulated amount in the DB. After the ETH hardfork the DB tracks
+    // the lifetime rewards and instead the smart contract tracks how much has been paid
+    // out. The delta in how much the DB has allocated and how much the smart contract
+    // has paid is the amount owed.
+    //
+    // In other words after hardforking, rewards amounts are strictly accumulative which
+    // means this condition will never trigger.
+    //
+    // Paid amounts is only populated with miner-tx, OXEN style payments. This array is empty
+    // if payouts are being done with SESH rewards.
+    if (paid_amounts.size()) {
+        auto cleanup_st = prepared_st("DELETE FROM batched_payments_accrued WHERE amount = 0");
+        exec_query(cleanup_st);
     }
     return true;
 }

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -595,19 +595,113 @@ std::pair<int, std::string> BlockchainSQLite::get_address_str(
     return result;
 }
 
+constexpr std::string_view WALLET_METADATA_FIELDS =
+        " amount,"
+        " lifetime_locked_stakes,"
+        " lifetime_unlocked_stakes,"
+        " lifetime_liquidated_stakes,"
+        " lifetime_rewards";
+
+static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
+        BlockchainSQLite& db,
+        std::string_view address,
+        std::optional<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>> metadata,
+        uint64_t height) {
+    BlockchainSQLite::wallet_info result = {};
+    result.height = height;
+    if (metadata) {
+        int64_t amount = std::get<0>(*metadata);
+        int64_t lifetime_locked_stakes = std::get<1>(*metadata);
+        int64_t lifetime_unlocked_stakes = std::get<2>(*metadata);
+        int64_t lifetime_liquidated_stakes = std::get<3>(*metadata);
+        int64_t lifetime_rewards = std::get<4>(*metadata);
+        assert(amount >= 0);
+        assert(lifetime_locked_stakes >= 0);
+        assert(lifetime_unlocked_stakes >= 0);
+        assert(lifetime_rewards >= 0);
+
+        int64_t rederived_amount = lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes;
+        if (amount != rederived_amount) {
+            log::error(
+                    logcat,
+                    "Internal error: SN contributor {} at height {} lifetime claimable amount "
+                    "does not match the sum of the unlocked stakes, rewards and liquidated stakes\n"
+                    "  lifetime claimable  {}\n"
+                    "  lifetime rewards    {}\n"
+                    "  lifetime unlocked   {}\n"
+                    "  lifetime liquidated {}\n"
+                    "Final calculated values were (claimable vs rederived claimable): {} != {}",
+                    address,
+                    height,
+                    cryptonote::print_money(amount,                     false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                    cryptonote::print_money(lifetime_unlocked_stakes,   false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                    cryptonote::print_money(lifetime_rewards,           false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                    cryptonote::print_money(lifetime_liquidated_stakes, false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                    cryptonote::print_money(amount,                     false, oxen::DISPLAY_DECIMAL_POINT + 3),
+                    cryptonote::print_money(rederived_amount,           false, oxen::DISPLAY_DECIMAL_POINT + 3));
+            assert(amount == rederived_amount);
+        }
+
+        result.found = true;
+        result.amount = cryptonote::reward_money::db_amount(amount);
+        result.lifetime_locked_stakes =
+                cryptonote::reward_money::db_amount(lifetime_locked_stakes);
+        result.lifetime_unlocked_stakes =
+                cryptonote::reward_money::db_amount(lifetime_unlocked_stakes);
+        result.lifetime_liquidated_stakes =
+                cryptonote::reward_money::db_amount(lifetime_liquidated_stakes);
+        result.lifetime_rewards = cryptonote::reward_money::db_amount(lifetime_rewards);
+        result.locked_stakes = result.lifetime_locked_stakes - result.lifetime_unlocked_stakes;
+
+        cryptonote::reward_money rederived_lifetime_rewards =
+                result.amount -
+                (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
+        assert(rederived_lifetime_rewards == result.lifetime_rewards);
+
+        // NOTE: Delayed payments is only supported on ETH addresses
+        if (eth::address eth_addr; tools::try_load_from_hex_guts(address, eth_addr)) {
+            cryptonote::BlockchainSQLite::delayed_payments_request request = {};
+            request.type = cryptonote::BlockchainSQLite::delayed_payments_type::address;
+            request.address = eth_addr;
+
+            block_payments delayed_payments = db.get_delayed_payments(request);
+            for (auto it : delayed_payments) {
+                const cryptonote::sql_payment& payment = it.second;
+                assert(payment.amount.to_coin() >= payment.liquidation.to_coin());
+                result.timelocked_stakes += payment.amount - payment.liquidation;
+            }
+        }
+    }
+    return result;
+}
+
+static BlockchainSQLite::wallet_info get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address) {
+    log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
+    auto tuple = db.prepared_maybe_get<int64_t, int64_t, int64_t, int64_t, int64_t>(
+            "SELECT"
+            " {}"
+            " FROM batched_payments_accrued"
+            " WHERE address = ?"_format(WALLET_METADATA_FIELDS),
+            address);
+
+    BlockchainSQLite::wallet_info result =
+            wallet_metadata_tuple_to_wallet_info(db, address, tuple, db.height);
+    return result;
+}
+
 void BlockchainSQLite::add_sn_rewards(const block_payments& payments, bool rewards_payment) {
     ZoneScoped;
     log::trace(logcat, "BlockchainDB_SQLITE::{}", __func__);
 
-    std::string query;
+    std::string insert_query;
     if (rewards_payment) {
-        query = "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
+        insert_query =
+                "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
                 " VALUES (?, ?, ?)"
-                " ON CONFLICT (address) DO UPDATE SET"
-                "   amount           = amount           + excluded.amount,"
-                "   lifetime_rewards = lifetime_rewards + excluded.amount;";
+                " ON CONFLICT (address) DO UPDATE SET amount = amount + excluded.amount";
     } else {
-        query = "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
+        insert_query =
+                "INSERT INTO batched_payments_accrued (address, payout_offset, amount)"
                 " VALUES (?, ?, ?)"
                 " ON CONFLICT (address) DO UPDATE SET"
                 "   amount                     = amount + excluded.amount,"
@@ -615,32 +709,39 @@ void BlockchainSQLite::add_sn_rewards(const block_payments& payments, bool rewar
                 "   lifetime_liquidated_stakes = lifetime_liquidated_stakes + ?;";
     }
 
-    auto insert_payment = prepared_st(query);
+    auto insert_payment = prepared_st(insert_query);
+    auto update_lifetime_rewards = prepared_st(
+            "UPDATE batched_payments_accrued"
+            " SET lifetime_rewards = lifetime_rewards + ?"
+            " WHERE address = ?");
+
     const auto& netconf = get_config(m_nettype);
 
     for (auto& it : payments) {
         const sql_payment& payment = it.second;
         auto [offset, address_str] = get_address_str(it.first, netconf.BATCHING_INTERVAL);
         cryptonote::reward_money amount = payment.amount - payment.liquidation;
+        auto amount_i64 = static_cast<int64_t>(amount.to_db());
         log::trace(
                 logcat,
                 "Adding record for SN reward contributor {} to database with amount {}",
                 address_str,
-                amount.to_db());
+                amount_i64);
 
         if (rewards_payment) {
-            db::exec_query(
-                    insert_payment, address_str, offset, static_cast<int64_t>(amount.to_db()));
+            exec_query(insert_payment, address_str, offset, amount_i64);
+            exec_query(update_lifetime_rewards, amount_i64, address_str);
         } else {
             db::exec_query(
                     insert_payment,
                     address_str,
                     offset,
-                    static_cast<int64_t>(amount.to_db()),
+                    amount_i64,
                     static_cast<int64_t>(payment.amount.to_db()),
                     static_cast<int64_t>(payment.liquidation.to_db()));
         }
         insert_payment->reset();
+        update_lifetime_rewards->reset();
     }
 }
 
@@ -764,77 +865,6 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     }
 
     return payments;
-}
-
-static BlockchainSQLite::wallet_info wallet_metadata_tuple_to_wallet_info(
-        BlockchainSQLite& db,
-        std::string_view address,
-        std::optional<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>> metadata,
-        uint64_t height) {
-    BlockchainSQLite::wallet_info result = {};
-    result.height = height;
-    if (metadata) {
-        int64_t amount_db = std::get<0>(*metadata);
-        int64_t lifetime_locked_stakes_db = std::get<1>(*metadata);
-        int64_t lifetime_unlocked_stakes_db = std::get<2>(*metadata);
-        int64_t lifetime_liquidated_stakes_db = std::get<3>(*metadata);
-        int64_t lifetime_rewards_db = std::get<4>(*metadata);
-        assert(amount_db >= 0);
-        assert(lifetime_locked_stakes_db >= 0);
-        assert(lifetime_unlocked_stakes_db >= 0);
-        assert(lifetime_rewards_db >= 0);
-        assert(amount_db ==
-               (lifetime_unlocked_stakes_db + lifetime_rewards_db - lifetime_liquidated_stakes_db));
-
-        result.found = true;
-        result.amount = cryptonote::reward_money::db_amount(amount_db);
-        result.lifetime_locked_stakes =
-                cryptonote::reward_money::db_amount(lifetime_locked_stakes_db);
-        result.lifetime_unlocked_stakes =
-                cryptonote::reward_money::db_amount(lifetime_unlocked_stakes_db);
-        result.lifetime_liquidated_stakes =
-                cryptonote::reward_money::db_amount(lifetime_liquidated_stakes_db);
-        result.lifetime_rewards = cryptonote::reward_money::db_amount(lifetime_rewards_db);
-        result.locked_stakes = result.lifetime_locked_stakes - result.lifetime_unlocked_stakes;
-        result.rewards = result.amount -
-                         (result.lifetime_unlocked_stakes - result.lifetime_liquidated_stakes);
-
-        // NOTE: Delayed payments is only supported on ETH addresses
-        if (eth::address eth_addr; tools::try_load_from_hex_guts(address, eth_addr)) {
-            cryptonote::BlockchainSQLite::delayed_payments_request request = {};
-            request.type = cryptonote::BlockchainSQLite::delayed_payments_type::address;
-            request.address = eth_addr;
-
-            block_payments delayed_payments = db.get_delayed_payments(request);
-            for (auto it : delayed_payments) {
-                const cryptonote::sql_payment& payment = it.second;
-                assert(payment.amount.to_coin() >= payment.liquidation.to_coin());
-                result.timelocked_stakes += payment.amount - payment.liquidation;
-            }
-        }
-    }
-    return result;
-}
-
-constexpr std::string_view WALLET_METADATA_FIELDS =
-        " amount,"
-        " lifetime_locked_stakes,"
-        " lifetime_unlocked_stakes,"
-        " lifetime_liquidated_stakes,"
-        " lifetime_rewards";
-
-static BlockchainSQLite::wallet_info get_accrued_rewards_impl(BlockchainSQLite& db, const std::string& address) {
-    log::trace(logcat, "BlockchainDB_SQLITE {} for {}", __func__, address);
-    auto tuple = db.prepared_maybe_get<int64_t, int64_t, int64_t, int64_t, int64_t>(
-            "SELECT"
-            " {}"
-            " FROM batched_payments_accrued"
-            " WHERE address = ?"_format(WALLET_METADATA_FIELDS),
-            address);
-
-    BlockchainSQLite::wallet_info result =
-            wallet_metadata_tuple_to_wallet_info(db, address, tuple, db.height);
-    return result;
 }
 
 static BlockchainSQLite::wallet_info get_accrued_rewards_at_impl(
@@ -1153,9 +1183,9 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
         // NOTE: Verify the DB operations did what we expected
         BlockchainSQLite::wallet_info wallet_info_after = get_accrued_rewards_impl(db, address);
         assert(wallet_info_after.found);
-        log::error(
+        log::trace(
                 logcat,
-                "SN contributor ({}) at height {} locked {} SESH ({} => {} total) into SN {}",
+                "SN contributor {} at height {} locked {} SESH ({} => {} total) into SN {}",
                 address,
                 db.height + 1,
                 cryptonote::print_money(it.amount.to_coin()),
@@ -1167,11 +1197,13 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
     }
 
     // NOTE: Submit purge stakes
-    auto purged_stakes = db.prepared_st("UPDATE batched_payments_accrued "
-                    "SET "
-                    "  lifetime_unlocked_stakes   = (lifetime_unlocked_stakes   + ?),"
-                    "  lifetime_liquidated_stakes = (lifetime_liquidated_stakes + ?)"
-                    "WHERE address = ?");
+    // For purged stakes, these funds have "disappeared" from the contract (node is in the SNL but
+    // _not_ in the contract). To account for this we need to undo the stakes we counted as being
+    // locked up.
+    auto purged_stakes = db.prepared_st(
+            "UPDATE batched_payments_accrued"
+            " SET lifetime_locked_stakes = (lifetime_locked_stakes - ?)"
+            " WHERE address = ?");
 
     for (const auto& it : block_add.purged_stakes) {
         assert(it.amount.to_db() > 0);
@@ -1199,9 +1231,9 @@ static void submit_stakes_metadata(BlockchainSQLite& db, const service_nodes::bl
         // NOTE: Verify the DB operations did what we expected
         BlockchainSQLite::wallet_info wallet_info_after = get_accrued_rewards_impl(db, address);
         assert(wallet_info_after.found);
-        log::error(
+        log::trace(
                 logcat,
-                "SN contributor ({}) at height {} purged {} SESH ({} => {} total) into SN {}",
+                "SN contributor {} at height {} purged {} SESH ({} => {} total) into SN {}",
                 address,
                 db.height + 1,
                 cryptonote::print_money(it.amount.to_coin()),

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -39,9 +39,16 @@
 
 namespace cryptonote {
 
-using block_payments = std::unordered_map<
-        std::variant<eth::address, cryptonote::account_public_address>,
-        cryptonote::reward_money>;
+struct sql_payment {
+    cryptonote::reward_money amount;  // The amount to payout not including the liqudation fee
+
+    // Fee to apply on the payment amount, 0 in most cases except when the payment is the return of
+    // a stake after being liquidated and the associated address is the operator.
+    cryptonote::reward_money liquidation;
+};
+
+using block_payments = std::
+        unordered_map<std::variant<eth::address, cryptonote::account_public_address>, sql_payment>;
 
 class BlockchainSQLite : public db::Database {
   public:
@@ -78,7 +85,25 @@ class BlockchainSQLite : public db::Database {
 
     // Add payments to the specified addresses to the SQL rewards table. The function throws if
     // insertion into the DB fails.
-    void add_sn_rewards(const block_payments& payments);
+    //
+    // If the payments are token rewards set `is_rewards` to true to ensure that rewards are
+    // tracked in a separate column. Set it to `false` if payments are for delayed/exit payments
+    // inorder to separate the tracked rewards from the exit payments values.
+    void add_sn_rewards(const block_payments& payments, bool is_rewards);
+
+    enum class delayed_payments_type {
+        all,
+        height,
+        address,
+    };
+
+    struct delayed_payments_request {
+        delayed_payments_type type;
+        uint64_t height;
+        eth::address address;
+    };
+
+    block_payments get_delayed_payments(const delayed_payments_request& request);
 
   private:
     // This function throws if adding the rewards to the SQL tables for 'block'
@@ -86,10 +111,7 @@ class BlockchainSQLite : public db::Database {
     void reward_handler(
             const cryptonote::block& block,
             const service_nodes::service_node_list::state_t& service_nodes_state,
-            const service_nodes::block_add_result& block_add,
-            block_payments payments = {});
-
-    block_payments get_delayed_payments(uint64_t height);
+            const service_nodes::block_add_result& block_add);
 
     std::unordered_map<account_public_address, std::string> address_str_cache;
     std::pair<hf, cryptonote::address_parse_info> parsed_governance_addr = {hf::none, {}};
@@ -121,8 +143,14 @@ class BlockchainSQLite : public db::Database {
     struct wallet_info {
         bool found;
         uint64_t height;
-        cryptonote::reward_money total_rewards;  // Rewards + unlocked stakes owed to wallet
-        cryptonote::reward_money locked_stakes;
+        cryptonote::reward_money amount;  // Rewards + unlocked stakes owed to wallet
+        cryptonote::reward_money lifetime_locked_stakes;
+        cryptonote::reward_money lifetime_unlocked_stakes;
+        cryptonote::reward_money lifetime_rewards;
+        cryptonote::reward_money lifetime_liquidated_stakes;
+        cryptonote::reward_money locked_stakes;      // SESH locked by the network
+        cryptonote::reward_money timelocked_stakes;  // SESH awaiting to be unlocked by the network
+        cryptonote::reward_money rewards;            // Total rewards the wallet has earnt
     };
 
     // Retrieves the amount (in atomic SENT) that has been accrued to the Ethereum `address`.

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -89,7 +89,7 @@ class BlockchainSQLite : public db::Database {
     // If the payments are token rewards set `is_rewards` to true to ensure that rewards are
     // tracked in a separate column. Set it to `false` if payments are for delayed/exit payments
     // inorder to separate the tracked rewards from the exit payments values.
-    void add_sn_rewards(const block_payments& payments, bool is_rewards);
+    void add_sn_rewards(hf hf_version, const block_payments& payments, bool is_rewards);
 
     enum class delayed_payments_type {
         all,

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -192,11 +192,9 @@ class BlockchainSQLite : public db::Database {
     // wallet info.
     wallet_info get_accrued_rewards(const account_public_address& address, uint64_t at_height);
 
-    // get_all_accrued_rewards -> queries the database for all the amount that has been accrued to
-    // service nodes will return 2 vectors corresponding to the addresses and the atomic value in
-    // oxen that the service nodes are owed.
-    std::pair<std::vector<std::string>, std::vector<cryptonote::reward_money>>
-    get_all_accrued_rewards();
+    // get_all_accrued_rewards -> queries the database for all the amounts that have been accrued to
+    // nodes and will return 2 vectors corresponding to the addresses's wallet info.
+    std::pair<std::vector<std::string>, std::vector<wallet_info>> get_all_accrued_rewards();
 
     // get_payments -> passing a block height will return an array of payments that should be
     // created in a coinbase transaction on that block given the current batching DB state.

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -141,39 +141,55 @@ class BlockchainSQLite : public db::Database {
 
   public:
     struct wallet_info {
+        uint64_t height;  // Height at which the wallet info was retrieved for
+
+        // True if the wallet has participated in the network or not. When false all values are
+        // zeroed (because the wallet has not earnt or spent any tokens on the network).
         bool found;
-        uint64_t height;
-        cryptonote::reward_money amount;  // Rewards + unlocked stakes owed to wallet
+
+        // For OXEN addresses, rewards that has been accrued but not paid out to the address yet.
+        //
+        // For ETH addresses, lifetime rewards _and_ unlocked stakes for the address. (Note that,
+        // unlike Oxen addresses, these rewards never reset to zero; but rather the rewards contract
+        // keeps track of the current paid and current total and pays out the difference).
+        cryptonote::reward_money amount;
+
+        // For ETH addresses _only_, the total amount of tokens that were locked by this wallet and
+        // so forth for lifetime unlocked, rewards and liquidated amounts.
         cryptonote::reward_money lifetime_locked_stakes;
         cryptonote::reward_money lifetime_unlocked_stakes;
         cryptonote::reward_money lifetime_rewards;
         cryptonote::reward_money lifetime_liquidated_stakes;
-        cryptonote::reward_money locked_stakes;      // SESH locked by the network
-        cryptonote::reward_money timelocked_stakes;  // SESH awaiting to be unlocked by the network
-        cryptonote::reward_money rewards;            // Total rewards the wallet has earnt
+
+        // For ETH addresses _only_, the amount of tokens currently locked in the network (e.g.
+        // staked in a node). This is defined as `lifetime locked - lifetimed unlocked`
+        cryptonote::reward_money locked_stakes;
+
+        // For ETH addresses _only_, the amount of tokens awaiting to be unlocked from the network
+        // (e.g. an exit has been processed and the stake is under a time lock before being
+        // claimable by the address)
+        cryptonote::reward_money timelocked_stakes;
+
+        // Total lifetime rewards the wallet has earnt from participating as a staker in a node.
+        // This is defined as `amount - (lifetime unlock - lifetime liquidated)` and precalculated
+        // for convenience
+        cryptonote::reward_money rewards;
     };
 
-    // Retrieves the amount (in atomic SENT) that has been accrued to the Ethereum `address`.
-    // Returns the current height and the atomic lifetime value that the address is owed.  (Note
-    // that, unlike Oxen addresses, these rewards never reset to zero; but rather the rewards
-    // contract keeps track of the current paid and current total and pays out the difference).
+    // See `wallet_info`
     wallet_info get_accrued_rewards(const eth::address& address);
 
-    // Retrieves the amount (in atomic OXEN) that has been accrued but not yet paid out to the Oxen
-    // wallet `address`.  Returns the current height and the atomic unpaid amount that the address
-    // is owed.
+    // See `wallet_info`
     wallet_info get_accrued_rewards(const account_public_address& address);
 
-    // Returns the amount that has been accrued to the Ethereum `address` as of the given recent
-    // block height `at_height`. Returns nullopt if `at_height` is higher than the current block
-    // height, or lower than the oldest stored recent height (see network_config's
-    // STORE_RECENT_REWARDS;, otherwise returns the balance.
+    // Returns `found` as `false` if `at_height` is higher than the current block height, or lower
+    // than the oldest stored recent height (see network_config's STORE_RECENT_REWARDS;, otherwise
+    // returns the balance.
     wallet_info get_accrued_rewards(const eth::address& address, uint64_t at_height);
 
-    // Returns the amount (in atomic OXEN) that has been accrued to the Oxen wallet `address` as of
-    // the given recent block height `at_height`.  Returns nullopt if `at_height` is higher than the
-    // known height, or lower than the stored recent heights (see network_config's
-    // STORE_RECENT_REWARDS); otherwise returns the balance.
+    // Returns `found` as `false` if `at_height` is higher than the known height, or lower than the
+    // stored recent heights (see network_config's STORE_RECENT_REWARDS); otherwise returns the
+    // wallet info.
     wallet_info get_accrued_rewards(const account_public_address& address, uint64_t at_height);
 
     // get_all_accrued_rewards -> queries the database for all the amount that has been accrued to

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -118,30 +118,35 @@ class BlockchainSQLite : public db::Database {
     uint64_t rescan_target{0};
 
   public:
-    // Retrieves the amount that has been accrued to the Ethereum `address`. Returns the current
-    // height and the atomic lifetime value that the address is owed. (Note that, unlike Oxen
-    // addresses, these rewards never reset to zero; but rather the rewards contract keeps track of
-    // the current paid and current total and pays out the difference).
-    std::pair<uint64_t, cryptonote::reward_money> get_accrued_rewards(const eth::address& address);
+    struct wallet_info {
+        bool found;
+        uint64_t height;
+        cryptonote::reward_money total_rewards;  // Rewards + unlocked stakes owed to wallet
+        cryptonote::reward_money locked_stakes;
+    };
 
-    // Retrieves the amount that has been accrued but not yet paid out to the Oxen wallet `address`.
-    // Returns the current height and the atomic unpaid amount that the address is owed.
-    std::pair<uint64_t, cryptonote::reward_money> get_accrued_rewards(
-            const account_public_address& address);
+    // Retrieves the amount (in atomic SENT) that has been accrued to the Ethereum `address`.
+    // Returns the current height and the atomic lifetime value that the address is owed.  (Note
+    // that, unlike Oxen addresses, these rewards never reset to zero; but rather the rewards
+    // contract keeps track of the current paid and current total and pays out the difference).
+    wallet_info get_accrued_rewards(const eth::address& address);
+
+    // Retrieves the amount (in atomic OXEN) that has been accrued but not yet paid out to the Oxen
+    // wallet `address`.  Returns the current height and the atomic unpaid amount that the address
+    // is owed.
+    wallet_info get_accrued_rewards(const account_public_address& address);
 
     // Returns the amount that has been accrued to the Ethereum `address` as of the given recent
     // block height `at_height`. Returns nullopt if `at_height` is higher than the current block
     // height, or lower than the oldest stored recent height (see network_config's
     // STORE_RECENT_REWARDS;, otherwise returns the balance.
-    std::optional<cryptonote::reward_money> get_accrued_rewards(
-            const eth::address& address, uint64_t at_height);
+    wallet_info get_accrued_rewards(const eth::address& address, uint64_t at_height);
 
-    // Returns the amount that has been accrued to the Oxen wallet `address` as of the given recent
-    // block height `at_height`. Returns nullopt if `at_height` is higher than the known height, or
-    // lower than the stored recent heights (see network_config's STORE_RECENT_REWARDS); otherwise
-    // returns the balance.
-    std::optional<cryptonote::reward_money> get_accrued_rewards(
-            const account_public_address& address, uint64_t height);
+    // Returns the amount (in atomic OXEN) that has been accrued to the Oxen wallet `address` as of
+    // the given recent block height `at_height`.  Returns nullopt if `at_height` is higher than the
+    // known height, or lower than the stored recent heights (see network_config's
+    // STORE_RECENT_REWARDS); otherwise returns the balance.
+    wallet_info get_accrued_rewards(const account_public_address& address, uint64_t at_height);
 
     // get_all_accrued_rewards -> queries the database for all the amount that has been accrued to
     // service nodes will return 2 vectors corresponding to the addresses and the atomic value in
@@ -178,19 +183,13 @@ class BlockchainSQLite : public db::Database {
             const service_nodes::block_add_result& block_add,
             const std::optional<service_nodes::rescan_context>& rescan = std::nullopt);
 
-    struct exit_stake {
-        eth::address addr;
-        cryptonote::reward_money amount;
-        uint32_t block_height;  // Block that the exit event was mined in
-        uint32_t tx_index;  // Index of transaction in the block that the exit event was mined in
-        uint32_t contributor_index;  // Index of the contributor in the event the exit stake is for
-    };
-
     // Add a payment to the delayed_payments table. 'at_height' should be greater than or equal to
     // the height of the table or otherwise the payments may be deleted without taking effect. This
     // function asserts if 'at_height' does not meet this criteria.
     bool add_delayed_payments(
-            std::span<const exit_stake> payments, uint64_t at_height, uint64_t delay_blocks);
+            std::span<const service_nodes::eth_stake> payments,
+            uint64_t at_height,
+            uint64_t delay_blocks);
 
     // validate_batch_payment -> used to make sure that list of miner_tx_vouts is correct. Compares
     // the miner_tx_vouts with a list previously extracted payments to make sure that the correct

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -152,6 +152,9 @@ class BlockchainSQLite : public db::Database {
         // For ETH addresses, lifetime rewards _and_ unlocked stakes for the address. (Note that,
         // unlike Oxen addresses, these rewards never reset to zero; but rather the rewards contract
         // keeps track of the current paid and current total and pays out the difference).
+        //
+        // For ETH addresses, this can be derived by
+        // `lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes`
         cryptonote::reward_money amount;
 
         // For ETH addresses _only_, the total amount of tokens that were locked by this wallet and
@@ -162,18 +165,14 @@ class BlockchainSQLite : public db::Database {
         cryptonote::reward_money lifetime_liquidated_stakes;
 
         // For ETH addresses _only_, the amount of tokens currently locked in the network (e.g.
-        // staked in a node). This is defined as `lifetime locked - lifetimed unlocked`
+        // staked in a node). This is defined as `lifetime locked - lifetimed unlocked` and
+        // precalculated for convenience. This number includes `timelocked_stakes`.
         cryptonote::reward_money locked_stakes;
 
         // For ETH addresses _only_, the amount of tokens awaiting to be unlocked from the network
         // (e.g. an exit has been processed and the stake is under a time lock before being
         // claimable by the address)
         cryptonote::reward_money timelocked_stakes;
-
-        // Total lifetime rewards the wallet has earnt from participating as a staker in a node.
-        // This is defined as `amount - (lifetime unlock - lifetime liquidated)` and precalculated
-        // for convenience
-        cryptonote::reward_money rewards;
     };
 
     // See `wallet_info`

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -247,11 +247,6 @@ class BlockchainSQLite : public db::Database {
     // batched_payments_paid database as height_paid.
     bool save_payments(uint64_t block_height, std::span<const batch_sn_payment> paid_amounts);
 
-    // Just before HF21, all pending oxen rewards for addresses not registered to transition
-    // will be paid out.  At HF21, all pending oxen rewards for addresses which *are*
-    // registered to transition will be converted to SENT.
-    void set_rewards_hf21(const std::unordered_map<eth::address, uint64_t>& rewards);
-
     uint64_t height;
 
   protected:

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -800,10 +800,10 @@ void bls_aggregator::get_rewards(oxenmq::Message& m) const {
     bls_signature sig = eth::sign(core.get_nettype(), core.get_service_keys().key_bls, msg);
 
     oxenc::bt_dict_producer d;
-    d.append("address", tools::view_guts(eth_addr));          // Address requesting balance
+    d.append("address", tools::view_guts(eth_addr));   // Address requesting balance
     d.append("amount", wallet_info.amount.to_coin());  // Balance
-    d.append("height", height);                               // Height of balance
-    d.append("signature", tools::view_guts(sig));             // Signature of addr + balance
+    d.append("height", height);                        // Height of balance
+    d.append("signature", tools::view_guts(sig));      // Signature of addr + balance
 
     m.send_reply("200", std::move(d).str());
 }

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -781,28 +781,29 @@ void bls_aggregator::get_rewards(oxenmq::Message& m) const {
         return;
     }
 
-    auto maybe_amount = core.blockchain.sqlite_db().get_accrued_rewards(eth_addr, height);
-    if (!maybe_amount) {
+    cryptonote::BlockchainSQLite::wallet_info wallet_info =
+            core.blockchain.sqlite_db().get_accrued_rewards(eth_addr, height);
+    if (!wallet_info.found) {
         m.send_reply("410", "Balances for height {} are not available"_format(height));
         return;
     }
-    auto amount = maybe_amount->to_coin();
 
     // We sign H(H(rewardTag || chainid || contract) || recipientAddress ||
     // recipientAmount),
     // where everything is in bytes, and recipientAmount is a 32-byte big
     // endian integer value.
-    std::array<std::byte, 32> amount_be = tools::encode_integer_be<32>(amount);
+    std::array<std::byte, 32> amount_be =
+            tools::encode_integer_be<32>(wallet_info.total_rewards.to_coin());
 
     std::vector<uint8_t> msg =
             get_reward_balance_msg_to_sign(core.get_nettype(), eth_addr, amount_be);
     bls_signature sig = eth::sign(core.get_nettype(), core.get_service_keys().key_bls, msg);
 
     oxenc::bt_dict_producer d;
-    d.append("address", tools::view_guts(eth_addr));  // Address requesting balance
-    d.append("amount", amount);                       // Balance
-    d.append("height", height);                       // Height of balance
-    d.append("signature", tools::view_guts(sig));     // Signature of addr + balance
+    d.append("address", tools::view_guts(eth_addr));          // Address requesting balance
+    d.append("amount", wallet_info.total_rewards.to_coin());  // Balance
+    d.append("height", height);                               // Height of balance
+    d.append("signature", tools::view_guts(sig));             // Signature of addr + balance
 
     m.send_reply("200", std::move(d).str());
 }
@@ -812,18 +813,18 @@ void bls_aggregator::rewards_request(
         uint64_t height,
         std::function<void(std::shared_ptr<const bls_rewards_response>)> callback) {
     ZoneScoped;
-    auto maybe_amount = core.blockchain.sqlite_db().get_accrued_rewards(addr, height);
-    auto amount = maybe_amount.value_or(cryptonote::reward_money::coin_amount(0));
+    cryptonote::BlockchainSQLite::wallet_info wallet_info =
+            core.blockchain.sqlite_db().get_accrued_rewards(addr, height);
 
     // FIXME: make this async
     oxen::log::trace(
             logcat,
             "Initiating rewards request of {} SENT for {} at height {}",
-            amount.to_coin(),
+            wallet_info.total_rewards,
             addr,
             height);
 
-    if (!maybe_amount)
+    if (!wallet_info.found)
         throw oxen::traced<std::invalid_argument>(fmt::format(
                 "Aggregating a rewards request for '{}' at height {} is invalid because "
                 "reward data is not available for that height. Request rejected.",
@@ -835,10 +836,13 @@ void bls_aggregator::rewards_request(
         throw oxen::traced<std::invalid_argument>(
                 "Aggregating a rewards request for the zero address for {} SENT at height {} is "
                 "invalid. Request rejected"_format(
-                        addr, amount, height, core.service_node_list.height()));
+                        addr,
+                        wallet_info.total_rewards.to_coin(),
+                        height,
+                        core.service_node_list.height()));
     }
 
-    if (amount.to_coin() == 0) {
+    if (wallet_info.total_rewards.to_coin() == 0) {
         throw oxen::traced<std::invalid_argument>(
                 "Aggregating a rewards request for '{}' for 0 SENT at height {} is invalid because "
                 "no rewards are available. Request rejected."_format(addr, height));
@@ -850,14 +854,15 @@ void bls_aggregator::rewards_request(
         auto cache_it = rewards_response_cache.find(addr);
         if (cache_it != rewards_response_cache.end()) {
             auto cache_response = cache_it->second;
-            if (cache_response->height == height && cache_response->amount == amount.to_coin()) {
+            if (cache_response->height == height &&
+                cache_response->amount == wallet_info.total_rewards.to_coin()) {
                 log::trace(
                         logcat,
                         "Serving rewards request from cache for address {} at height {} with "
                         "rewards {} amount",
                         addr,
                         height,
-                        amount);
+                        wallet_info.total_rewards.to_coin());
                 callback(cache_response);
                 return;
             }
@@ -867,10 +872,12 @@ void bls_aggregator::rewards_request(
     auto result_data = std::make_shared<aggregate_result<bls_rewards_response>>();
     auto& result = *result_data->result;
     result.addr = std::move(addr);
-    result.amount = amount.to_coin();
+    result.amount = wallet_info.total_rewards.to_coin();
     result.height = height;
     result.msg_to_sign = get_reward_balance_msg_to_sign(
-            core.get_nettype(), result.addr, tools::encode_integer_be<32>(amount.to_coin()));
+            core.get_nettype(),
+            result.addr,
+            tools::encode_integer_be<32>(wallet_info.total_rewards.to_coin()));
 
     oxenc::bt_dict_producer d;
     d.append("address", tools::view_guts(result.addr));

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -793,7 +793,7 @@ void bls_aggregator::get_rewards(oxenmq::Message& m) const {
     // where everything is in bytes, and recipientAmount is a 32-byte big
     // endian integer value.
     std::array<std::byte, 32> amount_be =
-            tools::encode_integer_be<32>(wallet_info.total_rewards.to_coin());
+            tools::encode_integer_be<32>(wallet_info.amount.to_coin());
 
     std::vector<uint8_t> msg =
             get_reward_balance_msg_to_sign(core.get_nettype(), eth_addr, amount_be);
@@ -801,7 +801,7 @@ void bls_aggregator::get_rewards(oxenmq::Message& m) const {
 
     oxenc::bt_dict_producer d;
     d.append("address", tools::view_guts(eth_addr));          // Address requesting balance
-    d.append("amount", wallet_info.total_rewards.to_coin());  // Balance
+    d.append("amount", wallet_info.amount.to_coin());  // Balance
     d.append("height", height);                               // Height of balance
     d.append("signature", tools::view_guts(sig));             // Signature of addr + balance
 
@@ -820,7 +820,7 @@ void bls_aggregator::rewards_request(
     oxen::log::trace(
             logcat,
             "Initiating rewards request of {} SENT for {} at height {}",
-            wallet_info.total_rewards,
+            wallet_info.amount,
             addr,
             height);
 
@@ -837,12 +837,12 @@ void bls_aggregator::rewards_request(
                 "Aggregating a rewards request for the zero address for {} SENT at height {} is "
                 "invalid. Request rejected"_format(
                         addr,
-                        wallet_info.total_rewards.to_coin(),
+                        wallet_info.amount.to_coin(),
                         height,
                         core.service_node_list.height()));
     }
 
-    if (wallet_info.total_rewards.to_coin() == 0) {
+    if (wallet_info.amount.to_coin() == 0) {
         throw oxen::traced<std::invalid_argument>(
                 "Aggregating a rewards request for '{}' for 0 SENT at height {} is invalid because "
                 "no rewards are available. Request rejected."_format(addr, height));
@@ -855,14 +855,14 @@ void bls_aggregator::rewards_request(
         if (cache_it != rewards_response_cache.end()) {
             auto cache_response = cache_it->second;
             if (cache_response->height == height &&
-                cache_response->amount == wallet_info.total_rewards.to_coin()) {
+                cache_response->amount == wallet_info.amount.to_coin()) {
                 log::trace(
                         logcat,
                         "Serving rewards request from cache for address {} at height {} with "
                         "rewards {} amount",
                         addr,
                         height,
-                        wallet_info.total_rewards.to_coin());
+                        wallet_info.amount.to_coin());
                 callback(cache_response);
                 return;
             }
@@ -872,12 +872,12 @@ void bls_aggregator::rewards_request(
     auto result_data = std::make_shared<aggregate_result<bls_rewards_response>>();
     auto& result = *result_data->result;
     result.addr = std::move(addr);
-    result.amount = wallet_info.total_rewards.to_coin();
+    result.amount = wallet_info.amount.to_coin();
     result.height = height;
     result.msg_to_sign = get_reward_balance_msg_to_sign(
             core.get_nettype(),
             result.addr,
-            tools::encode_integer_be<32>(wallet_info.total_rewards.to_coin()));
+            tools::encode_integer_be<32>(wallet_info.amount.to_coin()));
 
     oxenc::bt_dict_producer d;
     d.append("address", tools::view_guts(result.addr));

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1226,12 +1226,12 @@ void get_blob_hash(const std::string_view blob, crypto::hash& res) {
     cn_fast_hash(blob.data(), blob.size(), res);
 }
 //---------------------------------------------------------------
-std::string print_money(uint64_t amount, size_t decimal_places, bool strip_zeros) {
+std::string print_money(uint64_t amount, bool strip_zeros, size_t decimal_point) {
     std::string s = std::to_string(amount);
-    if (s.size() < decimal_places + 1) {
-        s.insert(0, decimal_places + 1 - s.size(), '0');
+    if (s.size() < decimal_point + 1) {
+        s.insert(0, decimal_point + 1 - s.size(), '0');
     }
-    s.insert(s.size() - decimal_places, ".");
+    s.insert(s.size() - decimal_point, ".");
     if (strip_zeros) {
         while (s.back() == '0')
             s.pop_back();
@@ -1241,10 +1241,11 @@ std::string print_money(uint64_t amount, size_t decimal_places, bool strip_zeros
     return s;
 }
 //---------------------------------------------------------------
-std::string format_money(uint64_t amount, size_t decimal_places, bool strip_zeros) {
-    auto value = print_money(amount, strip_zeros, decimal_places);
-    auto result = "{} {}"_format(value, get_unit());
-    return result;
+std::string format_money(uint64_t amount, bool strip_zeros, size_t decimal_point) {
+    auto value = print_money(amount, strip_zeros, decimal_point);
+    value += ' ';
+    value += get_unit();
+    return value;
 }
 //---------------------------------------------------------------
 std::string print_tx_verification_context(

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1226,13 +1226,13 @@ void get_blob_hash(const std::string_view blob, crypto::hash& res) {
     cn_fast_hash(blob.data(), blob.size(), res);
 }
 //---------------------------------------------------------------
-std::string print_money(uint64_t amount, bool strip_zeros, size_t decimal_point) {
+std::string print_money(uint64_t amount, strip_zeros strip_z, size_t decimal_point) {
     std::string s = std::to_string(amount);
     if (s.size() < decimal_point + 1) {
         s.insert(0, decimal_point + 1 - s.size(), '0');
     }
     s.insert(s.size() - decimal_point, ".");
-    if (strip_zeros) {
+    if (strip_z == strip_zeros::yes) {
         while (s.back() == '0')
             s.pop_back();
         if (s.back() == '.')
@@ -1241,8 +1241,8 @@ std::string print_money(uint64_t amount, bool strip_zeros, size_t decimal_point)
     return s;
 }
 //---------------------------------------------------------------
-std::string format_money(uint64_t amount, bool strip_zeros, size_t decimal_point) {
-    auto value = print_money(amount, strip_zeros, decimal_point);
+std::string format_money(uint64_t amount, strip_zeros strip_z, size_t decimal_point) {
+    auto value = print_money(amount, strip_z, decimal_point);
     value += ' ';
     value += get_unit();
     return value;

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -300,14 +300,14 @@ constexpr std::string_view get_unit() {
 // Returns a monetary value with a decimal point; optionally strips insignificant trailing 0s.
 std::string print_money(
         uint64_t amount,
-        size_t decimal_places = oxen::DISPLAY_DECIMAL_POINT,
-        bool strip_zeros = false);
+        bool strip_zeros = false,
+        size_t decimal_point = oxen::DISPLAY_DECIMAL_POINT);
 // Returns a formatted monetary value including the unit, e.g. "1.234567 OXEN"; strips
 // insignificant trailing 0s by default (unlike the above) but can be overridden to not do that.
 std::string format_money(
         uint64_t amount,
-        size_t decimal_places = oxen::DISPLAY_DECIMAL_POINT,
-        bool strip_zeros = true);
+        bool strip_zeros = true,
+        size_t decimal_point = oxen::DISPLAY_DECIMAL_POINT);
 
 std::string print_tx_verification_context(
         tx_verification_context const& tvc, transaction const* tx = nullptr);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -297,16 +297,23 @@ std::vector<uint64_t> absolute_output_offsets_to_relative(const std::vector<uint
 constexpr std::string_view get_unit() {
     return "OXEN"sv;
 }
+
+enum class strip_zeros {
+    no,
+    yes,
+};
+
 // Returns a monetary value with a decimal point; optionally strips insignificant trailing 0s.
 std::string print_money(
         uint64_t amount,
-        bool strip_zeros = false,
+        strip_zeros strip_z = strip_zeros::no,
         size_t decimal_point = oxen::DISPLAY_DECIMAL_POINT);
+
 // Returns a formatted monetary value including the unit, e.g. "1.234567 OXEN"; strips
 // insignificant trailing 0s by default (unlike the above) but can be overridden to not do that.
 std::string format_money(
         uint64_t amount,
-        bool strip_zeros = true,
+        strip_zeros strip_z = strip_zeros::yes,
         size_t decimal_point = oxen::DISPLAY_DECIMAL_POINT);
 
 std::string print_tx_verification_context(

--- a/src/cryptonote_core/sent_transition/sent_transition.cpp
+++ b/src/cryptonote_core/sent_transition/sent_transition.cpp
@@ -840,6 +840,8 @@ void transition(
         for (size_t contrib_index = 0; contrib_index < it.sn_info->contributors.size(); contrib_index++) {
             auto contrib_it = it.sn_info->contributors[contrib_index];
             assert(!it.zombie && "Contributors should only be populated on non-zombie nodes");
+            assert(contrib_it.ethereum_address);
+            assert(contrib_it.address == cryptonote::account_public_address{});
             service_nodes::eth_stake stake = {
                     .sn = crypto::ed25519_public_key{it.pkey},
                     .addr = contrib_it.ethereum_address,

--- a/src/cryptonote_core/sent_transition/sent_transition.cpp
+++ b/src/cryptonote_core/sent_transition/sent_transition.cpp
@@ -449,7 +449,6 @@ void transition(
     // batching db.  (If there is SENT left over at the end we'll put it back in, but under the
     // converted SENT address).
 
-    cryptonote::block_payments converted_rewards;
     auto [accrued_addr, accrued_value] = sql.get_all_accrued_rewards();
     assert(accrued_addr.size() == accrued_value.size());
     for (size_t i = 0; i < accrued_addr.size(); i++) {
@@ -464,14 +463,13 @@ void transition(
             continue;
 
         const auto& eth_addr = it->second;
-        unallocated[eth_addr] += oxen_to_sent(val);
+        unallocated[eth_addr] += oxen_to_sent(val.amount);
         log::debug(
                 logcat,
                 "oxen -> sent ({} -> {}) accrued unpaid oxen rewards: {}",
                 addr,
                 eth_addr,
-                val);
-        converted_rewards[oxen_addr] = val;
+                cryptonote::print_money(val.amount.to_coin()));
     }
 
     for (const auto& [eth, amount] : unallocated) {

--- a/src/cryptonote_core/sent_transition/sent_transition.cpp
+++ b/src/cryptonote_core/sent_transition/sent_transition.cpp
@@ -133,7 +133,10 @@ static void dump_transition_outcome_csv(
         FileFormatter file{
                 "{:%Y%m%d_%H%M%S}_sesh_transition_result_stake_req_{}_conv_ratio_{}_oxen_per_{}_sesh_eth_addr_allocation.csv"_format(
                         fmt::localtime(now),
-                        cryptonote::print_money(context.staking_requirement, decimal_places, true),
+                        cryptonote::print_money(
+                                context.staking_requirement,
+                                cryptonote::strip_zeros::yes,
+                                decimal_places),
                         cryptonote::print_money(context.conv_ratio.second),
                         cryptonote::print_money(context.conv_ratio.first))};
         file.print("height,{}\n", snl_state.height);
@@ -326,7 +329,10 @@ static void dump_transition_outcome_csv(
         FileFormatter file{
                 "{:%Y%m%d_%H%M%S}_sesh_transition_result_stake_req_{}_conv_ratio_{}_oxen_per_{}_sesh_transition_{}pct.csv"_format(
                         fmt::localtime(now),
-                        cryptonote::print_money(context.staking_requirement, decimal_places, true),
+                        cryptonote::print_money(
+                                context.staking_requirement,
+                                cryptonote::strip_zeros::yes,
+                                decimal_places),
                         cryptonote::print_money(context.conv_ratio.second),
                         cryptonote::print_money(context.conv_ratio.first),
                         int(transition_pct))};

--- a/src/cryptonote_core/sent_transition/sent_transition.cpp
+++ b/src/cryptonote_core/sent_transition/sent_transition.cpp
@@ -477,7 +477,7 @@ void transition(
                 "oxen -> sent ({} -> {}) accrued unpaid oxen rewards: {}",
                 addr,
                 eth_addr,
-                cryptonote::print_money(val.amount.to_coin()));
+                val.amount);
     }
 
     for (const auto& [eth, amount] : unallocated) {
@@ -795,12 +795,12 @@ void transition(
     {
         sql.db.exec("DELETE FROM batched_payments_accrued");
         cryptonote::block_payments rewards_payments;
-        for (auto it : unallocated) {
+        for (const auto& [eth_addr, amt] : unallocated) {
             cryptonote::sql_payment payment = {};
-            payment.amount = cryptonote::reward_money::coin_amount(it.second);
-            rewards_payments[it.first] = payment;
+            payment.amount = cryptonote::reward_money::coin_amount(amt);
+            rewards_payments[eth_addr] = payment;
         }
-        sql.add_sn_rewards(cryptonote::hf::hf21_eth, rewards_payments, /*rewards_payment=*/ true);
+        sql.add_sn_rewards(cryptonote::hf::hf21_eth, rewards_payments, /*rewards_payment=*/true);
     }
 
     // First, clear the old key image blacklist so we don't leave unconverted stakes locked
@@ -843,21 +843,20 @@ void transition(
     for (auto& it : post_transition_sns) {
         // Record the stake metadata to the `block_add_result`. The SQL DB will process these when
         // it's update set is triggered
-        for (size_t contrib_index = 0; contrib_index < it.sn_info->contributors.size(); contrib_index++) {
-            auto contrib_it = it.sn_info->contributors[contrib_index];
+        for (size_t contrib_index = 0; contrib_index < it.sn_info->contributors.size();
+             contrib_index++) {
+            const auto& contrib = it.sn_info->contributors[contrib_index];
             assert(!it.zombie && "Contributors should only be populated on non-zombie nodes");
-            assert(contrib_it.ethereum_address);
-            assert(contrib_it.address == cryptonote::account_public_address{});
-            service_nodes::eth_stake stake = {
-                    .sn = crypto::ed25519_public_key{it.pkey},
-                    .addr = contrib_it.ethereum_address,
-                    .amount = cryptonote::reward_money::coin_amount(contrib_it.amount),
-                    .liquidation = cryptonote::reward_money{},
-                    .block_height = static_cast<uint32_t>(snl_state.height),
-                    .tx_index = synthetic_tx_index++,
-                    .contributor_index = static_cast<uint32_t>(contrib_index),
-            };
-            add_result.locked_stakes.push_back(stake);
+            assert(contrib.ethereum_address);
+            assert(contrib.address == cryptonote::account_public_address{});
+            auto& s = add_result.locked_stakes.emplace_back();
+            s.sn = crypto::ed25519_public_key{it.pkey};
+            s.addr = contrib.ethereum_address;
+            s.amount = cryptonote::reward_money::coin_amount(contrib.amount);
+            s.liquidation = cryptonote::reward_money{};
+            s.block_height = static_cast<uint32_t>(snl_state.height);
+            s.tx_index = synthetic_tx_index++;
+            s.contributor_index = static_cast<uint32_t>(contrib_index);
         }
 
         // Update the SNL with the new SN details

--- a/src/cryptonote_core/sent_transition/sent_transition.cpp
+++ b/src/cryptonote_core/sent_transition/sent_transition.cpp
@@ -405,7 +405,9 @@ void transition(
         const transition_context& context,
         service_nodes::service_node_list::state_t& snl_state,
         cryptonote::BlockchainSQLite& sql,
-        network_type net) {
+        network_type net,
+        service_nodes::block_add_result& add_result,
+        uint32_t block_tx_count) {
 
     auto address_info_from_str = [](network_type network, const std::string& addr) {
         cryptonote::address_parse_info api;
@@ -782,8 +784,18 @@ void transition(
     }
 
     // Any yet-unallocated SENT balance goes in the rewards db to be claimed
-    // All OXEN rewards are wiped first
-    sql.set_rewards_hf21(unallocated);
+    // All OXEN rewards are wiped first, any unconverted are dropped (but were paid out last block
+    // anyway).
+    {
+        sql.db.exec("DELETE FROM batched_payments_accrued");
+        cryptonote::block_payments rewards_payments;
+        for (auto it : unallocated) {
+            cryptonote::sql_payment payment = {};
+            payment.amount = cryptonote::reward_money::coin_amount(it.second);
+            rewards_payments[it.first] = payment;
+        }
+        sql.add_sn_rewards(cryptonote::hf::hf21_eth, rewards_payments, /*rewards_payment=*/ true);
+    }
 
     // First, clear the old key image blacklist so we don't leave unconverted stakes locked
     // any longer than necessary (and can re-use the blacklist for perma-locks)
@@ -809,9 +821,40 @@ void transition(
                 final_allocation_before_distrib,
                 unallocated);
 
+    // When we collect stake metadata (like the individual contributions of a user, we store them
+    // into the database and have a unique clause on the (block, tx, contribution index) which
+    // prevents duplicates from being submitted.
+    //
+    // These are typically extracted from an individual smart contract event witnessed on Arbitrum
+    // and they get inserted into a TX. For HF21 we initially bootstrap the amount of locked tokens
+    // by a user by their participation in the $OXEN->$SESH migration. These locked amounts don't
+    // have a transaction associated with them. The DB is written to directly, so to encode these
+    // stakes we set a synthetic TX index which is guaranteed to not conflict with any other TXs in
+    // the block itself.
+    uint32_t synthetic_tx_index = static_cast<uint32_t>(block_tx_count);
+
     snl_state.service_nodes_infos.clear();
-    for (auto& it : post_transition_sns)
+    for (auto& it : post_transition_sns) {
+        // Record the stake metadata to the `block_add_result`. The SQL DB will process these when
+        // it's update set is triggered
+        for (size_t contrib_index = 0; contrib_index < it.sn_info->contributors.size(); contrib_index++) {
+            auto contrib_it = it.sn_info->contributors[contrib_index];
+            assert(!it.zombie && "Contributors should only be populated on non-zombie nodes");
+            service_nodes::eth_stake stake = {
+                    .sn = crypto::ed25519_public_key{it.pkey},
+                    .addr = contrib_it.ethereum_address,
+                    .amount = cryptonote::reward_money::coin_amount(contrib_it.amount),
+                    .liquidation = cryptonote::reward_money{},
+                    .block_height = static_cast<uint32_t>(snl_state.height),
+                    .tx_index = synthetic_tx_index++,
+                    .contributor_index = static_cast<uint32_t>(contrib_index),
+            };
+            add_result.locked_stakes.push_back(stake);
+        }
+
+        // Update the SNL with the new SN details
         snl_state.service_nodes_infos[it.pkey] = std::move(it.sn_info);
+    }
 }
 
 }  // namespace oxen::sent

--- a/src/cryptonote_core/sent_transition/sent_transition.h
+++ b/src/cryptonote_core/sent_transition/sent_transition.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <limits>
-#include <string_view>
 #include <unordered_map>
 
 #include "blockchain_db/sqlite/db_sqlite.h"
 #include "crypto/eth.h"
-#include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_config.h"
 #include "cryptonote_core/service_node_list.h"
 
@@ -74,6 +71,8 @@ void transition(
         const transition_context& context,
         service_nodes::service_node_list::state_t& sns,
         cryptonote::BlockchainSQLite& sql,
-        network_type net);
+        network_type net,
+        service_nodes::block_add_result& add_result,
+        uint32_t block_tx_count);
 
 }  // namespace oxen::sent

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -335,6 +335,80 @@ void service_node_list::init() {
             m_state.quorums.pulse = std::make_shared<const quorum>(copy);
         }
     }
+
+    // NOTE: In debug mode, check that the total locked SESH as stored in the SQL rewards DB matches
+    // the amount of locked SESH that is currently recorded on the SNL.
+#if !defined(NDEBUG)
+    if (blockchain.get_network_version() >= hf::hf21_eth) {
+        struct pubkey_stake {
+            crypto::ed25519_public_key pubkey;  // The SN pubkey
+            uint64_t stake;                     // Amount staked for SN pubkey for the ETH address
+        };
+
+        struct stake_history {
+            uint64_t total;                    // Total SESH the ETH address staked
+            std::vector<pubkey_stake> stakes;  // Individual stakes that the ETH address contributed
+        };
+
+        // NOTE: Enumerate all the current SESH that an ETH address has locked up in the network
+        std::unordered_map<eth::address, stake_history> eth_to_locked_stakes;
+
+        // NOTE: Enumerate SNL
+        for (auto it : m_state.service_nodes_infos) {
+            for (auto contrib_it : it.second->contributors) {
+                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
+                dest.total += contrib_it.amount;
+                dest.stakes.push_back({crypto::ed25519_public_key{it.first}, contrib_it.amount});
+            }
+        }
+
+        // NOTE: Enumerate nodes in the recently removed list (considered locked until exited)
+        for (auto it : m_state.recently_removed_nodes) {
+            for (auto contrib_it : it.info.contributors) {
+                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
+                dest.total += contrib_it.amount;
+                dest.stakes.push_back(
+                        {crypto::ed25519_public_key{it.service_node_pubkey}, contrib_it.amount});
+            }
+        }
+
+        // NOTE: Walk the locked stakes per ETH address and verify the numbers in the rewards DB
+        cryptonote::BlockchainSQLite& db = blockchain.sqlite_db();
+        for (auto it : eth_to_locked_stakes) {
+            cryptonote::BlockchainSQLite::wallet_info wallet_info =
+                    db.get_accrued_rewards(it.first);
+            if (!wallet_info.found) {
+                log::error(
+                        logcat,
+                        "Internal error: SN contributor ({}) was not recorded into the rewards DB",
+                        it.first);
+                assert(wallet_info.found);
+            }
+
+            if (wallet_info.locked_stakes.to_coin() != it.second.total) {
+                fmt::memory_buffer buffer;
+                fmt::format_to(
+                        std::back_inserter(buffer),
+                        "Internal error: SN contributor ({}) in the SNL has {} staked SESH but the "
+                        "rewards DB claims it has {} staked SESH",
+                        it.first,
+                        cryptonote::print_money(it.second.total),
+                        cryptonote::print_money(wallet_info.locked_stakes.to_coin()));
+
+                for (auto stake_it : it.second.stakes) {
+                    fmt::format_to(
+                            std::back_inserter(buffer),
+                            "\n  SN {} => {} SESH",
+                            stake_it.pubkey,
+                            cryptonote::print_money(stake_it.stake));
+                }
+
+                log::error(logcat, "{}", fmt::to_string(buffer));
+                assert(wallet_info.locked_stakes.to_coin() == it.second.total);
+            }
+        }
+    }
+#endif
 }
 
 template <std::predicate<const service_node_info&> UnaryPredicate>
@@ -1952,15 +2026,16 @@ void service_node_list::state_t::process_new_ethereum_tx(
                 "Internal error: incoming eth tx was processed multiple times!"};
 }
 
-bool service_node_list::state_t::process_confirmed_event(
+service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(
         const eth::event::NewServiceNodeV2& new_sn, const confirm_metadata& confirm) {
     ZoneScoped;
+    confirm_result result = {};
     if (service_nodes_infos.count(new_sn.sn_pubkey)) {
         log::warning(
                 logcat,
                 "Duplicate service node registration from ethereum for {} ignored",
                 new_sn.sn_pubkey);
-        return false;
+        return result;
     }
     if (auto it = std::find_if(
                 service_nodes_infos.begin(),
@@ -1973,7 +2048,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 "registration ignored",
                 new_sn.bls_pubkey,
                 new_sn.sn_pubkey);
-        return false;
+        return result;
     }
 
     try {
@@ -2004,16 +2079,19 @@ bool service_node_list::state_t::process_confirmed_event(
                     key,
                     confirm.confirmed_height);
         insert_info(key, std::move(service_node_info));
-        return true;
+        result.success = true;
+        result.need_swarm_update = true;
+        return result;
     } catch (const std::exception& e) {
         log::error(logcat, "Failed to register node from ethereum transaction: {}", e.what());
-        return false;
+        return result;
     }
 }
 
-bool service_node_list::state_t::process_confirmed_event(
+service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(
         const eth::event::ServiceNodeExitRequest& remreq, const confirm_metadata& confirm) {
     ZoneScoped;
+    confirm_result result = {};
     crypto::public_key snode_pk = find_public_key(remreq.bls_pubkey);
     if (!snode_pk) {
         log::info(
@@ -2022,7 +2100,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 remreq.bls_pubkey,
                 confirm.confirmed_height,
                 confirm.vote_index);
-        return false;
+        return result;
     }
 
     auto it = service_nodes_infos.find(snode_pk);
@@ -2033,7 +2111,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 remreq.bls_pubkey,
                 confirm.confirmed_height,
                 confirm.vote_index);
-        return false;
+        return result;
     }
 
     const auto& node_info = *it->second;
@@ -2045,7 +2123,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 confirm.vote_index,
                 snode_pk,
                 node_info.requested_unlock_height);
-        return false;
+        return result;
     }
 
     auto& netconf = get_config(confirm.nettype);
@@ -2069,12 +2147,14 @@ bool service_node_list::state_t::process_confirmed_event(
                 unlock_height);
 
     duplicate_info(it->second).requested_unlock_height = unlock_height;
-    return false;  // false => this doesn't affect swarms
+    result.success = true;
+    return result;  // NOTE: This doesn't affect swarms
 }
 
-bool service_node_list::state_t::process_confirmed_event(
+service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(
         const eth::event::ServiceNodeExit& exit, const confirm_metadata& confirm) {
     ZoneScoped;
+    confirm_result result = {};
     // NOTE: Retrieve node from the staging area
     auto node = std::find_if(
             recently_removed_nodes.begin(),
@@ -2087,7 +2167,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 "ETH exit event for BLS pubkey {}: Node has already been removed or did not exist, "
                 "skipping",
                 exit.bls_pubkey);
-        return false;
+        return result;
     } else if (oxen::log::get_level(logcat) <= oxen::log::Level::trace) {
         oxen::log::trace(
                 logcat,
@@ -2124,7 +2204,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 node->info.staking_requirement,
                 height,
                 node->liquidation_height);
-        return false;
+        return result;
     }
 
     // NOTE: Calculate how many blocks from now the funds are still to be locked for, if this node
@@ -2143,7 +2223,7 @@ bool service_node_list::state_t::process_confirmed_event(
     }
 
     // NOTE: Enumerate the contributors to refund to
-    std::vector<cryptonote::BlockchainSQLite::exit_stake> returned_stakes;
+    std::vector<service_nodes::eth_stake> returned_stakes;
     for (size_t contrib_index = 0; contrib_index < node->info.contributors.size();
          contrib_index++) {
         const auto& contributor = node->info.contributors[contrib_index];
@@ -2156,6 +2236,7 @@ bool service_node_list::state_t::process_confirmed_event(
         // network to stall as code tries to deserialise that address into an eth address and fails.
         if (contributor.ethereum_address) {
             auto& item = returned_stakes.emplace_back();
+            item.sn = crypto::ed25519_public_key{node->service_node_pubkey};
             item.addr = contributor.ethereum_address;
             item.amount = cryptonote::reward_money::coin_amount(contributor.amount);
             item.block_height = confirm.height;
@@ -2164,6 +2245,11 @@ bool service_node_list::state_t::process_confirmed_event(
         }
     }
 
+    // NOTE: Make a copy of the returned stakes before slashing is applied. This is to preserve
+    // the original amount that the user stake and is used to correctly count the amount of SESH
+    // that gets unlocked from the network.
+    result.exit_stakes = returned_stakes;
+
     if (returned_stakes.empty()) {
         log::warning(
                 logcat,
@@ -2171,7 +2257,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 "encountered, skipping",
                 node->info.bls_public_key,
                 node->service_node_pubkey);
-        return false;
+        return result;
     }
 
     // NOTE: Apply the slash penalty to the operator
@@ -2184,7 +2270,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 node->service_node_pubkey,
                 slash_amount,
                 returned_stakes[0].amount);
-        return false;
+        return result;
     }
     returned_stakes[0].amount = cryptonote::reward_money::coin_amount(
             returned_stakes[0].amount.to_coin() - slash_amount);
@@ -2225,12 +2311,14 @@ bool service_node_list::state_t::process_confirmed_event(
     // A exit event does not trigger a swarm update because the node is not in the SNL, it's in a
     // staging area where they're awaiting to get removed (e.g. at this point they've already exited
     // the list and the swarm has already reconfigured).
-    return false;
+    result.success = true;
+    return result;
 }
 
-bool service_node_list::state_t::process_confirmed_event(
+service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(
         const eth::event::StakingRequirementUpdated& req_change, const confirm_metadata& confirm) {
     ZoneScoped;
+    confirm_result result = {};
     auto old_staking_requirement = get_staking_requirement(confirm.nettype);
     staking_requirement = req_change.staking_requirement;
     auto new_staking_requirement = get_staking_requirement(confirm.nettype);
@@ -2252,12 +2340,14 @@ bool service_node_list::state_t::process_confirmed_event(
                 height);
     }
 
-    return false;  // This doesn't affect swarm composition
+    result.success = true;
+    return result;  // This doesn't affect swarm composition
 }
 
-bool service_node_list::state_t::process_confirmed_event(
+service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(
         const eth::event::ServiceNodePurge& purge, const confirm_metadata& confirm) {
     ZoneScoped;
+    confirm_result result = {};
     auto pk = find_public_key(purge.bls_pubkey);
     if (!pk) {
         log::info(
@@ -2266,7 +2356,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 purge.bls_pubkey,
                 confirm.confirmed_height,
                 confirm.vote_index);
-        return false;
+        return result;
     }
 
     auto it = service_nodes_infos.find(pk);
@@ -2277,7 +2367,7 @@ bool service_node_list::state_t::process_confirmed_event(
                 purge.bls_pubkey,
                 confirm.confirmed_height,
                 confirm.vote_index);
-        return false;
+        return result;
     }
 
     bool is_me = confirm.my_keys && confirm.my_keys->pub == pk;
@@ -2303,9 +2393,21 @@ bool service_node_list::state_t::process_confirmed_event(
                 confirm.vote_index,
                 purge.l2_height);
 
+    for (size_t contrib_index = 0; contrib_index < it->second->contributors.size(); contrib_index++) {
+        const auto& contributor = it->second->contributors[contrib_index];
+        eth_stake& stake = result.exit_stakes.emplace_back();
+        stake.sn = crypto::ed25519_public_key{it->first};
+        stake.addr = contributor.ethereum_address;
+        stake.amount = cryptonote::reward_money::coin_amount(contributor.amount);
+        stake.block_height = confirm.height;
+        stake.tx_index = confirm.tx_index;
+        stake.contributor_index = contrib_index;
+    }
     erase_info(it, recently_removed_node::type_t::purged);
 
-    return true;  // True: removing a SN affects swarms
+    result.success = true;
+    result.need_swarm_update = true; // NOTE: Removing a SN affects swarms
+    return result;
 }
 
 bool service_node_list::state_t::process_contribution_tx(
@@ -3856,6 +3958,7 @@ block_add_result service_node_list::state_t::update_from_block(
     // Process any votes to pending eth state changes (this has to be done before we process
     // transactions, because that might add new unconfirmed txes and make the vote index no longer
     // match up).
+    block_add_result result = {};
     if (hf_version >= feature::ETH_BLS) {
         ZoneScopedN("Process pending ETH state changes");
         // Basic block validation (long before this) is responsible for ensuring this:
@@ -3889,37 +3992,38 @@ block_add_result service_node_list::state_t::update_from_block(
                     unconf.denials,
                     height - unconf.height_added);
 
+            std::string fail;
+            auto event = eth::extract_event(sn_list->blockchain.db().get_tx(txhash), &fail);
+            if (std::holds_alternative<std::monostate>(event))
+                throw oxen::traced<std::runtime_error>{
+                        "Internal error: did not find state change tx data in blockchain database: {}"_format(
+                                fail)};
+
+            // NOTE: Grab TX index of the L2 transaction it was originally mined in
+            uint16_t tx_index = 0;
+            cryptonote::block block = db.get_block_from_height(unconf.height_added, nullptr);
+            bool found = false;
+            for (size_t index = 0; index < block.tx_hashes.size(); index++) {
+                if (block.tx_hashes[index] == txhash) {
+                    tx_index = index;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                throw oxen::traced<std::runtime_error>(
+                        "TX {} was confirmed from block {} but the TX hash does not exist "
+                        "in the DB, block {} cannot be added due to missing data"_format(
+                                txhash, unconf.height_added, height));
+            }
+
+            // NOTE: Handle event
+            confirm_result conf_result = {};
             if (*done) {
                 log::info(logcat, "State change tx {} confirmed by votes", txhash);
-
-                std::string fail;
-                auto event = eth::extract_event(sn_list->blockchain.db().get_tx(txhash), &fail);
-                if (std::holds_alternative<std::monostate>(event))
-                    throw oxen::traced<std::runtime_error>{
-                            "Internal error: did not find state change tx data in blockchain database: {}"_format(
-                                    fail)};
-
-                // NOTE: Grab TX index of the L2 transaction it was originally mined in
-                uint64_t tx_index = 0;
-                cryptonote::block block = db.get_block_from_height(unconf.height_added, nullptr);
-                bool found = false;
-                for (size_t index = 0; index < block.tx_hashes.size(); index++) {
-                    if (block.tx_hashes[index] == txhash) {
-                        tx_index = index;
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found) {
-                    throw oxen::traced<std::runtime_error>(
-                            "TX {} was confirmed from block {} but the TX hash does not exist "
-                            "in the DB, block {} cannot be added due to missing data"_format(
-                                    txhash, unconf.height_added, height));
-                }
-
-                need_swarm_update += std::visit(
-                        [&](const auto& e) {
+                conf_result = std::visit(
+                        [&](const auto& e) -> confirm_result {
                             confirm_metadata confirm = {
                                     .nettype = nettype,
                                     .hf_version = hf_version,
@@ -3932,17 +4036,50 @@ block_add_result service_node_list::state_t::update_from_block(
                             return process_confirmed_event(e, confirm);
                         },
                         event);
-
             } else {
                 log::warning(
                         logcat,
                         "State change tx {} denied by {}",
                         txhash,
                         unconf.is_denied() ? "votes" : "expiry");
-
                 // Nothing to process here
             }
 
+            // NOTE: Collect stakes metadata
+            // TODO: We only care about successfully confirmed events. This means that we will not
+            // correctly count ETH-related transactions that were mined in to the chain but failed
+            // validation/confirmations.
+            //
+            // This currently leaves a hole in terms of "losing" visiblity of locked/unlocked SESH
+            // through the collected stake metadata here.
+            if (conf_result.success) {
+                if (auto *ptr = std::get_if<eth::event::NewServiceNodeV2>(&event)) {
+                    for (size_t it_index = 0; it_index < ptr->contributors.size(); it_index++) {
+                        const eth::event::ContributorV2& it = ptr->contributors[it_index];
+                        eth_stake stake = {
+                            .sn = crypto::ed25519_public_key{ptr->sn_pubkey},
+                            .addr = it.address,
+                            .amount = cryptonote::reward_money::coin_amount(it.amount),
+                            .block_height = static_cast<uint32_t>(block.get_height()),
+                            .tx_index = static_cast<uint32_t>(tx_index),
+                            .contributor_index = static_cast<uint32_t>(it_index),
+                        };
+
+                        result.locked_stakes.push_back(stake);
+                    }
+                }
+
+                if (std::holds_alternative<eth::event::ServiceNodeExit>(event) ||
+                    std::holds_alternative<eth::event::ServiceNodePurge>(event)) {
+                    result.unlocked_stakes.insert(
+                            result.unlocked_stakes.end(),
+                            conf_result.exit_stakes.begin(),
+                            conf_result.exit_stakes.end());
+                }
+            }
+
+            // NOTE: Post-amble, advance iterator
+            need_swarm_update += conf_result.need_swarm_update;
             unconf_it = unconfirmed_l2_txes.erase(unconf_it);
         }
     }
@@ -4005,7 +4142,6 @@ block_add_result service_node_list::state_t::update_from_block(
     TracyCZoneEnd(process_txs_in_block);
 
     // NOTE: Calculate both lists in one loop
-    block_add_result result = {};
     result.payable_nodes_hf19_onwards.reserve(pre_block_precomputed.payable_node_count);
 
     std::vector<service_node_pubkey_info> post_block_active_snode_list = {};
@@ -5064,13 +5200,20 @@ static std::string serialize_db_blob(
     return result;
 }
 
+// NOTE: Private version only exposed in impl file as we don't use this outside of this file and
+// only for one niche usecase at the moment, resetting the stagenet.
+enum state_version {
+    state_version_v0,
+    state_version_v1_track_stakes,
+};
+
 // Serialise the service node state into the archive `ar`. If a serializer is passed in the function
 // produces the binary string and returns it. If it's deserializing the `state` object is populated
 // and an empty string is returned.
 template <typename Archive>
 static std::string serialize_snl_directly(Archive& ar, service_node_list::state_t& state) {
     ZoneScoped;
-    uint32_t version = 0;
+    uint32_t version = state_version_v1_track_stakes;
     field_varint(ar, "version", version);
     field_varint(ar, "height", state.height);
     // NOTE: Serialization code struggles with the SN info stored behind a const
@@ -5085,8 +5228,10 @@ static std::string serialize_snl_directly(Archive& ar, service_node_list::state_
     field_varint(ar, "staking_requirement", state.staking_requirement);
     field(ar, "recently_removed_nodes", state.recently_removed_nodes);
 
-    if constexpr (Archive::is_deserializer)
+    if constexpr (Archive::is_deserializer) {
+        state.version = version;
         state.initialize_alt_pk_maps();
+    }
 
     std::string result;
     if constexpr (!Archive::is_deserializer)
@@ -6425,6 +6570,14 @@ bool service_node_list::load(const uint64_t current_height) {
     }
 
     if (!load_result.success)
+        return false;
+
+    // NOTE: In stagenet reset the DB if they have v0. v1 starts tracking the locked/unlocked stakes
+    // in the SQL DB which means they need to rescan the blockchain starting from the HF21 block and
+    // accumulate the locked and unlocked stakes from the transactions that the chain has witnessed
+    // and confirmed.
+    if (blockchain.nettype() == cryptonote::network_type::STAGENET &&
+        m_state.version == state_version_v0)
         return false;
 
     // NOTE: Load uptime proof data

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2296,7 +2296,8 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
 
     std::string exit_label = "";
     if (slash_amount)
-        exit_label = "liquidation ({})"_format(cryptonote::format_money(slash_amount, false));
+        exit_label = "liquidation ({})"_format(
+                cryptonote::format_money(slash_amount, cryptonote::strip_zeros::no));
     else
         exit_label = "exit";
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -320,6 +320,7 @@ static void verify_rewards_db_values(
         // NOTE: Enumerate SNL
         for (auto it : state.service_nodes_infos) {
             for (auto contrib_it : it.second->contributors) {
+                assert(contrib_it.ethereum_address);
                 auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
                 dest.total += contrib_it.amount;
                 dest.stakes.push_back({crypto::ed25519_public_key{it.first}, contrib_it.amount});
@@ -329,6 +330,7 @@ static void verify_rewards_db_values(
         // NOTE: Enumerate nodes in the recently removed list (considered locked until exited)
         for (auto it : state.recently_removed_nodes) {
             for (auto contrib_it : it.info.contributors) {
+                assert(contrib_it.ethereum_address);
                 auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
                 dest.total += contrib_it.amount;
                 dest.stakes.push_back(
@@ -352,6 +354,8 @@ static void verify_rewards_db_values(
             cryptonote::BlockchainSQLite::wallet_info wallet_info =
                     db.get_accrued_rewards(it.first);
             if (!wallet_info.found) {
+                if (mocknet_is_mock_ethereum_address(it.first))
+                    continue;
                 log::error(
                         logcat,
                         "Internal error: SN contributor ({}) was not recorded into the rewards DB",
@@ -3913,6 +3917,7 @@ block_add_result service_node_list::state_t::update_from_block(
                 (uint8_t)nettype);
         print_sns();
         auto& sqlite_db = *sqlite_db_ptr;
+
         oxen::sent::transition_context context =
                 oxen::sent::get_transition_context(nettype, height);
         oxen::sent::transition(context, *this, sqlite_db, nettype, result, block.tx_hashes.size());

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3874,76 +3874,76 @@ block_add_result service_node_list::state_t::update_from_block(
             auto& txhash = unconf_it->first;
             auto& unconf = unconf_it->second;
             (vote ? unconf.confirmations : unconf.denials) += vote_weight;
+            std::optional<bool> done = unconf.confirmed(height);
+            if (!done) {
+                ++unconf_it;
+                continue;
+            }
 
-            if (auto done = unconf.confirmed(height)) {
-                log::debug(
-                        logcat,
-                        "State change tx {} finalized; received {}/{} confirm/deny votes in {} "
-                        "blocks",
-                        txhash,
-                        unconf.confirmations,
-                        unconf.denials,
-                        height - unconf.height_added);
+            log::debug(
+                    logcat,
+                    "State change tx {} finalized; received {}/{} confirm/deny votes in {} "
+                    "blocks",
+                    txhash,
+                    unconf.confirmations,
+                    unconf.denials,
+                    height - unconf.height_added);
 
-                if (*done) {
-                    log::info(logcat, "State change tx {} confirmed by votes", txhash);
+            if (*done) {
+                log::info(logcat, "State change tx {} confirmed by votes", txhash);
 
-                    std::string fail;
-                    auto event = eth::extract_event(sn_list->blockchain.db().get_tx(txhash), &fail);
-                    if (std::holds_alternative<std::monostate>(event))
-                        throw oxen::traced<std::runtime_error>{
-                                "Internal error: did not find state change tx data in blockchain database: {}"_format(
-                                        fail)};
+                std::string fail;
+                auto event = eth::extract_event(sn_list->blockchain.db().get_tx(txhash), &fail);
+                if (std::holds_alternative<std::monostate>(event))
+                    throw oxen::traced<std::runtime_error>{
+                            "Internal error: did not find state change tx data in blockchain database: {}"_format(
+                                    fail)};
 
-                    // NOTE: Grab TX index of the L2 transaction it was originally mined in
-                    uint64_t tx_index = 0;
-                    cryptonote::block block =
-                            db.get_block_from_height(unconf.height_added, nullptr);
-                    bool found = false;
-                    for (size_t index = 0; index < block.tx_hashes.size(); index++) {
-                        if (block.tx_hashes[index] == txhash) {
-                            tx_index = index;
-                            found = true;
-                            break;
-                        }
+                // NOTE: Grab TX index of the L2 transaction it was originally mined in
+                uint64_t tx_index = 0;
+                cryptonote::block block = db.get_block_from_height(unconf.height_added, nullptr);
+                bool found = false;
+                for (size_t index = 0; index < block.tx_hashes.size(); index++) {
+                    if (block.tx_hashes[index] == txhash) {
+                        tx_index = index;
+                        found = true;
+                        break;
                     }
-
-                    if (!found) {
-                        throw oxen::traced<std::runtime_error>(
-                                "TX {} was confirmed from block {} but the TX hash does not exist "
-                                "in the DB, block {} cannot be added due to missing data"_format(
-                                        txhash, unconf.height_added, height));
-                    }
-
-                    need_swarm_update += std::visit(
-                            [&](const auto& e) {
-                                confirm_metadata confirm = {
-                                        .nettype = nettype,
-                                        .hf_version = hf_version,
-                                        .height = unconf.height_added,
-                                        .confirmed_height = height,
-                                        .vote_index = i,
-                                        .tx_index = tx_index,
-                                        .my_keys = my_keys,
-                                };
-                                return process_confirmed_event(e, confirm);
-                            },
-                            event);
-
-                } else {
-                    log::warning(
-                            logcat,
-                            "State change tx {} denied by {}",
-                            txhash,
-                            unconf.is_denied() ? "votes" : "expiry");
-
-                    // Nothing to process here
                 }
 
-                unconf_it = unconfirmed_l2_txes.erase(unconf_it);
+                if (!found) {
+                    throw oxen::traced<std::runtime_error>(
+                            "TX {} was confirmed from block {} but the TX hash does not exist "
+                            "in the DB, block {} cannot be added due to missing data"_format(
+                                    txhash, unconf.height_added, height));
+                }
+
+                need_swarm_update += std::visit(
+                        [&](const auto& e) {
+                            confirm_metadata confirm = {
+                                    .nettype = nettype,
+                                    .hf_version = hf_version,
+                                    .height = unconf.height_added,
+                                    .confirmed_height = height,
+                                    .vote_index = i,
+                                    .tx_index = tx_index,
+                                    .my_keys = my_keys,
+                            };
+                            return process_confirmed_event(e, confirm);
+                        },
+                        event);
+
             } else {
-                ++unconf_it;
+                log::warning(
+                        logcat,
+                        "State change tx {} denied by {}",
+                        txhash,
+                        unconf.is_denied() ? "votes" : "expiry");
+
+                // Nothing to process here
             }
+
+            unconf_it = unconfirmed_l2_txes.erase(unconf_it);
         }
     }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -336,7 +336,8 @@ static void verify_rewards_db_values(
             }
         }
 
-        // NOTE: Enumerate payments sitting in the timelocked queue (considered locked until expired)
+        // NOTE: Enumerate payments sitting in the timelocked queue (considered locked until
+        // expired)
         cryptonote::BlockchainSQLite::delayed_payments_request request = {};
         request.type = cryptonote::BlockchainSQLite::delayed_payments_type::all;
 
@@ -2407,7 +2408,8 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
                 confirm.vote_index,
                 purge.l2_height);
 
-    for (size_t contrib_index = 0; contrib_index < it->second->contributors.size(); contrib_index++) {
+    for (size_t contrib_index = 0; contrib_index < it->second->contributors.size();
+         contrib_index++) {
         const auto& contributor = it->second->contributors[contrib_index];
         eth_stake& stake = result.exit_stakes.emplace_back();
         stake.sn = crypto::ed25519_public_key{it->first};
@@ -2420,7 +2422,7 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
     erase_info(it, recently_removed_node::type_t::purged);
 
     result.success = true;
-    result.need_swarm_update = true; // NOTE: Removing a SN affects swarms
+    result.need_swarm_update = true;  // NOTE: Removing a SN affects swarms
     return result;
 }
 
@@ -4067,17 +4069,17 @@ block_add_result service_node_list::state_t::update_from_block(
             // This currently leaves a hole in terms of "losing" visiblity of locked/unlocked SESH
             // through the collected stake metadata here.
             if (conf_result.success) {
-                if (auto *ptr = std::get_if<eth::event::NewServiceNodeV2>(&event)) {
+                if (auto* ptr = std::get_if<eth::event::NewServiceNodeV2>(&event)) {
                     for (size_t it_index = 0; it_index < ptr->contributors.size(); it_index++) {
                         const eth::event::ContributorV2& it = ptr->contributors[it_index];
                         eth_stake stake = {
-                            .sn = crypto::ed25519_public_key{ptr->sn_pubkey},
-                            .addr = it.address,
-                            .amount = cryptonote::reward_money::coin_amount(it.amount),
-                            .liquidation = cryptonote::reward_money{},
-                            .block_height = static_cast<uint32_t>(block.get_height()),
-                            .tx_index = static_cast<uint32_t>(tx_index),
-                            .contributor_index = static_cast<uint32_t>(it_index),
+                                .sn = crypto::ed25519_public_key{ptr->sn_pubkey},
+                                .addr = it.address,
+                                .amount = cryptonote::reward_money::coin_amount(it.amount),
+                                .liquidation = cryptonote::reward_money{},
+                                .block_height = static_cast<uint32_t>(block.get_height()),
+                                .tx_index = static_cast<uint32_t>(tx_index),
+                                .contributor_index = static_cast<uint32_t>(it_index),
                         };
 
                         result.locked_stakes.push_back(stake);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -291,6 +291,99 @@ static uint64_t min_recent_height(cryptonote::network_type nettype, uint64_t hei
     return result;
 }
 
+// NOTE: In debug mode, check that the total locked SESH as stored in the SQL rewards DB matches
+// the amount of locked SESH that is currently recorded on the SNL. We only verify if the SNL
+// height matches the rewards DB height (e.g. the 2 are in sync).
+//
+// The values we are verifying are do not contribute to chain consensus, they are auxiliary values
+// like the amount of locked SESH, the amount of timelocked SESH for analytics purposes hence gating
+// these checks into debug builds.
+static void verify_rewards_db_values(
+        [[maybe_unused]] cryptonote::Blockchain& blockchain,
+        [[maybe_unused]] const service_node_list::state_t& state) {
+#if !defined(NDEBUG)
+    cryptonote::BlockchainSQLite& db = blockchain.sqlite_db();
+    if (blockchain.get_network_version() >= hf::hf21_eth && db.height == state.height) {
+        struct pubkey_stake {
+            crypto::ed25519_public_key pubkey;  // The SN pubkey
+            uint64_t stake;                     // Amount staked for SN pubkey for the ETH address
+        };
+
+        struct stake_history {
+            uint64_t total;                    // Total SESH the ETH address staked
+            std::vector<pubkey_stake> stakes;  // Individual stakes that the ETH address contributed
+        };
+
+        // NOTE: Enumerate all the current SESH that an ETH address has locked up in the network
+        std::unordered_map<eth::address, stake_history> eth_to_locked_stakes;
+
+        // NOTE: Enumerate SNL
+        for (auto it : state.service_nodes_infos) {
+            for (auto contrib_it : it.second->contributors) {
+                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
+                dest.total += contrib_it.amount;
+                dest.stakes.push_back({crypto::ed25519_public_key{it.first}, contrib_it.amount});
+            }
+        }
+
+        // NOTE: Enumerate nodes in the recently removed list (considered locked until exited)
+        for (auto it : state.recently_removed_nodes) {
+            for (auto contrib_it : it.info.contributors) {
+                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
+                dest.total += contrib_it.amount;
+                dest.stakes.push_back(
+                        {crypto::ed25519_public_key{it.service_node_pubkey}, contrib_it.amount});
+            }
+        }
+
+        // NOTE: Enumerate payments sitting in the timelocked queue (considered locked until expired)
+        cryptonote::BlockchainSQLite::delayed_payments_request request = {};
+        request.type = cryptonote::BlockchainSQLite::delayed_payments_type::all;
+
+        cryptonote::block_payments locked_payments = db.get_delayed_payments(request);
+        for (auto it : locked_payments) {
+            auto& dest = eth_to_locked_stakes[*std::get_if<eth::address>(&it.first)];
+            dest.total += it.second.amount.to_coin();
+        }
+
+        // NOTE: Walk the locked stakes per ETH address and verify the numbers in the rewards DB
+        for (auto it : eth_to_locked_stakes) {
+            cryptonote::BlockchainSQLite::wallet_info wallet_info =
+                    db.get_accrued_rewards(it.first);
+            if (!wallet_info.found) {
+                log::error(
+                        logcat,
+                        "Internal error: SN contributor ({}) was not recorded into the rewards DB",
+                        it.first);
+                assert(wallet_info.found);
+            }
+
+            if (wallet_info.locked_stakes.to_coin() != it.second.total) {
+                fmt::memory_buffer buffer;
+                fmt::format_to(
+                        std::back_inserter(buffer),
+                        "Internal error: SN contributor ({}) in the SNL has {} staked SESH but the "
+                        "rewards DB claims it has {} staked SESH",
+                        it.first,
+                        cryptonote::print_money(it.second.total),
+                        cryptonote::print_money(wallet_info.locked_stakes.to_coin()));
+
+                for (auto stake_it : it.second.stakes) {
+                    fmt::format_to(
+                            std::back_inserter(buffer),
+                            "\n  SN {} => {} SESH",
+                            stake_it.pubkey,
+                            cryptonote::print_money(stake_it.stake));
+                }
+
+                log::error(logcat, "{}", fmt::to_string(buffer));
+                assert(wallet_info.locked_stakes.to_coin() == it.second.total);
+            }
+        }
+    }
+#endif
+}
+
 service_node_list::service_node_list(cryptonote::Blockchain& blockchain) :
         blockchain(blockchain)  // Warning: don't touch `blockchain`, it gets initialized *after* us
         ,
@@ -336,79 +429,7 @@ void service_node_list::init() {
         }
     }
 
-    // NOTE: In debug mode, check that the total locked SESH as stored in the SQL rewards DB matches
-    // the amount of locked SESH that is currently recorded on the SNL.
-#if !defined(NDEBUG)
-    if (blockchain.get_network_version() >= hf::hf21_eth) {
-        struct pubkey_stake {
-            crypto::ed25519_public_key pubkey;  // The SN pubkey
-            uint64_t stake;                     // Amount staked for SN pubkey for the ETH address
-        };
-
-        struct stake_history {
-            uint64_t total;                    // Total SESH the ETH address staked
-            std::vector<pubkey_stake> stakes;  // Individual stakes that the ETH address contributed
-        };
-
-        // NOTE: Enumerate all the current SESH that an ETH address has locked up in the network
-        std::unordered_map<eth::address, stake_history> eth_to_locked_stakes;
-
-        // NOTE: Enumerate SNL
-        for (auto it : m_state.service_nodes_infos) {
-            for (auto contrib_it : it.second->contributors) {
-                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
-                dest.total += contrib_it.amount;
-                dest.stakes.push_back({crypto::ed25519_public_key{it.first}, contrib_it.amount});
-            }
-        }
-
-        // NOTE: Enumerate nodes in the recently removed list (considered locked until exited)
-        for (auto it : m_state.recently_removed_nodes) {
-            for (auto contrib_it : it.info.contributors) {
-                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
-                dest.total += contrib_it.amount;
-                dest.stakes.push_back(
-                        {crypto::ed25519_public_key{it.service_node_pubkey}, contrib_it.amount});
-            }
-        }
-
-        // NOTE: Walk the locked stakes per ETH address and verify the numbers in the rewards DB
-        cryptonote::BlockchainSQLite& db = blockchain.sqlite_db();
-        for (auto it : eth_to_locked_stakes) {
-            cryptonote::BlockchainSQLite::wallet_info wallet_info =
-                    db.get_accrued_rewards(it.first);
-            if (!wallet_info.found) {
-                log::error(
-                        logcat,
-                        "Internal error: SN contributor ({}) was not recorded into the rewards DB",
-                        it.first);
-                assert(wallet_info.found);
-            }
-
-            if (wallet_info.locked_stakes.to_coin() != it.second.total) {
-                fmt::memory_buffer buffer;
-                fmt::format_to(
-                        std::back_inserter(buffer),
-                        "Internal error: SN contributor ({}) in the SNL has {} staked SESH but the "
-                        "rewards DB claims it has {} staked SESH",
-                        it.first,
-                        cryptonote::print_money(it.second.total),
-                        cryptonote::print_money(wallet_info.locked_stakes.to_coin()));
-
-                for (auto stake_it : it.second.stakes) {
-                    fmt::format_to(
-                            std::back_inserter(buffer),
-                            "\n  SN {} => {} SESH",
-                            stake_it.pubkey,
-                            cryptonote::print_money(stake_it.stake));
-                }
-
-                log::error(logcat, "{}", fmt::to_string(buffer));
-                assert(wallet_info.locked_stakes.to_coin() == it.second.total);
-            }
-        }
-    }
-#endif
+    verify_rewards_db_values(blockchain, m_state);
 }
 
 template <std::predicate<const service_node_info&> UnaryPredicate>
@@ -2223,10 +2244,8 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
     }
 
     // NOTE: Enumerate the contributors to refund to
-    std::vector<service_nodes::eth_stake> returned_stakes;
-    for (size_t contrib_index = 0; contrib_index < node->info.contributors.size();
-         contrib_index++) {
-        const auto& contributor = node->info.contributors[contrib_index];
+    for (size_t index = 0; index < node->info.contributors.size(); index++) {
+        const auto& contributor = node->info.contributors[index];
         // TODO: Once merge code is in this can be re-evaluated. Right now in the localdev tests
         // we don't have migration code so we're putting in bad data into the DB. The DB checks if
         // the payment has an eth address defined, if it does it stores the delayed payment as an
@@ -2235,22 +2254,17 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
         // This leads us to storing a cryptonote address in the delayed payments which causes the
         // network to stall as code tries to deserialise that address into an eth address and fails.
         if (contributor.ethereum_address) {
-            auto& item = returned_stakes.emplace_back();
+            auto& item = result.exit_stakes.emplace_back();
             item.sn = crypto::ed25519_public_key{node->service_node_pubkey};
             item.addr = contributor.ethereum_address;
             item.amount = cryptonote::reward_money::coin_amount(contributor.amount);
             item.block_height = confirm.height;
             item.tx_index = confirm.tx_index;
-            item.contributor_index = contrib_index;
+            item.contributor_index = index;
         }
     }
 
-    // NOTE: Make a copy of the returned stakes before slashing is applied. This is to preserve
-    // the original amount that the user stake and is used to correctly count the amount of SESH
-    // that gets unlocked from the network.
-    result.exit_stakes = returned_stakes;
-
-    if (returned_stakes.empty()) {
+    if (result.exit_stakes.empty()) {
         log::warning(
                 logcat,
                 "ETH exit event for BLS pubkey {}: SN {} has 0 contributors detected, null data "
@@ -2261,7 +2275,7 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
     }
 
     // NOTE: Apply the slash penalty to the operator
-    if (slash_amount > returned_stakes[0].amount.to_coin()) {
+    if (slash_amount > result.exit_stakes[0].amount.to_coin()) {
         log::error(
                 logcat,
                 "ETH exit of BLS pubkey {} rejected: SN {} returned amount {} is less than the "
@@ -2269,11 +2283,11 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
                 node->info.bls_public_key,
                 node->service_node_pubkey,
                 slash_amount,
-                returned_stakes[0].amount);
+                result.exit_stakes[0].amount);
         return result;
     }
-    returned_stakes[0].amount = cryptonote::reward_money::coin_amount(
-            returned_stakes[0].amount.to_coin() - slash_amount);
+
+    result.exit_stakes[0].liquidation = cryptonote::reward_money::coin_amount(slash_amount);
 
     std::string exit_label = "";
     if (slash_amount)
@@ -2299,7 +2313,7 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
 
     // NOTE: Add the funds to the unlock queue in the DB, can be retrieved by BLS aggregation when
     // fully unlocked..
-    sn_list->blockchain.sqlite_db().add_delayed_payments(returned_stakes, height, block_delay);
+    sn_list->blockchain.sqlite_db().add_delayed_payments(result.exit_stakes, height, block_delay);
 
     // NOTE: Remove the x25519/bls lookup entries:
     x25519_map.erase(snpk_to_xpk(node->service_node_pubkey));
@@ -4060,6 +4074,7 @@ block_add_result service_node_list::state_t::update_from_block(
                             .sn = crypto::ed25519_public_key{ptr->sn_pubkey},
                             .addr = it.address,
                             .amount = cryptonote::reward_money::coin_amount(it.amount),
+                            .liquidation = cryptonote::reward_money{},
                             .block_height = static_cast<uint32_t>(block.get_height()),
                             .tx_index = static_cast<uint32_t>(tx_index),
                             .contributor_index = static_cast<uint32_t>(it_index),
@@ -4069,13 +4084,11 @@ block_add_result service_node_list::state_t::update_from_block(
                     }
                 }
 
-                if (std::holds_alternative<eth::event::ServiceNodeExit>(event) ||
-                    std::holds_alternative<eth::event::ServiceNodePurge>(event)) {
-                    result.unlocked_stakes.insert(
-                            result.unlocked_stakes.end(),
-                            conf_result.exit_stakes.begin(),
-                            conf_result.exit_stakes.end());
-                }
+                if (std::holds_alternative<eth::event::ServiceNodeExit>(event))
+                    result.unlocked_stakes = conf_result.exit_stakes;
+
+                if (std::holds_alternative<eth::event::ServiceNodePurge>(event))
+                    result.purged_stakes = conf_result.exit_stakes;
             }
 
             // NOTE: Post-amble, advance iterator

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -318,23 +318,23 @@ static void verify_rewards_db_values(
         std::unordered_map<eth::address, stake_history> eth_to_locked_stakes;
 
         // NOTE: Enumerate SNL
-        for (auto it : state.service_nodes_infos) {
-            for (auto contrib_it : it.second->contributors) {
-                assert(contrib_it.ethereum_address);
-                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
-                dest.total += contrib_it.amount;
-                dest.stakes.push_back({crypto::ed25519_public_key{it.first}, contrib_it.amount});
+        for (const auto& [pk, sni] : state.service_nodes_infos) {
+            for (const auto& contrib : sni->contributors) {
+                assert(contrib.ethereum_address);
+                auto& dest = eth_to_locked_stakes[contrib.ethereum_address];
+                dest.total += contrib.amount;
+                dest.stakes.push_back({crypto::ed25519_public_key{pk}, contrib.amount});
             }
         }
 
         // NOTE: Enumerate nodes in the recently removed list (considered locked until exited)
-        for (auto it : state.recently_removed_nodes) {
-            for (auto contrib_it : it.info.contributors) {
-                assert(contrib_it.ethereum_address);
-                auto& dest = eth_to_locked_stakes[contrib_it.ethereum_address];
-                dest.total += contrib_it.amount;
+        for (const auto& it : state.recently_removed_nodes) {
+            for (const auto& contrib : it.info.contributors) {
+                assert(contrib.ethereum_address);
+                auto& dest = eth_to_locked_stakes[contrib.ethereum_address];
+                dest.total += contrib.amount;
                 dest.stakes.push_back(
-                        {crypto::ed25519_public_key{it.service_node_pubkey}, contrib_it.amount});
+                        {crypto::ed25519_public_key{it.service_node_pubkey}, contrib.amount});
             }
         }
 
@@ -344,45 +344,44 @@ static void verify_rewards_db_values(
         request.type = cryptonote::BlockchainSQLite::delayed_payments_type::all;
 
         cryptonote::block_payments locked_payments = db.get_delayed_payments(request);
-        for (auto it : locked_payments) {
-            auto& dest = eth_to_locked_stakes[*std::get_if<eth::address>(&it.first)];
-            dest.total += it.second.amount.to_coin();
+        for (const auto& [addr, payment] : locked_payments) {
+            auto& dest = eth_to_locked_stakes[*std::get_if<eth::address>(&addr)];
+            dest.total += payment.amount.to_coin();
         }
 
         // NOTE: Walk the locked stakes per ETH address and verify the numbers in the rewards DB
-        for (auto it : eth_to_locked_stakes) {
-            cryptonote::BlockchainSQLite::wallet_info wallet_info =
-                    db.get_accrued_rewards(it.first);
+        for (const auto& [addr, history] : eth_to_locked_stakes) {
+            cryptonote::BlockchainSQLite::wallet_info wallet_info = db.get_accrued_rewards(addr);
             if (!wallet_info.found) {
-                if (mocknet_is_mock_ethereum_address(it.first))
+                if (mocknet_is_mock_ethereum_address(addr))
                     continue;
                 log::error(
                         logcat,
                         "Internal error: SN contributor ({}) was not recorded into the rewards DB",
-                        it.first);
+                        addr);
                 assert(wallet_info.found);
             }
 
-            if (wallet_info.locked_stakes.to_coin() != it.second.total) {
+            if (wallet_info.locked_stakes.to_coin() != history.total) {
                 fmt::memory_buffer buffer;
                 fmt::format_to(
                         std::back_inserter(buffer),
                         "Internal error: SN contributor ({}) in the SNL has {} staked SESH but the "
                         "rewards DB claims it has {} staked SESH",
-                        it.first,
-                        cryptonote::print_money(it.second.total),
+                        addr,
+                        cryptonote::print_money(history.total),
                         cryptonote::print_money(wallet_info.locked_stakes.to_coin()));
 
-                for (auto stake_it : it.second.stakes) {
+                for (const auto& stake : history.stakes) {
                     fmt::format_to(
                             std::back_inserter(buffer),
                             "\n  SN {} => {} SESH",
-                            stake_it.pubkey,
-                            cryptonote::print_money(stake_it.stake));
+                            stake.pubkey,
+                            cryptonote::print_money(stake.stake));
                 }
 
                 log::error(logcat, "{}", fmt::to_string(buffer));
-                assert(wallet_info.locked_stakes.to_coin() == it.second.total);
+                assert(wallet_info.locked_stakes.to_coin() == history.total);
             }
         }
     }
@@ -2107,11 +2106,10 @@ service_node_list::state_t::confirm_result service_node_list::state_t::process_c
         insert_info(key, std::move(service_node_info));
         result.success = true;
         result.need_swarm_update = true;
-        return result;
     } catch (const std::exception& e) {
         log::error(logcat, "Failed to register node from ethereum transaction: {}", e.what());
-        return result;
     }
+    return result;
 }
 
 service_node_list::state_t::confirm_result service_node_list::state_t::process_confirmed_event(

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -4084,9 +4084,6 @@ block_add_result service_node_list::state_t::update_from_block(
                     }
                 }
 
-                if (std::holds_alternative<eth::event::ServiceNodeExit>(event))
-                    result.unlocked_stakes = conf_result.exit_stakes;
-
                 if (std::holds_alternative<eth::event::ServiceNodePurge>(event))
                     result.purged_stakes = conf_result.exit_stakes;
             }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3869,6 +3869,7 @@ block_add_result service_node_list::state_t::update_from_block(
 
     // On first block of hf21, do hf21 transition.
     // TODO: chaingen doesn't have a BlockchainSQLite so it can't test this correctly.
+    block_add_result result = {};
     auto hf21_height = hard_fork_begins(nettype, hf::hf21_eth);
     if (hf21_height && height == *hf21_height && sqlite_db_ptr) {
         auto print_sns = [&]() {
@@ -3914,7 +3915,7 @@ block_add_result service_node_list::state_t::update_from_block(
         auto& sqlite_db = *sqlite_db_ptr;
         oxen::sent::transition_context context =
                 oxen::sent::get_transition_context(nettype, height);
-        oxen::sent::transition(context, *this, sqlite_db, nettype);
+        oxen::sent::transition(context, *this, sqlite_db, nettype, result, block.tx_hashes.size());
         print_sns();
     }
 
@@ -3974,7 +3975,6 @@ block_add_result service_node_list::state_t::update_from_block(
     // Process any votes to pending eth state changes (this has to be done before we process
     // transactions, because that might add new unconfirmed txes and make the vote index no longer
     // match up).
-    block_add_result result = {};
     if (hf_version >= feature::ETH_BLS) {
         ZoneScopedN("Process pending ETH state changes");
         // Basic block validation (long before this) is responsible for ensuring this:
@@ -6997,9 +6997,10 @@ service_node_list::hf21_transition_result service_node_list::hf21_dry_run(
         insert_payment->reset();
     }
 
+    block_add_result add_result = {};
     oxen::sent::transition_context context =
             oxen::sent::get_transition_context(nettype, state_copy.height);
-    oxen::sent::transition(context, state_copy, db_copy, nettype);
+    oxen::sent::transition(context, state_copy, db_copy, nettype, add_result, /*block_tx_count=*/0);
 
     service_node_list::hf21_transition_result result = {};
     result.sns_after = std::move(state_copy.service_nodes_infos);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -6992,7 +6992,7 @@ service_node_list::hf21_transition_result service_node_list::hf21_dry_run(
     auto old_rewards = blockchain.sqlite_db().get_all_accrued_rewards();
     for (size_t i = 0; i < old_rewards.first.size(); i++) {
         const auto& addr = old_rewards.first[i];
-        const cryptonote::reward_money& amt = old_rewards.second[i];
+        const cryptonote::reward_money& amt = old_rewards.second[i].amount;
         db::exec_query(insert_payment, addr, 0, static_cast<int64_t>(amt.to_db()));
         insert_payment->reset();
     }
@@ -7001,7 +7001,16 @@ service_node_list::hf21_transition_result service_node_list::hf21_dry_run(
             oxen::sent::get_transition_context(nettype, state_copy.height);
     oxen::sent::transition(context, state_copy, db_copy, nettype);
 
-    return {state_copy.service_nodes_infos, db_copy.get_all_accrued_rewards()};
+    service_node_list::hf21_transition_result result = {};
+    result.sns_after = std::move(state_copy.service_nodes_infos);
+
+    auto accrued_rewards_after = db_copy.get_all_accrued_rewards();
+    result.rewards_after.first = std::move(accrued_rewards_after.first);
+    result.rewards_after.second.reserve(accrued_rewards_after.second.size());
+    for (auto it : accrued_rewards_after.second)
+        result.rewards_after.second.push_back(it.amount);
+
+    return result;
 }
 
 }  // namespace service_nodes

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -214,10 +214,21 @@ struct pulse_sort_key {
     }
 };
 
+struct eth_stake {
+    crypto::ed25519_public_key sn;
+    eth::address addr;
+    cryptonote::reward_money amount;
+    uint32_t block_height;  // Block that the exit event was mined in
+    uint32_t tx_index;  // Index of transaction in the block that the exit event was mined in
+    uint32_t contributor_index;  // Index of the contributor in the event the exit stake is for
+};
+
 struct block_add_result {
     // List of payable nodes. Populated when the block height is >= HF19, empty
     // otherwise
     std::vector<crypto::public_key> payable_nodes_hf19_onwards;
+    std::vector<eth_stake> locked_stakes;
+    std::vector<eth_stake> unlocked_stakes;
 };
 
 struct service_node_info  // registration information
@@ -1032,6 +1043,7 @@ class service_node_list {
     using block_height = uint64_t;
 
     struct state_t {
+        uint32_t version;
         crypto::hash block_hash{};
         bool only_loaded_quorums{false};
         service_nodes_infos_t service_nodes_infos;
@@ -1165,23 +1177,30 @@ class service_node_list {
             const service_node_keys* my_keys;
         };
 
+        struct confirm_result {
+            bool success;
+            bool need_swarm_update;
+            std::vector<eth_stake> exit_stakes;
+        };
+
         // Applies a pulse-quorums-confirmed L2 event to the service node list state.  Returns true
         // if processing the event affects swarms, false if it does not.
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const eth::event::NewServiceNodeV2& new_sn, const confirm_metadata& confirm);
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const eth::event::ServiceNodeExitRequest& rem_req, const confirm_metadata& confirm);
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const eth::event::ServiceNodeExit& exit, const confirm_metadata& confirm);
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const eth::event::StakingRequirementUpdated& req_change,
                 const confirm_metadata& confirm);
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const eth::event::ServiceNodePurge& purge, const confirm_metadata& confirm);
-        bool process_confirmed_event(
+        confirm_result process_confirmed_event(
                 const std::monostate&,  // do-nothing fallback for "not an event" variant
                 const confirm_metadata&) {
-            return false;
+            confirm_result result = {};
+            return result;
         }
 
         // Returns the block leader of the next block: that is, the round 0 pulse quorum leader, and

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -217,8 +217,9 @@ struct pulse_sort_key {
 struct eth_stake {
     crypto::ed25519_public_key sn;
     eth::address addr;
-    cryptonote::reward_money amount;
-    uint32_t block_height;  // Block that the exit event was mined in
+    cryptonote::reward_money amount;       // Original stake amount
+    cryptonote::reward_money liquidation;  // Liquidation penalty on `amount` if applicable
+    uint32_t block_height;                 // Block that the exit event was mined in
     uint32_t tx_index;  // Index of transaction in the block that the exit event was mined in
     uint32_t contributor_index;  // Index of the contributor in the event the exit stake is for
 };
@@ -229,6 +230,7 @@ struct block_add_result {
     std::vector<crypto::public_key> payable_nodes_hf19_onwards;
     std::vector<eth_stake> locked_stakes;
     std::vector<eth_stake> unlocked_stakes;
+    std::vector<eth_stake> purged_stakes;
 };
 
 struct service_node_info  // registration information

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -229,7 +229,6 @@ struct block_add_result {
     // otherwise
     std::vector<crypto::public_key> payable_nodes_hf19_onwards;
     std::vector<eth_stake> locked_stakes;
-    std::vector<eth_stake> unlocked_stakes;
     std::vector<eth_stake> purged_stakes;
 };
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -63,6 +63,7 @@ class Blockchain;
 class BlockchainDB;
 class BlockchainSQLite;
 struct checkpoint_t;
+struct wallet_info;
 };  // namespace cryptonote
 
 namespace service_nodes {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1984,8 +1984,7 @@ static void append_printable_service_node_list_entry(
         stream << '\n';
     }
 
-    if (detailed_view)  // Print contributors
-    {
+    if (detailed_view) {  // Print contributors
         auto n_contributors = entry["contributors"].size();
         stream << indent2 << "Contributors (" << n_contributors << "):\n";
         for (auto& contributor : entry["contributors"]) {
@@ -1994,9 +1993,9 @@ static void append_printable_service_node_list_entry(
             stream << indent3 << (addr.size() == 40 ? "0x" : "") << addr;
             auto amount = contributor["amount"].get<uint64_t>();
             auto reserved = contributor.value("reserved", amount);
-            stream << " (" << cryptonote::print_money(amount, true);
+            stream << " (" << cryptonote::print_money(amount, cryptonote::strip_zeros::yes);
             if (reserved != amount)
-                stream << " / " << cryptonote::print_money(reserved, true);
+                stream << " / " << cryptonote::print_money(reserved, cryptonote::strip_zeros::yes);
             if (!is_funded || n_contributors > 1) {
                 auto required = entry["staking_requirement"].get<uint64_t>();
                 stream << " = " << std::round(reserved / (double)required * 10000.) / 100. << "%";

--- a/src/network_config/mocknet.cpp
+++ b/src/network_config/mocknet.cpp
@@ -460,8 +460,7 @@ void mocknet_push_mock_pulse_block(cryptonote::core& core) {
     }
 }
 
-bool mocknet_is_mock_ethereum_address(const eth::address& addr)
-{
+bool mocknet_is_mock_ethereum_address(const eth::address& addr) {
     bool result = addr == MOCK_ETH_ADDRESS;
     return result;
 }

--- a/src/network_config/mocknet.cpp
+++ b/src/network_config/mocknet.cpp
@@ -59,7 +59,7 @@ struct mocknet_key {
 };
 
 const eth::address MOCK_ETH_ADDRESS = tools::make_from_hex_guts<eth::address>(
-        "485973e8dfFA8Abd3AB91292bFCE25896C687bA5"sv, false);
+        "4444444444444444444444444444444444444444"sv, false);
 
 // NOTE: Ed25519 public key is stuffed in the last 32 bytes of the secret key
 // but it's useful to have the pubkey separated to visually grok instantly for
@@ -239,10 +239,14 @@ void mocknet_inject_nodes(uint8_t nettype_u8, void* snl_state_ptr, uint8_t hf_ve
         {
             service_nodes::service_node_info::contributor_t contributor = {};
             contributor.amount = state->get_staking_requirement(nettype);
-
-            service_nodes::service_node_info::contribution_t contribution = {};
-            contribution.amount = contributor.amount;
-            contributor.locked_contributions.push_back(contribution);
+            if (hf_version >= static_cast<uint8_t>(cryptonote::feature::ETH_BLS)) {
+                contributor.ethereum_address = MOCK_ETH_ADDRESS;
+                contributor.ethereum_beneficiary = MOCK_ETH_ADDRESS;
+            } else {
+                service_nodes::service_node_info::contribution_t contribution = {};
+                contribution.amount = contributor.amount;
+                contributor.locked_contributions.push_back(contribution);
+            }
 
             info->contributors.push_back(contributor);
         }
@@ -454,6 +458,12 @@ void mocknet_push_mock_pulse_block(cryptonote::core& core) {
 
         // NOTE: Construct the addresses and the shares of the bonus tokens here!
     }
+}
+
+bool mocknet_is_mock_ethereum_address(const eth::address& addr)
+{
+    bool result = addr == MOCK_ETH_ADDRESS;
+    return result;
 }
 
 void mocknet_get_transition_context(oxen::sent::transition_context& context) {

--- a/src/network_config/mocknet.h
+++ b/src/network_config/mocknet.h
@@ -8,6 +8,11 @@ namespace service_nodes {
 struct quorum;
 };
 
+namespace eth {
+struct address;
+};
+
+
 namespace oxen::sent {
 struct transition_context;
 };
@@ -31,6 +36,7 @@ void mocknet_replace_quorum_with_mock_nodes(
         service_nodes::quorum& quorum, uint64_t top_block_height);
 void mocknet_inject_nodes(uint8_t nettype, void* snl_state_ptr, uint8_t hf_version);
 void mocknet_push_mock_pulse_block(cryptonote::core& core);
+bool mocknet_is_mock_ethereum_address(const eth::address& addr);
 void mocknet_get_transition_context(oxen::sent::transition_context& context);
 #else
 #define mocknet_add_cli_arg(...)
@@ -41,5 +47,6 @@ void mocknet_get_transition_context(oxen::sent::transition_context& context);
 #define mocknet_replace_quorum_with_mock_nodes(...)
 #define mocknet_inject_nodes(...)
 #define mocknet_push_mock_pulse_block(...)
+#define mocknet_is_mock_ethereum_address(...) false
 #define mocknet_get_transition_context(...)
 #endif

--- a/src/network_config/mocknet.h
+++ b/src/network_config/mocknet.h
@@ -12,7 +12,6 @@ namespace eth {
 struct address;
 };
 
-
 namespace oxen::sent {
 struct transition_context;
 };

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3894,10 +3894,10 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
             cryptonote::reward_money amount = {};
             if (eth::address eth_address{};
                 tools::try_load_from_hex_guts<eth::address>(address, eth_address)) {
-                amount = sql_db.get_accrued_rewards(eth_address).total_rewards.to_coin();
+                amount = sql_db.get_accrued_rewards(eth_address).amount.to_coin();
             } else if (address_parse_info parse_info{};
                        get_account_address_from_str(parse_info, net, address)) {
-                amount = sql_db.get_accrued_rewards(parse_info.address).total_rewards.to_coin();
+                amount = sql_db.get_accrued_rewards(parse_info.address).amount.to_coin();
             }
             balances[address] = amount.to_coin();
         }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3894,10 +3894,10 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
             cryptonote::reward_money amount = {};
             if (eth::address eth_address{};
                 tools::try_load_from_hex_guts<eth::address>(address, eth_address)) {
-                std::tie(std::ignore, amount) = sql_db.get_accrued_rewards(eth_address);
+                amount = sql_db.get_accrued_rewards(eth_address).total_rewards.to_coin();
             } else if (address_parse_info parse_info{};
                        get_account_address_from_str(parse_info, net, address)) {
-                std::tie(std::ignore, amount) = sql_db.get_accrued_rewards(parse_info.address);
+                amount = sql_db.get_accrued_rewards(parse_info.address).total_rewards.to_coin();
             }
             balances[address] = amount.to_coin();
         }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3881,8 +3881,8 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context) {
     }
 }
 
-static nlohmann::json wallet_info_to_json(std::string address, const BlockchainSQLite::wallet_info& wallet_info)
-{
+static nlohmann::json wallet_info_to_json(
+        std::string address, const BlockchainSQLite::wallet_info& wallet_info) {
     nlohmann::json result = {
             {"found", wallet_info.found},
             {"address", address},

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3881,18 +3881,17 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context) {
     }
 }
 
-static nlohmann::json wallet_info_to_json(std::string_view address, const BlockchainSQLite::wallet_info& wallet_info)
+static nlohmann::json wallet_info_to_json(const BlockchainSQLite::wallet_info& wallet_info)
 {
     nlohmann::json result = {
-            {"address", address},
             {"found", wallet_info.found},
             {"amount", wallet_info.amount.to_coin()},
             {"lifetime_locked_stakes", wallet_info.lifetime_locked_stakes.to_coin()},
             {"lifetime_unlocked_stakes", wallet_info.lifetime_unlocked_stakes.to_coin()},
             {"lifetime_rewards", wallet_info.lifetime_rewards.to_coin()},
             {"lifetime_liquidated_stakes", wallet_info.lifetime_liquidated_stakes.to_coin()},
+            {"locked_stakes", wallet_info.locked_stakes.to_coin()},
             {"timelocked_stakes", wallet_info.timelocked_stakes.to_coin()},
-            {"rewards", wallet_info.rewards.to_coin()},
     };
     return result;
 }
@@ -3917,7 +3916,7 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
                        get_account_address_from_str(oxen, net, address)) {
                 wallet_info = sql_db.get_accrued_rewards(oxen.address);
             }
-            array.push_back(wallet_info_to_json(address, wallet_info));
+            array.push_back(wallet_info_to_json(wallet_info));
             if (height == 0)
                 height = wallet_info.height;
             assert(wallet_info.height == height);
@@ -3928,7 +3927,7 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
         for (size_t i = 0; i < addresses.size(); i++) {
             const std::string& address = addresses[i];
             const BlockchainSQLite::wallet_info& wallet_info = wallets[i];
-            array.push_back(wallet_info_to_json(address, wallet_info));
+            array.push_back(wallet_info_to_json(wallet_info));
 
             if (height == 0)
                 height = wallet_info.height;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3881,30 +3881,58 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context) {
     }
 }
 
+static nlohmann::json wallet_info_to_json(std::string_view address, const BlockchainSQLite::wallet_info& wallet_info)
+{
+    nlohmann::json result = {
+            {"address", address},
+            {"found", wallet_info.found},
+            {"amount", wallet_info.amount.to_coin()},
+            {"lifetime_locked_stakes", wallet_info.lifetime_locked_stakes.to_coin()},
+            {"lifetime_unlocked_stakes", wallet_info.lifetime_unlocked_stakes.to_coin()},
+            {"lifetime_rewards", wallet_info.lifetime_rewards.to_coin()},
+            {"lifetime_liquidated_stakes", wallet_info.lifetime_liquidated_stakes.to_coin()},
+            {"timelocked_stakes", wallet_info.timelocked_stakes.to_coin()},
+            {"rewards", wallet_info.rewards.to_coin()},
+    };
+    return result;
+}
+
 void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
     auto& balances = rpc.response["balances"];
-    balances = json::object();
+    balances = json::array();
 
     const auto& req = rpc.request;
     auto net = nettype();
     BlockchainSQLite& sql_db = m_core.blockchain.sqlite_db();
 
+    nlohmann::json::array_t& array = balances.get_ref<nlohmann::json::array_t&>();
+    uint64_t height = 0;
     if (req.addresses.size() > 0) {
+        array.reserve(req.addresses.size());
         for (const auto& address : req.addresses) {
-            cryptonote::reward_money amount = {};
-            if (eth::address eth_address{};
-                tools::try_load_from_hex_guts<eth::address>(address, eth_address)) {
-                amount = sql_db.get_accrued_rewards(eth_address).amount.to_coin();
-            } else if (address_parse_info parse_info{};
-                       get_account_address_from_str(parse_info, net, address)) {
-                amount = sql_db.get_accrued_rewards(parse_info.address).amount.to_coin();
+            BlockchainSQLite::wallet_info wallet_info = {};
+            if (eth::address eth{}; tools::try_load_from_hex_guts<eth::address>(address, eth)) {
+                wallet_info = sql_db.get_accrued_rewards(eth);
+            } else if (address_parse_info oxen{};
+                       get_account_address_from_str(oxen, net, address)) {
+                wallet_info = sql_db.get_accrued_rewards(oxen.address);
             }
-            balances[address] = amount.to_coin();
+            array.push_back(wallet_info_to_json(address, wallet_info));
+            if (height == 0)
+                height = wallet_info.height;
+            assert(wallet_info.height == height);
         }
     } else {
-        auto [addresses, amounts] = sql_db.get_all_accrued_rewards();
+        auto [addresses, wallets] = sql_db.get_all_accrued_rewards();
+        array.reserve(addresses.size());
         for (size_t i = 0; i < addresses.size(); i++) {
-            balances[addresses[i]] = amounts[i].to_coin();
+            const std::string& address = addresses[i];
+            const BlockchainSQLite::wallet_info& wallet_info = wallets[i];
+            array.push_back(wallet_info_to_json(address, wallet_info));
+
+            if (height == 0)
+                height = wallet_info.height;
+            assert(wallet_info.height == height);
         }
     }
 
@@ -3921,6 +3949,7 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
         rpc.response.erase("balances");
     }
 
+    rpc.response["height"] = height;
     rpc.response["status"] = STATUS_OK;
 }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3223,7 +3223,7 @@ void core_rpc_server::invoke(HF21_DRY_RUN& req, rpc_context) {
     for (size_t i = 0; i < rewards_before_pair.first.size(); i++) {
         const auto& addr = rewards_before_pair.first[i];
         const auto& amt = rewards_before_pair.second[i];
-        rewards_before[addr] = amt.to_coin();
+        rewards_before[addr] = amt.amount.to_coin();
     }
     for (size_t i = 0; i < transition_result.rewards_after.first.size(); i++) {
         const auto& addr = transition_result.rewards_after.first[i];

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3881,10 +3881,11 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context) {
     }
 }
 
-static nlohmann::json wallet_info_to_json(const BlockchainSQLite::wallet_info& wallet_info)
+static nlohmann::json wallet_info_to_json(std::string address, const BlockchainSQLite::wallet_info& wallet_info)
 {
     nlohmann::json result = {
             {"found", wallet_info.found},
+            {"address", address},
             {"amount", wallet_info.amount.to_coin()},
             {"lifetime_locked_stakes", wallet_info.lifetime_locked_stakes.to_coin()},
             {"lifetime_unlocked_stakes", wallet_info.lifetime_unlocked_stakes.to_coin()},
@@ -3916,7 +3917,7 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
                        get_account_address_from_str(oxen, net, address)) {
                 wallet_info = sql_db.get_accrued_rewards(oxen.address);
             }
-            array.push_back(wallet_info_to_json(wallet_info));
+            array.push_back(wallet_info_to_json(address, wallet_info));
             if (height == 0)
                 height = wallet_info.height;
             assert(wallet_info.height == height);
@@ -3927,7 +3928,7 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
         for (size_t i = 0; i < addresses.size(); i++) {
             const std::string& address = addresses[i];
             const BlockchainSQLite::wallet_info& wallet_info = wallets[i];
-            array.push_back(wallet_info_to_json(wallet_info));
+            array.push_back(wallet_info_to_json(address, wallet_info));
 
             if (height == 0)
                 height = wallet_info.height;
@@ -3936,20 +3937,26 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
     }
 
     if (rpc.request.oxen10_compat) {
-        // Oxen 10.x wallets expect `"addresses": [...], "amounts": [...]` because old Monero
+        // Oxen 10.x wallets expect `"addresses": [...], "amounts": [...]`
         // serialization didn't support dicts, so rewrite it if this came through the old endpoint
         // name to maintain compatibility.
         auto& addrs = rpc.response["addresses"];
         auto& amts = rpc.response["amounts"];
-        for (auto& [addr, amt] : balances.items()) {
-            addrs.emplace_back(std::move(addr));
-            amts.emplace_back(std::move(amt));
+        for (auto& it : array) {
+            nlohmann::json::iterator address = it.find("address");
+            nlohmann::json::iterator amount = it.find("amount");
+            assert(address != it.end());
+            assert(amount != it.end());
+            assert(address->is_string());
+            assert(amount->is_number_unsigned());
+            addrs.emplace_back(address->get<std::string>());
+            amts.emplace_back(amount->get<uint64_t>());
         }
         rpc.response.erase("balances");
+    } else {
+        rpc.response["height"] = height;
     }
 
-    rpc.response["height"] = height;
     rpc.response["status"] = STATUS_OK;
 }
-
 }  // namespace cryptonote::rpc

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3945,12 +3945,15 @@ void core_rpc_server::invoke(GET_ACCRUED_REWARDS& rpc, rpc_context) {
         for (auto& it : array) {
             nlohmann::json::iterator address = it.find("address");
             nlohmann::json::iterator amount = it.find("amount");
-            assert(address != it.end());
-            assert(amount != it.end());
-            assert(address->is_string());
-            assert(amount->is_number_unsigned());
-            addrs.emplace_back(address->get<std::string>());
-            amts.emplace_back(amount->get<uint64_t>());
+            if (address == it.end() || amount == it.end()) {
+                assert(address != it.end());
+                assert(amount != it.end());
+            } else {
+                assert(address->is_string());
+                assert(amount->is_number_unsigned());
+                addrs.emplace_back(address->get<std::string>());
+                amts.emplace_back(amount->get<uint64_t>());
+            }
         }
         rpc.response.erase("balances");
     } else {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2249,8 +2249,26 @@ struct GET_PENDING_EVENTS : PUBLIC {
 ///    with balances are returned.
 ///
 /// Outputs:
-///  - `balances` -- a dict where keys are the wallet addresses and values are the balance (in
-///    atomic SENT units).
+///  - `balances` -- an array of objects containing the reward metadata for the associated addresses
+///    in the same order as specified in the input `addresses`, irrespective of if the wallet exists
+///    or not. Each object contains the following fields:
+///    - `amount` -- the total amount of claimable tokens for the given address. This includes the
+///    earnt rewards as well as unlocked stakes that are available to be claimed.
+///    - `found` -- flag that indicates if the address has ever participated in the network. When
+///    false, all rewards metadata values will be 0.
+///    - `lifetime_liquidated_stakes` -- the total amount of tokens in the lifetime of the network
+///    that have been liquidated from the stakes for this address.
+///    - `lifetime_locked_stakes` -- the total amount of tokens in the lifetime of the network that
+///    has been staked into nodes for this address.
+///    - `lifetime_rewards` -- the total amount of tokens in the lifetime of the network that has
+///    been earnt from staking into nodes for this address.
+///    - `lifetime_unlocked_stakes` -- the total amount of tokens in the lifetime of the network
+///    that has been unlocked from the nodes this address has staked into.
+///    - `locked_stakes` -- the amount of tokens currently locked into nodes on the network. This is
+///    defined as `lifetime locked - lifetime unlocked`.
+///    - `timelocked_stakes` -- the amount of tokens that have been unstaked from nodes but cannot
+//     be claimed until the time lock on those individual stakes have been unlocked.
+
 struct GET_ACCRUED_REWARDS : PUBLIC {
     static constexpr auto names() { return NAMES("get_accrued_rewards"); }
     struct request_parameters {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2252,6 +2252,9 @@ struct GET_PENDING_EVENTS : PUBLIC {
 ///  - `balances` -- an array of objects containing the reward metadata for the associated addresses
 ///    in the same order as specified in the input `addresses`, irrespective of if the wallet exists
 ///    or not. Each object contains the following fields:
+///    - `address` -- the address of the wallet this object is for. This matches 1:1 with the given
+///    requested addresses in input. If no addresses were specified then all addresses are returned
+///    and this field identifies said address it's describing.
 ///    - `amount` -- the total amount of claimable tokens for the given address. This includes the
 ///    earnt rewards as well as unlocked stakes that are available to be claimed.
 ///    - `found` -- flag that indicates if the address has ever participated in the network. When

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -15275,17 +15275,19 @@ void wallet2::refresh_batching_cache() {
             res["status"] != rpc::STATUS_OK, error::get_accrued_rewards_error, res["status"]);
 
     batching_records_cache.clear();
-    for (auto it : res["balances"]) {
-        nlohmann::json::iterator address = it.find("address");
-        nlohmann::json::iterator amount = it.find("amount");
-        assert(address != it.end());
-        assert(amount != it.end());
-        assert(address->is_string());
-        assert(amount->is_number_unsigned());
-
-        auto address_str = address->get_ref<const std::string&>();
-        assert(batching_records_cache.count(address_str) == 0);
-        batching_records_cache[address_str] = amount->get<uint64_t>();
+    for (const auto& it : res["balances"]) {
+        nlohmann::json::const_iterator address = it.find("address");
+        nlohmann::json::const_iterator amount = it.find("amount");
+        if (address == it.end() || amount == it.end()) {
+            assert(address != it.end());
+            assert(amount != it.end());
+        } else {
+            assert(address->is_string());
+            assert(amount->is_number_unsigned());
+            const auto& address_str = address->get_ref<const std::string&>();
+            assert(batching_records_cache.count(address_str) == 0);
+            batching_records_cache[address_str] = amount->get<uint64_t>();
+        }
     }
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -15274,9 +15274,19 @@ void wallet2::refresh_batching_cache() {
     THROW_WALLET_EXCEPTION_IF(
             res["status"] != rpc::STATUS_OK, error::get_accrued_rewards_error, res["status"]);
 
-    auto records = res["balances"].get<std::unordered_map<std::string, uint64_t>>();
     batching_records_cache.clear();
-    batching_records_cache = std::move(records);
+    for (auto it : res["balances"]) {
+        nlohmann::json::iterator address = it.find("address");
+        nlohmann::json::iterator amount = it.find("amount");
+        assert(address != it.end());
+        assert(amount != it.end());
+        assert(address->is_string());
+        assert(amount->is_number_unsigned());
+
+        auto address_str = address->get_ref<const std::string&>();
+        assert(batching_records_cache.count(address_str) == 0);
+        batching_records_cache[address_str] = amount->get<uint64_t>();
+    }
 }
 
 uint64_t wallet2::get_batched_amount(std::optional<std::string> address) const {

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -56,9 +56,9 @@ TEST(SQLITE, AddSNRewards)
 
   cryptonote::get_account_address_from_str(wallet_address, cryptonote::network_type::FAKECHAIN, "LCFxT37LAogDn1jLQKf4y7aAqfi21DjovX9qyijaLYQSdrxY1U5VGcnMJMjWrD9RhjeK5Lym67wZ73uh9AujXLQ1RKmXEyL");
 
-  t1[wallet_address.address] = cryptonote::reward_money::db_amount(16500000001'789/2);
+  t1[wallet_address.address].amount = cryptonote::reward_money::db_amount(16500000001'789/2);
 
-  EXPECT_NO_THROW(sqliteDB.add_sn_rewards(t1));
+  EXPECT_NO_THROW(sqliteDB.add_sn_rewards(t1, false));
   EXPECT_EQ(sqliteDB.batching_count(), 1);
 
   std::vector<cryptonote::batch_sn_payment> p1;
@@ -134,9 +134,9 @@ TEST(SQLITE, CalculateRewards)
   auto& a1 = first_address.address;
   auto& a2 = second_address.address;
   auto& a3 = third_address.address;
-  EXPECT_EQ(rewards[a1].to_coin(), cryptonote::reward_money::coin_amount(66).to_coin());
-  EXPECT_EQ(rewards[a2].to_coin(), cryptonote::reward_money::coin_amount(66).to_coin());
-  EXPECT_EQ(rewards[a3].to_coin(), cryptonote::reward_money::coin_amount(68).to_coin());
+  EXPECT_EQ(rewards[a1].amount.to_coin(), 66);
+  EXPECT_EQ(rewards[a2].amount.to_coin(), 66);
+  EXPECT_EQ(rewards[a3].amount.to_coin(), 68);
 
   // Check that 3 contributors receives their portion of the block reward when the operator takes a 10% fee
   multiple_contributors.portions_for_operator = cryptonote::old::STAKING_PORTIONS/10;
@@ -145,7 +145,7 @@ TEST(SQLITE, CalculateRewards)
   rewards.clear();
   sqliteDB.add_rewards(hf_version, reward, multiple_contributors, rewards);
   // Operator gets 10%, remainder split among operator and contributors:
-  EXPECT_EQ(rewards[a1].to_coin(), cryptonote::reward_money::coin_amount(99 + 297).to_coin()); // fee + share
-  EXPECT_EQ(rewards[a2].to_coin(), cryptonote::reward_money::coin_amount(297).to_coin());
-  EXPECT_EQ(rewards[a3].to_coin(), cryptonote::reward_money::coin_amount(306).to_coin());
+  EXPECT_EQ(rewards[a1].amount.to_coin(), 99 + 297); // fee + share
+  EXPECT_EQ(rewards[a2].amount.to_coin(), 297);
+  EXPECT_EQ(rewards[a3].amount.to_coin(), 306);
 }

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -58,7 +58,7 @@ TEST(SQLITE, AddSNRewards)
 
   t1[wallet_address.address].amount = cryptonote::reward_money::db_amount(16500000001'789/2);
 
-  EXPECT_NO_THROW(sqliteDB.add_sn_rewards(t1, false));
+  EXPECT_NO_THROW(sqliteDB.add_sn_rewards(cryptonote::hf::_next, t1, false));
   EXPECT_EQ(sqliteDB.batching_count(), 1);
 
   std::vector<cryptonote::batch_sn_payment> p1;

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -105,7 +105,7 @@ TEST(SQLITE, CalculateRewards)
     contributor.amount = reward.to_coin();
 
     sqliteDB.add_rewards(hf_version, reward, single_contributor, rewards);
-    EXPECT_EQ(rewards[first_address.address].to_coin(), reward.to_coin());
+    EXPECT_EQ(rewards[first_address.address].amount.to_coin(), reward.to_coin());
   }
 
   // Check that 3 contributor receives their portion of the block reward


### PR DESCRIPTION
This adds some new fields to the rewards DB.

*Batched Accrued Rewards*
- lifetime_locked_stakes
- lifetime_unlocked_stakes
- lifetime_liquidated_stakes
- lifetime_rewards

These numbers expose some more metadata on what exactly is the composition of the `amount` value (which is rewards + unlocked stake) into separate fields. You can calculate how many tokens are actively locked in the network `(lifetime locked - (lifetime unlocked + lifetime liquidated))` or see how many rewards an address has earnt (`lifetime_rewards`) or how much has been liquidated from the address (`lifetime_liquidated`).

I've updated the `get_accrued_rewards` to return a struct now which has all this metadata plus more. It's basically all documented in the API

```cpp
struct wallet_info {
        uint64_t height;  // Height at which the wallet info was retrieved for

        // True if the wallet has participated in the network or not. When false all values are
        // zeroed (because the wallet has not earnt or spent any tokens on the network).
        bool found;

        // For OXEN addresses, rewards that has been accrued but not paid out to the address yet.
        //
        // For ETH addresses, lifetime rewards _and_ unlocked stakes for the address. (Note that,
        // unlike Oxen addresses, these rewards never reset to zero; but rather the rewards contract
        // keeps track of the current paid and current total and pays out the difference).
        //
        // For ETH addresses, this can be derived by
        // `lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes`
        cryptonote::reward_money amount;

        // For ETH addresses _only_, the total amount of tokens that were locked by this wallet and
        // so forth for lifetime unlocked, rewards and liquidated amounts.
        cryptonote::reward_money lifetime_locked_stakes;
        cryptonote::reward_money lifetime_unlocked_stakes;
        cryptonote::reward_money lifetime_rewards;
        cryptonote::reward_money lifetime_liquidated_stakes;

        // For ETH addresses _only_, the amount of tokens currently locked in the network (e.g.
        // staked in a node). This is defined as `lifetime locked - lifetimed unlocked` and
        // precalculated for convenience. This number includes `timelocked_stakes`.
        cryptonote::reward_money locked_stakes;

        // For ETH addresses _only_, the amount of tokens awaiting to be unlocked from the network
        // (e.g. an exit has been processed and the stake is under a time lock before being
        // claimable by the address)
        cryptonote::reward_money timelocked_stakes;
    };
```

The way this is achieved is by simply storing the result of the ETH transactions that we confirm and witness and feed it down into the rewards DB where it enumerates them together. These new fields don't kick in until the ETH hardfork so they're all gated and should return 0 if queried before then. This way collecting this metadata only needs to happen on the ETH code path instead of also requiring to work on the OXEN path.

Since it's gated, this will only trigger a rescan on stagenet which has 50k blocks. Since the new fields are written on the ETH hardfork there'll be no rescan needed for mainnet. It'll just gracefully start enumerating the fields when the hardfork elapses.

This does overlap with the Oxen 10 backwards compat fix that was recently patched. I had to patch ontop again to preserve the old behaviour. For Oxen 11, I just made it support parsing the new `wallet_info` struct that we return in the RPC call.

The `get_accrued_rewards` now returns something like this 

```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "balances": [
      {
        "address": "0x26b0227617159797b9301a8EA6FB264f17d37Cb4",
        "amount": 181398273044375,
        "found": true,
        "lifetime_liquidated_stakes": 240000000012,
        "lifetime_locked_stakes": 270774959746030,
        "lifetime_rewards": 8985313298357,
        "lifetime_unlocked_stakes": 172652959746030,
        "locked_stakes": 98122000000000,
        "rewards": 8985313298357,
        "timelocked_stakes": 18122000000000
      }
    ],
    "height": 50062,
    "status": "OK"
  }
}
```