### PR TITLE
increase ONS fees after HF21

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4683,16 +4683,14 @@ bool Blockchain::check_tx_inputs(
 
             service_nodes::service_node_info::contribution_t contribution = {};
             uint64_t unlock_height = 0;
-            if (hf_version < hf::hf21_eth) {
-                if (!service_node_list.is_key_image_locked(
-                            unlock.key_image, &unlock_height, &contribution)) {
-                    log::error(
-                            log::Cat("verify"),
-                            "Requested key image: {} to unlock is not locked",
-                            unlock.key_image);
-                    tvc.m_invalid_input = true;
-                    return false;
-                }
+            if (!service_node_list.is_key_image_locked(
+                        unlock.key_image, &unlock_height, &contribution)) {
+                log::error(
+                        log::Cat("verify"),
+                        "Requested key image: {} to unlock is not locked",
+                        unlock.key_image);
+                tvc.m_invalid_input = true;
+                return false;
             }
 
             if (!crypto::check_signature(
@@ -4719,7 +4717,6 @@ bool Blockchain::check_tx_inputs(
                     tx.type,
                     get_transaction_hash(tx));
             tvc.m_invalid_type = true;
-            ;
             return false;
         }
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4261,6 +4261,14 @@ bool Blockchain::check_tx_inputs(
         }
     }
 
+    if (hf_version >= hf::hf21_eth &&
+        tools::equals_any(tx.type, txtype::stake, txtype::key_image_unlock)) {
+
+        log::error(logcat, "Staking and unlock transactions are invalid in HF21+");
+        tvc.m_invalid_type = true;
+        return false;
+    }
+
     if (tx.is_transfer()) {
         if (tx.type != txtype::oxen_name_system && !std::holds_alternative<txin_gen>(tx.vin[0]) &&
             hf_version >= feature::MIN_2_OUTPUTS && tx.vout.size() < 2) {

--- a/src/oxen_economy.h
+++ b/src/oxen_economy.h
@@ -128,7 +128,8 @@ constexpr uint64_t burn_needed(cryptonote::hf hf_version, mapping_type type) {
 
     // The base amount for session/wallet/lokinet-1year:
     const uint64_t basic_fee =
-            (hf_version >= cryptonote::hf::hf18         ? 7 * oxen::COIN
+            (hf_version >= cryptonote::hf::hf21_eth     ? 100 * oxen::COIN
+             : hf_version >= cryptonote::hf::hf18       ? 7 * oxen::COIN
              : hf_version >= cryptonote::hf::hf16_pulse ? 15 * oxen::COIN
                                                         : 20 * oxen::COIN);
     switch (type) {


### PR DESCRIPTION
Rather than disabling ONS registration/update transactions, increase the fees; an ethereum/arbitrum contract is planned to replace it.

also removes an unnecessary/incorrect hf gate in a tx acceptance check]