### PR TITLE
Fix recent omq-related HF20 issues

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1989,67 +1989,61 @@ void core::check_service_node_ip_address() {
             [connection_error_callback](auto, std::string_view) { connection_error_callback(); });
 }
 //-----------------------------------------------------------------------------------------------
-bool core::check_service_node_time() {
-    if (!is_active_sn()) {
-        return true;
-    }
+void core::check_service_node_time() {
+    if (!is_active_sn())
+        return;
 
     crypto::public_key pubkey = service_node_list.get_random_pubkey();
-    crypto::x25519_public_key x_pkey{0};
-    constexpr std::array<uint16_t, 3> MIN_TIMESTAMP_VERSION{9, 1, 0};
-    std::array<uint16_t, 3> proofversion;
-    service_node_list.access_proof(pubkey, [&](auto& proof) {
-        x_pkey = proof.pubkey_x25519;
-        proofversion = proof.proof->version;
-    });
+    auto x_pkey = crypto::null<crypto::x25519_public_key>;
+    service_node_list.access_proof(pubkey, [&](auto& proof) { x_pkey = proof.pubkey_x25519; });
 
-    if (proofversion >= MIN_TIMESTAMP_VERSION && x_pkey) {
-        m_omq->request(
-                tools::view_guts(x_pkey),
-                "quorum.timestamp",
-                [this, pubkey](bool success, std::vector<std::string> data) {
-                    const time_t local_seconds = time(nullptr);
-                    log::debug(
-                            logcat,
-                            "Timestamp message received: {}, local time is: ",
-                            data[0],
-                            local_seconds);
-                    if (success) {
-                        int64_t received_seconds;
-                        if (tools::parse_int(data[0], received_seconds)) {
-                            uint16_t variance;
-                            if (received_seconds > local_seconds + 65535 ||
-                                received_seconds < local_seconds - 65535) {
-                                variance = 65535;
-                            } else {
-                                variance = std::abs(local_seconds - received_seconds);
-                            }
-                            std::lock_guard<std::mutex> lk(m_sn_timestamp_mutex);
-                            // Records the variance into the record of our performance (m_sn_times)
-                            service_nodes::timesync_entry entry{
-                                    variance <= service_nodes::THRESHOLD_SECONDS_OUT_OF_SYNC};
-                            m_sn_times.add(entry);
+    if (!x_pkey)
+        return;  // No valid proof from this snode yet
 
-                            // Counts the number of times we have been out of sync
-                            if (m_sn_times.failures() >
-                                (m_sn_times.size() * service_nodes::MAXIMUM_EXTERNAL_OUT_OF_SYNC /
-                                 100)) {
-                                log::warning(logcat, "service node time might be out of sync");
-                                // If we are out of sync record the other service node as in sync
-                                service_node_list.record_timesync_status(pubkey, true);
-                            } else {
-                                service_node_list.record_timesync_status(
-                                        pubkey,
-                                        variance <= service_nodes::THRESHOLD_SECONDS_OUT_OF_SYNC);
-                            }
+    m_omq->request(
+            tools::view_guts(x_pkey),
+            "quorum.timestamp",
+            [this, pubkey](bool success, std::vector<std::string> data) {
+                const time_t local_seconds = time(nullptr);
+                log::debug(
+                        logcat,
+                        "Timestamp message received: {}, local time is: ",
+                        data[0],
+                        local_seconds);
+                if (success) {
+                    int64_t received_seconds;
+                    if (tools::parse_int(data[0], received_seconds)) {
+                        uint16_t variance;
+                        if (received_seconds > local_seconds + 65535 ||
+                            received_seconds < local_seconds - 65535) {
+                            variance = 65535;
                         } else {
-                            success = false;
+                            variance = std::abs(local_seconds - received_seconds);
                         }
+                        std::lock_guard<std::mutex> lk(m_sn_timestamp_mutex);
+                        // Records the variance into the record of our performance (m_sn_times)
+                        service_nodes::timesync_entry entry{
+                                variance <= service_nodes::THRESHOLD_SECONDS_OUT_OF_SYNC};
+                        m_sn_times.add(entry);
+
+                        // Counts the number of times we have been out of sync
+                        if (m_sn_times.failures() >
+                            (m_sn_times.size() * service_nodes::MAXIMUM_EXTERNAL_OUT_OF_SYNC /
+                             100)) {
+                            log::warning(logcat, "service node time might be out of sync");
+                            // If we are out of sync record the other service node as in sync
+                            service_node_list.record_timesync_status(pubkey, true);
+                        } else {
+                            service_node_list.record_timesync_status(
+                                    pubkey,
+                                    variance <= service_nodes::THRESHOLD_SECONDS_OUT_OF_SYNC);
+                        }
+                    } else {
+                        success = false;
                     }
-                    service_node_list.record_timestamp_participation(pubkey, success);
-                });
-    }
-    return true;
+                }
+                service_node_list.record_timestamp_participation(pubkey, success);
+            });
 }
 //-----------------------------------------------------------------------------------------------
 bool core::is_key_image_spent(const crypto::key_image& key_image) const {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -732,7 +732,7 @@ class core final {
      */
     bool check_tx_semantic(const transaction& tx, bool kept_by_block) const;
     void check_service_node_ip_address();
-    bool check_service_node_time();
+    void check_service_node_time();
     void set_semantics_failed(const crypto::hash& tx_hash);
 
     void parse_incoming_tx_pre(tx_verification_batch_info& tx_info);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -247,10 +247,6 @@ struct service_node_list_transient_storage {
 static auto logcat = log::Cat("service_nodes");
 
 constexpr auto X25519_MAP_PRUNING_INTERVAL = 5min;
-constexpr auto X25519_MAP_PRUNING_LAG = 24h;
-static_assert(
-        X25519_MAP_PRUNING_LAG > cryptonote::config::mainnet::config.UPTIME_PROOF_VALIDITY,
-        "x25519 map pruning lag is too short!");
 
 static uint64_t min_recent_height(cryptonote::network_type nettype, uint64_t height) {
     const uint64_t KEEP_WINDOW = cryptonote::get_config(nettype).HISTORY_RECENT_KEEP_WINDOW;
@@ -5316,7 +5312,7 @@ static bool update_val(T& val, const T& to) {
     return false;
 }
 
-proof_info::proof_info() : proof(std::make_unique<uptime_proof::Proof>()) {};
+proof_info::proof_info() : proof(std::make_unique<uptime_proof::Proof>()) {}
 
 void proof_info::store(const crypto::public_key& pubkey, cryptonote::Blockchain& blockchain) {
     if (!proof)
@@ -5372,6 +5368,21 @@ void proof_info::update_pubkey(const crypto::ed25519_public_key& pk) {
         pubkey_x25519.zero();
         proof->pubkey_ed25519.zero();
     }
+}
+
+bool service_node_list::state_t::should_keep_info(
+        const crypto::public_key& pubkey, std::chrono::nanoseconds proof_age) const {
+    if (proof_age < INFO_PRUNING_LAG)
+        return false;
+
+    if (service_nodes_infos.count(pubkey))
+        return true;
+
+    for (const auto& recently_removed : recently_removed_nodes)
+        if (recently_removed.service_node_pubkey == pubkey)
+            return true;
+
+    return false;
 }
 
 bool service_node_list::handle_uptime_proof(
@@ -5641,9 +5652,11 @@ bool service_node_list::handle_uptime_proof(
 
     if (vers.first < feature::SN_PK_IS_ED25519) {
         if (now - x25519_map_last_pruned >= X25519_MAP_PRUNING_INTERVAL) {
-            time_t cutoff = std::chrono::system_clock::to_time_t(now - X25519_MAP_PRUNING_LAG);
-            std::erase_if(
-                    x25519_to_pub, [&cutoff](const auto& x) { return x.second.second < cutoff; });
+            std::erase_if(x25519_to_pub, [this, &now](const auto& x) {
+                return !m_state.should_keep_info(
+                        x.second.first,
+                        now - std::chrono::system_clock::from_time_t(x.second.second));
+            });
             x25519_map_last_pruned = now;
         }
 
@@ -5667,30 +5680,15 @@ bool service_node_list::handle_uptime_proof(
 void service_node_list::cleanup_proofs() {
     log::debug(logcat, "Cleaning up expired SN proofs");
     auto locks = tools::unique_locks(m_sn_mutex, blockchain);
-    uint64_t now = std::time(nullptr);
+    auto now = std::chrono::system_clock::now();
     auto& db = blockchain.db();
     cryptonote::db_wtxn_guard guard{db};
     for (auto it = proofs.begin(); it != proofs.end();) {
         auto& pubkey = it->first;
         auto& proof = it->second;
 
-        bool still_storing_sn_info = false;
-        if (m_state.service_nodes_infos.count(pubkey))
-            still_storing_sn_info = true;
-
-        if (!still_storing_sn_info) {
-            for (const auto& recently_removed_it : m_state.recently_removed_nodes) {
-                if (recently_removed_it.service_node_pubkey == pubkey) {
-                    still_storing_sn_info = true;
-                    break;
-                }
-            }
-        }
-
-        // 6h here because there's no harm in leaving proofs around a bit longer (they aren't big,
-        // and we only store one per SN), and it's possible that we could reorg a few blocks and
-        // resurrect a service node but don't want to prematurely expire the proof.
-        if (!still_storing_sn_info && proof.timestamp + 6 * 60 * 60 < now) {
+        if (!m_state.should_keep_info(
+                    pubkey, now - std::chrono::system_clock::from_time_t(proof.timestamp))) {
             db.remove_service_node_proof(pubkey);
             it = proofs.erase(it);
         } else

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1281,7 +1281,6 @@ bool service_node_list::state_t::process_state_change_tx(
 
             if (sn_list && !sn_list->m_rescanning) {
                 auto& proof = sn_list->proofs[key];
-                proof.timestamp = proof.effective_timestamp = 0;
                 proof.store(key, sn_list->blockchain);
             }
             return true;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -1089,6 +1089,20 @@ class service_node_list {
                 const;  // return: All nodes that are active and have been online for a period
                         // greater than SERVICE_NODE_PAYABLE_AFTER_BLOCKS
 
+        // How long we should attempt to keep expired proofs and x25519-to-sn-pk map entries once a
+        // node is no longer referenced (i.e. not active and not in the recently removed list).  We
+        // allow a fairly large 6h here because there's no harm in leaving proofs around a bit
+        // longer (they aren't big, and we only store one per SN), and it's possible that we could
+        // reorg a few blocks and resurrect a service node but don't want to prematurely expire the
+        // proof.
+        static constexpr auto INFO_PRUNING_LAG = 6h;
+
+        // Returns true if we want to keep proof & x25519 pubkey info for this node given the age of
+        // the proof, false if it can be deleted.  We keep if the snode is currently registered or
+        // in the recently removed node set; or the proof is less than `INFO_PRUNING_LAG` old.
+        bool should_keep_info(
+                const crypto::public_key& snpk, std::chrono::nanoseconds proof_age) const;
+
         // Takes a BLS pubkey, returns the SN pubkey if known, otherwise null.  Note that "known"
         // here includes both registered SNs and SNs in the recently expired list (i.e. left oxend,
         // but not yet confirmed gone from the contract).

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -666,7 +666,8 @@ class service_node_list {
     void for_each_service_node_info_and_proof(It begin, End end, Func f) const {
         static const proof_info empty_proof{};
         std::lock_guard lock{m_sn_mutex};
-        for (auto sni_end = m_state.service_nodes_infos.end(); begin != end; ++begin) {
+        auto sni_end = m_state.service_nodes_infos.end();
+        for (; begin != end; ++begin) {
             auto it = m_state.service_nodes_infos.find(*begin);
             if (it != sni_end) {
                 auto pit = proofs.find(it->first);

--- a/src/logging/oxen_logger.cpp
+++ b/src/logging/oxen_logger.cpp
@@ -24,6 +24,7 @@ void set_additional_log_categories(log::Level& log_level) {
             log::set_level("net.http", log::Level::err);
             log::set_level("net.p2p", log::Level::err);
             log::set_level("net.p2p.msg", log::Level::err);
+            log::set_level("omq", log::Level::err);
             log::set_level("global", log::Level::info);
             log::set_level("verify", log::Level::err);
             log::set_level("serialization", log::Level::err);
@@ -37,6 +38,7 @@ void set_additional_log_categories(log::Level& log_level) {
             log::set_level("net.http", log::Level::err);
             log::set_level("net.p2p", log::Level::err);
             log::set_level("net.p2p.msg", log::Level::err);
+            log::set_level("omq", log::Level::warn);
             log::set_level("verify", log::Level::err);
             log::set_level("serialization", log::Level::err);
             log::set_level("blockchain", log::Level::warn);


### PR DESCRIPTION
- Service nodes starting producing warnings such as these 24h after the HF20 hard fork:

    [omq:error|oxenmq/connections.cpp:188] peer lookup failed for c098dff7d980d0f68e0daea77533f85f277e803384d996c3259237ba6ca24b1c
    [omq:error|oxenmq/proxy.cpp:132] Unable to send to c098dff7d980d0f68e0daea77533f85f277e803384d996c3259237ba6ca24b1c: no valid connection address found

This was caused by the x25519-to-pubkey map having entries expired for decommissioned service nodes that should have still be contactable, and so timesync checks were throwing up the error code because the timesync code assumed that having a valid proof meant we had contact info for the node.

This unifies the cleanup to be the same as proof cleanup, so that we keep the ability to map X-to-SN pubkeys as long as we keep the proofs so that the lookup failure shouldn't be possible anymore.

- Removes some very old code that cleared the proof timestamp when a node gets decommissioned.  This dates back to early Loki versions, to a time when decomissioning only had anything to do with proofs, and so this was a sort of unifying condition that reset all node's concepts of a node's last uptime proof by completely eliminating it, so that the node would not get recommissioned until the next proof comes in.

This is long obsolete: there are many decomm reasons that have nothing at all to do with proofs, and so removing the proof timestamp just obscures information about when a node actually stopped sending proofs.

- Removes some obsolete code version-gating when we would attempt timesync checks.

- Bumps the OMQ log threshold to error by default, to suppress the common warnings about nodes not being recognized as service nodes.  (The first error message up above, however, would still show up and actually is worth seeing if it occurs, as are most omq error or critical logs).