### PR TITLE
oxend status: show pending registration mempool & confirmations

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -544,7 +544,9 @@ bool rpc_command_executor::show_status() {
     std::string my_sn_key, my_bls;
     int64_t my_decomm_remaining = 0;
     uint64_t my_sn_last_uptime = 0;
-    bool my_sn_registered = false, my_sn_staked = false, my_sn_active = false;
+    bool my_sn_registered = false, my_sn_staked = false, my_sn_active = false,
+         my_reg_in_mempool = false, my_reg_confirming = false;
+    double my_reg_conf = 0, my_reg_conf_required = 0;
     uint16_t my_reason_all = 0, my_reason_any = 0;
     if (info["service_node"].get<bool>()) {
         auto maybe_service_keys = try_running(
@@ -574,6 +576,23 @@ bool rpc_command_executor::show_status() {
                 my_sn_last_uptime = state["last_uptime_proof"].get<uint64_t>();
                 my_reason_all = state.value<uint16_t>("last_decommission_reason_consensus_all", 0);
                 my_reason_any = state.value<uint16_t>("last_decommission_reason_consensus_any", 0);
+            }
+        }
+        if (!my_sn_registered) {
+            if (auto maybe_pending = try_running(
+                        [this] {
+                            return invoke<GET_PENDING_EVENTS>(json{{"include_mempool", true}});
+                        },
+                        "Failed to retrieve pending L2 events")) {
+                for (const auto& reg : maybe_pending->at("registrations")) {
+                    if (reg.at("sn_pubkey") != my_sn_key)
+                        continue;
+
+                    auto reg_height = reg.value<uint64_t>("height", 0);
+                    (reg_height == 0 ? my_reg_in_mempool : my_reg_confirming) = true;
+                    my_reg_conf = reg.value<double>("confirmations", 0);
+                    my_reg_conf_required = reg.value<double>("required", 0);
+                }
             }
         }
     }
@@ -628,9 +647,15 @@ bool rpc_command_executor::show_status() {
 
     if (!my_sn_key.empty()) {
         msg.flush().append("SN: {} ", my_sn_key);
-        if (!my_sn_registered)
-            msg += "not registered";
-        else if (!my_sn_staked)
+        if (!my_sn_registered) {
+            if (my_reg_in_mempool)
+                msg += "incoming reg";
+            else if (my_reg_confirming)
+                msg += "confirming reg ({}/{})"_format(
+                        my_reg_conf, my_reg_conf + my_reg_conf_required);
+            else
+                msg += "not registered";
+        } else if (!my_sn_staked)
             msg += "awaiting";
         else if (my_sn_active)
             msg += "active";


### PR DESCRIPTION
This makes `oxend status` query for incoming registrations if the SN is not found in get_service_nodes, and then shows the confirmation status instead of just showing "not registered".

Some example outputs:

In interactive mode, unmined L2 registration in the mempool:
```
status
Height: 754811 ON TESTNET, v11.0.6-9243623fb-dev(net v21), 8(out)+0(in) connections, uptime 3m3s
SN: 5ec3d29f58335adae2b2989d635c3fd90e18b0ea17b441914d5c5da7441e0e62 incoming reg, proof: (never), last pings: NOT RECEIVED (storage), NOT RECEIVED (lokinet)
BLS pk: 21fe4377778c0f14129cbdfd4c8f60987c8d871d34aad95f67727978af5da7c20e5a4413c885fbe604b58b4c3d3137674f4b2e0ff7dba4c6525984d88e54824b
[2025-04-09 19:15:01] [+4m19.463s] [global:info|service_node_list.cpp:1822] New service node registration v2 tx (3dd0aa68e3528fe25fc8d0d01a8fe346c8887937779d77c23157cd566804431e) from ethereum: 5ec3d29f58335adae2b2989d635c3fd90e18b0ea17b441914d5c5da7441e0e62 (THIS NODE) @ height: 754811; awaiting confirmations
status
Height: 754812 ON TESTNET, v11.0.6-9243623fb-dev(net v21), 8(out)+0(in) connections, uptime 4m28s
SN: 5ec3d29f58335adae2b2989d635c3fd90e18b0ea17b441914d5c5da7441e0e62 confirming reg (1/5), proof: (never), last pings: NOT RECEIVED (storage), NOT RECEIVED (lokinet)
BLS pk: 21fe4377778c0f14129cbdfd4c8f60987c8d871d34aad95f67727978af5da7c20e5a4413c885fbe604b58b4c3d3137674f4b2e0ff7dba4c6525984d88e54824b
```

oxend command mode:
```
$ oxend-decaf18 status
[2025-04-09 18:48:42] [+0.001s] [global:info|daemon/main.cpp:327] Oxen 'Wistful Wagyu' (v11.0.6-9243623fb-dev)
Height: 754798 ON TESTNET, v11.0.6-9243623fb-dev(net v21), 8(out)+5(in) connections, uptime 1m13s
SN: decaf18aa6d2008994aaa5a997e7a10f688984127c532c98cca6166e3229b7ed confirming reg (3/5), proof: (never), last pings: 18sec (storage), 17sec (lokinet)
BLS pk: 1d8d4499f58572b68112978a27498b436457aed0ce9a8ca0d83a5e50253775032749b85fbbeaf1551910e9308dc7830dd6f0931bd71183f5e4b04c14849a7e43
```

