### PR TITLE
Report L2 status in get_info & oxend status

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -57,7 +57,7 @@ if(NOT TARGET oxen::logging)
 endif()
 
 system_or_submodule(OXENC oxenc liboxenc>=1.4.0 oxen-encoding)
-system_or_submodule(OXENMQ oxenmq liboxenmq>=1.2.20 oxen-mq)
+system_or_submodule(OXENMQ oxenmq liboxenmq>=1.2.21 oxen-mq)
 
 add_subdirectory(db_drivers)
 add_subdirectory(randomx EXCLUDE_FROM_ALL)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -602,6 +602,10 @@ bool rpc_command_executor::show_status() {
     auto msg = tools::success_msg_writer("Height: {}", height);
     if (height != net_height)
         msg.append("/{} ({:.1f}%)", net_height, get_sync_percentage(height, net_height));
+    msg.append(" (L2: {}", info["l2_height"].get<int64_t>());
+    if (auto tracker_l2 = info.value<int64_t>("l2_tracker_height", -1); tracker_l2 >= 0)
+        msg.append("/{}", tracker_l2);
+    msg.append(")");
 
     auto nettype = cryptonote::network_type_from_string(info.value("nettype", ""));
     if (nettype != cryptonote::network_type::MAINNET) {
@@ -638,7 +642,7 @@ bool rpc_command_executor::show_status() {
     if (restricted_response) {
         std::chrono::seconds uptime{now - info["start_time"].get<std::time_t>()};
         msg.append(
-                ", {}(out)+{}(in) connections, uptime {}",
+                ", {}(out)+{}(in) conns, up {}",
                 info["outgoing_connections_count"].get<int>(),
                 info["incoming_connections_count"].get<int>(),
                 tools::friendly_duration(uptime));

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -602,9 +602,10 @@ bool rpc_command_executor::show_status() {
     auto msg = tools::success_msg_writer("Height: {}", height);
     if (height != net_height)
         msg.append("/{} ({:.1f}%)", net_height, get_sync_percentage(height, net_height));
-    msg.append(" (L2: {}", info["l2_height"].get<int64_t>());
+    auto l2_height_chain = info["l2_height"].get<int64_t>();
+    msg.append(" (L2 blk: {}", l2_height_chain);
     if (auto tracker_l2 = info.value<int64_t>("l2_tracker_height", -1); tracker_l2 >= 0)
-        msg.append("/{}", tracker_l2);
+        msg.append(", cur: {:+d}", tracker_l2 - l2_height_chain);
     msg.append(")");
 
     auto nettype = cryptonote::network_type_from_string(info.value("nettype", ""));

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -602,11 +602,19 @@ bool rpc_command_executor::show_status() {
     auto msg = tools::success_msg_writer("Height: {}", height);
     if (height != net_height)
         msg.append("/{} ({:.1f}%)", net_height, get_sync_percentage(height, net_height));
-    auto l2_height_chain = info["l2_height"].get<int64_t>();
-    msg.append(" (L2 blk: {}", l2_height_chain);
-    if (auto tracker_l2 = info.value<int64_t>("l2_tracker_height", -1); tracker_l2 >= 0)
-        msg.append(", cur: {:+d}", tracker_l2 - l2_height_chain);
-    msg.append(")");
+    auto l2_height_chain = info.value<int64_t>("l2_height", 0);
+    auto tracker_l2 = info.value<int64_t>("l2_tracker_height", -1);
+    if (l2_height_chain == 0) {
+        // We are most likely in a pre-HF21 part of the chain, so only print the cur L2 tracker
+        // height (if we have it):
+        if (tracker_l2 >= 0)
+            msg.append(" (L2 cur: {})", tracker_l2);
+    } else {
+        msg.append(" (L2 blk: {}", l2_height_chain);
+        if (tracker_l2 >= 0)
+            msg.append(", cur: {:+d}", tracker_l2 - l2_height_chain);
+        msg.append(")");
+    }
 
     auto nettype = cryptonote::network_type_from_string(info.value("nettype", ""));
     if (nettype != cryptonote::network_type::MAINNET) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -226,6 +226,8 @@ void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
 
     info.response["height"] = height;
     info.response["l2_height"] = top_block.l2_height;
+    if (auto* l2 = bs.maybe_l2_tracker())
+        info.response["l2_tracker_height"] = l2->get_latest_height();
     info.response_hex["top_block_hash"] = get_block_hash(top_block);
     info.response["target_height"] = m_core.get_target_blockchain_height();
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -504,7 +504,10 @@ struct MINING_STATUS : LEGACY, NO_ARGS {
 ///
 /// - `status` -- General RPC status string. `"OK"` means everything looks good.
 /// - `height` -- Current length of longest chain known to daemon.
-/// - `l2_height` -- Current Arbitrum height that the network is synchronized to
+/// - `l2_height` -- Current Arbitrum height that the network is synchronized to, i.e. in the
+///   current top block.
+/// - `l2_tracker_height` -- The current L2 height known by this node's L2 tracker.  Omitted if this
+///   node does not have an L2 tracker.
 /// - `target_height` -- The height of the next block in the chain.
 /// - `immutable_height` -- The latest height in the blockchain that can not be reorganized (i.e.
 ///   is backed by at least 2 Service Node, or 1 hardcoded checkpoint, 0 if N/A).  Omitted if it


### PR DESCRIPTION
Currently it's not entirely obvious how to tell that your oxend is getting L2 updates properly; this commit aims to fix that.

This adds a `l2_tracker_height` field to get_info that reports the current L2 height via the node's l2 tracker, as an alternative to the existing `l2_tracker` field that reports the l2_height of the top block.

This new field is then used in the `oxend status` output to report the current L2 block heights of both the network and provider, such as:

    Height: 765478 (L2: 146073927/146074408) ON TESTNET, v11.2.0-bb1bf0fe5-dirty-dev(net v21), 8(out)+0(in) conns, up 18s
    SN: 5ec3d29f58335adae2b2989d635c3fd90e18b0ea17b441914d5c5da7441e0e62 not registered, proof: (never), last pings: NOT RECEIVED (storage), NOT RECEIVED (lokinet)
    BLS pk: 21fe4377778c0f14129cbdfd4c8f60987c8d871d34aad95f67727978af5da7c20e5a4413c885fbe604b58b4c3d3137674f4b2e0ff7dba4c6525984d88e54824b

I also shortened some of the strings on the status line to make it fit better in smaller terminals.

During testing of this, I encountered (and fixed) a somewhat obscure bug that causes interactive oxend commands to timeout if run on an uncontactable, deregistered, but not yet purged, service node, and so this updates the oxen-mq release with a bugfix version as well.