### PR TITLE
Separate uptime proof requirements for different networks

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5402,7 +5402,7 @@ bool service_node_list::handle_uptime_proof(
         return false;
     }
 
-    for (auto const& min : MIN_UPTIME_PROOF_VERSIONS) {
+    for (auto const& min : MIN_UPTIME_PROOF_VERSIONS(blockchain.nettype())) {
         if (vers >= min.hardfork_revision) {
             if (proof->version < min.oxend) {
                 log::debug(

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -205,11 +205,24 @@ struct proof_version {
     std::array<uint16_t, 3> storage_server;
 };
 
-inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS = {
-        proof_version{{cryptonote::hf::hf19_reward_batching, 6}, {10, 6, 0}, {0, 9, 11}, {2, 8, 0}},
+inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS_MAINNET = {
         proof_version{{cryptonote::hf::hf20_eth_transition, 0}, {11, 2, 0}, {0, 9, 13}, {2, 10, 0}},
+};
+inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS_STAGENET = {
         proof_version{{cryptonote::hf::hf21_eth, 0}, {11, 0, 7}, {0, 9, 13}, {2, 10, 0}},
 };
+inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS_TESTNET = {
+        proof_version{{cryptonote::hf::hf21_eth, 0}, {11, 2, 0}, {0, 9, 13}, {2, 10, 0}},
+};
+
+inline constexpr std::span<const proof_version> MIN_UPTIME_PROOF_VERSIONS(
+        cryptonote::network_type nettype) {
+    switch (nettype) {
+        case cryptonote::network_type::MAINNET: return MIN_UPTIME_PROOF_VERSIONS_MAINNET;
+        case cryptonote::network_type::STAGENET: return MIN_UPTIME_PROOF_VERSIONS_STAGENET;
+        default: return MIN_UPTIME_PROOF_VERSIONS_TESTNET;
+    }
+}
 
 using swarm_id_t = uint64_t;
 inline constexpr swarm_id_t UNASSIGNED_SWARM_ID = UINT64_MAX;


### PR DESCRIPTION
Stagenet is somewhat broken currently because the updated dev created a 11.2.1 package that has mainnet's proof requirement, and triggers proof rejection of proofs from 11.0.7 (of which about a third of stagenet still runs).

This separates the min uptime proof variable into separate values for mainnet, stagenet, and testnets so that mainnet changes won't affect the other networks in the future.

Also drops the now-obsolete hf19 min version.