### PR TITLE
Add hardfork block&timestamp calculator

### DIFF
--- a/contrib/hardfork-calc.py
+++ b/contrib/hardfork-calc.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import sys
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+try:
+    dates = [datetime.fromisoformat(a) for a in sys.argv[1:]]
+    if not dates:
+        raise RuntimeError("No date(s) provided!")
+except Exception as e:
+    print(
+        f"""
+Invalid arguments: {e}
+
+Usage: {sys.argv[0]} 2025-04-29T09:30:00+10:00 [...] -- calculates Oxen fork block & timestamps.
+""",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+zones = [
+        ("Melbourne", ZoneInfo("Australia/Melbourne")),
+        ("Fredericton", ZoneInfo("America/Halifax"))
+        ]
+
+for d in dates:
+    x = d.astimezone(timezone.utc)
+    z = d.timestamp()
+    print("\n\nFork block & timestamp for hardfork.cpp:\n")
+    # Blocks since HF16 are based on the timestamp of the last block before HF15, which was block
+    # 641110 with timestamp 1602469341:
+    print(f"    {((z - 1602469341) / 120) + 641110},")
+    print(f"    {int(z)} /* {x:%A, %B %e, %Y %H:%M} UTC */\n")
+    for name, zone in zones:
+        y = d.astimezone(zone)
+        print(f"{name} time: {y:%A, %B %e, %Y %H:%M %Z}")
+    print()


### PR DESCRIPTION
Example usage/output:
```
./contrib/hardfork-calc.py 2025-05-13T{09:00,09:30,10:00,10:30}:00+10:00

Fork block & timestamp for hardfork.cpp:

    1846289,
    1747090800 /* Monday, May 12, 2025 23:00 UTC */

Melbourne time: Tuesday, May 13, 2025 09:00 AEST
Fredericton time: Monday, May 12, 2025 20:00 ADT

Fork block & timestamp for hardfork.cpp:

    1846304,
    1747092600 /* Monday, May 12, 2025 23:30 UTC */

Melbourne time: Tuesday, May 13, 2025 09:30 AEST
Fredericton time: Monday, May 12, 2025 20:30 ADT

Fork block & timestamp for hardfork.cpp:

    1846319,
    1747094400 /* Tuesday, May 13, 2025 00:00 UTC */

Melbourne time: Tuesday, May 13, 2025 10:00 AEST
Fredericton time: Monday, May 12, 2025 21:00 ADT

Fork block & timestamp for hardfork.cpp:

    1846334,
    1747096200 /* Tuesday, May 13, 2025 00:30 UTC */

Melbourne time: Tuesday, May 13, 2025 10:30 AEST
Fredericton time: Monday, May 12, 2025 21:30 ADT
```