### PR TITLE
Move systemd "ready" notification earlier in the startup

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -153,12 +153,12 @@ Blockchain::~Blockchain() {
 
 void Blockchain::extend_watchdog_timeout(uint64_t height) {
 #ifdef ENABLE_SYSTEMD
-    // Tell systemd that we're doing something so that it should let us continue starting up
-    // (giving us 120s until we have to send the next notification):
+    // Tell systemd that we're doing something; we use this during early rescanning (before the
+    // timer for regular operations is set up, but after we've told systemd that we started) to keep
+    // the process alive and update the systemctl status value with the rescan status.
     sd_notify(
             0,
-            "EXTEND_TIMEOUT_USEC=120000000\nSTATUS=Recanning blockchain; height {}/{}"_format(
-                    height, m_db->height())
+            "WATCHDOG=1\nSTATUS=Recanning blockchain; height {}/{}"_format(height, m_db->height())
                     .c_str());
 #endif
 }
@@ -762,6 +762,7 @@ bool Blockchain::init(
         const cryptonote::test_options* test_options,
         difficulty_type fixed_difficulty,
         const GetCheckpointsCallback& get_checkpoints /* = nullptr*/,
+        std::function<void()> pre_rescan_cb,
         const std::atomic<bool>* abort)
 
 {
@@ -859,6 +860,11 @@ bool Blockchain::init(
                     std::chrono::system_clock::now() -
                     std::chrono::system_clock::from_time_t(top_block_timestamp)));
     rtxn_guard.stop();
+
+    // We've not got the initial blockchain loaded, so fire the callback so that core can treat us
+    // as "started" before we dive into the potentially slow block popping and rescanning.
+    if (pre_rescan_cb)
+        pre_rescan_cb();
 
     uint64_t num_popped_blocks = 0;
     while (!m_db->is_read_only()) {

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -165,6 +165,9 @@ class Blockchain {
      * @param test_options test parameters
      * @param fixed_difficulty fixed difficulty for testing purposes; 0 means disabled
      * @param get_checkpoints if set, will be called to get checkpoints data
+     * @param pre_rescan_cb if set will be called once databases have been loaded successfully from
+     * disk, but before the potentially heavy/slow operations (popping blocks or rescanning the
+     * chain that may be required).
      * @param abort if set, will be checked periodically during subsystem scanning: if it becomes
      * true then initialization will be aborted.
      *
@@ -179,6 +182,7 @@ class Blockchain {
             const cryptonote::test_options* test_options = nullptr,
             difficulty_type fixed_difficulty = 0,
             const GetCheckpointsCallback& get_checkpoints = nullptr,
+            std::function<void()> pre_rescan_cb = nullptr,
             const std::atomic<bool>* abort = nullptr);
 
     // Common initializer for test code

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -564,6 +564,7 @@ bool core::init(
         const boost::program_options::variables_map& vm,
         const cryptonote::test_options* test_options,
         const GetCheckpointsCallback& get_checkpoints /* = nullptr */,
+        std::function<void()> pre_rescan_cb,
         const std::atomic<bool>* abort) {
     ZoneScoped;
     start_time = std::time(nullptr);
@@ -875,6 +876,7 @@ bool core::init(
                                                                     : test_options,
             command_line::get_arg(vm, arg_fixed_difficulty),
             get_checkpoints,
+            std::move(pre_rescan_cb),
             abort);
     CHECK_AND_ASSERT_MES(r, false, "Failed to initialize blockchain storage");
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -365,6 +365,9 @@ class core final {
      * @param get_checkpoints if set, will be called to get checkpoints data, must return
      * checkpoints data pointer and size or nullptr if there ain't any checkpoints for specific
      * network type
+     * @param pre_rescan_cb if set, will be called just before we start popping blocks or rescanning
+     * the database.  This is used by daemon.cpp as the point at which to tell systemd that startup
+     * is complete before potentially starting in on slow operations.
      * @param abort optional atomic<bool> that will be checked periodically during potentially long
      * sections of initialization (most notably: service node state/ons/reward rescanning) to
      * allowing abort initialization.
@@ -375,6 +378,7 @@ class core final {
             const boost::program_options::variables_map& vm,
             const test_options* test_options = NULL,
             const GetCheckpointsCallback& get_checkpoints = nullptr,
+            std::function<void()> pre_rescan_cb = nullptr,
             const std::atomic<bool>* abort = nullptr);
 
     /**

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -367,7 +367,18 @@ bool daemon::run(bool interactive) {
         get_checkpoints = blocks::GetCheckpointsData;
 #endif
         log::info(logcat, "Starting core");
-        if (!core->init(vm, nullptr, get_checkpoints, &shutdown))
+        if (!core->init(
+                    vm,
+                    nullptr,
+                    get_checkpoints,
+#ifdef ENABLE_SYSTEMD
+                    [this] {
+                        sd_notify(0, ("READY=1\nSTATUS=" + core->get_status_string()).c_str());
+                    },
+#else
+                    nullptr,
+#endif
+                    &shutdown))
             throw oxen::traced<std::runtime_error>("Failed to start core");
 
         log::info(logcat, "Starting OxenMQ");
@@ -409,10 +420,6 @@ bool daemon::run(bool interactive) {
                 globallogcat,
                 fg(fmt::terminal_color::green) | fmt::emphasis::bold,
                 "Starting up main network");
-
-#ifdef ENABLE_SYSTEMD
-        sd_notify(0, ("READY=1\nSTATUS=" + core->get_status_string()).c_str());
-#endif
 
         p2p->run();  // blocks until p2p goes down
         log::info(


### PR DESCRIPTION
Currently we only send READY=1 to systemd after any block popping or blockchain rescanning, but unfortunately those can take an extended period, during which the `systemctl start oxend` command will be stalled waiting for it.

This moves it to just before we start popping or rescanning.  This is a bit unfortunate that we won't (from a systemctl perspective) fail to start for various runtime reasons (such as being unable to bind to the p2p or omq ports), but that seems better than making "systemctl start oxend" stall for an hour (most notably including on upgrades).