### PR TITLE
Duplicate filtering of incoming proofs

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2283,10 +2283,42 @@ bool core::submit_uptime_proof() {
     }
     return true;
 }
+
+bool core::proof_filter_t::insert(const NOTIFY_BTENCODED_UPTIME_PROOF::request& req) {
+    crypto::hash proof_hash;
+    crypto_generichash_blake2b_state st;
+    crypto_generichash_blake2b_init(&st, nullptr, 0, proof_hash.size());
+    crypto_generichash_blake2b_update(
+            &st, reinterpret_cast<const unsigned char*>(req.proof.data()), req.proof.size());
+    if (req.sig)
+        crypto_generichash_blake2b_update(
+                &st, reinterpret_cast<const unsigned char*>(req.sig->data()), req.sig->size());
+    crypto_generichash_blake2b_update(
+            &st, reinterpret_cast<const unsigned char*>(req.ed_sig.data()), req.ed_sig.size());
+    crypto_generichash_blake2b_final(&st, proof_hash.data(), proof_hash.size());
+
+    std::lock_guard lock{mut};
+    if (auto now = std::chrono::steady_clock::now(); now >= rotate) {
+        seen_old.clear();
+        std::swap(seen, seen_old);
+        rotate = now + ROTATE_INTERVAL;
+    }
+    if (seen.count(proof_hash) || seen_old.count(proof_hash))
+        return false;
+    seen.insert(proof_hash);
+    return true;
+}
+
 //-----------------------------------------------------------------------------------------------
 bool core::handle_uptime_proof(
         const NOTIFY_BTENCODED_UPTIME_PROOF::request& req, bool& my_uptime_proof_confirmation) {
     ZoneScoped;
+
+    if (!proof_filter.insert(req)) {
+        log::debug(logcat, "Ignoring recently received duplicate proof");
+        return false;
+    }
+
     std::unique_ptr<uptime_proof::Proof> proof;
     try {
         // height -1 or would use new rules 1 block too early

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -944,6 +944,26 @@ class core final {
     // TODO: remove this after HF20:
     bool m_skip_proof_l2_check = false;
 
+    // Recently seen proof filter for uptime proofs so that we can drop repeated proofs without
+    // processing them.
+    struct proof_filter_t {
+
+        std::mutex mut;
+        // seen/seen_old store BLAKE2b hashes of (proof || signature || ed_sig) of incoming proofs
+        // seen in the last 0-30s, and the last 30-60s.  Every 60s we rotate seen into seen_old, so
+        // that (by checking both) we always have de-duplication of any proofs received in the last
+        // 30s.
+        std::unordered_set<crypto::hash> seen, seen_old;
+        static constexpr auto ROTATE_INTERVAL = 30s;
+        std::chrono::steady_clock::time_point rotate =
+                std::chrono::steady_clock::now() + ROTATE_INTERVAL;
+
+        // Inserts a new proof, rotating seen->seen_old if due.  Thread-safe.  Returns true if the
+        // proof was not found and inserted, false if it has been recently seen.
+        bool insert(const NOTIFY_BTENCODED_UPTIME_PROOF::request& req);
+
+    } proof_filter;
+
     struct {
         std::shared_mutex mutex;
         bool building = false;


### PR DESCRIPTION
This adds a de-duplicating bloom filter of incoming proofs that we have recently seen so that we can avoid check most proofs that we receive, thus lowering CPU usage.

Since HF20 started including BLS keys in proofs, CPU usage has increased considerably, and profiling reveals this to all be in BLS key verification.  Investigation of proof handling revealed the issue: we check a proof for validity before we consider whether we already have a proof from the node, and this means we generally check every proof many times because proof gossipping means we will receive every proof from every peer we are connected to.  For an average 8-in, 8-out node that means we process every proof 16 times and reject 15 of those 16 with "already received one uptime proof for this node recently", and nodes with more peers incur a heavier burden.

This solves it by putting a 30s bloom filter on the initial raw proof handling so that we can do a much cheaper hash of the proof value to filter out any proofs that were already received in the past 30-60s without needing to process them at all (aside from the added hash).

I also considered moving the "have we received a proof" handling earlier in the handle proof function, but that was more awkward because we would require a service node lock to do that check, but then release the lock for the expensive processing, and then take out the lock again after verification (and then check again for already-received to avoid a race).  Given that we usually receive many copies of the proof in a very small time window it seems likely that we would still end up with non-negligible duplicate proof processing (across threads) with that approach.