### PR TITLE
Update mainnet seeds; move seed node list to network_config

### DIFF
--- a/src/network_config/devnet.h
+++ b/src/network_config/devnet.h
@@ -4,6 +4,11 @@
 #include "testnet.h"
 
 namespace cryptonote::config::devnet {
+
+inline constexpr std::array seeds = {
+        "144.76.164.202:38856"sv,  // public-eu.optf.ngo
+};
+
 inline constexpr network_config config{
         .NETWORK_TYPE = network_type::DEVNET,
         .DEFAULT_CONFIG_SUBDIR = "devnet3"sv,
@@ -32,6 +37,7 @@ inline constexpr network_config config{
                   0x57,
                   0xab,
                   0xd7}},
+        .P2P_SEED_NODES = seeds,
         .GENESIS_TX =
                 "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
                 "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"

--- a/src/network_config/fakechain.h
+++ b/src/network_config/fakechain.h
@@ -17,6 +17,7 @@ inline constexpr network_config config{
         .RPC_DEFAULT_PORT = mainnet::config.RPC_DEFAULT_PORT,
         .QNET_DEFAULT_PORT = mainnet::config.QNET_DEFAULT_PORT,
         .NETWORK_ID = mainnet::config.NETWORK_ID,
+        .P2P_SEED_NODES = {},
         .GENESIS_TX = mainnet::config.GENESIS_TX,
         .GENESIS_NONCE = mainnet::config.GENESIS_NONCE,
         .GOVERNANCE_REWARD_INTERVAL = 200min,

--- a/src/network_config/localdev.h
+++ b/src/network_config/localdev.h
@@ -32,6 +32,7 @@ inline constexpr network_config config{
         .RPC_DEFAULT_PORT = devnet::config.RPC_DEFAULT_PORT,
         .QNET_DEFAULT_PORT = devnet::config.QNET_DEFAULT_PORT,
         .NETWORK_ID = devnet::config.NETWORK_ID,
+        .P2P_SEED_NODES = {},
         .GENESIS_TX = devnet::config.GENESIS_TX,
         .GENESIS_NONCE = devnet::config.GENESIS_NONCE,
         .GOVERNANCE_REWARD_INTERVAL = mainnet::config.GOVERNANCE_REWARD_INTERVAL,

--- a/src/network_config/mainnet.h
+++ b/src/network_config/mainnet.h
@@ -6,6 +6,14 @@
 using namespace std::literals;
 namespace cryptonote::config::mainnet {
 
+inline constexpr std::array seeds = {
+        "116.203.196.12:22022"sv,  // Hetzner seed node
+        "185.150.191.51:22022"sv,  // Jason's seed node
+        "199.127.61.170:22022"sv,  // Oxen Foundation server "holstein"
+        "23.88.6.250:22022"sv,     // Session project server "chianina"
+        "104.194.8.115:22000"sv,   // Oxen Foundation server "brahman"
+};
+
 inline constexpr auto TARGET_BLOCK_TIME = 2min;
 inline constexpr network_config config{
         .NETWORK_TYPE = network_type::MAINNET,
@@ -34,6 +42,7 @@ inline constexpr network_config config{
                   0x66,
                   0x65,
                   0x79}},
+        .P2P_SEED_NODES = seeds,
         .GENESIS_TX =
                 "021e01ff000380808d93f5d771027c4fd4553bc9886f1f49e3f76d945bf71e8632a94e6c177b19cbc7"
                 "80e7e6bdb48080b4ccd4dfc60302c8b9f6461f58ef3f2107e577c7425d06af584a1c7482bf19060e84"

--- a/src/network_config/network_config.h
+++ b/src/network_config/network_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <span>
 
 #include "../cryptonote_config.h"
 
@@ -31,6 +32,10 @@ struct network_config final {
     const uint16_t RPC_DEFAULT_PORT;
     const uint16_t QNET_DEFAULT_PORT;
     const std::array<unsigned char, 16> NETWORK_ID;
+
+    // oxen blockchain p2p seed nodes.
+    const std::span<const std::string_view> P2P_SEED_NODES;
+
     const std::string_view GENESIS_TX;
     const uint32_t GENESIS_NONCE;
     const std::chrono::seconds GOVERNANCE_REWARD_INTERVAL;

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -4,6 +4,11 @@
 #include "testnet.h"
 
 namespace cryptonote::config::stagenet {
+
+inline constexpr std::array seeds = {
+        "104.243.40.38:11020"sv,  // angus.oxen.io
+};
+
 inline constexpr network_config config{
         .NETWORK_TYPE = network_type::STAGENET,
         .DEFAULT_CONFIG_SUBDIR = "stagenet4"sv,
@@ -32,6 +37,7 @@ inline constexpr network_config config{
                   0x65,
                   0x62,
                   0x65}},
+        .P2P_SEED_NODES = seeds,
         .GENESIS_TX =
                 "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec1526d"
                 "a33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c656f"

--- a/src/network_config/testnet.h
+++ b/src/network_config/testnet.h
@@ -3,6 +3,11 @@
 #include "mainnet.h"
 
 namespace cryptonote::config::testnet {
+
+inline constexpr std::array seeds = {
+        "144.76.164.202:38156"sv,  // public-eu.optf.ngo
+};
+
 inline constexpr network_config config{
         .NETWORK_TYPE = network_type::TESTNET,
         .DEFAULT_CONFIG_SUBDIR = "testnet"sv,
@@ -32,6 +37,7 @@ inline constexpr network_config config{
                 0x15,
                 0xbf,
         }},
+        .P2P_SEED_NODES = seeds,
         .GENESIS_TX =
                 "04011e1e01ff00018080c9db97f4fb2702fa27e905f604faa4eb084ee675faca77b0cfea9adec152"
                 "6da33cae5e286f31624201dae05bf3fa1662b7fd373c92426763d921cf3745e10ee43edb510f690c"

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -427,8 +427,6 @@ class node_server
     void record_addr_failed(const epee::net_utils::network_address& addr);
     bool is_addr_recently_failed(const epee::net_utils::network_address& addr);
     bool is_priority_node(const epee::net_utils::network_address& na);
-    std::set<std::string> get_seed_nodes(cryptonote::network_type nettype) const;
-    std::set<std::string> get_seed_nodes();
     bool connect_to_seed();
 
     template <class Container>

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -88,9 +88,9 @@ node_server<t_payload_net_handler>::~node_server() {
     }
 }
 //-----------------------------------------------------------------------------------
-inline bool append_net_address(
+static bool append_net_address(
         std::vector<epee::net_utils::network_address>& seed_nodes,
-        std::string const& addr,
+        std::string_view addr,
         uint16_t default_port);
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
@@ -520,9 +520,9 @@ bool node_server<t_payload_net_handler>::handle_command_line(
     return true;
 }
 //-----------------------------------------------------------------------------------
-inline bool append_net_address(
+static bool append_net_address(
         std::vector<epee::net_utils::network_address>& seed_nodes,
-        std::string const& addr,
+        std::string_view addr,
         uint16_t default_port) {
     using namespace boost::asio;
 
@@ -573,34 +573,6 @@ inline bool append_net_address(
     return true;
 }
 
-//-----------------------------------------------------------------------------------
-template <class t_payload_net_handler>
-std::set<std::string> node_server<t_payload_net_handler>::get_seed_nodes(
-        cryptonote::network_type nettype) const {
-    std::set<std::string> full_addrs;
-    if (nettype == cryptonote::network_type::TESTNET) {
-        full_addrs.insert("144.76.164.202:38156");  // public-eu.optf.ngo
-    } else if (nettype == cryptonote::network_type::DEVNET) {
-        full_addrs.insert("144.76.164.202:38856");
-    } else if (nettype == cryptonote::network_type::STAGENET) {
-        full_addrs.insert("104.243.40.38:11020");  // angus.oxen.io
-    } else if (nettype == cryptonote::network_type::MAINNET) {
-        full_addrs.insert("116.203.196.12:22022");  // Hetzner seed node
-        full_addrs.insert("185.150.191.32:22022");  // Jason's seed node
-        full_addrs.insert("199.127.60.6:22022");    // Oxen Foundation server "holstein"
-        full_addrs.insert("23.88.6.250:22022");     // Official Session open group server
-        full_addrs.insert("104.194.8.115:22000");   // Oxen Foundation server "brahman"
-    }
-    // LOCALDEV and FAKECHAIN don't have seed nodes
-    return full_addrs;
-}
-//-----------------------------------------------------------------------------------
-template <class t_payload_net_handler>
-std::set<std::string> node_server<t_payload_net_handler>::get_seed_nodes() {
-    if (!m_exclusive_peers.empty() || m_offline)
-        return {};
-    return get_seed_nodes(m_nettype);
-}
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 typename node_server<t_payload_net_handler>::network_zone&
@@ -1598,12 +1570,13 @@ bool node_server<t_payload_net_handler>::connect_to_seed() {
     if (!m_seed_nodes_initialized) {
         std::unique_lock lock{m_seed_nodes_mutex};
         if (!m_seed_nodes_initialized) {
-            for (const auto& full_addr : get_seed_nodes()) {
+            const auto& netconf = cryptonote::get_config(m_nettype);
+            for (const auto& full_addr : netconf.P2P_SEED_NODES) {
                 log::debug(logcat, "Seed node: {}", full_addr);
                 append_net_address(
                         m_seed_nodes,
                         full_addr,
-                        cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT);
+                        netconf.P2P_DEFAULT_PORT);
             }
             log::debug(logcat, "Number of seed nodes: {}", m_seed_nodes.size());
             m_seed_nodes_initialized = true;
@@ -1637,13 +1610,14 @@ bool node_server<t_payload_net_handler>::connect_to_seed() {
                 {
                     shlock.unlock();
                     {
+                        const auto& netconf = cryptonote::get_config(m_nettype);
                         std::unique_lock lock{m_seed_nodes_mutex};
-                        for (const auto& peer : get_seed_nodes(m_nettype)) {
+                        for (const auto& peer : netconf.P2P_SEED_NODES) {
                             log::debug(logcat, "Fallback seed node: {}", peer);
                             append_net_address(
                                     m_seed_nodes,
                                     peer,
-                                    cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT);
+                                    netconf.P2P_DEFAULT_PORT);
                         }
                     }
                     shlock.lock();
@@ -2597,8 +2571,8 @@ bool node_server<t_payload_net_handler>::parse_peers_and_add_to_container(
         Container& container) {
     std::vector<std::string> perrs = command_line::get_arg(vm, arg);
 
+    const uint16_t default_port = cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT;
     for (const std::string& pr_str : perrs) {
-        const uint16_t default_port = cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT;
         expect<epee::net_utils::network_address> adr =
                 net::get_network_address(pr_str, default_port);
         if (adr) {


### PR DESCRIPTION
Two of the mainnet nodes were pointing at servers that have moved, and one had an obsolete comment. In particular, of the 5 nodes:

- "Hetzner seed node" is still good.
- "Jason's seed node" IP changed.
- "holstein" IP changed.
- "Official SOGS" is still good, but the comment has been updated as that machine isn't the official SOGS server anymore.
- "brahman" is still good.

The middle of `src/p2p/net_node.inl` is a terrible place for these to be defined, so I moved them into network_config as part of this updating commit.