### PR TITLE
Fix null-pointer deref in uninitialised MDB read TX

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3821,8 +3821,15 @@ bool BlockchainLMDB::block_rtxn_start(MDB_txn** mtxn, mdb_txn_cursors** mcur) co
 }
 
 void BlockchainLMDB::block_rtxn_stop() const {
-    mdb_txn_reset(m_tinfo->m_ti_rtxn);
-    memset(&m_tinfo->m_ti_rflags, 0, sizeof(m_tinfo->m_ti_rflags));
+    if (mdb_threadinfo* mdb_tls = m_tinfo.get(); mdb_tls) {
+        mdb_txn_reset(mdb_tls->m_ti_rtxn);
+        memset(&mdb_tls->m_ti_rflags, 0, sizeof(mdb_tls->m_ti_rflags));
+    } else {
+        // NOTE: If a read transaction is not present (i.e. m_tinfo is not initialised) then the
+        // current legacy code was built to reuse the already open write transaction (so we expect
+        // m_write_txn to be set).
+        assert(m_write_txn);
+    }
 }
 
 bool BlockchainLMDB::block_rtxn_start() const {


### PR DESCRIPTION
In legacy monero code, if a thread is trying to open a read transaction (typically w/ db_rtxn_guard) on the DB and the thread already has a write transaction open, then db_rtxn_guard will not create `m_tinfo` and instead reuse the write transaction.

When db_rtxn_guard destructs, it will attempt to call block_rtxn_stop and `m_tinfo` is not initialised hence the null check here to avoid a null pointer dereference.

This triggers frequently on the local devnet scripts where a daemon starts up and immediately receives a block over P2P before it's done any read transactions on the DB. Since it opens a write transaction to receive the block and it has not opened a read transaction before, the behaviour is to re-use the write transaction.

When db_rtxn_guard RAII helper destructs it will attempt to "close" the read transaction. This function doesn't check if the read transaction was actually initialised (because it reused the write transaction) causing a null pointer dereference.

This used to work before the LMDB resize simplify PR was merged because when a block was received, it'd open a batch that queried the DB for historical blocks in an attempt to measure a reasonable batch size for the transaction. That was removed and so we hit a situation where a write transaction was initiated before a read transaction was.

It'd be nice to ensure all threads initialise their TLS MDB data structures upfront but this is not easily done due to the sprawly nature of threads that are spawned by various boost/daemon/epee systems that happen before the DB is even loaded which means they must be lazily initialised on the worker threads when it invokes that code path.