### PR TITLE
Fixes various issues with ONS RPC

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -148,7 +148,7 @@ endif()
 if(NOT TARGET nlohmann_json::nlohmann_json)
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
-    system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 nlohmann-json)
+    system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 ethyl/external/json)
 
     if(CMAKE_BUILD_TYPE STREQUAL "Release")
         set(default_nlohmann_diags OFF)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -145,6 +145,22 @@ if(BUILD_PYBIND)
 endif()
 
 
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
+    system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 nlohmann-json)
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        set(default_nlohmann_diags OFF)
+    else()
+        set(default_nlohmann_diags ON)
+    endif()
+    option(WITH_NLOHMANN_JSON_DIAGNOSTICS "Enables nlohmann-json extended diagnostic exception info" ${default_nlohmann_diags})
+    if(WITH_NLOHMANN_JSON_DIAGNOSTICS)
+        target_compile_definitions(nlohmann_json INTERFACE JSON_DIAGNOSTICS)
+    endif()
+endif()
+
 if(NOT WIN32 AND NOT APPLE)
   set(CPR_FORCE_OPENSSL_BACKEND ON CACHE BOOL "" FORCE)
 endif()
@@ -154,12 +170,6 @@ set(ethyl_ENABLE_LTO FALSE CACHE BOOL "" FORCE)
 add_subdirectory(ethyl EXCLUDE_FROM_ALL)
 oxen_install_library(ethyl)
 oxen_install_library(cpr)  # comes via ethyl
-
-if(NOT TARGET nlohmann_json::nlohmann_json)
-    set(JSON_BuildTests OFF CACHE INTERNAL "")
-    set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
-    system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 nlohmann-json)
-endif()
 
 
 # NOTE: By default cpptrace is configured to make stack-traces using libdwarf.

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -554,15 +554,18 @@ static constexpr std::array ons_str_type_mappings = {
         stringtypemap{"lokinet_5years"sv, mapping_type::lokinet_5years},
         stringtypemap{"lokinet_10years"sv, mapping_type::lokinet_10years}};
 
-std::optional<mapping_type> parse_ons_type(std::string input) {
+std::optional<mapping_type> parse_ons_type(std::string input, bool queryable_types_only) {
     // Lower-case the input:
     for (auto& c : input)
         if (c >= 'A' && c <= 'Z')
             c += ('A' - 'a');
 
     for (const auto& [str, map] : ons_str_type_mappings)
-        if (str == input)
+        if (str == input) {
+            if (queryable_types_only && is_lokinet_type(map) && map != mapping_type::lokinet)
+                return std::nullopt;
             return map;
+        }
 
     return std::nullopt;
 }
@@ -575,10 +578,13 @@ static constexpr std::array ons_int_type_mappings = {
         inttypemap{2, mapping_type::lokinet},
         inttypemap{1, mapping_type::wallet},
         inttypemap{0, mapping_type::session}};
-std::optional<mapping_type> parse_ons_type(uint16_t input) {
+std::optional<mapping_type> parse_ons_type(uint16_t input, bool queryable_types_only) {
     for (const auto& [inttype, map] : ons_int_type_mappings)
-        if (inttype == input)
+        if (inttype == input) {
+            if (queryable_types_only && is_lokinet_type(map) && map != mapping_type::lokinet)
+                return std::nullopt;
             return map;
+        }
 
     return std::nullopt;
 }

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -833,33 +833,34 @@ static bool check_condition(
 
 bool validate_ons_name(mapping_type type, std::string name, std::string* reason) {
     bool const is_lokinet = is_lokinet_type(type);
-    size_t max_name_len = 0;
+    size_t min_name_len = 1, max_name_len = 0;
 
-    if (is_lokinet)
+    if (is_lokinet) {
+        min_name_len = "a.loki"sv.size();
         max_name_len = name.find('-') != std::string::npos ? LOKINET_DOMAIN_NAME_MAX
                                                            : LOKINET_DOMAIN_NAME_MAX_NOHYPHEN;
-    else if (type == mapping_type::session)
+    } else if (type == mapping_type::session)
         max_name_len = ons::SESSION_DISPLAY_NAME_MAX;
     else if (type == mapping_type::wallet)
         max_name_len = ons::WALLET_NAME_MAX;
     else {
         if (reason)
-            *reason =
-                    "ONS type={} specifies unhandled mapping type in name validation"_format(type);
+            *reason = "ONS type '{}' is not supported"_format(type);
         return false;
     }
 
     // NOTE: Validate name length
     name = tools::lowercase_ascii_string(name);
     if (check_condition(
-                (name.empty() || name.size() > max_name_len),
+                name.size() < min_name_len || name.size() > max_name_len,
                 reason,
-                "ONS type={} specifies mapping from name->value where the name's length={} is 0 or "
-                "exceeds the maximum length={}, given name={}",
+                "ONS {0} name '{1}' (length={2}) is invalid: {0} names must be between {3} and {4} "
+                "characters long",
                 type,
+                name,
                 name.size(),
-                max_name_len,
-                name))
+                min_name_len,
+                max_name_len))
         return false;
 
     std::string_view name_view{name};  // Will chop this down as we validate each part
@@ -883,34 +884,22 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
             if (check_condition(
                         name == reserved,
                         reason,
-                        "ONS type={} specifies mapping from name->value using protocol reserved "
-                        "name={}",
+                        "ONS {} name '{}' is a reserved name that cannot be registered",
                         type,
                         name))
                 return false;
-
-        auto constexpr SHORTEST_DOMAIN = "a.loki"sv;
-        if (check_condition(
-                    name.size() < SHORTEST_DOMAIN.size(),
-                    reason,
-                    "ONS type={} specifies mapping from name->value where the name is shorter than "
-                    "the shortest possible name={}, given name={}",
-                    type,
-                    SHORTEST_DOMAIN,
-                    name))
-            return false;
 
         // Must end with .loki
         auto constexpr SUFFIX = ".loki"sv;
         if (check_condition(
                     !name_view.ends_with(SUFFIX),
                     reason,
-                    "ONS type={} specifies mapping from name->value where the name does not end "
-                    "with the domain .loki, name={}",
+                    "ONS {0} name '{1}' is invalid: {0} names must end with '.loki'",
                     type,
                     name))
             return false;
 
+        assert(name_view.size() > SUFFIX.size());  // Implied by min_name_len check
         name_view.remove_suffix(SUFFIX.size());
 
         // All domains containing '--' as 3rd/4th letter are reserved except for xn-- punycode
@@ -919,7 +908,9 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
                     name_view.size() >= 4 && name_view.substr(2, 2) == "--"sv &&
                             !name_view.starts_with("xn--"sv),
                     reason,
-                    "ONS type={} specifies reserved name `?\?--*.loki': {}",
+                    // This \? looks stupid, but is to suppress a trigraph warning
+                    "ONS {} name '{}' is invalid: names matching '?\?--*' are reserved (other than "
+                    "punycode xn--*)",
                     type,
                     name))
             return false;
@@ -928,8 +919,7 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
         if (check_condition(
                     !char_is_alphanum(name_view.front()),
                     reason,
-                    "ONS type={} specifies mapping from name->value where the name does not start "
-                    "with an alphanumeric character, name={}",
+                    "ONS {} name '{}' is invalid: names must start with a-z or 0-9",
                     type,
                     name))
             return false;
@@ -941,10 +931,9 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
             if (check_condition(
                         !char_is_alphanum(name_view.back()),
                         reason,
-                        "ONS type={} specifies mapping from name->value where the character "
-                        "preceding the .loki is not alphanumeric, char={}, name={}",
+                        "ONS {} name '{}' is invalid: the name before '.loki' must end with a-z or "
+                        "0-9",
                         type,
-                        name_view.back(),
                         name))
                 return false;
             name_view.remove_suffix(1);
@@ -954,8 +943,7 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
         if (check_condition(
                     !std::all_of(name_view.begin(), name_view.end(), char_is_alphanum_or<'-'>),
                     reason,
-                    "ONS type={} specifies mapping from name->value where the domain name contains "
-                    "more than the permitted alphanumeric or hyphen characters, name={}",
+                    "ONS {} name '{}' is invalid: names may only contain a-z, 0-9, and '-'",
                     type,
                     name))
             return false;
@@ -965,40 +953,25 @@ bool validate_ons_name(mapping_type type, std::string name, std::string* reason)
         // hyphens or underscores) in between and must end with a (alphanumeric or underscore)
         // ^[a-z0-9_]([a-z0-9-_]*[a-z0-9_])?$
 
-        // Must start with (alphanumeric or underscore)
-        if (check_condition(
-                    !char_is_alphanum_or<'_'>(name_view.front()),
-                    reason,
-                    "ONS type={} specifies mapping from name->value where the name does not start "
-                    "with an alphanumeric or underscore character, name={}",
-                    type,
-                    name))
-            return false;
-        name_view.remove_prefix(1);
-
-        if (!name_view.empty()) {
-            // Must NOT end with a hyphen '-'
-            if (check_condition(
-                        !char_is_alphanum_or<'_'>(name_view.back()),
-                        reason,
-                        "ONS type={} specifies mapping from name->value where the last character "
-                        "is a hyphen '-' which is disallowed, name={}",
-                        type,
-                        name))
-                return false;
-            name_view.remove_suffix(1);
-        }
-
         // Inbetween start and preceding suffix, (alphanumeric, hyphen or underscore) characters
         // permitted
         if (check_condition(
                     !std::all_of(name_view.begin(), name_view.end(), char_is_alphanum_or<'-', '_'>),
                     reason,
-                    "ONS type={} specifies mapping from name->value where the name contains more "
-                    "than the permitted alphanumeric, underscore or hyphen characters, name={}",
+                    "Invalid ONS {} name '{}': only a-z, 0-9, _, and - are permitted",
                     type,
                     name))
             return false;
