### PR TITLE
Allow startup (but not proofs!) during HF20 without an L2

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -454,13 +454,16 @@ bool core::handle_command_line(const boost::program_options::variables_map& vm) 
         if (command_line::get_arg(vm, arg_l2_provider).empty() &&
             command_line::get_arg(vm, arg_l2_oxend).empty()) {
             auto latest_hf_known = get_latest_hard_fork(m_nettype);
-            if (latest_hf_known.version < hf::hf20_eth_transition) {
-                // If HF20 is not yet scheduled on this chain then only warn but don't error.
-                log::warning(globallogcat, "No L2 provider URL was given.");
-                log::warning(
+            if (latest_hf_known.version < hf::hf21_eth) {
+                // If HF21 is not yet scheduled on this chain then show an error in the logs because
+                // we won't send proofs, but don't make it fatal.  This is needed, in particular, to
+                // help with HF20 package migration where oxend might get restarted with
+                // service-node=1 configured by without the l2-provider= configuration added yet.
+                log::error(globallogcat, "No L2 providers given.");
+                log::error(
                         globallogcat,
-                        "At least one L2 provider URL (or L2 oxend proxy) will be REQUIRED "
-                        "starting with the HF20/Anchor release");
+                        "At least one L2 provider URL (or L2 oxend proxy) is REQUIRED. Uptime "
+                        "proofs will not be sent until this is corrected!");
             } else {
                 log::error(
                         logcat,


### PR DESCRIPTION
Due to a quirk of how oxend gets installed, oxend will get restarted during upgrade with service-node=1 set in the config but before the session-service-node package has had a chance to rewrite the config with the needed l2-provider= entries.

Currently this causes the package upgrade to stall for a few minutes in a restart loop until systemd gives up trying to start it.  This fixes it by allowing the startup without an l2-provider (but still not allowing proofs to go out until a provider is added).