### PR TITLE
Add snode address change OMQ subscription

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5190,11 +5190,12 @@ void proof_info::store(const crypto::public_key& pubkey, cryptonote::Blockchain&
     db.set_service_node_proof(pubkey, *this);
 }
 
-bool proof_info::update(
+std::pair<bool, bool> proof_info::update(
         uint64_t ts,
         std::unique_ptr<uptime_proof::Proof> new_proof,
         const crypto::x25519_public_key& pk_x2) {
     bool update_db = false;
+    bool contact_changed = !proof || proof->contact_info_changed(*new_proof);
     if (!proof || *proof != *new_proof) {
         update_db = true;
         proof = std::move(new_proof);
@@ -5219,7 +5220,7 @@ bool proof_info::update(
     else
         public_ips[0] = {proof->public_ip, now};
 
-    return update_db;
+    return {update_db, contact_changed};
 }
 
 void proof_info::update_pubkey(const crypto::ed25519_public_key& pk) {
@@ -5497,12 +5498,10 @@ bool service_node_list::handle_uptime_proof(
     }
 
     auto old_x25519 = iproof.pubkey_x25519;
-    if (iproof.update(
-                std::chrono::system_clock::to_time_t(now),
-                std::move(proof),
-                derived_x25519_pubkey)) {
+    auto [updated, contact_changed] = iproof.update(
+            std::chrono::system_clock::to_time_t(now), std::move(proof), derived_x25519_pubkey);
+    if (updated)
         iproof.store(iproof.proof->pubkey, blockchain);
-    }
 
     if (vers.first < feature::SN_PK_IS_ED25519) {
         if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
@@ -5522,6 +5521,9 @@ bool service_node_list::handle_uptime_proof(
         if (derived_x25519_pubkey && (old_x25519 != derived_x25519_pubkey))
             x25519_pkey = derived_x25519_pubkey;
     }
+
+    if (contact_changed && snode_addr_change_notifier)
+        snode_addr_change_notifier(*iproof.proof, derived_x25519_pubkey);
 
     return true;
 }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -176,10 +176,14 @@ struct proof_info {
     void update_pubkey(const crypto::ed25519_public_key& pk);
 
     // Called to update data received from a proof is received, updating values in the local object.
-    // Returns true if serializable data is changed (in which case `store()` should be called).
+    // Returns a pair of bools:
+    // - the first is true if serializable data is changed (in which case `store()` should be
+    // called).
+    // - the second value is true if this proof has updated the contact info for this node (i.e. if
+    //   any of edpk/ip/ports have changed).
     // Note that this does not update the m_x25519_to_pub map if the x25519 key changes (that's the
     // caller's responsibility).
-    bool update(
+    std::pair<bool, bool> update(
             uint64_t ts,
             std::unique_ptr<uptime_proof::Proof> new_proof,
             const crypto::x25519_public_key& pk_x2);
@@ -831,6 +835,9 @@ class service_node_list {
             std::unique_ptr<uptime_proof::Proof> proof,
             bool& my_uptime_proof_confirmation,
             crypto::x25519_public_key& x25519_pkey);
+
+    std::function<void(const uptime_proof::Proof&, const crypto::x25519_public_key&)>
+            snode_addr_change_notifier;
 
     void record_checkpoint_participation(
             crypto::public_key const& pubkey, uint64_t height, bool participated);

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -151,6 +151,21 @@ Proof::Proof(
     }
 }
 
+bool Proof::contact_info_changed(const Proof& other) const {
+    auto fields = [](const Proof& p) {
+        return std::tie(
+                p.version,
+                p.storage_server_version,
+                p.lokinet_version,
+                p.pubkey_ed25519,
+                p.public_ip,
+                p.storage_https_port,
+                p.storage_omq_port,
+                p.qnet_port);
+    };
+    return fields(*this) != fields(other);
+}
+
 std::string Proof::bt_encode_uptime_proof(hf hardfork, cryptonote::network_type nettype) const {
     // NOTE: After Oxen 11, new fields can be added to the encoded proof without breaking older
     // clients (i.e. no need to hardfork-gate additions): the signature applies over the entire

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -45,6 +45,15 @@ class Proof {
     uint16_t storage_omq_port{};
     uint16_t qnet_port{};
 
+    // Returns true if this Proof and the given Proof value have different contact-dependent fields:
+    // that is, if any of the ed pubkey, IP, or ports of various services are different across the
+    // two proofs.
+    bool contact_info_changed(const Proof& other) const {
+        return pubkey_ed25519 != other.pubkey_ed25519 || public_ip != other.public_ip ||
+               storage_https_port != other.storage_https_port ||
+               storage_omq_port != other.storage_omq_port || qnet_port != other.qnet_port;
+    }
+
     // Non-consensus field: stores the current git version or release tag to assist debugging.
     std::string version_tag;
 

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -46,13 +46,9 @@ class Proof {
     uint16_t qnet_port{};
 
     // Returns true if this Proof and the given Proof value have different contact-dependent fields:
-    // that is, if any of the ed pubkey, IP, or ports of various services are different across the
-    // two proofs.
-    bool contact_info_changed(const Proof& other) const {
-        return pubkey_ed25519 != other.pubkey_ed25519 || public_ip != other.public_ip ||
-               storage_https_port != other.storage_https_port ||
-               storage_omq_port != other.storage_omq_port || qnet_port != other.qnet_port;
-    }
+    // that is, if oxend/lokinet/SS version, the ed/X pubkeys, IP, or ports of various services are
+    // different across the two proofs.
+    bool contact_info_changed(const Proof& other) const;
 
     // Non-consensus field: stores the current git version or release tag to assist debugging.
     std::string version_tag;

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -359,14 +359,7 @@ omq_rpc::omq_rpc(
     });
     core_.service_node_list.snode_addr_change_notifier =
             [this](const uptime_proof::Proof& proof, const crypto::x25519_public_key& xpk) {
-                send_snode_addr_notifications(
-                        proof.pubkey,
-                        proof.pubkey_ed25519,
-                        xpk,
-                        epee::string_tools::get_ip_string_from_int32(proof.public_ip),
-                        proof.qnet_port,
-                        proof.storage_https_port,
-                        proof.storage_omq_port);
+                send_snode_addr_notifications(proof, xpk);
             };
 }
 
@@ -433,23 +426,18 @@ void omq_rpc::send_mempool_notifications(
 }
 
 void omq_rpc::send_snode_addr_notifications(
-        const crypto::public_key& snode_pk,
-        const crypto::ed25519_public_key& ed_pk,
-        const crypto::x25519_public_key& x_pk,
-        std::string_view public_ip,
-        uint16_t qnet_port,
-        uint16_t storage_https_port,
-        uint16_t storage_quic_port) {
+        const uptime_proof::Proof& proof, const crypto::x25519_public_key& x_pk) {
     oxenc::bt_dict_producer addr;
     // 'l' + 3 '32:...' values +  + 32:...
-    constexpr size_t MAX_RECORD_LENGTH = 2       // de around the dict
-                                       + 3       // 1:K
-                                       + 6 * 4   // 2:.. for the 6 other, length-2 dict keys
-                                       + 3 * 35  // 32:... for the three pubkeys
-                                       + 18      // IP, at longest: 15:AAA.BBB.CCC.DDD
-                                       + 3 * 7;  // iXXXXXe port, times 3.
-    // 2 for the le around it, and then currently send exactly one record inside the list:
-    addr.reserve(2 + 1 * MAX_RECORD_LENGTH);
+    constexpr size_t MAX_RECORD_LENGTH = 2        // de around the dict
+                                       + 3 * 2    // 1:K + 1:v
+                                       + 8 * 4    // 2:.. for the 8 other, length-2 dict keys
+                                       + 3 * 35   // 32:... for the three pubkeys
+                                       + 18       // IP, at longest: 15:AAA.BBB.CCC.DDD
+                                       + 3 * 7    // iXXXXXe port, times 3.
+                                       + 3 * 14;  // 3 versions such as `liAAeiBBeiCCee`
+    addr.reserve(MAX_RECORD_LENGTH);
+
     // - K -- the snode's primary key (32 bytes).
     // - Ke -- the server's Ed pubkey, but only if different from K; otherwise this key is omitted.
     // - Kx -- the server's X pubkey, derived from the Ed pubkey.  32 bytes.
@@ -457,14 +445,20 @@ void omq_rpc::send_snode_addr_notifications(
     // - qn -- the service node oxend OMQ port (AKA "quorumnet" port), integer.
     // - sh -- the storage server HTTPS port, integer.
     // - sq -- the storage server QUIC (UDP) and OMQ (TCP) port, integer.
-    addr.append("K", tools::view_guts(snode_pk));
-    if (tools::view_guts(snode_pk) != tools::view_guts(ed_pk))
-        addr.append("Ke", tools::view_guts(ed_pk));
+    // - v -- oxend version triplet
+    // - vl -- lokinet version triplet
+    // - vs -- storage server version triplet
+    addr.append("K", tools::view_guts(proof.pubkey));
+    if (tools::view_guts(proof.pubkey) != tools::view_guts(proof.pubkey_ed25519))
+        addr.append("Ke", tools::view_guts(proof.pubkey_ed25519));
     addr.append("Kx", tools::view_guts(x_pk));
-    addr.append("ip", public_ip);
-    addr.append("qn", qnet_port);
-    addr.append("sh", storage_https_port);
-    addr.append("sq", storage_quic_port);
+    addr.append("ip", epee::string_tools::get_ip_string_from_int32(proof.public_ip));
+    addr.append("qn", proof.qnet_port);
+    addr.append("sh", proof.storage_https_port);
+    addr.append("sq", proof.storage_omq_port);
+    addr.append_list("v", proof.version);
+    addr.append_list("vl", proof.lokinet_version);
+    addr.append_list("vs", proof.storage_server_version);
     send_notifies(
             subs_mutex_,
             snode_addr_subs_,

--- a/src/rpc/omq_server.cpp
+++ b/src/rpc/omq_server.cpp
@@ -8,10 +8,14 @@
 #include <oxenmq/fmt.h>
 #include <oxenmq/oxenmq.h>
 
+#include <chrono>
+#include <utility>
 #include <variant>
 
 #include "common/string_util.h"
+#include "crypto/crypto.h"
 #include "cryptonote_config.h"
+#include "epee/string_tools.h"
 #include "rpc/common/param_parser.hpp"
 
 namespace cryptonote::rpc {
@@ -331,11 +335,17 @@ omq_rpc::omq_rpc(
     // or anyone on a private RPC node with public access level.
     omq.add_category("sub", AuthLevel::basic);
 
+    // Triggers on mempool additions:
     omq.add_request_command(
             "sub", "mempool", [this](oxenmq::Message& m) { on_mempool_sub_request(m); });
 
+    // Triggers on new blocks:
     omq.add_request_command(
             "sub", "block", [this](oxenmq::Message& m) { on_block_sub_request(m); });
+
+    // Triggers whenever there are IP and/or port changes to the service node list.
+    omq.add_request_command(
+            "sub", "snode_addr", [this](oxenmq::Message& m) { on_snode_addr_sub_request(m); });
 
     core_.blockchain.hook_block_post_add([this](const auto& info) {
         send_block_notifications(info.block);
@@ -347,6 +357,17 @@ omq_rpc::omq_rpc(
                                     const tx_pool_options& opts) {
         send_mempool_notifications(id, tx, blob, opts);
     });
+    core_.service_node_list.snode_addr_change_notifier =
+            [this](const uptime_proof::Proof& proof, const crypto::x25519_public_key& xpk) {
+                send_snode_addr_notifications(
+                        proof.pubkey,
+                        proof.pubkey_ed25519,
+                        xpk,
+                        epee::string_tools::get_ip_string_from_int32(proof.public_ip),
+                        proof.qnet_port,
+                        proof.storage_https_port,
+                        proof.storage_omq_port);
+            };
 }
 
 template <typename Mutex, typename Subs, typename Call>
@@ -409,6 +430,48 @@ void omq_rpc::send_mempool_notifications(
         if (sub.type == mempool_sub_type::all || opts.approved_blink)
             omq.send(conn, "notify.mempool", tools::view_guts(id), blob);
     });
+}
+
+void omq_rpc::send_snode_addr_notifications(
+        const crypto::public_key& snode_pk,
+        const crypto::ed25519_public_key& ed_pk,
+        const crypto::x25519_public_key& x_pk,
+        std::string_view public_ip,
+        uint16_t qnet_port,
+        uint16_t storage_https_port,
+        uint16_t storage_quic_port) {
+    oxenc::bt_dict_producer addr;
+    // 'l' + 3 '32:...' values +  + 32:...
+    constexpr size_t MAX_RECORD_LENGTH = 2       // de around the dict
+                                       + 3       // 1:K
+                                       + 6 * 4   // 2:.. for the 6 other, length-2 dict keys
+                                       + 3 * 35  // 32:... for the three pubkeys
+                                       + 18      // IP, at longest: 15:AAA.BBB.CCC.DDD
+                                       + 3 * 7;  // iXXXXXe port, times 3.
+    // 2 for the le around it, and then currently send exactly one record inside the list:
+    addr.reserve(2 + 1 * MAX_RECORD_LENGTH);
+    // - K -- the snode's primary key (32 bytes).
+    // - Ke -- the server's Ed pubkey, but only if different from K; otherwise this key is omitted.
+    // - Kx -- the server's X pubkey, derived from the Ed pubkey.  32 bytes.
+    // - ip -- the service node public IP address, as a string.
+    // - qn -- the service node oxend OMQ port (AKA "quorumnet" port), integer.
+    // - sh -- the storage server HTTPS port, integer.
+    // - sq -- the storage server QUIC (UDP) and OMQ (TCP) port, integer.
+    addr.append("K", tools::view_guts(snode_pk));
+    if (tools::view_guts(snode_pk) != tools::view_guts(ed_pk))
+        addr.append("Ke", tools::view_guts(ed_pk));
+    addr.append("Kx", tools::view_guts(x_pk));
+    addr.append("ip", public_ip);
+    addr.append("qn", qnet_port);
+    addr.append("sh", storage_https_port);
+    addr.append("sq", storage_quic_port);
+    send_notifies(
+            subs_mutex_,
+            snode_addr_subs_,
+            "snode addrs",
+            [this, payload = std::move(addr).str()](auto& conn, auto& sub) {
+                core_.omq().send(conn, "notify.snode_addr", payload);
+            });
 }
 
 /// Get a set of blocks, their transactions, and their created outputs' global indices
@@ -637,6 +700,31 @@ void omq_rpc::on_mempool_sub_request(oxenmq::Message& m) {
     }
 }
 
+template <typename SubType>
+static void process_sub(
+        oxenmq::Message& m,
+        std::string_view type,
+        std::unordered_map<oxenmq::ConnectionID, SubType>& subs) {
+
+    auto expiry = std::chrono::steady_clock::now() + 30min;
+    auto result = subs.emplace(m.conn, expiry);
+
+    if (!result.second) {
+        result.first->second.expiry = expiry;
+        m.send_reply("ALREADY");
+    } else {
+        m.send_reply("OK");
+    }
+
+    log::debug(
+            logcat,
+            "{} {} subscription from conn id {}@{}",
+            result.second ? "New" : "Renewed",
+            type,
+            m.conn.to_string(),
+            m.remote);
+}
+
 // New block subscriptions: [sub.block].  This sends a notification every time a new block is
 // added to the blockchain.
 //
@@ -650,24 +738,35 @@ void omq_rpc::on_mempool_sub_request(oxenmq::Message& m) {
 // encoded block hash).
 void omq_rpc::on_block_sub_request(oxenmq::Message& m) {
     std::unique_lock lock{subs_mutex_};
-    auto expiry = std::chrono::steady_clock::now() + 30min;
-    auto result = block_subs_.emplace(m.conn, block_sub{expiry});
-    if (!result.second) {
-        result.first->second.expiry = expiry;
-        log::trace(
-                logcat,
-                "Renewed block subscription request from conn id {}@{}",
-                m.conn.to_string(),
-                m.remote);
-        m.send_reply("ALREADY");
-    } else {
-        log::debug(
-                logcat,
-                "New block subscription request from conn {}@{}",
-                m.conn.to_string(),
-                m.remote);
-        m.send_reply("OK");
-    }
+    process_sub(m, "block", block_subs_);
+}
+
+// Snode address change subscriptions: [sub.snode_addr].  This sends a notification every time a new
+// IP address and/or ports are accepted for a service snode, including upon initially learning the
+// service node IP/port information.
+//
+// The subscription request itself returns "OK" if this is a new subscription, and "ALREADY" if the
+// request renewed an existing subscription on the same connection.  To keep track of all service
+// node IPs it is suggested that after an "OK" the client should fetch the entire list of snode
+// addresses (via get_service_nodes) as some updates may otherwise be missed.
+//
+// The notification for such changes consists of a message
+// [notify.snode_addr, snode_primary_key, data] where data is a bt-encoded array of updated values.
+// Each value is a dict with keys:
+//
+// - K -- the snode's primary key (32 bytes).
+// - Ke -- the server's Ed pubkey, but only if different from K; otherwise this key is omitted.
+// - Kx -- the server's X pubkey, derived from the Ed pubkey.  32 bytes.
+// - ip -- the service node public IP address, as a string.
+// - qn -- the service node oxend OMQ port (AKA "quorumnet" port), integer.
+// - sh -- the storage server HTTPS port, integer.
+// - sq -- the storage server QUIC (UDP) and OMQ (TCP) port, integer.
+//
+// These notification requests are *not* fired unless at least one of the values has actually
+// changed (i.e. new uptime proofs with the same values do not trigger a notification).
+void omq_rpc::on_snode_addr_sub_request(oxenmq::Message& m) {
+    std::unique_lock lock{subs_mutex_};
+    process_sub(m, "snode address", snode_addr_subs_);
 }
 
 }  // namespace cryptonote::rpc

--- a/src/rpc/omq_server.h
+++ b/src/rpc/omq_server.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "core_rpc_server.h"
+#include "crypto/crypto.h"
 #include "cryptonote_core/blockchain.h"
 #include "oxenmq/connections.h"
 
@@ -48,21 +49,22 @@ void init_omq_options(boost::program_options::options_description& desc);
  */
 class omq_rpc final {
 
+    struct basic_sub {
+        std::chrono::steady_clock::time_point expiry;
+    };
+
     enum class mempool_sub_type { all, blink };
     struct mempool_sub {
         std::chrono::steady_clock::time_point expiry;
         mempool_sub_type type;
     };
 
-    struct block_sub {
-        std::chrono::steady_clock::time_point expiry;
-    };
-
     cryptonote::core& core_;
     core_rpc_server& rpc_;
     std::shared_timed_mutex subs_mutex_;
     std::unordered_map<oxenmq::ConnectionID, mempool_sub> mempool_subs_;
-    std::unordered_map<oxenmq::ConnectionID, block_sub> block_subs_;
+    std::unordered_map<oxenmq::ConnectionID, basic_sub> block_subs_;
+    std::unordered_map<oxenmq::ConnectionID, basic_sub> snode_addr_subs_;
 
   public:
     omq_rpc(cryptonote::core& core,
@@ -77,12 +79,23 @@ class omq_rpc final {
             const std::string& blob,
             const tx_pool_options& opts);
 
+    void send_snode_addr_notifications(
+            const crypto::public_key& snode_pk,
+            const crypto::ed25519_public_key& ed_pk,
+            const crypto::x25519_public_key& x_pk,
+            std::string_view public_ip,
+            uint16_t qnet_port,
+            uint16_t storage_https_port,
+            uint16_t storage_quic_port);
+
   private:
     void on_get_blocks(oxenmq::Message& m);
 
     void on_mempool_sub_request(oxenmq::Message& m);
 
     void on_block_sub_request(oxenmq::Message& m);
+
+    void on_snode_addr_sub_request(oxenmq::Message& m);
 };
 
 }  // namespace cryptonote::rpc

--- a/src/rpc/omq_server.h
+++ b/src/rpc/omq_server.h
@@ -80,13 +80,7 @@ class omq_rpc final {
             const tx_pool_options& opts);
 
     void send_snode_addr_notifications(
-            const crypto::public_key& snode_pk,
-            const crypto::ed25519_public_key& ed_pk,
-            const crypto::x25519_public_key& x_pk,
-            std::string_view public_ip,
-            uint16_t qnet_port,
-            uint16_t storage_https_port,
-            uint16_t storage_quic_port);
+            const uptime_proof::Proof& proof, const crypto::x25519_public_key& x_pk);
 
   private:
     void on_get_blocks(oxenmq::Message& m);

--- a/utils/lmq-watch.py
+++ b/utils/lmq-watch.py
@@ -11,6 +11,7 @@ import re
 import time
 import random
 import shutil
+import oxenc
 
 
 context = zmq.Context()
@@ -40,10 +41,11 @@ if len(sys.argv) > 1 and len(sys.argv[1]) == 64 and all(x in "0123456789abcdefAB
 
 if (not 2 <= len(sys.argv) <= 3
         or any(x in y for x in ("--help", "-h") for y in sys.argv[1:])
-        or not all(x in ('BLOCK', 'TX', 'BLINK') for x in sys.argv[1:])):
-    print("Usage: {} [ipc:///path/to/sock|tcp://1.2.3.4:5678] [SERVER_CURVE_PUBKEY [LOCAL_CURVE_PRIVKEY]] [BLOCK] [TX|BLINK]\n"
+        or not all(x in ('BLOCK', 'TX', 'BLINK', 'SNODEADDR') for x in sys.argv[1:])):
+    print("Usage: {} [ipc:///path/to/sock|tcp://1.2.3.4:5678] [SERVER_CURVE_PUBKEY [LOCAL_CURVE_PRIVKEY]] [BLOCK] [TX|BLINK] [SNODEADDR]\n"
             "  Connects to the given server and waits for new blocks (if BLOCK specified), new mempool transactions of\n"
-            "  any type (if TX specified), and/or new blinks (if BLINK specified).  TX and BLINK are mutually exclusive.".format(sys.argv[0]),
+            "  any type (if TX specified), new blinks (if BLINK specified), and/or snode address changes (if SNODEADDR\n"
+            "  given).  TX and BLINK are mutually exclusive.".format(sys.argv[0]),
             file=sys.stderr)
     sys.exit(1)
 
@@ -60,6 +62,8 @@ def subscribe():
         socket.send_multipart([b'sub.mempool', b'_txallsub', b'all'])
     elif 'BLINK' in sys.argv[1:]:
         socket.send_multipart([b'sub.mempool', b'_txblinksub', b'blink'])
+    elif 'SNODEADDR' in sys.argv[1:]:
+        socket.send_multipart([b'sub.snode_addr', b'_snaddrsub'])
     global last_sub_time
     last_sub_time = time.time()
 
@@ -81,10 +85,10 @@ while True:
         continue
 
     m = socket.recv_multipart()
-    if len(m) == 3 and m[0] == b'REPLY' and m[1] in (b'_blocksub', b'_txallsub', b'_txblinksub') and m[2] in (b'OK', b'ALREADY'):
+    if len(m) == 3 and m[0] == b'REPLY' and m[1] in (b'_blocksub', b'_txallsub', b'_txblinksub', b'_snaddrsub') and m[2] in (b'OK', b'ALREADY'):
         if m[2] == b'ALREADY':
             continue
-        what = 'new blocks' if m[1] == b'_blocksub' else 'new txes' if m[1] == b'_txallsub' else 'new blinks'
+        what = 'new blocks' if m[1] == b'_blocksub' else 'new txes' if m[1] == b'_txallsub' else 'snode addr changes' if m[1] == b'_snaddrsub' else 'new blinks'
         if what in subbed:
             print("Re-subscribed to {} (perhaps the server restarted?)".format(what))
         else:
@@ -94,6 +98,15 @@ while True:
         print("New TX: {}".format(m[1].hex()))
     elif len(m) == 3 and m[0] == b'notify.block':
         print("New block: Height {}, hash {}".format(int(m[1]), m[2].hex()))
+    elif len(m) == 2 and m[0] == b'notify.snode_addr':
+        try:
+            info = oxenc.bt_deserialize(m[1])
+        except Exception as e:
+            print(f"Failed to decode snode addr info: {e}")
+            continue
+
+        print(f"Snode address change for {info[b'K'].hex()}:")
+        print(f"  {info[b'ip'].decode()}, :{info[b'qn']} (quorumnet), :{info[b'sh']} (SS HTTPS), :{info[b'sq']} (SS QUIC)")
     else:
         print("Received unexpected {}-part message from oxend:".format(len(m)), file=sys.stderr)
         for x in m:


### PR DESCRIPTION
Currently there are bugs in storage server around noticing new IP addresses.  This adds a mechanism into oxend so that storage server can subscribe to snode IP/port address changes to get them pushed as soon as oxend received the uptime proof with the new address, so that storage server will be able to update the record it uses to reach other storage servers as soon as possible.

This works by sending a "sub.snode_addr" request to oxend (and repeated occasionally to prevent the subscription from timing out), after which oxend will fire "notify.snode_addr" commands back along the connection whenever a proof is received that changes IP/port/pubkey info.

The change to the utils/ script here is for testing this:

```
$ ./lmq-watch.py ipc:///home/jagerman/.oxen/stagenet4/lokid.sock SNODEADDR
Connecting to ipc:///home/jagerman/.oxen/stagenet4/lokid.sock
Subscribed to snode addr changes
Snode address change for 13ef07a5dbc9ed07aa5720628a45d615eef0adba513210566a083964dea00502:
  144.91.127.110, :10036 (quorumnet), :0 (SS HTTPS), :0 (SS QUIC)
Snode address change for 001013496a4353101fc1438b6e21a43576a2f1bb6ca6b5861ed03c52534e0255:
  80.246.144.221, :10034 (quorumnet), :0 (SS HTTPS), :0 (SS QUIC)
Snode address change for ceda33e5a8f002e3fd341d2bf7fc05d796435664830d68ab61c5175137628164:
  45.207.195.210, :11025 (quorumnet), :0 (SS HTTPS), :0 (SS QUIC)
...
```
Note that you are unlikely to see much output from this unless your node hasn't been synced in a while, since it only reports on changed values; this particular stagenet oxend had not synced in 3-4 weeks.  A mainnet node that was fully synced received just one in my testing, for [this IP change](https://oxen.observer/tx/8373a7b0c0ce67dea33fa99ffe5ffc946f1e5af8fdf7d2f5dfbf10d1555ddbcc).