+
+        // Must start with (alphanumeric or underscore)
+        if (check_condition(
+                    name_view.front() == '-' || name_view.back() == '-',
+                    reason,
+                    "Invalid ONS {} name '{}': names may not begin or end with a hyphen ('-')",
+                    type,
+                    name))
+            return false;
+
     } else {
         log::error(logcat, "Type not implemented");
         return false;

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -2738,8 +2738,6 @@ std::vector<mapping_record> name_system_db::get_mappings(
     assert(name_base64_hash.size() == 44 && name_base64_hash.back() == '=' &&
            oxenc::is_base64(name_base64_hash));
     std::vector<mapping_record> result;
-    if (types.empty())
-        return result;
 
     std::string sql_statement;
     std::vector<std::variant<uint16_t, uint64_t, std::string_view>> bind;
@@ -2752,13 +2750,13 @@ std::vector<mapping_record> name_system_db::get_mappings(
 
     // Generate string statement
     if (types.size()) {
-        sql_statement += " AND type IN (";
+        fmt::format_to(
+                std::back_inserter(sql_statement),
+                " AND type IN ({})",
+                fmt::join(std::string(types.size(), '?'), ", "));
 
-        for (size_t i = 0; i < types.size(); i++) {
-            sql_statement += i > 0 ? ", ?" : "?";
-            bind.emplace_back(db_mapping_type(types[i]));
-        }
-        sql_statement += ")";
+        for (auto t : types)
+            bind.emplace_back(db_mapping_type(t));
     }
 
     if (blockchain_height) {

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -2732,9 +2732,9 @@ std::optional<mapping_value> name_system_db::resolve(
 }
 
 std::vector<mapping_record> name_system_db::get_mappings(
-        std::vector<mapping_type> const& types,
         std::string_view name_base64_hash,
-        std::optional<uint64_t> blockchain_height) {
+        std::optional<uint64_t> blockchain_height,
+        const std::unordered_set<mapping_type>& only_types) {
     assert(name_base64_hash.size() == 44 && name_base64_hash.back() == '=' &&
            oxenc::is_base64(name_base64_hash));
     std::vector<mapping_record> result;
@@ -2748,14 +2748,12 @@ std::vector<mapping_record> name_system_db::get_mappings(
     sql_statement += "WHERE name_hash = ?";
     bind.emplace_back(name_base64_hash);
 
-    // Generate string statement
-    if (types.size()) {
+    if (!only_types.empty()) {
         fmt::format_to(
                 std::back_inserter(sql_statement),
                 " AND type IN ({})",
-                fmt::join(std::string(types.size(), '?'), ", "));
-
-        for (auto t : types)
+                fmt::join(std::string(only_types.size(), '?'), ", "));
+        for (auto t : only_types)
             bind.emplace_back(db_mapping_type(t));
     }
 

--- a/src/cryptonote_core/oxen_name_system.h
+++ b/src/cryptonote_core/oxen_name_system.h
@@ -271,9 +271,12 @@ struct settings_record {
     int version;
 };
 
-std::optional<mapping_type> parse_ons_type(std::string input);
-
-std::optional<mapping_type> parse_ons_type(uint16_t input);
+// Look up the ONS type from string or integer input.  Returns the mapping_type if the input is a
+// valid type value, otherwise returns nullopt.  If the queryable_types_only parameter is given and
+// true, then only the base types (session/wallet/lokinet) but not the special registration types
+// (e.g. lokinet_5years) will be accepted.
+std::optional<mapping_type> parse_ons_type(std::string input, bool queryable_types_only = false);
+std::optional<mapping_type> parse_ons_type(uint16_t input, bool queryable_types_only = false);
 
 struct mapping_record {
     // NOTE: We keep expired entries in the DB indefinitely because we need to

--- a/src/cryptonote_core/oxen_name_system.h
+++ b/src/cryptonote_core/oxen_name_system.h
@@ -367,16 +367,15 @@ struct name_system_db {
             std::string str, uint64_t blockchain_height, cryptonote::address_parse_info& addr_info);
     // The get_mapping* methods can return any mapping, or only active mappings: for only active
     // mappings, pass in the blockchain height.  If you omit it (or explicitly pass std::nullopt)
-    // then you will get the latest mappingsvalues regardless of whether expired or not they are
-    // expired.
+    // then you will get the latest mappingsvalues regardless of whether or not they are expired.
     mapping_record get_mapping(
             mapping_type type,
             std::string_view name_base64_hash,
             std::optional<uint64_t> blockchain_height = std::nullopt);
     std::vector<mapping_record> get_mappings(
-            std::vector<mapping_type> const& types,
             std::string_view name_base64_hash,
-            std::optional<uint64_t> blockchain_height = std::nullopt);
+            std::optional<uint64_t> blockchain_height = std::nullopt,
+            const std::unordered_set<mapping_type>& only_types = {});
     std::vector<mapping_record> get_mappings_by_owner(
             generic_owner const& key, std::optional<uint64_t> blockchain_height = std::nullopt);
     std::vector<mapping_record> get_mappings_by_owners(

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1906,10 +1906,11 @@ bool tx_memory_pool::fill_block_template(
 
     std::unordered_set<crypto::key_image> k_images;
 
-    // Track ONS buys because we can't put more than one for the same ONS name into the same block
-    // (otherwise the *block* will fail but validation won't, because validation here won't see the
-    // earlier tx has having taken effect, but the block addition will).
-    std::unordered_set<crypto::hash> ons_buys;
+    // Track ONS operations (buys, updates, renewals) because we can't put more than one for the
+    // same ONS name into the same block (otherwise the *block* will fail but validation won't,
+    // because validation here won't see the earlier tx has having taken effect to modify that name,
+    // but actual block addition does).
+    std::unordered_set<crypto::hash> ons_seen;
 
     log::debug(
             logcat,
@@ -2024,8 +2025,8 @@ bool tx_memory_pool::fill_block_template(
             // (one of the two will just get delayed for a block), and perfectly figuring out
             // whether two might conflict is complicated enough that it's not worth doing here.
             cryptonote::tx_extra_oxen_name_system ons;
-            if (cryptonote::get_field_from_tx_extra(tx.extra, ons) && ons.is_buying() &&
-                !ons_buys.emplace(ons.name_hash).second) {
+            if (cryptonote::get_field_from_tx_extra(tx.extra, ons) &&
+                !ons_seen.emplace(ons.name_hash).second) {
 
                 log::debug(logcat, "  conflicting ONS buy in mempool");
                 continue;

--- a/src/rpc/common/param_parser.hpp
+++ b/src/rpc/common/param_parser.hpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 #include "common/json_binary_proxy.h"
 
@@ -120,6 +121,13 @@ constexpr bool is_tuple_like<std::pair<S, T>> = true;
 template <typename... T>
 constexpr bool is_tuple_like<std::tuple<T...>> = true;
 
+// Allow std::variant<T, std::vector<T>> as a way to allow a field that takes either a single value
+// or an array of values.
+template <typename T>
+constexpr bool is_singleton_vec_variant = false;
+template <typename T>
+constexpr bool is_singleton_vec_variant<std::variant<T, std::vector<T>>> = !is_expandable_list<T>;
+
 template <typename TupleLike, size_t... Is>
 void load_tuple_values(bt_list_consumer&, TupleLike&, std::index_sequence<Is...>);
 
@@ -142,6 +150,11 @@ void load_value(BTConsumer& c, T& val) {
     } else if constexpr (is_tuple_like<T>) {
         auto lc = c.consume_list_consumer();
         load_tuple_values(lc, val, std::make_index_sequence<std::tuple_size_v<T>>{});
+    } else if constexpr (is_singleton_vec_variant<T>) {
+        if (c.is_list())
+            load_value(c, val.template emplace<1>());
+        else
+            load_value(c, val.template emplace<0>());
     } else
         static_assert(std::is_same_v<T, void>, "Unsupported load_value type");
 }
@@ -201,6 +214,10 @@ void load_value(json_range& r, T& val) {
         } catch (const std::exception& e) {
             throw oxen::traced<std::domain_error>{"Invalid values in '" + key + "'"};
         }
+    } else if constexpr (is_singleton_vec_variant<T>) {
+        if (e.is_array())
+            return load_value(r, val.template emplace<1>());
+        return load_value(r, val.template emplace<0>());
     } else {
         static_assert(std::is_same_v<T, void>, "Unsupported load type");
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3721,6 +3721,11 @@ void core_rpc_server::invoke(TEST_TRIGGER_UPTIME_PROOF& test_trigger_uptime_proo
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(ONS_INFO& info, rpc_context context) {
+
+    if (!context.admin)
+        check_quantity_limit(
+                info.request.name_hash.size(), ONS_INFO::MAX_REQUEST_ENTRIES, "name_hash");
+
     auto binary_format = info.is_bt() ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
 
     auto height = m_core.blockchain.get_current_blockchain_height();
@@ -3729,14 +3734,6 @@ void core_rpc_server::invoke(ONS_INFO& info, rpc_context context) {
         req_height = height;
 
     auto& db = m_core.blockchain.name_system_db();
-
-    // This also takes 32 raw bytes, but that is undocumented (because it is painful to pass
-    // through json).
-    auto name_hash = ons::name_hash_input_to_base64(info.request.name_hash);
-    if (!name_hash)
-        throw rpc_error{
-                ERROR_WRONG_PARAM,
-                "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
 
     std::unordered_set<ons::mapping_type> type_filter;
     if (info.request.type) {
@@ -3749,26 +3746,40 @@ void core_rpc_server::invoke(ONS_INFO& info, rpc_context context) {
                             *info.request.type)};
     }
 
-    auto result = json::array();
-    for (const auto& record : db.get_mappings(*name_hash, req_height, type_filter)) {
-        auto& elem = result.emplace_back();
-        elem["type"] = record.type;
-        elem["name_hash"] = record.name_hash;
-        elem["owner"] = record.owner.to_string(nettype());
-        if (record.backup_owner)
-            elem["backup_owner"] = record.backup_owner.to_string(nettype());
+    auto& result = (info.response["result"] = json::object());
 
-        json_binary_proxy elem_hex{elem, binary_format};
-        elem_hex["encrypted_value"] = record.encrypted_value.to_view();
-        if (record.expiration_height) {
-            elem["expiration_height"] = *record.expiration_height;
-            elem["expired"] = *record.expiration_height < height;
+    for (const auto& name_in : info.request.name_hash) {
+        auto& name_res = result[name_in];
+        if (name_res.is_array())
+            continue;  // Duplicate that we've already looked up
+        name_res = json::array();
+
+        // This also takes 32 raw bytes, but that is undocumented (because it is painful to pass
+        // through json).
+        auto name_hash = ons::name_hash_input_to_base64(name_in);
+        if (!name_hash)
+            throw rpc_error{
+                    ERROR_WRONG_PARAM,
+                    "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
+
+        for (const auto& record : db.get_mappings(*name_hash, req_height, type_filter)) {
+            auto& elem = name_res.emplace_back();
+            elem["type"] = record.type;
+            elem["owner"] = record.owner.to_string(nettype());
+            if (record.backup_owner)
+                elem["backup_owner"] = record.backup_owner.to_string(nettype());
+
+            json_binary_proxy elem_hex{elem, binary_format};
+            elem_hex["encrypted_value"] = record.encrypted_value.to_view();
+            if (record.expiration_height) {
+                elem["expiration_height"] = *record.expiration_height;
+                elem["expired"] = *record.expiration_height < height;
+            }
+            elem["update_height"] = record.update_height;
+            elem_hex["txid"] = record.txid;
         }
-        elem["update_height"] = record.update_height;
-        elem_hex["txid"] = record.txid;
     }
 
-    info.response["result"] = std::move(result);
     info.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3767,6 +3767,9 @@ void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_conte
                 ons_owners_to_names.request.entries.size(),
                 ONS_OWNERS_TO_NAMES::MAX_REQUEST_ENTRIES);
 
+    auto binary_format =
+            ons_owners_to_names.is_bt() ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
+
     std::unordered_map<ons::generic_owner, size_t> owner_to_request_index;
     std::vector<ons::generic_owner> owners;
 
@@ -3792,9 +3795,8 @@ void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_conte
     if (!ons_owners_to_names.request.include_expired)
         height = m_core.blockchain.get_current_blockchain_height();
 
-    std::vector<ONS_OWNERS_TO_NAMES::response_entry> entries;
-    std::vector<ons::mapping_record> records = db.get_mappings_by_owners(owners, height);
-    for (auto& record : records) {
+    auto entries = nlohmann::json::array();
+    for (auto& record : db.get_mappings_by_owners(owners, height)) {
         auto it = owner_to_request_index.end();
         if (record.owner)
             it = owner_to_request_index.find(record.owner);
@@ -3810,23 +3812,22 @@ void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_conte
                             " could not be mapped back a index in the request 'entries' array"};
 
         auto& entry = entries.emplace_back();
-        entry.request_index = it->second;
-        entry.type = record.type;
-        entry.name_hash = std::move(record.name_hash);
+        entry["request_index"] = it->second;
+        entry["type"] = static_cast<uint16_t>(record.type);
+        entry["name_hash"] = std::move(record.name_hash);
         if (record.owner)
-            entry.owner = record.owner.to_string(nettype());
+            entry["owner"] = record.owner.to_string(nettype());
         if (record.backup_owner)
-            entry.backup_owner = record.backup_owner.to_string(nettype());
-        // FIXME: binary proxy
-        entry.encrypted_value = oxenc::to_hex(record.encrypted_value.to_view());
-        entry.update_height = record.update_height;
-        entry.expiration_height = record.expiration_height;
-        // FIXME: binary proxy
-        entry.txid = tools::hex_guts(record.txid);
+            entry["backup_owner"] = record.backup_owner.to_string(nettype());
+        json_binary_proxy entry_hex{entry, binary_format};
+        entry_hex["encrypted_value"] = record.encrypted_value.to_view();
+        entry["update_height"] = record.update_height;
+        if (record.expiration_height)
+            entry["expiration_height"] = *record.expiration_height;
+        entry_hex["txid"] = record.txid;
     }
 
-    // FIXME: this seems broken; how can this vector of some random struct magically become json?
-    ons_owners_to_names.response["entries"] = entries;
+    ons_owners_to_names.response["entries"] = std::move(entries);
     ons_owners_to_names.response["status"] = STATUS_OK;
 }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3738,8 +3738,19 @@ void core_rpc_server::invoke(ONS_INFO& info, rpc_context context) {
                 ERROR_WRONG_PARAM,
                 "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
 
+    std::unordered_set<ons::mapping_type> type_filter;
+    if (info.request.type) {
+        if (auto t = ons::parse_ons_type(*info.request.type, /*queryable_type_only=*/true))
+            type_filter.insert(*t);
+        else
+            throw rpc_error{
+                    ERROR_WRONG_PARAM,
+                    "Invalid type: expected 0 (session), 1 (wallet), or 2 (lokinet), not: {}"_format(
+                            *info.request.type)};
+    }
+
     auto result = json::array();
-    for (const auto& record : db.get_mappings(*name_hash, req_height)) {
+    for (const auto& record : db.get_mappings(*name_hash, req_height, type_filter)) {
         auto& elem = result.emplace_back();
         elem["type"] = record.type;
         elem["name_hash"] = record.name_hash;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3720,71 +3720,45 @@ void core_rpc_server::invoke(TEST_TRIGGER_UPTIME_PROOF& test_trigger_uptime_proo
     test_trigger_uptime_proof.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
-void core_rpc_server::invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_context context) {
+void core_rpc_server::invoke(ONS_INFO& info, rpc_context context) {
+    auto binary_format = info.is_bt() ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
 
-    if (!context.admin) {
-        check_quantity_limit(
-                ons_names_to_owners.request.name_hash.size(),
-                ONS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES);
-        check_quantity_limit(
-                ons_names_to_owners.request.type.size(),
-                ONS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES,
-                "types");
-    }
+    auto height = m_core.blockchain.get_current_blockchain_height();
+    std::optional<uint64_t> req_height;
+    if (!info.request.include_expired)
+        req_height = height;
 
-    std::optional<uint64_t> height = m_core.blockchain.get_current_blockchain_height();
-    std::vector<ons::mapping_type> types;
-    types.clear();
-    if (types.capacity() < ons_names_to_owners.request.type.size())
-        types.reserve(ons_names_to_owners.request.type.size());
-    for (const auto type_str : ons_names_to_owners.request.type) {
-        const auto maybe_type = ons::parse_ons_type(type_str);
-        if (!maybe_type.has_value()) {
-            ons_names_to_owners.response["status"] = "invalid type provided";
-            return;
+    auto& db = m_core.blockchain.name_system_db();
+
+    // This also takes 32 raw bytes, but that is undocumented (because it is painful to pass
+    // through json).
+    auto name_hash = ons::name_hash_input_to_base64(info.request.name_hash);
+    if (!name_hash)
+        throw rpc_error{
+                ERROR_WRONG_PARAM,
+                "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
+
+    auto result = json::array();
+    for (const auto& record : db.get_mappings(*name_hash, req_height)) {
+        auto& elem = result.emplace_back();
+        elem["type"] = record.type;
+        elem["name_hash"] = record.name_hash;
+        elem["owner"] = record.owner.to_string(nettype());
+        if (record.backup_owner)
+            elem["backup_owner"] = record.backup_owner.to_string(nettype());
+
+        json_binary_proxy elem_hex{elem, binary_format};
+        elem_hex["encrypted_value"] = record.encrypted_value.to_view();
+        if (record.expiration_height) {
+            elem["expiration_height"] = *record.expiration_height;
+            elem["expired"] = *record.expiration_height < height;
         }
-        types.push_back(*maybe_type);
+        elem["update_height"] = record.update_height;
+        elem_hex["txid"] = record.txid;
     }
 
-    ons_names_to_owners.response = nlohmann::json{
-        {"type", ons_names_to_owners.request.type},
-        {"result", nlohmann::json::array()},
-    };
-
-    auto binary_format =
-            ons_names_to_owners.is_bt() ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
-
-    ons::name_system_db& db = m_core.blockchain.name_system_db();
-    for (size_t request_index = 0; request_index < ons_names_to_owners.request.name_hash.size();
-         request_index++) {
-        const auto& request = ons_names_to_owners.request.name_hash[request_index];
-        // This also takes 32 raw bytes, but that is undocumented (because it is painful to pass
-        // through json).
-        auto name_hash = ons::name_hash_input_to_base64(request);
-        if (!name_hash)
-            throw rpc_error{
-                    ERROR_WRONG_PARAM,
-                    "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
-
-        std::vector<ons::mapping_record> records = db.get_mappings(types, *name_hash, height);
-        for (const auto& record : records) {
-            auto& elem = ons_names_to_owners.response["result"].emplace_back();
-            elem["type"] = record.type;
-            elem["name_hash"] = record.name_hash;
-            elem["owner"] = record.owner.to_string(nettype());
-            if (record.backup_owner)
-                elem["backup_owner"] = record.backup_owner.to_string(nettype());
-
-            json_binary_proxy elem_hex{elem, binary_format};
-            elem_hex["encrypted_value"] = record.encrypted_value.to_view();
-            if (record.expiration_height)
-                elem["expiration_height"] = *(record.expiration_height);
-            elem["update_height"] = record.update_height;
-            elem_hex["txid"] = record.txid;
-        }
-    }
-
-    ons_names_to_owners.response["status"] = STATUS_OK;
+    info.response["result"] = std::move(result);
+    info.response["status"] = STATUS_OK;
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_context context) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3745,7 +3745,11 @@ void core_rpc_server::invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_conte
         }
         types.push_back(*maybe_type);
     }
-    ons_names_to_owners.response["type"] = ons_names_to_owners.request.type;
+
+    ons_names_to_owners.response = nlohmann::json{
+        {"type", ons_names_to_owners.request.type},
+        {"result", nlohmann::json::array()},
+    };
 
     auto binary_format =
             ons_names_to_owners.is_bt() ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
@@ -3762,22 +3766,21 @@ void core_rpc_server::invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_conte
                     ERROR_WRONG_PARAM,
                     "Invalid name_hash: expected hash as 64 hex digits or 43/44 base64 characters"};
 
-        std::vector<ons::mapping_record> record = db.get_mappings(types, *name_hash, height);
-        for (size_t type_index = 0; type_index < ons_names_to_owners.request.type.size();
-             type_index++) {
+        std::vector<ons::mapping_record> records = db.get_mappings(types, *name_hash, height);
+        for (const auto& record : records) {
             auto& elem = ons_names_to_owners.response["result"].emplace_back();
-            elem["type"] = record[type_index].type;
-            elem["name_hash"] = record[type_index].name_hash;
-            elem["owner"] = record[type_index].owner.to_string(nettype());
-            if (record[type_index].backup_owner)
-                elem["backup_owner"] = record[type_index].backup_owner.to_string(nettype());
+            elem["type"] = record.type;
+            elem["name_hash"] = record.name_hash;
+            elem["owner"] = record.owner.to_string(nettype());
+            if (record.backup_owner)
+                elem["backup_owner"] = record.backup_owner.to_string(nettype());
 
             json_binary_proxy elem_hex{elem, binary_format};
-            elem_hex["encrypted_value"] = record[type_index].encrypted_value.to_view();
-            if (record[0].expiration_height)
-                elem["expiration_height"] = *(record[type_index].expiration_height);
-            elem["update_height"] = record[type_index].update_height;
-            elem_hex["txid"] = record[type_index].txid;
+            elem_hex["encrypted_value"] = record.encrypted_value.to_view();
+            if (record.expiration_height)
+                elem["expiration_height"] = *(record.expiration_height);
+            elem["update_height"] = record.update_height;
+            elem_hex["txid"] = record.txid;
         }
     }
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -216,7 +216,7 @@ class core_rpc_server {
     void invoke(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_context context);
     void invoke(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_context context);
     void invoke(GET_ACCRUED_REWARDS& rpc, rpc_context context);
-    void invoke(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_context context);
+    void invoke(ONS_INFO& info, rpc_context context);
 
     // Deprecated Monero NIH binary endpoints:
     GET_ALT_BLOCKS_HASHES_BIN::response invoke(

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -449,15 +449,19 @@ void parse_request(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_input in) {
 }
 
 void parse_request(ONS_INFO& info, rpc_input in) {
-    std::vector<uint16_t> types;
+    std::variant<std::string, std::vector<std::string>> name_hashes;
     get_values(
             in,
             "include_expired",
             info.request.include_expired,
             "name_hash",
-            required{info.request.name_hash},
+            required{name_hashes},
             "type",
             info.request.type);
+    if (auto* single = std::get_if<0>(&name_hashes))
+        info.request.name_hash.push_back(std::move(*single));
+    else
+        info.request.name_hash = std::move(std::get<1>(name_hashes));
 }
 
 void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -448,13 +448,14 @@ void parse_request(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_input in) {
             ons_owners_to_names.request.include_expired);
 }
 
-void parse_request(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_input in) {
+void parse_request(ONS_INFO& info, rpc_input in) {
+    std::vector<uint16_t> types;
     get_values(
             in,
+            "include_expired",
+            info.request.include_expired,
             "name_hash",
-            required{ons_names_to_owners.request.name_hash},
-            "type",
-            ons_names_to_owners.request.type);
+            required{info.request.name_hash});
 }
 
 void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -455,7 +455,9 @@ void parse_request(ONS_INFO& info, rpc_input in) {
             "include_expired",
             info.request.include_expired,
             "name_hash",
-            required{info.request.name_hash});
+            required{info.request.name_hash},
+            "type",
+            info.request.type);
 }
 
 void parse_request(GET_QUORUM_STATE& qs, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -46,7 +46,7 @@ void parse_request(HARD_FORK_INFO& hfinfo, rpc_input in);
 void parse_request(IN_PEERS& in_peers, rpc_input in);
 void parse_request(IS_KEY_IMAGE_SPENT& spent, rpc_input in);
 void parse_request(LOKINET_PING& lokinet_ping, rpc_input in);
-void parse_request(ONS_NAMES_TO_OWNERS& ons_names_to_owners, rpc_input in);
+void parse_request(ONS_INFO& info, rpc_input in);
 void parse_request(ONS_OWNERS_TO_NAMES& ons_owners_to_names, rpc_input in);
 void parse_request(ONS_RESOLVE& ons, rpc_input in);
 void parse_request(OUT_PEERS& out_peers, rpc_input in);

--- a/src/rpc/core_rpc_server_commands_defs.cpp
+++ b/src/rpc/core_rpc_server_commands_defs.cpp
@@ -105,20 +105,6 @@ void from_json(const nlohmann::json& j, GET_OUTPUT_HISTOGRAM::entry& e) {
     j.at("recent_instances").get_to(e.recent_instances);
 };
 
-void to_json(nlohmann::json& j, const ONS_OWNERS_TO_NAMES::response_entry& r) {
-    j = nlohmann::json{
-            {"request_index", r.request_index},
-            {"type", r.type},
-            {"name_hash", r.name_hash},
-            {"owner", r.owner},
-            {"backup_owner", r.backup_owner},
-            {"encrypted_value", r.encrypted_value},
-            {"update_height", r.update_height},
-            {"expiration_height", r.expiration_height},
-            {"txid", r.txid},
-    };
-}
-
 KV_SERIALIZE_MAP_CODE_BEGIN(GET_OUTPUT_DISTRIBUTION::request)
 KV_SERIALIZE(amounts)
 KV_SERIALIZE_OPT(from_height, (uint64_t)0)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2904,8 +2904,6 @@ struct ONS_RESOLVE : PUBLIC {
 struct ONS_INFO : PUBLIC {
     static constexpr auto names() { return NAMES("ons_info"); }
 
-    static constexpr size_t MAX_REQUEST_ENTRIES = 256;
-
     struct request_parameters {
         std::string name_hash;
         bool include_expired = false;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2879,20 +2879,24 @@ struct ONS_RESOLVE : PUBLIC {
 ///
 /// Inputs:
 ///
-/// - `name_hash` -- A hashed name to look up.  See ons_resolve for details on how to properly
-///   construct this hash.  The value can be provided as either hex or base64.
-/// - `type` -- Optional record type to look up, where 0 = session, 1 = wallet, 2 = lokinet.  If
-///   omitted (or null) then all matching name_hash entries, regardless of type, will be returned.
-///   When specified, the return will consist of 0 or 1 entries.
+/// - `name_hash` -- A single hashed name to look up.  Either this or `name_hashes` must be
+///   specified (but not both).  See ons_resolve for details on how to properly construct these
+///   hashed name values.  The value(s) can be provided as either hex or base64.
+/// - `name_hashes` -- An array of hashed names to look up multiple names at once.
+/// - `type` -- Optional record type to restrict lookups, where 0 = session, 1 = wallet, 2 =
+///   lokinet.  If omitted (or null) then all matching name_hash entries, regardless of type, will
+///   be returned, otherwise only records of the given type are returned.
 /// - `include_expired` -- Optional bool; if provided and true then expired records will be
 ///   included, otherwise they will not be.
 ///
 /// Outputs:
 ///
 /// - `status` -- Generic RPC error code. "OK" is the success value.
-/// - `result` -- Array of found records; each one is a dict containing keys:
+/// - `result` -- Object of results, with one key per unique input name_hash.  The key is a
+///   name_hash that was looked up (in the same hex or base64 encoding that was provided), and each
+///   value is an array of match results (which will be empty if there was no match), returned as
+///   objects containing keys:
 ///   - `type` -- the record type value (0 - session, 1 - wallet, 2 - lokinet)
-///   - `name_hash` -- the name_hash value, base64 encoded (even if hex was input).
 ///   - `owner` -- the record owner, which is usually an Oxen wallet address
 ///   - `backup_owner` -- a second owner; omitted if there is no backup owner.
 ///   - `encrypted_value` -- the encrypted ONS record.  (See `ons_resolve`)
@@ -2900,15 +2904,16 @@ struct ONS_RESOLVE : PUBLIC {
 ///     non-expiring records.
 ///   - `expired` -- true if this record is expired (i.e. we are past `expiration_height`), false
 ///     otherwise.  Omitted for non-expiring records.
-///   - `update_height` -- the height at which this record was last modified (or created, if
-///     unmodified).
-///   - `txid` -- the transaction id that last updated (or created, if unmodified) this ONS record.
+///   - `update_height` -- the height at which this record was last modified, renewed, or created.
+///   - `txid` -- the transaction id that last modified, renewed, or created this ONS record.
 ///
 struct ONS_INFO : PUBLIC {
     static constexpr auto names() { return NAMES("ons_info"); }
 
+    static constexpr size_t MAX_REQUEST_ENTRIES = 256;
+
     struct request_parameters {
-        std::string name_hash;
+        std::vector<std::string> name_hash;
         std::optional<uint16_t> type;
         bool include_expired = false;
     } request;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2679,26 +2679,6 @@ struct TEST_TRIGGER_UPTIME_PROOF : NO_ARGS {
     static constexpr auto names() { return NAMES("test_trigger_uptime_proof"); }
 };
 
-OXEN_RPC_DOC_INTROSPECT
-// Get the name mapping for an Oxen Name Service entry. Oxen currently supports mappings
-// for Session, Wallet and Lokinet.
-struct ONS_NAMES_TO_OWNERS : PUBLIC {
-    static constexpr auto names() { return NAMES("ons_names_to_owners", "lns_names_to_owners"); }
-
-    static constexpr size_t MAX_REQUEST_ENTRIES = 256;
-    static constexpr size_t MAX_TYPE_REQUEST_ENTRIES = 8;
-
-    struct request_parameters {
-        std::vector<std::string> name_hash;  // The 32-byte BLAKE2b hash of the name to resolve to a
-                                             // public key via Oxen Name Service. The value must be
-                                             // provided either in hex (64 hex digits) or base64 (44
-                                             // characters with padding, or 43 characters without).
-        std::vector<uint16_t> type;  // If empty, query all types. Currently supported types are 0
-                                     // (session), 1 (wallet) and 2 (lokinet). In future updates
-                                     // more mapping types will be available.
-    } request;
-};
-
 /// RPC: ons/ons_owners_to_names
 ///
 /// Get all the name mappings for the queried owner. The owner can be either a ed25519 public key
@@ -2759,7 +2739,7 @@ void to_json(nlohmann::json& j, const ONS_OWNERS_TO_NAMES::response_entry& r);
 ///
 /// Performs a simple ONS lookup of a BLAKE2b-hashed name.  This RPC method is meant for simple,
 /// single-value resolutions that do not care about registration details, etc.; if you need more
-/// information use ONS_NAMES_TO_OWNERS instead.
+/// information use `ons_info` instead.
 ///
 /// Inputs:
 ///
@@ -2783,7 +2763,7 @@ void to_json(nlohmann::json& j, const ONS_OWNERS_TO_NAMES::response_entry& r);
 ///
 /// 1. Lower-case the name.
 /// 2. Calculate the name hash as a null-key, 32-byte BLAKE2b hash of the lower-case name.
-/// 3. Obtain the encrypted value and the nonce from this RPC call (or ONS_NAMES_TO_OWNERS); when
+/// 3. Obtain the encrypted value and the nonce from this RPC call (or `ons_info`); when
 ///    using json encode the name hash using either hex or base64.
 /// 4. Calculate the decryption key as a 32-byte BLAKE2b *keyed* hash of the name using the
 ///    (unkeyed) name hash calculated above (in step 2) as the hash key.
@@ -2889,6 +2869,49 @@ struct ONS_RESOLVE : PUBLIC {
     } request;
 };
 
+/// RPC: ons/ons_info
+///
+/// Get the name mapping(s) for an Oxen Name Service entry, including metadata about the
+/// registration.  Oxen currently supports mappings for Session, Wallet and Lokinet.  Any types with
+/// a matching name hash are returned.
+///
+/// To simply resolve a record of a single type without metadata, see `ons_resolve` instead.
+///
+/// Inputs:
+///
+/// - `name_hash` -- A hashed name to look up.  See ons_resolve for details on how to properly
+///   construct this hash.  The value can be provided as either hex or base64.
+/// - `include_expired` -- Optional bool; if provided and true then expired records will be
+///   included, otherwise they will not be.
+///
+/// Outputs:
+///
+/// - `status` -- Generic RPC error code. "OK" is the success value.
+/// - `result` -- Array of found records; each one is a dict containing keys:
+///   - `type` -- the record type value (0 - session, 1 - wallet, 2 - lokinet)
+///   - `name_hash` -- the name_hash value, base64 encoded (even if hex was input).
+///   - `owner` -- the record owner, which is usually an Oxen wallet address
+///   - `backup_owner` -- a second owner; omitted if there is no backup owner.
+///   - `encrypted_value` -- the encrypted ONS record.  (See `ons_resolve`)
+///   - `expiration_height` -- if this record has an expiration, this is the height.  Omitted for
+///     non-expiring records.
+///   - `expired` -- true if this record is expired (i.e. we are past `expiration_height`), false
+///     otherwise.  Omitted for non-expiring records.
+///   - `update_height` -- the height at which this record was last modified (or created, if
+///     unmodified).
+///   - `txid` -- the transaction id that last updated (or created, if unmodified) this ONS record.
+///
+struct ONS_INFO : PUBLIC {
+    static constexpr auto names() { return NAMES("ons_info"); }
+
+    static constexpr size_t MAX_REQUEST_ENTRIES = 256;
+
+    struct request_parameters {
+        std::string name_hash;
+        bool include_expired = false;
+    } request;
+};
+
 /// RPC: daemon/flush_cache
 ///
 /// Clear TXs from the daemon cache, currently only the cache storing TX hashes that were
@@ -2970,6 +2993,7 @@ using core_rpc_types = tools::type_list<
         MINING_STATUS,
         ONS_OWNERS_TO_NAMES,
         ONS_RESOLVE,
+        ONS_INFO,
         OUT_PEERS,
         POP_BLOCKS,
         PRUNE_BLOCKCHAIN,
@@ -2985,8 +3009,7 @@ using core_rpc_types = tools::type_list<
         SUBMIT_TRANSACTION,
         SYNC_INFO,
         TEST_TRIGGER_P2P_RESYNC,
-        TEST_TRIGGER_UPTIME_PROOF,
-        ONS_NAMES_TO_OWNERS>;
+        TEST_TRIGGER_UPTIME_PROOF>;
 
 using FIXME_old_rpc_types = tools::type_list<RELAY_TX, GET_OUTPUT_DISTRIBUTION>;
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2881,6 +2881,9 @@ struct ONS_RESOLVE : PUBLIC {
 ///
 /// - `name_hash` -- A hashed name to look up.  See ons_resolve for details on how to properly
 ///   construct this hash.  The value can be provided as either hex or base64.
+/// - `type` -- Optional record type to look up, where 0 = session, 1 = wallet, 2 = lokinet.  If
+///   omitted (or null) then all matching name_hash entries, regardless of type, will be returned.
+///   When specified, the return will consist of 0 or 1 entries.
 /// - `include_expired` -- Optional bool; if provided and true then expired records will be
 ///   included, otherwise they will not be.
 ///
@@ -2906,6 +2909,7 @@ struct ONS_INFO : PUBLIC {
 
     struct request_parameters {
         std::string name_hash;
+        std::optional<uint16_t> type;
         bool include_expired = false;
     } request;
 };

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6813,7 +6813,7 @@ bool simple_wallet::ons_renew_mapping(std::vector<std::string> args) {
     SCOPED_WALLET_UNLOCK();
     std::string reason;
     std::vector<tools::wallet2::pending_tx> ptx_vector;
-    nlohmann::json response;
+    nlohmann::json record;
     try {
         ptx_vector = m_wallet->ons_create_renewal_tx(
                 type,
@@ -6822,7 +6822,7 @@ bool simple_wallet::ons_renew_mapping(std::vector<std::string> args) {
                 priority,
                 m_current_subaddress_account,
                 subaddr_indices,
-                &response);
+                &record);
         if (ptx_vector.empty()) {
             fail_msg_writer() << reason;
             return true;
@@ -6851,7 +6851,7 @@ bool simple_wallet::ons_renew_mapping(std::vector<std::string> args) {
                      get_config(m_wallet->nettype()).BLOCKS_PER_DAY();
         std::cout << "Renewal years: {} ({} blocks)\n"_format(years, blocks);
         std::cout << "New expiry:    Block {}\n"_format(
-                response[0]["expiration_height"].get<uint64_t>() + blocks);
+                record["expiration_height"].get<uint64_t>() + blocks);
         std::cout << std::flush;
 
         if (!confirm_and_send_tx(dsts, ptx_vector, false /*blink*/))
@@ -6899,7 +6899,7 @@ bool simple_wallet::ons_update_mapping(std::vector<std::string> args) {
     SCOPED_WALLET_UNLOCK();
     std::string reason;
     std::vector<tools::wallet2::pending_tx> ptx_vector;
-    nlohmann::json response;
+    nlohmann::json record;
     try {
         ptx_vector = m_wallet->ons_create_update_mapping_tx(
                 type,
@@ -6912,13 +6912,13 @@ bool simple_wallet::ons_update_mapping(std::vector<std::string> args) {
                 priority,
                 m_current_subaddress_account,
                 subaddr_indices,
-                &response);
+                &record);
         if (ptx_vector.empty()) {
             fail_msg_writer() << reason;
             return true;
         }
 
-        auto enc_hex = response[0]["encrypted_value"].get<std::string>();
+        auto enc_hex = record["encrypted_value"].get<std::string>();
         if (!oxenc::is_hex(enc_hex) || enc_hex.size() > 2 * ons::mapping_value::BUFFER_SIZE) {
             log::error(logcat, "invalid ONS data returned from oxend");
             fail_msg_writer() << tr("invalid ONS data returned from oxend");
@@ -6963,21 +6963,20 @@ bool simple_wallet::ons_update_mapping(std::vector<std::string> args) {
         }
 
         if (owner.size()) {
-            std::cout << "Old Owner:        {}"_format(
-                    response[0]["owner"].get<std::string_view>());
+            std::cout << "Old Owner:        {}"_format(record["owner"].get<std::string_view>());
             std::cout << "New Owner:        {}"_format(owner);
         } else {
             std::cout << "Owner:            {} (unchanged)"_format(
-                    response[0]["owner"].get<std::string_view>());
+                    record["owner"].get<std::string_view>());
         }
         std::cout << std::endl;
 
         if (backup_owner.size()) {
             std::cout << "Old Backup Owner: {}\nNew Backup Owner: {}"_format(
-                    response[0].value("backup_owner", ""), backup_owner);
+                    record.value("backup_owner", ""), backup_owner);
         } else {
             std::cout << "Backup Owner:     {} (unchanged)"_format(
-                    response[0].value("backup_owner", ""));
+                    record.value("backup_owner", ""));
         }
         std::cout << std::endl;
         if (!confirm_and_send_tx(dsts, ptx_vector, false /*blink*/))

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -49,7 +49,6 @@
 #define __STDC_FORMAT_MACROS  // NOTE(oxen): Explicitly define the PRIu64 macro on Mingw
 #endif
 
-#include <ctype.h>
 #include <fmt/core.h>
 #include <fmt/std.h>
 #include <locale.h>
@@ -57,15 +56,14 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
+#include <cinttypes>
 #include <fstream>
 #include <iostream>
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
 #include <thread>
 
-#include "common/base58.h"
 #include "common/command_line.h"
 #include "common/i18n.h"
 #include "common/scoped_message_writer.h"
@@ -74,15 +72,10 @@
 #include "crypto/crypto.h"  // for crypto::secret_key definition
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/oxen_name_system.h"
-#include "cryptonote_core/service_node_list.h"
-#include "cryptonote_core/service_node_voting.h"
-#include "cryptonote_protocol/cryptonote_protocol_handler.h"
 #include "epee/console_handler.h"
-#include "epee/int-util.h"
 #include "epee/readline_suspend.h"
 #include "mnemonics/electrum-words.h"
 #include "multisig/multisig.h"
-#include "rapidjson/document.h"
 #include "ringct/rctSigs.h"
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "simplewallet.h"
@@ -349,7 +342,7 @@ namespace {
             "ons_make_update_mapping_signature [type=session|lokinet] [owner=<value>] "
             "[backup_owner=<value>] [value=<encrypted_ons_value>] <name>");
     const char* USAGE_ONS_BY_OWNER("ons_by_owner [<owner> ...]");
-    const char* USAGE_ONS_LOOKUP("ons_lookup [type=session|wallet|lokinet] <name> [<name> ...]");
+    const char* USAGE_ONS_LOOKUP("ons_lookup <name>");
 
     std::string input_line(const std::string& prompt, bool yesno = false) {
         std::string buf;
@@ -3201,7 +3194,7 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
             "ons_lookup",
             [this](const auto& x) { return ons_lookup(x); },
             tr(USAGE_ONS_LOOKUP),
-            tr("Query the ed25519 public keys that own the Oxen Name System names."));
+            tr("Query the given Oxen Name System name, including supplemental registration info."));
 
     m_cmd_binder.set_handler(
             "ons_make_update_mapping_signature",
@@ -7093,68 +7086,20 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
     if (!try_connect_to_daemon())
         return false;
 
-    if (args.empty()) {
+    if (args.size() != 1) {
         PRINT_USAGE(USAGE_ONS_LOOKUP);
         return true;
     }
 
-    std::string typestr = eat_named_argument(args, ONS_TYPE_PREFIX);
-
-    std::vector<uint16_t> requested_types;
-    // Parse ONS Types
-    if (!typestr.empty()) {
-        auto hf_version = m_wallet->get_hard_fork_version();
-        if (!hf_version) {
-            fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
-            return false;
-        }
-
-        for (auto type : tools::split(typestr, ",")) {
-            ons::mapping_type mapping_type;
-            std::string reason;
-            if (!ons::validate_mapping_type(
-                        type, *hf_version, ons::ons_tx_type::lookup, &mapping_type, &reason)) {
-                fail_msg_writer() << reason;
-                return false;
-            }
-            requested_types.push_back(ons::db_mapping_type(mapping_type));
-        }
-    }
-
-    if (requested_types.empty()) {
-        auto hf_version = m_wallet->get_hard_fork_version();
-        if (!hf_version) {
-            fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
-            return false;
-        }
-        auto all_types = ons::all_mapping_types(static_cast<hf>(*hf_version));
-        std::transform(
-                all_types.begin(),
-                all_types.end(),
-                std::back_inserter(requested_types),
-                ons::db_mapping_type);
-    }
-
-    if (args.empty()) {
-        PRINT_USAGE(USAGE_ONS_LOOKUP);
-        return true;
-    }
-
-    nlohmann::json req_params{
-            {"name_hash", nlohmann::json::array()},
-            {"type", std::move(requested_types)},
-    };
-    for (const auto& name : args) {
-        auto lower = tools::lowercase_ascii_string(name);
-        req_params["name_hash"].emplace_back(ons::name_to_base64_hash(lower));
-    }
-
-    auto [success, response] = m_wallet->ons_names_to_owners(req_params);
+    auto name = tools::lowercase_ascii_string(args[0]);
+    auto [success, response] = m_wallet->ons_info(
+            {{"name_hash", ons::name_to_base64_hash(name)}, {"include_expired", true}});
     if (!success) {
         fail_msg_writer() << "Connection to daemon failed when requesting ONS owners";
         return false;
     }
 
+    bool ret = true;
     for (auto const& mapping : response) {
         auto enc_hex = mapping["encrypted_value"].get<std::string>();
         ons::mapping_value value{};
@@ -7162,42 +7107,39 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         value.encrypted = true;
         oxenc::from_hex(enc_hex.begin(), enc_hex.end(), value.buffer.begin());
 
-        // TODO: We lost the mapping of result to name e.g. entry_index so we don't know which name
-        // matches which, try them all for now. These endpoints need a larger re-evaluation (note,
-        // only 3 projects in the ecosystem use this endpoint, simplewallet, oxen-observer and GUI
-        // wallet)
-        std::string_view name;
-        for (const auto& check_name : args) {
-            if (value.decrypt(check_name, mapping["type"])) {
-                name = check_name;
-                break;
-            }
+        const auto maybe_type = ons::parse_ons_type(mapping["type"].get<uint16_t>());
+        if (!maybe_type)
+            fail_msg_writer() << "Daemon returned invalid mapping type=" << mapping["type"].dump();
+        const auto type = *maybe_type;
+
+        if (!value.decrypt(name, type)) {
+            fail_msg_writer() << "Failed to decrypt the mapping value=" << enc_hex;
+            ret = false;
+            continue;
         }
 
-        if (name.empty())
-            continue;
-
         auto writer = message_writer();
-        writer << "Name: " << name
-               << "\n    Type: " << static_cast<ons::mapping_type>(mapping["type"])
-               << "\n    Value: " << value.to_readable_value(m_wallet->nettype(), mapping["type"])
+        const auto expired_label = mapping.value("expired", false) ? " -- EXPIRED!"sv : ""sv;
+        writer << "\nName: " << name << expired_label << "\n    Type: " << type
+               << "\n    Value: " << value.to_readable_value(m_wallet->nettype(), type)
                << "\n    Owner: " << mapping["owner"].get<std::string_view>();
-        if (auto got = mapping.find("backup_owner"); got != mapping.end())
-            writer << "\n    Backup owner: " << mapping["backup_owner"].get<std::string_view>();
+        if (auto it = mapping.find("backup_owner"); it != mapping.end())
+            writer << "\n    Backup owner: " << it->get<std::string_view>();
         writer << "\n    Last updated height: " << mapping["update_height"].get<int64_t>();
-        if (auto got = mapping.find("expiration_height"); got != mapping.end())
-            writer << "\n    Expiration height: " << mapping["expiration_height"].get<int64_t>();
+        if (auto it = mapping.find("expiration_height"); it != mapping.end())
+            writer << "\n    Expiration height: " << it->get<int64_t>() << expired_label;
         writer << "\n    Encrypted value: " << enc_hex;
         writer << "\n";
 
-        tools::wallet2::ons_detail detail = {
-                static_cast<ons::mapping_type>(mapping["type"]),
-                std::string(name),
-                mapping["name_hash"]};
-        m_wallet->set_ons_cache_record(detail);
+        m_wallet->set_ons_cache_record({type, name, mapping["name_hash"].get<std::string>()});
     }
 
-    return true;
+    if (response.empty()) {
+        fail_msg_writer() << name << " not found\n";
+        ret = false;
+    }
+
+    return ret;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::ons_by_owner(const std::vector<std::string>& args) {
@@ -7244,31 +7186,31 @@ bool simple_wallet::ons_by_owner(const std::vector<std::string>& args) {
     for (auto const& entry : result["entries"]) {
         std::string_view name;
         std::string value;
-        ons::mapping_type ons_type = static_cast<ons::mapping_type>(entry["type"].get<uint16_t>());
-        if (auto got = cache.find(entry["name_hash"]); got != cache.end()) {
-            name = got->second.name;
+        auto ons_type = ons::parse_ons_type(entry["type"].get<uint16_t>());
+        if (auto it = cache.find(entry["name_hash"]); it != cache.end()) {
+            name = it->second.name;
             ons::mapping_value mv;
             auto enc_val_hex = entry["encrypted_value"].get<std::string_view>();
-            if (oxenc::is_hex(enc_val_hex) &&
+            if (oxenc::is_hex(enc_val_hex) && ons_type &&
                 ons::mapping_value::validate_encrypted(
-                        ons_type, oxenc::from_hex(enc_val_hex), &mv) &&
-                mv.decrypt(name, ons_type))
-                value = mv.to_readable_value(nettype, ons_type);
+                        *ons_type, oxenc::from_hex(enc_val_hex), &mv) &&
+                mv.decrypt(name, *ons_type))
+                value = mv.to_readable_value(nettype, *ons_type);
         }
 
         auto writer = message_writer();
-        writer << "Name (hashed): " << entry["name_hash"].get<std::string_view>();
+        writer << "\nName (hashed): " << entry["name_hash"].get<std::string_view>();
         if (!name.empty())
             writer << "\n    Name: " << name;
-        writer << "\n    Type: " << ons_type;
+        writer << "\n    Type: " << (ons_type ? ons::mapping_type_str(*ons_type) : "unknown");
         if (!value.empty())
             writer << "\n    Value: " << value;
         writer << "\n    Owner: " << entry["owner"].get<std::string_view>();
-        if (auto got = entry.find("backup_owner"); got != entry.end())
-            writer << "\n    Backup owner: " << entry["backup_owner"].get<std::string_view>();
+        if (auto it = entry.find("backup_owner"); it != entry.end() && !it->is_null())
+            writer << "\n    Backup owner: " << it->get<std::string_view>();
         writer << "\n    Last updated height: " << entry["update_height"].get<int64_t>();
-        if (auto got = entry.find("expiration_height"); got != entry.end())
-            writer << "\n    Expiration height: " << entry["expiration_height"].get<int64_t>();
+        if (auto it = entry.find("expiration_height"); it != entry.end() && !it->is_null())
+            writer << "\n    Expiration height: " << it->get<uint64_t>();
         writer << "\n    Encrypted value: " << entry["encrypted_value"].get<std::string_view>();
     }
     return true;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7140,11 +7140,13 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         return true;
     }
 
-    nlohmann::json req_params{{"entries", {}}};
-    for (auto& name : args) {
-        name = tools::lowercase_ascii_string(std::move(name));
-        req_params["entries"].emplace_back(nlohmann::json{
-                {"name_hash", ons::name_to_base64_hash(name)}, {"types", requested_types}});
+    nlohmann::json req_params{
+            {"name_hash", nlohmann::json::array()},
+            {"type", std::move(requested_types)},
+    };
+    for (const auto& name : args) {
+        auto lower = tools::lowercase_ascii_string(name);
+        req_params["name_hash"].emplace_back(ons::name_to_base64_hash(lower));
     }
 
     auto [success, response] = m_wallet->ons_names_to_owners(req_params);
@@ -7153,30 +7155,27 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         return false;
     }
 
-    int last_index = -1;
     for (auto const& mapping : response) {
         auto enc_hex = mapping["encrypted_value"].get<std::string>();
-        if (mapping["entry_index"].get<uint64_t>() >= args.size() || !oxenc::is_hex(enc_hex) ||
-            enc_hex.size() > 2 * ons::mapping_value::BUFFER_SIZE) {
-            fail_msg_writer() << "Received invalid ONS mapping data from oxend";
-            return false;
-        }
-
-        // Print any skipped (i.e. not registered) results:
-        for (size_t i = last_index + 1; i < mapping["entry_index"]; i++)
-            fail_msg_writer() << args[i] << " not found\n";
-        last_index = mapping["entry_index"];
-
-        const auto& name = args[mapping["entry_index"]];
         ons::mapping_value value{};
         value.len = enc_hex.size() / 2;
         value.encrypted = true;
         oxenc::from_hex(enc_hex.begin(), enc_hex.end(), value.buffer.begin());
 
-        if (!value.decrypt(name, mapping["type"])) {
-            fail_msg_writer() << "Failed to decrypt the mapping value=" << enc_hex;
-            return false;
+        // TODO: We lost the mapping of result to name e.g. entry_index so we don't know which name
+        // matches which, try them all for now. These endpoints need a larger re-evaluation (note,
+        // only 3 projects in the ecosystem use this endpoint, simplewallet, oxen-observer and GUI
+        // wallet)
+        std::string_view name;
+        for (const auto& check_name : args) {
+            if (value.decrypt(check_name, mapping["type"])) {
+                name = check_name;
+                break;
+            }
         }
+
+        if (name.empty())
+            continue;
 
         auto writer = message_writer();
         writer << "Name: " << name
@@ -7192,11 +7191,11 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args) {
         writer << "\n";
 
         tools::wallet2::ons_detail detail = {
-                static_cast<ons::mapping_type>(mapping["type"]), name, mapping["name_hash"]};
+                static_cast<ons::mapping_type>(mapping["type"]),
+                std::string(name),
+                mapping["name_hash"]};
         m_wallet->set_ons_cache_record(detail);
     }
-    for (size_t i = last_index + 1; i < args.size(); i++)
-        fail_msg_writer() << args[i] << " not found\n";
 
     return true;
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6973,8 +6973,8 @@ bool simple_wallet::ons_update_mapping(std::vector<std::string> args) {
         std::cout << std::endl;
 
         if (backup_owner.size()) {
-            std::cout << "Old Backup Owner: {}"_format(response[0].value("backup_owner", ""));
-            std::cout << "New Backup Owner: {}"_format(backup_owner);
+            std::cout << "Old Backup Owner: {}\nNew Backup Owner: {}"_format(
+                    response[0].value("backup_owner", ""), backup_owner);
         } else {
             std::cout << "Backup Owner:     {} (unchanged)"_format(
                     response[0].value("backup_owner", ""));

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -393,8 +393,7 @@ std::pair<bool, nlohmann::json> NodeRPCProxy::ons_owners_to_names(
     return result;
 }
 
-std::pair<bool, nlohmann::json> NodeRPCProxy::ons_names_to_owners(
-        nlohmann::json const& request) const {
+std::pair<bool, nlohmann::json> NodeRPCProxy::ons_info(nlohmann::json const& request) const {
     std::pair<bool, nlohmann::json> result;
     auto& [success, resolved] = result;
     success = false;
@@ -403,7 +402,7 @@ std::pair<bool, nlohmann::json> NodeRPCProxy::ons_names_to_owners(
         return result;
 
     try {
-        auto res = m_http_client.json_rpc("ons_names_to_owners", request);
+        auto res = m_http_client.json_rpc("ons_info", request);
         if (!res.contains("result") || !res.contains("status"))
             throw std::runtime_error("Missing result or status"_format(res.dump()));
         if (res["status"] != "OK")

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -404,8 +404,13 @@ std::pair<bool, nlohmann::json> NodeRPCProxy::ons_names_to_owners(
 
     try {
         auto res = m_http_client.json_rpc("ons_names_to_owners", request);
-        resolved = res;
-    } catch (...) {
+        if (!res.contains("result") || !res.contains("status"))
+            throw std::runtime_error("Missing result or status"_format(res.dump()));
+        if (res["status"] != "OK")
+            throw std::runtime_error("Response status was not OK"_format(res.dump()));
+        resolved = res["result"];
+    } catch (const std::exception& e) {
+        log::error(logcat, "Failed to get ONS name->owners: {}", e.what());
         return result;
     }
     success = true;

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -403,13 +403,18 @@ std::pair<bool, nlohmann::json> NodeRPCProxy::ons_info(nlohmann::json const& req
 
     try {
         auto res = m_http_client.json_rpc("ons_info", request);
-        if (!res.contains("result") || !res.contains("status"))
-            throw std::runtime_error("Missing result or status"_format(res.dump()));
-        if (res["status"] != "OK")
-            throw std::runtime_error("Response status was not OK"_format(res.dump()));
+        auto st_it = res.find("status");
+        auto res_it = res.find("result");
+        if (st_it == res.end() || res_it == res.end() || !st_it->is_string() ||
+            !res_it->is_object()) {
+            log::error(logcat, "Did not find expected result or status in:\n{}", res.dump());
+            throw std::runtime_error{"Missing result or status"};
+        }
+        if (auto status = st_it->get<std::string_view>(); status != "OK")
+            throw std::runtime_error{"Received error status '{}'"_format(status)};
         resolved = res["result"];
     } catch (const std::exception& e) {
-        log::error(logcat, "Failed to get ONS name->owners: {}", e.what());
+        log::error(logcat, "Failed to get ONS info: {}", e.what());
         return result;
     }
     success = true;

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -403,7 +403,7 @@ std::pair<bool, nlohmann::json> NodeRPCProxy::ons_names_to_owners(
         return result;
 
     try {
-        auto res = m_http_client.json_rpc("get_output_histogram", request);
+        auto res = m_http_client.json_rpc("ons_names_to_owners", request);
         resolved = res;
     } catch (...) {
         return result;

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -66,7 +66,7 @@ class NodeRPCProxy {
             const std::string& contributor) const;
     std::pair<bool, nlohmann::json> get_service_node_blacklisted_key_images() const;
     std::pair<bool, nlohmann::json> ons_owners_to_names(nlohmann::json const& request) const;
-    std::pair<bool, nlohmann::json> ons_names_to_owners(nlohmann::json const& request) const;
+    std::pair<bool, nlohmann::json> ons_info(nlohmann::json const& request) const;
     std::pair<bool, nlohmann::json> ons_resolve(nlohmann::json const& request) const;
 
   private:

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9778,6 +9778,8 @@ static bool try_generate_ons_signature(
     return true;
 }
 
+// The `record`, if provided, will be set to (json) null if the record was not found, and a json
+// object with "type", etc. keys for the name if found.
 static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
         wallet2 const& wallet,
         ons::mapping_type type,
@@ -9790,7 +9792,7 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
         ons::ons_tx_type txtype,
         uint32_t account_index,
         std::string* reason,
-        nlohmann::json* response) {
+        nlohmann::json* record = nullptr) {
     ons_prepared_args result = {};
     if (priority == tools::tx_priority_blink) {
         if (reason)
@@ -9822,15 +9824,31 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
                                 wallet.nettype(), *backup_owner, result.backup_owner, reason))
         return {};
 
-    auto [success, response_] = wallet.ons_info(
-            {{"name_hash", oxenc::to_base64(tools::view_guts(result.name_hash))},
-             {"type", ons::db_mapping_type(type)}});
+    auto name_hash = oxenc::to_base64(tools::view_guts(result.name_hash));
+    auto [success, response] =
+            wallet.ons_info({{"name_hash", name_hash}, {"type", ons::db_mapping_type(type)}});
 
-    if (!response)
-        response = &response_;
-    else
-        *response = std::move(response_);
-    if (!success) {
+    bool bad_resp = false;
+    nlohmann::json tmp;
+    if (!success || !response.is_object())
+        bad_resp = true;
+    else if (auto it = response.find(name_hash); it == response.end() || !it->is_array())
+        bad_resp = true;
+    else {
+        if (it->empty()) {
+            if (record)
+                *record = nullptr;
+            else
+                record = &tmp;
+        } else {
+            if (record)
+                *record = std::move(it->front());
+            else
+                record = &it->front();
+        }
+    }
+
+    if (bad_resp) {
         if (reason)
             *reason =
                     "Failed to query previous owner for ONS entry: communication with daemon "
@@ -9838,8 +9856,10 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
         return result;
     }
 
-    if (response->size()) {
-        auto txid = response->front()["txid"].get<std::string_view>();
+    const auto& rec = *record;
+
+    if (!rec.is_null()) {
+        auto txid = rec["txid"].get<std::string_view>();
         if (!tools::try_load_from_hex_guts(txid, result.prev_txid)) {
             if (reason)
                 *reason =
@@ -9850,7 +9870,7 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
     }
 
     if (txtype == ons::ons_tx_type::update && make_signature) {
-        if (response->empty()) {
+        if (record->is_null()) {
             if (reason)
                 *reason =
                         "Signature requested when preparing ONS TX but record to update does "
@@ -9860,8 +9880,8 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
 
         cryptonote::address_parse_info curr_owner_parsed = {};
         cryptonote::address_parse_info curr_backup_owner_parsed = {};
-        auto rowner = response->front()["owner"].get<std::string>();
-        std::string rbackup_owner = response->front().value("backup_owner", "");
+        auto rowner = rec["owner"].get<std::string>();
+        std::string rbackup_owner = rec.value("backup_owner", "");
         bool curr_owner = cryptonote::get_account_address_from_str(
                 curr_owner_parsed, wallet.nettype(), rowner);
         bool curr_backup_owner = rbackup_owner.size() &&
@@ -9882,7 +9902,7 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
             }
         }
     } else if (txtype == ons::ons_tx_type::renew) {
-        if (response->empty()) {
+        if (rec.is_null()) {
             if (reason)
                 *reason = "Renewal requested but record to renew does not exist or has expired";
             return result;
@@ -9903,7 +9923,6 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_buy_mapping_tx(
         uint32_t priority,
         uint32_t account_index,
         std::set<uint32_t> subaddr_indices) {
-    nlohmann::json response;
     constexpr bool make_signature = false;
     ons_prepared_args prepared_args = prepare_tx_extra_oxen_name_system_values(
             *this,
@@ -9916,8 +9935,7 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_buy_mapping_tx(
             make_signature,
             ons::ons_tx_type::buy,
             account_index,
-            reason,
-            &response);
+            reason);
     if (!owner)
         prepared_args.owner =
                 ons::make_monero_owner(get_subaddress({account_index, 0}), account_index != 0);
@@ -9978,7 +9996,7 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_renewal_tx(
         uint32_t priority,
         uint32_t account_index,
         std::set<uint32_t> subaddr_indices,
-        nlohmann::json* response) {
+        nlohmann::json* record) {
     constexpr bool make_signature = false;
     ons_prepared_args prepared_args = prepare_tx_extra_oxen_name_system_values(
             *this,
@@ -9992,7 +10010,7 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_renewal_tx(
             ons::ons_tx_type::renew,
             account_index,
             reason,
-            response);
+            record);
 
     if (!prepared_args)
         return {};
@@ -10034,7 +10052,7 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_update_mapping_tx(
         uint32_t priority,
         uint32_t account_index,
         std::set<uint32_t> subaddr_indices,
-        nlohmann::json* response) {
+        nlohmann::json* record) {
     if (!value && !owner && !backup_owner) {
         if (reason)
             *reason =
@@ -10056,7 +10074,7 @@ std::vector<wallet2::pending_tx> wallet2::ons_create_update_mapping_tx(
             ons::ons_tx_type::update,
             account_index,
             reason,
-            response);
+            record);
     if (!prepared_args)
         return {};
 
@@ -10135,7 +10153,6 @@ bool wallet2::ons_make_update_mapping_signature(
         ons::generic_signature& signature,
         uint32_t account_index,
         std::string* reason) {
-    nlohmann::json response;
     constexpr bool make_signature = true;
     ons_prepared_args prepared_args = prepare_tx_extra_oxen_name_system_values(
             *this,
@@ -10148,8 +10165,7 @@ bool wallet2::ons_make_update_mapping_signature(
             make_signature,
             ons::ons_tx_type::update,
             account_index,
-            reason,
-            &response);
+            reason);
     if (!prepared_args)
         return false;
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9822,11 +9822,10 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
                                 wallet.nettype(), *backup_owner, result.backup_owner, reason))
         return {};
 
-    nlohmann::json req_params{
-            {"name_hash", std::array{oxenc::to_base64(tools::view_guts(result.name_hash))}},
-            {"types", std::vector<uint16_t>{ons::db_mapping_type(type)}}};
+    auto [success, response_] = wallet.ons_info(
+            {{"name_hash", oxenc::to_base64(tools::view_guts(result.name_hash))},
+             {"type", ons::db_mapping_type(type)}});
 
-    auto [success, response_] = wallet.ons_info(req_params);
     if (!response)
         response = &response_;
     else
@@ -9839,14 +9838,13 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
         return result;
     }
 
-    if ((*response).size()) {
-        if (!tools::try_load_from_hex_guts(
-                    (*response)[0]["txid"].get<std::string_view>(), result.prev_txid)) {
+    if (response->size()) {
+        auto txid = response->front()["txid"].get<std::string_view>();
+        if (!tools::try_load_from_hex_guts(txid, result.prev_txid)) {
             if (reason)
-                *reason = "Failed to convert response txid=" +
-                          (*response)[0]["txid"].get<std::string>() +
-                          " from the daemon into a 32 byte hash, it must be a 64 char hex "
-                          "string";
+                *reason =
+                        "Failed to convert response txid={} from the daemon into a 32-byte hash;"
+                        " expected a 64-char hex string"_format(txid);
             return result;
         }
     }
@@ -9864,7 +9862,6 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
         cryptonote::address_parse_info curr_backup_owner_parsed = {};
         auto& rowner = response->front()["owner"];
         std::string* rbackup_owner = response->front().value("backup_owner", nullptr);
-        ;
         bool curr_owner = cryptonote::get_account_address_from_str(
                 curr_owner_parsed, wallet.nettype(), rowner.get<std::string_view>());
         bool curr_backup_owner =

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -132,6 +132,8 @@ namespace {
 
     constexpr float SECOND_OUTPUT_RELATEDNESS_THRESHOLD = 0.0f;
 
+    constexpr auto NO_DAEMON_STATUS = "No daemon status provided!"sv;
+
     constexpr std::string_view KEY_IMAGE_EXPORT_FILE_MAGIC = "Loki key image export\002"sv;
     constexpr std::string_view MULTISIG_EXPORT_FILE_MAGIC = "Loki multisig export\001"sv;
     constexpr std::string_view OUTPUT_EXPORT_FILE_MAGIC = "Loki output export\003"sv;
@@ -1070,10 +1072,11 @@ namespace {
         std::string bd;
 
         // easy case if we have the whole tx
-        if (entry.contains("as_hex") || (entry.contains("prunable") && entry.contains("pruned"))) {
+        if (auto hex_it = entry.find("as_hex");
+            hex_it != entry.end() || (entry.contains("prunable") && entry.contains("pruned"))) {
             std::string hex_blob;
-            if (entry["as_hex"])
-                hex_blob = entry["as_hex"].get<std::string>();
+            if (hex_it != entry.end())
+                hex_blob = hex_it->get<std::string>();
             else
                 hex_blob =
                         entry["pruned"].get<std::string>() + entry["prunable"].get<std::string>();
@@ -1084,9 +1087,9 @@ namespace {
                     cryptonote::parse_and_validate_tx_from_blob(bd, tx), false, "Invalid tx data");
             tx_hash = cryptonote::get_transaction_hash(tx);
             // if the hash was given, check it matches
+            auto tx_hash = entry.value("tx_hash", ""sv);
             CHECK_AND_ASSERT_MES(
-                    entry["tx_hash"].empty() ||
-                            tools::hex_guts(tx_hash) == entry["tx_hash"].get<std::string_view>(),
+                    tx_hash.empty() || tools::hex_guts(tx_hash) == tx_hash,
                     false,
                     "Response claims a different hash than the data yields");
             return true;
@@ -6357,7 +6360,8 @@ bool wallet2::check_connection(rpc::version_t* version, bool* ssl, bool throw_on
     if (!m_rpc_version) {
         try {
             auto res = m_http_client.json_rpc("get_version", {});
-            if (res["status"] != rpc::STATUS_OK)
+            auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
+            if (status != rpc::STATUS_OK)
                 return false;
             m_rpc_version = res["version"];
         } catch (...) {
@@ -6605,7 +6609,8 @@ void wallet2::trim_hashchain() {
         nlohmann::json req_params{{"height", m_blockchain.size() - 1}};
         try {
             auto res = m_http_client.json_rpc("get_block_header_by_height", req_params);
-            if (res["status"] == rpc::STATUS_OK) {
+            auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
+            if (status == rpc::STATUS_OK) {
                 crypto::hash hash;
                 tools::load_from_hex_guts(
                         res["block_header"]["hash"].get<std::string_view>(), hash);
@@ -7402,14 +7407,13 @@ void wallet2::rescan_spent() {
 
         nlohmann::json req_params{{"key_images", key_images}};
         auto kispent_res = m_http_client.json_rpc("is_key_image_spent", req_params);
+        auto kispent_status = kispent_res.value<std::string_view>("status", NO_DAEMON_STATUS);
         THROW_WALLET_EXCEPTION_IF(
-                kispent_res["status"] == rpc::STATUS_BUSY,
-                error::daemon_busy,
-                "is_key_image_spent");
+                kispent_status == rpc::STATUS_BUSY, error::daemon_busy, "is_key_image_spent");
         THROW_WALLET_EXCEPTION_IF(
-                kispent_res["status"] != rpc::STATUS_OK,
+                kispent_status != rpc::STATUS_OK,
                 error::is_key_image_spent_error,
-                get_rpc_status(kispent_res["status"]));
+                get_rpc_status(kispent_status));
         THROW_WALLET_EXCEPTION_IF(
                 kispent_res["spent_status"].size() != n_outputs,
                 error::wallet_internal_error,
@@ -7816,30 +7820,30 @@ void wallet2::commit_tx(pending_tx& ptx, bool blink) {
         };
         auto daemon_send_resp =
                 m_http_client.json_rpc("send_raw_transaction", send_transaction_params);
+        auto status = daemon_send_resp.value<std::string_view>("status", NO_DAEMON_STATUS);
+
         THROW_WALLET_EXCEPTION_IF(
-                daemon_send_resp["status"] == rpc::STATUS_BUSY,
-                error::daemon_busy,
-                "sendrawtransaction");
+                status == rpc::STATUS_BUSY, error::daemon_busy, "sendrawtransaction");
         if (blink)
             THROW_WALLET_EXCEPTION_IF(
-                    daemon_send_resp["status"] != rpc::STATUS_OK,
+                    status != rpc::STATUS_OK,
                     error::tx_blink_rejected,
                     ptx.tx,
-                    get_rpc_status(daemon_send_resp["status"]),
+                    get_rpc_status(status),
                     daemon_send_resp.value<std::string>("reason", "Daemon provided no reason"s));
         else
             THROW_WALLET_EXCEPTION_IF(
-                    daemon_send_resp["status"] != rpc::STATUS_OK,
+                    status != rpc::STATUS_OK,
                     error::tx_rejected,
                     ptx.tx,
-                    get_rpc_status(daemon_send_resp["status"]),
+                    get_rpc_status(status),
                     daemon_send_resp.value<std::string>("reason", "Daemon provided no reason"s));
         // sanity checks
         for (size_t idx : ptx.selected_transfers) {
             THROW_WALLET_EXCEPTION_IF(
                     idx >= m_transfers.size(),
                     error::wallet_internal_error,
-                    "Bad output index in selected transfers: " + std::to_string(idx));
+                    "Bad output index in selected transfers: {}"_format(idx));
         }
     }
     crypto::hash txid;
@@ -10310,12 +10314,11 @@ void wallet2::get_outs(
                     {"unlocked", true},
                     {"recent_cutoff", time(nullptr) - RECENT_OUTPUT_ZONE}};
             res = m_http_client.json_rpc("get_output_histogram", req_params);
+            auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
             THROW_WALLET_EXCEPTION_IF(
-                    res["status"] == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
+                    status == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
             THROW_WALLET_EXCEPTION_IF(
-                    res["status"] != rpc::STATUS_OK,
-                    error::get_histogram_error,
-                    get_rpc_status(res["status"]));
+                    status != rpc::STATUS_OK, error::get_histogram_error, get_rpc_status(status));
         }
 
         // if we want to segregate fake outs pre or post fork, get distribution
@@ -13724,10 +13727,11 @@ std::vector<size_t> wallet2::select_available_outputs_from_histogram(
             {"unlocked", unlocked},
             {"recent_cutoff", 0}};
     auto res = m_http_client.json_rpc("get_output_histogram", req_params);
+    auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
+            status == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] != rpc::STATUS_OK, error::get_histogram_error, res["status"]);
+            status != rpc::STATUS_OK, error::get_histogram_error, get_rpc_status(status));
 
     std::set<uint64_t> mixable;
     for (const auto& i : res["histogram"]) {
@@ -13757,10 +13761,11 @@ uint64_t wallet2::get_num_rct_outputs() {
             {"unlocked", true},
             {"recent_cutoff", 0}};
     auto res = m_http_client.json_rpc("get_output_histogram", req_params);
+    auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
+            status == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] != rpc::STATUS_OK, error::get_histogram_error, res["status"]);
+            status != rpc::STATUS_OK, error::get_histogram_error, get_rpc_status(status));
     THROW_WALLET_EXCEPTION_IF(
             res["histogram"].size() != 1,
             error::get_histogram_error,
@@ -15203,10 +15208,11 @@ std::unordered_map<std::string, wallet2::ons_detail> wallet2::get_ons_cache() {
 void wallet2::refresh_batching_cache() {
     nlohmann::json req_params{{"addresses", std::vector<std::string>{}}};
     auto res = m_http_client.json_rpc(rpc::GET_ACCRUED_REWARDS::names()[0], req_params);
+    auto status = res.value<std::string_view>("status", NO_DAEMON_STATUS);
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
+            status == rpc::STATUS_BUSY, error::daemon_busy, "get_output_histogram");
     THROW_WALLET_EXCEPTION_IF(
-            res["status"] != rpc::STATUS_OK, error::get_accrued_rewards_error, res["status"]);
+            status != rpc::STATUS_OK, error::get_accrued_rewards_error, get_rpc_status(status));
 
     auto records = res["balances"].get<std::unordered_map<std::string, uint64_t>>();
     batching_records_cache.clear();
@@ -17021,10 +17027,8 @@ void wallet2::on_device_progress(const hw::device_progress& event) {
         m_callback->on_device_progress(event);
 }
 //----------------------------------------------------------------------------------------------------
-std::string wallet2::get_rpc_status(const std::string& s) const {
-    if (m_trusted_daemon)
-        return s;
-    return "<error>";
+std::string wallet2::get_rpc_status(std::string_view s) const {
+    return std::string{m_trusted_daemon ? s : "<error>"sv};
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::hash_m_transfers(int64_t transfer_height, crypto::hash& hash) const {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -229,78 +229,6 @@ namespace {
         return false;
     }
 
-    std::string get_text_reason(
-            const nlohmann::json& res, cryptonote::transaction const* tx, bool blink) {
-        if (blink) {
-            return res["reason"].get<std::string>();
-        } else {
-            std::ostringstream os;
-
-            const auto tvc = res["tvc"];
-            if (auto got = tvc.find("m_verbose_error"); got != tvc.end())
-                os << res["tvc"]["m_verbose_error"].get<std::string_view>() << "\n";
-            if (auto got = tvc.find("m_verifivation_failed"); got != tvc.end())
-                os << "Verification failed, connection should be dropped, ";  // bad tx, should drop
-                                                                              // connection
-            if (auto got = tvc.find("m_verifivation_impossible"); got != tvc.end())
-                os << "Verification impossible, related to alt chain, ";  // the transaction is
-                                                                          // related with an
-                                                                          // alternative blockchain
-            if (auto got = tvc.find("m_should_be_relayed"); got == tvc.end())
-                os << "TX should NOT be relayed, ";
-            if (auto got = tvc.find("m_added_to_pool"); got != tvc.end())
-                os << "TX added to pool, ";
-            if (auto got = tvc.find("m_low_mixin"); got != tvc.end())
-                os << "Insufficient mixin, ";
-            if (auto got = tvc.find("m_double_spend"); got != tvc.end())
-                os << "Double spend TX, ";
-            if (auto got = tvc.find("m_invalid_input"); got != tvc.end())
-                os << "Invalid inputs, ";
-            if (auto got = tvc.find("m_invalid_output"); got != tvc.end())
-                os << "Invalid outputs, ";
-            if (auto got = tvc.find("m_too_few_outputs"); got != tvc.end())
-                os << "Need at least 2 outputs, ";
-            if (auto got = tvc.find("m_too_big"); got != tvc.end())
-                os << "TX too big, ";
-            if (auto got = tvc.find("m_overspend"); got != tvc.end())
-                os << "Overspend, ";
-            if (auto got = tvc.find("m_fee_too_low"); got != tvc.end())
-                os << "Fee too low, ";
-            if (auto got = tvc.find("m_invalid_version"); got != tvc.end())
-                os << "TX has invalid version, ";
-            if (auto got = tvc.find("m_invalid_type"); got != tvc.end())
-                os << "TX has invalid type, ";
-            if (auto got = tvc.find("m_key_image_locked_by_snode"); got != tvc.end())
-                os << "Key image is locked by service node, ";
-            if (auto got = tvc.find("m_key_image_blacklisted"); got != tvc.end())
-                os << "Key image is blacklisted on the service node network, ";
-
-            const auto m_vote_ctx = tvc["m_vote_ctx"];
-            if (auto got = m_vote_ctx.find("m_validator_index_out_of_bounds");
-                got != m_vote_ctx.end())
-                os << "Validator index out of bounds";
-            if (auto got = m_vote_ctx.find("m_signature_not_valid"); got != m_vote_ctx.end())
-                os << "Signature not valid, ";
-            if (auto got = m_vote_ctx.find("m_added_to_pool"); got != m_vote_ctx.end())
-                os << "Added to pool, ";
-            if (auto got = m_vote_ctx.find("m_not_enough_votes"); got != m_vote_ctx.end())
-                os << "Not enough votes, ";
-            if (auto got = m_vote_ctx.find("m_incorrect_voting_group"); got != m_vote_ctx.end())
-                os << "Incorrect voting group specified,";
-            if (auto got = m_vote_ctx.find("m_votes_not_sorted"); got != m_vote_ctx.end())
-                os << "Votes are not stored in ascending order";
-
-            if (tx)
-                os << "TX Version: {}, Type: {}"_format(tx->version, tx->type);
-
-            std::string buf = os.str();
-            if (buf.size() >= 2 && buf[buf.size() - 2] == ',')
-                buf.resize(buf.size() - 2);
-
-            return buf;
-        }
-    }
-
     size_t get_num_outputs(
             const std::vector<cryptonote::tx_destination_entry>& dsts,
             const std::vector<tools::wallet2::transfer_details>& transfers,
@@ -7898,14 +7826,14 @@ void wallet2::commit_tx(pending_tx& ptx, bool blink) {
                     error::tx_blink_rejected,
                     ptx.tx,
                     get_rpc_status(daemon_send_resp["status"]),
-                    get_text_reason(daemon_send_resp, &ptx.tx, blink));
+                    daemon_send_resp.value<std::string>("reason", "Daemon provided no reason"s));
         else
             THROW_WALLET_EXCEPTION_IF(
                     daemon_send_resp["status"] != rpc::STATUS_OK,
                     error::tx_rejected,
                     ptx.tx,
                     get_rpc_status(daemon_send_resp["status"]),
-                    get_text_reason(daemon_send_resp, &ptx.tx, blink));
+                    daemon_send_resp.value<std::string>("reason", "Daemon provided no reason"s));
         // sanity checks
         for (size_t idx : ptx.selected_transfers) {
             THROW_WALLET_EXCEPTION_IF(

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9822,80 +9822,74 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
                                 wallet.nettype(), *backup_owner, result.backup_owner, reason))
         return {};
 
-    {
-        nlohmann::json req_params{
-                {"entries",
-                 {{"name_hash", oxenc::to_base64(tools::view_guts(result.name_hash))},
-                  {"types", std::vector<uint16_t>{ons::db_mapping_type(type)}}}},
-        };
-        auto [success, response_] = wallet.ons_names_to_owners(req_params);
-        if (!response)
-            response = &response_;
-        else
-            *response = std::move(response_);
-        if (!success) {
+    nlohmann::json req_params{
+            {"name_hash", std::array{oxenc::to_base64(tools::view_guts(result.name_hash))}},
+            {"types", std::vector<uint16_t>{ons::db_mapping_type(type)}}};
+
+    auto [success, response_] = wallet.ons_names_to_owners(req_params);
+    if (!response)
+        response = &response_;
+    else
+        *response = std::move(response_);
+    if (!success) {
+        if (reason)
+            *reason =
+                    "Failed to query previous owner for ONS entry: communication with daemon "
+                    "failed";
+        return result;
+    }
+
+    if ((*response).size()) {
+        if (!tools::try_load_from_hex_guts(
+                    (*response)[0]["txid"].get<std::string_view>(), result.prev_txid)) {
+            if (reason)
+                *reason = "Failed to convert response txid=" +
+                          (*response)[0]["txid"].get<std::string>() +
+                          " from the daemon into a 32 byte hash, it must be a 64 char hex "
+                          "string";
+            return result;
+        }
+    }
+
+    if (txtype == ons::ons_tx_type::update && make_signature) {
+        if (response->empty()) {
             if (reason)
                 *reason =
-                        "Failed to query previous owner for ONS entry: communication with daemon "
-                        "failed";
+                        "Signature requested when preparing ONS TX but record to update does "
+                        "not exist";
             return result;
         }
 
-        if ((*response)["entries"].size()) {
-            if (!tools::try_load_from_hex_guts(
-                        (*response)["entries"][0]["txid"].get<std::string_view>(),
-                        result.prev_txid)) {
-                if (reason)
-                    *reason = "Failed to convert response txid=" +
-                              (*response)["entries"][0]["txid"].get<std::string>() +
-                              " from the daemon into a 32 byte hash, it must be a 64 char hex "
-                              "string";
+        cryptonote::address_parse_info curr_owner_parsed = {};
+        cryptonote::address_parse_info curr_backup_owner_parsed = {};
+        auto& rowner = response->front()["owner"];
+        std::string* rbackup_owner = response->front().value("backup_owner", nullptr);
+        ;
+        bool curr_owner = cryptonote::get_account_address_from_str(
+                curr_owner_parsed, wallet.nettype(), rowner.get<std::string_view>());
+        bool curr_backup_owner =
+                rbackup_owner &&
+                cryptonote::get_account_address_from_str(
+                        curr_backup_owner_parsed, wallet.nettype(), *rbackup_owner);
+        if (!try_generate_ons_signature(wallet, rowner, owner, backup_owner, result)) {
+            if (!rbackup_owner ||
+                !try_generate_ons_signature(wallet, *rbackup_owner, owner, backup_owner, result)) {
+                if (reason) {
+                    *reason =
+                            "Signature requested when preparing ONS TX, but this wallet is not "
+                            "the owner of the record owner=" +
+                            rowner.get<std::string>();
+                    if (rbackup_owner)
+                        *reason += ", backup_owner=" + *rbackup_owner;
+                }
                 return result;
             }
         }
-
-        if (txtype == ons::ons_tx_type::update && make_signature) {
-            if (response->empty()) {
-                if (reason)
-                    *reason =
-                            "Signature requested when preparing ONS TX but record to update does "
-                            "not exist";
-                return result;
-            }
-
-            cryptonote::address_parse_info curr_owner_parsed = {};
-            cryptonote::address_parse_info curr_backup_owner_parsed = {};
-            auto& rowner = (*response)["entries"].front()["owner"];
-            std::string* rbackup_owner =
-                    (*response)["entries"].front().value("backup_owner", nullptr);
-            ;
-            bool curr_owner = cryptonote::get_account_address_from_str(
-                    curr_owner_parsed, wallet.nettype(), rowner.get<std::string_view>());
-            bool curr_backup_owner =
-                    rbackup_owner &&
-                    cryptonote::get_account_address_from_str(
-                            curr_backup_owner_parsed, wallet.nettype(), *rbackup_owner);
-            if (!try_generate_ons_signature(wallet, rowner, owner, backup_owner, result)) {
-                if (!rbackup_owner ||
-                    !try_generate_ons_signature(
-                            wallet, *rbackup_owner, owner, backup_owner, result)) {
-                    if (reason) {
-                        *reason =
-                                "Signature requested when preparing ONS TX, but this wallet is not "
-                                "the owner of the record owner=" +
-                                rowner.get<std::string>();
-                        if (rbackup_owner)
-                            *reason += ", backup_owner=" + *rbackup_owner;
-                    }
-                    return result;
-                }
-            }
-        } else if (txtype == ons::ons_tx_type::renew) {
-            if ((*response)["entries"].empty()) {
-                if (reason)
-                    *reason = "Renewal requested but record to renew does not exist or has expired";
-                return result;
-            }
+    } else if (txtype == ons::ons_tx_type::renew) {
+        if (response->empty()) {
+            if (reason)
+                *reason = "Renewal requested but record to renew does not exist or has expired";
+            return result;
         }
     }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9860,25 +9860,24 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
 
         cryptonote::address_parse_info curr_owner_parsed = {};
         cryptonote::address_parse_info curr_backup_owner_parsed = {};
-        auto& rowner = response->front()["owner"];
-        std::string* rbackup_owner = response->front().value("backup_owner", nullptr);
+        auto rowner = response->front()["owner"].get<std::string>();
+        std::string rbackup_owner = response->front().value("backup_owner", "");
         bool curr_owner = cryptonote::get_account_address_from_str(
-                curr_owner_parsed, wallet.nettype(), rowner.get<std::string_view>());
-        bool curr_backup_owner =
-                rbackup_owner &&
-                cryptonote::get_account_address_from_str(
-                        curr_backup_owner_parsed, wallet.nettype(), *rbackup_owner);
+                curr_owner_parsed, wallet.nettype(), rowner);
+        bool curr_backup_owner = rbackup_owner.size() &&
+                                 cryptonote::get_account_address_from_str(
+                                         curr_backup_owner_parsed, wallet.nettype(), rbackup_owner);
         if (!try_generate_ons_signature(wallet, rowner, owner, backup_owner, result)) {
-            if (!rbackup_owner ||
-                !try_generate_ons_signature(wallet, *rbackup_owner, owner, backup_owner, result)) {
-                if (reason) {
+            if (rbackup_owner.empty() ||
+                !try_generate_ons_signature(wallet, rbackup_owner, owner, backup_owner, result)) {
+                if (reason)
                     *reason =
                             "Signature requested when preparing ONS TX, but this wallet is not "
-                            "the owner of the record owner=" +
-                            rowner.get<std::string>();
-                    if (rbackup_owner)
-                        *reason += ", backup_owner=" + *rbackup_owner;
-                }
+                            "the owner of the record (owner: {}{})"_format(
+                                    rowner,
+                                    rbackup_owner.empty()
+                                            ? ""
+                                            : ", backup_owner: {}"_format(rbackup_owner));
                 return result;
             }
         }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9826,7 +9826,7 @@ static ons_prepared_args prepare_tx_extra_oxen_name_system_values(
             {"name_hash", std::array{oxenc::to_base64(tools::view_guts(result.name_hash))}},
             {"types", std::vector<uint16_t>{ons::db_mapping_type(type)}}};
 
-    auto [success, response_] = wallet.ons_names_to_owners(req_params);
+    auto [success, response_] = wallet.ons_info(req_params);
     if (!response)
         response = &response_;
     else

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -2194,7 +2194,7 @@ class wallet2 {
     std::optional<epee::wipeable_string> on_device_passphrase_request(bool& on_device);
     void on_device_progress(const hw::device_progress& event);
 
-    std::string get_rpc_status(const std::string& s) const;
+    std::string get_rpc_status(std::string_view s) const;
 
     bool should_expand(const cryptonote::subaddress_index& index) const;
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1876,7 +1876,7 @@ class wallet2 {
             uint32_t priority = 0,
             uint32_t account_index = 0,
             std::set<uint32_t> subaddr_indices = {},
-            nlohmann::json* response = {});
+            nlohmann::json* record = nullptr);
 
     // ONS renewal (for lokinet registrations, not for session/wallet)
     std::vector<pending_tx> ons_create_renewal_tx(
@@ -1886,7 +1886,7 @@ class wallet2 {
             uint32_t priority = 0,
             uint32_t account_index = 0,
             std::set<uint32_t> subaddr_indices = {},
-            nlohmann::json* response = {});
+            nlohmann::json* record = nullptr);
 
     // Generate just the signature required for putting into ons_update_mapping command in the
     // wallet

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1080,8 +1080,8 @@ class wallet2 {
     auto ons_owners_to_names(nlohmann::json const& request) const {
         return m_node_rpc_proxy.ons_owners_to_names(request);
     }
-    auto ons_names_to_owners(nlohmann::json const& request) const {
-        return m_node_rpc_proxy.ons_names_to_owners(request);
+    auto ons_info(nlohmann::json const& request) const {
+        return m_node_rpc_proxy.ons_info(request);
     }
     auto resolve(nlohmann::json const& request) const {
         return m_node_rpc_proxy.ons_resolve(request);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3454,70 +3454,50 @@ ONS_KNOWN_NAMES::response wallet_rpc_server::invoke(ONS_KNOWN_NAMES::request&& r
     require_open();
     ONS_KNOWN_NAMES::response res{};
 
-    std::vector<ons::mapping_type> entry_types;
-    auto cache = m_wallet->get_ons_cache();
-    res.known_names.reserve(cache.size());
-    entry_types.reserve(cache.size());
-    for (auto& [name, details] : m_wallet->get_ons_cache()) {
-        auto& entry = res.known_names.emplace_back();
-        auto& type = entry_types.emplace_back(details.type);
-        if (type > ons::mapping_type::lokinet && type <= ons::mapping_type::lokinet_10years)
-            type = ons::mapping_type::lokinet;
-        entry.type = ons::mapping_type_str(type);
-        entry.hashed = details.hashed_name;
-        entry.name = details.name;
-    }
-
     auto nettype = m_wallet->nettype();
-    nlohmann::json req_params{{"include_expired", req.include_expired}, {"entries", {}}};
+    nlohmann::json req_params{{"include_expired", req.include_expired}};
 
-    uint64_t curr_height = req.include_expired ? m_wallet->get_blockchain_current_height() : 0;
+    std::unordered_set<std::string_view> seen;
 
     // Query oxend for the full record info
-    for (auto it = res.known_names.begin(); it != res.known_names.end();) {
-        const size_t num_entries = std::distance(it, res.known_names.end());
-        const auto end = num_entries < rpc::ONS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES
-                               ? res.known_names.end()
-                               : it + rpc::ONS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES;
-        for (auto it2 = it; it2 != end; it2++) {
-            auto& e = req_params["entries"].emplace_back(nlohmann::json{
-                    {"name_hash", it2->hashed},
-                    {"types",
-                     static_cast<uint16_t>(
-                             entry_types[std::distance(res.known_names.begin(), it2)])}});
-        }
+    for (const auto& [name, details] : m_wallet->get_ons_cache()) {
+        if (auto [it, ins] = seen.emplace(details.hashed_name); !ins)
+            continue;  // Don't lookup duplicate hash entries
 
-        if (auto [success, records] = m_wallet->ons_names_to_owners(req_params); success) {
-            size_t type_offset = std::distance(res.known_names.begin(), it);
-            for (auto& rec : records) {
-                if (rec["entry_index"].get<size_t>() >= num_entries) {
-                    log::warning(
-                            logcat,
-                            "Got back invalid entry_index {} for a request for {} entries",
-                            rec["entry_index"].get<size_t>(),
-                            num_entries);
-                    continue;
+        req_params["name_hash"] = details.hashed_name;
+
+        if (auto [success, records] = m_wallet->ons_info(req_params); success) {
+            for (const auto& rec : records) {
+                auto& res_e = res.known_names.emplace_back();
+                res_e.name = details.name;
+                res_e.hashed = details.hashed_name;
+                auto type = ons::parse_ons_type(rec["type"].get<uint16_t>());
+                if (type)
+                    res_e.type = ons::mapping_type_str(*type);
+                else
+                    res_e.type = "unknown";
+
+                res_e.owner = rec["owner"].get<std::string>();
+                if (auto it = rec.find("backup_owner"); it != rec.end())
+                    res_e.backup_owner = it->get<std::string>();
+                res_e.encrypted_value = rec["encrypted_value"].get<std::string>();
+                res_e.update_height = rec["update_height"].get<uint64_t>();
+                if (auto it = rec.find("expiration_height"); it != rec.end()) {
+                    if (auto height = it->get<uint64_t>(); height > 0) {
+                        res_e.expiration_height = height;
+                        res_e.expired = rec["expired"].get<bool>();
+                    }
                 }
+                res_e.txid = rec["txid"].get<std::string>();
 
-                auto& res_e = *(it + rec["entry_index"].get<int64_t>());
-                res_e.owner = std::move(rec["owner"]);
-                res_e.backup_owner = std::move(rec["backup_owner"]);
-                res_e.encrypted_value = std::move(rec["encrypted_value"]);
-                res_e.update_height = rec["update_height"];
-                res_e.expiration_height = rec["expiration_height"];
-                if (req.include_expired && res_e.expiration_height)
-                    res_e.expired = *res_e.expiration_height < curr_height;
-                res_e.txid = std::move(rec["txid"]);
-
-                if (req.decrypt && !res_e.encrypted_value.empty() &&
+                if (req.decrypt && type && !res_e.encrypted_value.empty() &&
                     oxenc::is_hex(res_e.encrypted_value)) {
                     ons::mapping_value value;
-                    const auto type = entry_types[type_offset + rec["entry_index"].get<int64_t>()];
                     std::string errmsg;
                     if (ons::mapping_value::validate_encrypted(
-                                type, oxenc::from_hex(res_e.encrypted_value), &value, &errmsg) &&
-                        value.decrypt(res_e.name, type))
-                        res_e.value = value.to_readable_value(nettype, type);
+                                *type, oxenc::from_hex(res_e.encrypted_value), &value, &errmsg) &&
+                        value.decrypt(res_e.name, *type))
+                        res_e.value = value.to_readable_value(nettype, *type);
                     else
                         log::warning(
                                 logcat,
@@ -3527,17 +3507,7 @@ ONS_KNOWN_NAMES::response wallet_rpc_server::invoke(ONS_KNOWN_NAMES::request&& r
                 }
             }
         }
-
-        it = end;
     }
-
-    // Erase anything we didn't get a response for (it will have update_height of 0)
-    res.known_names.erase(
-            std::remove_if(
-                    res.known_names.begin(),
-                    res.known_names.end(),
-                    [](const auto& n) { return n.update_height == 0; }),
-            res.known_names.end());
 
     // Now sort whatever we got back
     std::sort(res.known_names.begin(), res.known_names.end(), [](const auto& a, const auto& b) {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3126,7 +3126,7 @@ SET_LOG_CATEGORIES::response wallet_rpc_server::invoke(SET_LOG_CATEGORIES::reque
 //------------------------------------------------------------------------------------------------------------------------------
 GET_VERSION::response wallet_rpc_server::invoke(GET_VERSION::request&& req) {
     GET_VERSION::response res{};
-    res.version = WALLET_RPC_VERSION;
+    res.version = RPC_VERSION_CODE;
     return res;
 }
 //------------------------------------------------------------------------------------------------------------------------------
@@ -3456,21 +3456,35 @@ ONS_KNOWN_NAMES::response wallet_rpc_server::invoke(ONS_KNOWN_NAMES::request&& r
 
     auto nettype = m_wallet->nettype();
     nlohmann::json req_params{{"include_expired", req.include_expired}};
+    auto& name_hash = (req_params["name_hash"] = nlohmann::json::array());
+    name_hash.get_ref<nlohmann::json::array_t&>().reserve(
+            std::min(rpc::ONS_INFO::MAX_REQUEST_ENTRIES, res.known_names.size()));
 
-    std::unordered_set<std::string_view> seen;
+    // Tracks seen name hashes, and maps them to actual record names:
+    std::unordered_map<std::string, std::string_view> seen;
 
-    // Query oxend for the full record info
-    for (const auto& [name, details] : m_wallet->get_ons_cache()) {
-        if (auto [it, ins] = seen.emplace(details.hashed_name); !ins)
-            continue;  // Don't lookup duplicate hash entries
+    const auto cache = m_wallet->get_ons_cache();
+    for (auto it = cache.begin(); it != cache.end();) {
+        name_hash.clear();
+        // Fill up to the next request limit:
+        for (; it != cache.end() && name_hash.size() < rpc::ONS_INFO::MAX_REQUEST_ENTRIES; ++it) {
+            const auto& [hashed_name, details] = *it;
+            if (!seen.emplace(hashed_name, details.name).second)
+                continue;  // Don't lookup duplicate entries
+            name_hash.push_back(hashed_name);
+        }
 
-        req_params["name_hash"] = details.hashed_name;
+        auto [success, records] = m_wallet->ons_info(req_params);
+        if (!success)
+            // Something deeper in wallet2 should have already logged an error
+            throw wallet_rpc_error{
+                    error_code::UNKNOWN_ERROR, "Error looking up ONS records via daemon"};
 
-        if (auto [success, records] = m_wallet->ons_info(req_params); success) {
-            for (const auto& rec : records) {
+        for (const auto& [nhash, recs] : records.items()) {
+            for (const auto& rec : recs) {
                 auto& res_e = res.known_names.emplace_back();
-                res_e.name = details.name;
-                res_e.hashed = details.hashed_name;
+                res_e.hashed = nhash;
+                res_e.name = seen[nhash];
                 auto type = ons::parse_ons_type(rec["type"].get<uint16_t>());
                 if (type)
                     res_e.type = ons::mapping_type_str(*type);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -38,26 +38,20 @@
 #include "wallet/transfer_view.h"
 #include "wallet_rpc_server_error_codes.h"
 
-// When making *any* change here, bump minor
-// If the change is incompatible, then bump major and set minor to 0
-// This ensures WALLET_RPC_VERSION always increases, that every change
-// has its own version, and that clients can just test major to see
-// whether they can talk to a given wallet without having to know in
-// advance which version they will stop working with
-// Don't go over 32767 for any of these
-#define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 17
-#define MAKE_WALLET_RPC_VERSION(major, minor) (((major) << 16) | (minor))
-#define WALLET_RPC_VERSION \
-    MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
-
-#define WALLET_RPC_STATUS_OK "OK"
-#define WALLET_RPC_STATUS_BUSY "BUSY"
-
 /// Namespace for wallet RPC commands.  Every RPC commands gets defined here and added to
 /// `wallet_rpc_types` list at the bottom of the file.
 
 namespace tools::wallet_rpc {
+
+// When making *any* change here, bump minor
+// If the change is incompatible, then bump major and set minor to 0
+// This ensures RPC_VERSION_CODE always increases, that every change
+// has its own version, and that clients can just test major to see
+// whether they can talk to a given wallet without having to know in
+// advance which version they will stop working with
+inline constexpr std::array<uint16_t, 2> RPC_VERSION = {1, 18};
+inline constexpr uint32_t RPC_VERSION_CODE =
+        (static_cast<uint32_t>(RPC_VERSION[0]) << 16) | RPC_VERSION[1];
 
 /// Base class that all wallet rpc commands inherit from
 struct RPC_COMMAND {};

--- a/tests/core_tests/oxen_tests.cpp
+++ b/tests/core_tests/oxen_tests.cpp
@@ -1390,7 +1390,7 @@ bool oxen_name_system_get_mappings::generate(std::vector<test_event_entry> &even
       DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
       ons::name_system_db &ons_db = c.blockchain.name_system_db();
       std::string session_name_hash = ons::name_to_base64_hash(tools::lowercase_ascii_string(session_name1));
-      std::vector<ons::mapping_record> records = ons_db.get_mappings({ons::mapping_type::session}, session_name_hash);
+      std::vector<ons::mapping_record> records = ons_db.get_mappings(session_name_hash, std::nullopt, {ons::mapping_type::session});
       CHECK_EQ(records.size(), 1);
       CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, bob_key.session_value, session_height, std::nullopt, session_tx_hash, bob_key.owner, {} /*backup_owner*/));
       return true;
@@ -2092,7 +2092,7 @@ bool oxen_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
     ons::name_system_db &ons_db = c.blockchain.name_system_db();
 
     std::string name_hash = ons::name_to_base64_hash(session_name1);
-    std::vector<ons::mapping_record> records = ons_db.get_mappings({ons::mapping_type::session}, name_hash);
+    std::vector<ons::mapping_record> records = ons_db.get_mappings(name_hash, std::nullopt, {ons::mapping_type::session});
 
     CHECK_EQ(records.size(), 1);
     CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, miner_key.session_value, register_height, std::nullopt, session_tx_hash1, miner_key.owner, {} /*backup_owner*/));
@@ -2118,7 +2118,7 @@ bool oxen_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
     ons::name_system_db &ons_db = c.blockchain.name_system_db();
 
     std::string name_hash = ons::name_to_base64_hash(session_name1);
-    std::vector<ons::mapping_record> records = ons_db.get_mappings({ons::mapping_type::session}, name_hash);
+    std::vector<ons::mapping_record> records = ons_db.get_mappings(name_hash, std::nullopt, {ons::mapping_type::session});
 
     CHECK_EQ(records.size(), 1);
     CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, bob_key.session_value, blockchain_height, std::nullopt, session_tx_hash2, miner_key.owner, {} /*backup_owner*/));


### PR DESCRIPTION
- add a cmake option,` -DWITH_NLOHMANN_JSON_DIAGNOSTICS=ON`, to enable nlohmann::json extended diagnostics to make working with json exceptions much easier.  The option defaults to ON for non-Release builds.
- ons_names_to_owners in the wallet was calling the entirely wrong daemon endpoint
- get_mappings was returning nothing when given no types, instead of all types.
- replaced ONS_NAMES_TO_OWNERS awkward interfaces with a new, simpler ONS_INFO
- fix some bugs breaking simplewallet's ons_by_owner command
