### PR TITLE
Wallet crash fixes from bad payload parsing

### DIFF
--- a/contrib/epee/include/epee/storages/portable_storage.h
+++ b/contrib/epee/include/epee/storages/portable_storage.h
@@ -180,15 +180,18 @@ namespace epee
     bool portable_storage::get_value(const std::string& value_name, T& val, section* parent_section)
     {
       static_assert(variant_contains<T, storage_entry>);
-      //TRY_ENTRY();
-      if(!parent_section) parent_section = &m_root;
+      if (!parent_section)
+          parent_section = &m_root;
       storage_entry* pentry = find_storage_entry(value_name, parent_section);
-      if(!pentry)
-        return false;
+      if (!pentry)
+          return false;
 
-      var::visit([&val](const auto& v) { convert_t(v, val); }, *pentry);
-      return true;
-      //CATCH_ENTRY("portable_storage::template<>get_value", false);
+      try {
+          var::visit([&val](const auto& v) { convert_t(v, val); }, *pentry);
+          return true;
+      } catch (const std::exception&) {
+          return false;
+      }
     }
     //---------------------------------------------------------------------------------------------------------------
     template <typename T>

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1142,7 +1142,7 @@ namespace {
         std::string bd;
 
         // easy case if we have the whole tx
-        if (entry["as_hex"] || (entry["prunable"] && entry["pruned"])) {
+        if (entry.contains("as_hex") || (entry.contains("prunable") && entry.contains("pruned"))) {
             std::string hex_blob;
             if (entry["as_hex"])
                 hex_blob = entry["as_hex"].get<std::string>();
@@ -1164,7 +1164,7 @@ namespace {
             return true;
         }
         // case of a pruned tx with its prunable data hash
-        if (entry["pruned"] && entry["prunable_hash"]) {
+        if (entry.contains("pruned") && entry.contains("prunable_hash")) {
             crypto::hash ph;
             CHECK_AND_ASSERT_MES(
                     tools::try_load_from_hex_guts(

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -225,10 +225,17 @@ void wallet_rpc_server::handle_json_rpc_request(HttpResponse& res, HttpRequest& 
         if (!ps.load_from_json(body))
             return jsonrpc_error_response(res, -32700, "Parse error", {});
 
-        epee::serialization::storage_entry epee_id{std::string{}};
-        ps.get_value("id", epee_id, nullptr);
-
-        nlohmann::json id = var::get<std::string>(epee_id);
+        nlohmann::json id;
+        epee::serialization::storage_entry epee_id;
+        if (std::string str_val; ps.get_value("id", str_val, nullptr)) {
+            epee_id = str_val;
+            id = std::move(str_val);
+         } else if (int64_t i64_val; ps.get_value("id", i64_val, nullptr)) {
+            epee_id = i64_val;
+            id = i64_val;
+        } else {
+            return jsonrpc_error_response(res, -32700, "Parse error, missing a valid (string or integer) JSON RPC 'id'", {});
+        }
 
         std::string method;
         if (!ps.get_value("method", method, nullptr)) {
@@ -328,7 +335,7 @@ void wallet_rpc_server::handle_json_rpc_request(HttpResponse& res, HttpRequest& 
         }
 
         if (json_error.code != 0)
-            return jsonrpc_error_response(res, json_error.code, std::move(json_error.message), {});
+            return jsonrpc_error_response(res, json_error.code, std::move(json_error.message), id);
 
         res.writeHeader("Server", server_header());
         res.writeHeader("Content-Type", "application/json");

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -230,11 +230,15 @@ void wallet_rpc_server::handle_json_rpc_request(HttpResponse& res, HttpRequest& 
         if (std::string str_val; ps.get_value("id", str_val, nullptr)) {
             epee_id = str_val;
             id = std::move(str_val);
-         } else if (int64_t i64_val; ps.get_value("id", i64_val, nullptr)) {
+        } else if (int64_t i64_val; ps.get_value("id", i64_val, nullptr)) {
             epee_id = i64_val;
             id = i64_val;
         } else {
-            return jsonrpc_error_response(res, -32700, "Parse error, missing a valid (string or integer) JSON RPC 'id'", {});
+            return jsonrpc_error_response(
+                    res,
+                    -32700,
+                    "Parse error, missing a valid (string or integer) JSON RPC 'id'",
+                    {});
         }
 
         std::string method;


### PR DESCRIPTION
The reference pruned TX parsing code looks like this: https://github.com/monero-project/monero/blob/3b01c490953fe92f3c6628fa31d280a4f0490d28/src/wallet/wallet2.cpp#L960 so a simple key-check suffices to determine if that branch should execute.