### PR TITLE
Pulse late stage retry + fixes

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -849,12 +849,29 @@ std::vector<cryptonote::batch_sn_payment> BlockchainSQLite::get_sn_payments(uint
     // The block before HF21, addresses which have not registered an ETH address for the
     // SENT transition will have their balances paid out, regardless of balance.
     bool pre_hf21_final_payout = false;
-    auto hf21_begins = *cryptonote::hard_fork_begins(m_nettype, hf::hf21_eth);
-    if (block_height == hf21_begins - 1) {
+    auto hf21_begins = cryptonote::hard_fork_begins(m_nettype, hf::hf21_eth);
+    if (hf21_begins && block_height == *hf21_begins - 1) {
+        pre_hf21_final_payout = true;
+
+        if (m_nettype == network_type::TESTNET) {
+            // Testnet forked before this final block payout code was added (and just dropped
+            // pending rewards), so skip the handling.
+            using namespace oxenc::literals;
+            constexpr auto id = "223a7865e16fcab802a1dc17616415bf"_hex_u;
+            static_assert(
+                    std::equal(
+                            id.begin(),
+                            id.end(),
+                            get_config(network_type::TESTNET).NETWORK_ID.begin()),
+                    "If rebooting testnet, remove this workaround code!");
+            pre_hf21_final_payout = false;
+        }
+    }
+
+    if (pre_hf21_final_payout) {
         log::debug(
                 logcat,
                 "block before hf21, doing final payout to addresses not registered for conversion");
-        pre_hf21_final_payout = true;
         auto all_accrued_amounts = prepared_results<std::string_view, int64_t>(
                 "SELECT address, amount FROM batched_payments_accrued ORDER BY address ASC");
         accrued_pairs.clear();

--- a/src/common/formattable.h
+++ b/src/common/formattable.h
@@ -6,6 +6,7 @@
 #include <oxenc/base64.h>
 #include <oxenc/hex.h>
 
+#include <concepts>
 #include <span>
 #include <string_view>
 #include <type_traits>
@@ -22,9 +23,12 @@ namespace formattable {
 //
 // The function should return something string-like (string, string_view, const char*).
 //
-// For instance to opt-in MyType for such string formatting, use:
+// For instance to opt-in MyType for such string formatting, either specialize via_to_string with a
+// true value:
 //
 //     template <> inline constexpr bool formattable::via_to_string<MyType> = true;
+//
+// or have a `static constexpr bool to_string_formattable = true;` in the class.
 //
 // You can also partially specialize via concepts; for instance to make all derived classes of a
 // common base type formattable via to_string you could do:
@@ -43,9 +47,17 @@ constexpr bool via_underlying = false;
 namespace detail {
 
     template <typename T>
-    concept callable_to_string_method = requires(T v) { v.to_string(); };
+    concept callable_to_string_method = requires(const T v) {
+        { v.to_string() } -> std::convertible_to<std::string_view>;
+    };
     template <typename T>
-    concept callable_to_hex_string_method = requires(T v) { v.to_hex_string(); };
+    concept callable_to_hex_string_method = requires(const T v) {
+        { v.to_hex_string() } -> std::convertible_to<std::string_view>;
+    };
+
+    template <typename T>
+    concept static_member_to_string_formattable =
+            T::to_string_formattable && callable_to_string_method<T>;
 
 }  // namespace detail
 
@@ -251,7 +263,8 @@ struct underlying_t_formatter : fmt::formatter<std::underlying_type_t<T>> {
 namespace fmt {
 
 template <typename T, typename Char>
-    requires ::formattable::via_to_string<T>
+    requires ::formattable::via_to_string<T> ||
+             ::formattable::detail::static_member_to_string_formattable<T>
 struct formatter<T, Char> : ::formattable::to_string_formatter<T> {};
 
 template <typename T, typename Char>

--- a/src/common/formattable.h
+++ b/src/common/formattable.h
@@ -59,64 +59,118 @@ struct to_string_formatter : fmt::formatter<std::string_view> {
     }
 };
 
-// fmt-compatible formatter for things like pubkeys that have a .data() and .size(); if printed bare
-// (i.e. "{}") then these get output as `<00000000000000000123456789abcdef>`, but we also permit
-// them to be formatted using a format of `{:x}`, `{:z}`, `{:a}`, `{:b}`, or `{:r}` where `x` means
-// the full hex byte value, `z` means the hex value without leading 0's, `:a` is base32z, `:b` is
+// fmt-compatible formatter for things like pubkeys that have a .data() and .size(); we permit them
+// to be formatted using a format of `{:x}`, `{:z}`, `{:a}`, `{:b}`, or `{:r}` where `x` means the
+// full hex byte value, `z` means the hex value without leading 0's, `:a` is base32z, `:b` is
 // base64, and `:r` means output raw bytes.  If no format string is given at all (i.e. just "{}")
-// then the format is equivalent to `{:x}`, i.e. we return the full hex value.  Other flags (such as
-// alignment, fill, width) are not currently supported.
+// then the format is (by default) equivalent to `{:x}`, i.e. we return the full hex value, but some
+// types override that -- for example, eth::address's default format is `0xaBc...` rather than
+// `abc...`.
 //
-// For example, for input span \0\0\0\0\0\0\0\x02 `fmt::format("0x{:z} 0x{:x} {}", val)` would
-// produced the string `"0x2 0x0000000000000002 0000000000000002"`.
+// Width and precision formats can be used to ellipsize the value, where width is the number of
+// output characters in total (including the single ellipsis character) and precision is the number
+// of characters after the ellipsis.  For instance, {:10.2x} would produce "abcdef1…89".  When
+// ellipsizing, you must specify at least width and '.'; omitting the trailing width is the same as
+// specifying 0 (which means: do not include any trailing value).  Width must be at least 2, and at
+// least 2 larger than the trailing char size.
 //
-// Some types extend this to override the default format -- for example, eth::address's
-// default format is `0xabc...` rather than `abc...`.
+// Other flags (such as alignment and fill), and width without precision, are not currently
+// supported, but are also less useful as this is generally used with fixed-width types (and so
+// alignment and fill characters can easily be put into the format string itself).
+//
+// For example, for input span \0\0\0\0\0\0\0\x02 `fmt::format("0x{0:z} 0x{0:9.4x} {0}", val)` would
+// produce the string `"0x2 0x0000…0002 0000000000000002"`.
 struct hex_span_formatter {
   protected:
     enum class output { default_, full_hex, stripped_hex, b32z, b64, raw };
     output mode = output::default_;
+    bool ellipsis = false;
+    int ellipsis_width = -1, ellipsis_tail = -1;
 
   public:
     constexpr fmt::format_parse_context::iterator parse(fmt::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        const auto end = ctx.end();
         mode = output::default_;
 
-        if (it == end)
-            return it;
-        char c = *it;
-        switch (c) {
-            case '}': return it;
-            case 'x': mode = output::full_hex; break;
-            case 'z': mode = output::stripped_hex; break;
-            case 'r': mode = output::raw; break;
-            case 'a': mode = output::b32z; break;
-            case 'b': mode = output::b64; break;
-            default: throw fmt::format_error{"invalid format type for hex-formattable value"};
+        auto it = ctx.begin();
+        for (; it != ctx.end(); ++it) {
+            char c = *it;
+            if (c == '}')
+                break;
+            switch (c) {
+                case 'x': mode = output::full_hex; break;
+                case 'z': mode = output::stripped_hex; break;
+                case 'r': mode = output::raw; break;
+                case 'a': mode = output::b32z; break;
+                case 'b': mode = output::b64; break;
+                case '0':
+                    if (!ellipsis && !ellipsis_width)
+                        throw fmt::format_error{
+                                "invalid format for hex-formattable value: 0-fill not currently "
+                                "supported"};
+                    [[fallthrough]];
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9': {
+                    auto& v = ellipsis ? ellipsis_tail : ellipsis_width;
+                    v = (v == -1 ? 0 : v) * 10 + (c - '0');
+                    break;
+                }
+                case '.':
+                    if (!ellipsis && ellipsis_width >= 2) {
+                        ellipsis = true;
+                        break;
+                    } else
+                        [[fallthrough]];
+                default: throw fmt::format_error{"invalid format type for hex-formattable value"};
+            }
+
+            // If we found a mode then that should be terminal, i.e. immediately followed by '}':
+            if (mode != output::default_) {
+                if (++it == ctx.end() || *it != '}')
+                    throw fmt::format_error{"invalid format for hex-formattable value"};
+                break;
+            }
         }
-        if (++it != end && *it != '}')
-            throw fmt::format_error{"invalid format for hex-formattable value"};
+
+        if (ellipsis) {
+            if (ellipsis_tail < 0)
+                throw fmt::format_error{
+                        "invalid ellipsis format for hex-formattable value: "
+                        "missing ellipsis suffix length"};
+            if (ellipsis_tail > ellipsis_width - 2)
+                throw fmt::format_error{
+                        "invalid ellipsis format for hex-formattable value: "
+                        "ellipsis suffix too long"};
+        } else if (ellipsis_width > 0)
+            throw fmt::format_error{
+                    "invalid format for hex-formattable value: width without ellipsizing precision "
+                    "is not currently supported"};
 
         return it;
     }
 
     // Called to produce a default format; subclasses can override to change the default.
     virtual fmt::format_context::iterator default_format(
-            std::span<const unsigned char> val, fmt::format_context& ctx) const {
-        auto out = ctx.out();
-        out = oxenc::to_hex(val.begin(), val.end(), out);
-        return out;
+            std::span<const unsigned char> val, fmt::format_context::iterator& out) const {
+        return oxenc::to_hex(val.begin(), val.end(), out);
     }
 
     auto format(std::span<const unsigned char> val, fmt::format_context& ctx) const {
-        if (mode == output::default_)
-            return default_format(val, ctx);
+        fmt::memory_buffer buf;
+
+        auto out = ellipsis ? fmt::appender(buf) : ctx.out();
 
         using namespace fmt;
-        auto out = ctx.out();
         auto it = val.begin();
-        if (mode == output::raw)
+        if (mode == output::default_)
+            out = default_format(val, out);
+        else if (mode == output::raw)
             out = std::copy(it, val.end(), out);
         else if (mode == output::b64)
             out = oxenc::to_base64(it, val.end(), out);
@@ -145,7 +199,23 @@ struct hex_span_formatter {
             // Anything else is regular hex byte encoding:
             out = oxenc::to_hex(it, val.end(), out);
         }
-        return out;
+
+        if (!ellipsis)
+            return out;
+
+        assert(ellipsis_tail >= 0);
+        assert(ellipsis_width >= ellipsis_tail + 2);
+        std::string_view full{buf.data(), buf.size()};
+        auto final_out = ctx.out();
+        if (full.size() <= static_cast<size_t>(ellipsis_width))
+            std::copy(full.begin(), full.end(), final_out);
+        else {
+            std::copy(full.begin(), full.begin() + (ellipsis_width - 1 - ellipsis_tail), final_out);
+            constexpr std::string_view ellipsis{"…"};
+            std::copy(ellipsis.begin(), ellipsis.end(), final_out);
+            std::copy(full.begin() + (full.size() - ellipsis_tail), full.end(), final_out);
+        }
+        return final_out;
     }
     auto format(std::span<const char> val, fmt::format_context& ctx) const {
         return format(

--- a/src/common/guts.h
+++ b/src/common/guts.h
@@ -66,13 +66,13 @@ std::string hex_guts(const T& val) {
 /// type.  This additionally requires that S have alignment no more strict than T, and that S evenly
 /// divides T.
 template <safe_to_memcpy S = uint8_t, safe_to_memcpy T>
-    requires(sizeof(T) % sizeof(S) == 0 && alignof(S) < alignof(T))
+    requires(sizeof(T) % sizeof(S) == 0 && alignof(S) <= alignof(T))
 constexpr auto span_guts(T& val) {
     return std::span<S, sizeof(T) / sizeof(S)>{reinterpret_cast<S*>(&val), sizeof(val)};
 }
 /// const version of the above, return a span<const S>
 template <safe_to_memcpy S = uint8_t, safe_to_memcpy T>
-    requires(sizeof(T) % sizeof(S) == 0 && alignof(S) < alignof(T))
+    requires(sizeof(T) % sizeof(S) == 0 && alignof(S) <= alignof(T))
 constexpr auto span_guts(const T& val) {
     return std::span<const S, sizeof(T) / sizeof(S)>{reinterpret_cast<const S*>(&val), sizeof(val)};
 }

--- a/src/crypto/eth.cpp
+++ b/src/crypto/eth.cpp
@@ -5,8 +5,7 @@
 #include "crypto/hash.h"
 
 fmt::format_context::iterator fmt::formatter<eth::address>::default_format(
-        std::span<const unsigned char> val, fmt::format_context& ctx) const {
-    auto out = ctx.out();
+        std::span<const unsigned char> val, fmt::format_context::iterator& out) const {
     *out++ = '0';
     *out++ = 'x';
 

--- a/src/crypto/eth.h
+++ b/src/crypto/eth.h
@@ -31,10 +31,11 @@ struct std::hash<eth::bls_public_key> : crypto::raw_hasher<eth::bls_public_key> 
 template <>
 struct std::hash<eth::address> : crypto::raw_hasher<eth::address> {};
 
-// For an eth address, override the default format of <...hex...> to be 0x...hex... instead.  (But
-// don't override for non-default formatting).
+// For an eth address, override the default format of lower-case hex to be 0x...hEx... instead,
+// using the usual ETH address checksum capitalization.  (But don't override for non-default
+// formatting, so that something like "{:x}" can still output the expected straight hex).
 template <>
 struct fmt::formatter<eth::address> : formattable::hex_span_formatter {
     fmt::format_context::iterator default_format(
-            std::span<const unsigned char> val, fmt::format_context& ctx) const override;
+            std::span<const unsigned char> val, fmt::format_context::iterator& out) const override;
 };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -96,6 +96,7 @@ using namespace crypto;
 using namespace cryptonote;
 
 static auto logcat = log::Cat("blockchain");
+static auto logverify = log::Cat("verify");
 
 DISABLE_VS_WARNINGS(4267)
 
@@ -218,15 +219,11 @@ bool Blockchain::scan_outputkeys_for_indexes(
                     outputs,
                     true);
             if (absolute_offsets.size() != outputs.size()) {
-                log::error(
-                        log::Cat("verify"),
-                        "Output does not exist! amount = {}",
-                        tx_in_to_key.amount);
+                log::error(logverify, "Output does not exist! amount = {}", tx_in_to_key.amount);
                 return false;
             }
         } catch (...) {
-            log::error(
-                    log::Cat("verify"), "Output does not exist! amount = {}", tx_in_to_key.amount);
+            log::error(logverify, "Output does not exist! amount = {}", tx_in_to_key.amount);
             return false;
         }
     } else {
@@ -249,16 +246,11 @@ bool Blockchain::scan_outputkeys_for_indexes(
                         true);
                 if (add_offsets.size() != add_outputs.size()) {
                     log::error(
-                            log::Cat("verify"),
-                            "Output does not exist! amount = {}",
-                            tx_in_to_key.amount);
+                            logverify, "Output does not exist! amount = {}", tx_in_to_key.amount);
                     return false;
                 }
             } catch (...) {
-                log::error(
-                        log::Cat("verify"),
-                        "Output does not exist! amount = {}",
-                        tx_in_to_key.amount);
+                log::error(logverify, "Output does not exist! amount = {}", tx_in_to_key.amount);
                 return false;
             }
             outputs.insert(outputs.end(), add_outputs.begin(), add_outputs.end());
@@ -282,7 +274,7 @@ bool Blockchain::scan_outputkeys_for_indexes(
                             output_index.pubkey,
                             output_index.commitment)) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Failed to handle_output for output no = {}, with absolute offset {}",
                             count,
                             i);
@@ -290,7 +282,7 @@ bool Blockchain::scan_outputkeys_for_indexes(
                 }
             } catch (...) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Output does not exist! amount = {}, absolute_offset = {}",
                         tx_in_to_key.amount,
                         i);
@@ -307,10 +299,10 @@ bool Blockchain::scan_outputkeys_for_indexes(
             }
 
         } catch (const OUTPUT_DNE& e) {
-            log::error(log::Cat("verify"), "Output does not exist: {}", e.what());
+            log::error(logverify, "Output does not exist: {}", e.what());
             return false;
         } catch (const TX_DNE& e) {
-            log::error(log::Cat("verify"), "Transaction does not exist: {}", e.what());
+            log::error(logverify, "Transaction does not exist: {}", e.what());
             return false;
         }
     }
@@ -1647,7 +1639,7 @@ bool Blockchain::prevalidate_block_rewards(const block& b, uint64_t height, hf h
         txversion max_version = transaction::get_min_version_for_hf(hf_version);
         if (miner_tx.version < min_version || miner_tx.version > max_version) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Coinbase invalid version: {} for hardfork: {} min/max version: {}/{}",
                     miner_tx.version,
                     static_cast<int>(hf_version),
@@ -1692,7 +1684,7 @@ bool Blockchain::validate_block_rewards(
     if (b.major_version >= feature::ETH_BLS) {
         if (b.miner_tx) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Invalid block: HF {} blocks must not have a miner tx",
                     static_cast<int>(b.major_version));
             return false;
@@ -1710,7 +1702,7 @@ bool Blockchain::validate_block_rewards(
 
         if (b.l2_reward > max_l2r || b.l2_reward < min_l2r) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "block has invalid l2_reward {} not in [{}, {}]",
                     print_money(b.l2_reward),
                     print_money(min_l2r),
@@ -1722,7 +1714,7 @@ bool Blockchain::validate_block_rewards(
         // height, which is the minimum of the last 15 blocks.
         if (auto expected_reward = eth_consensus_reward(height); b.reward != expected_reward) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "block reward for height {} is incorrect; block has {} but expected {}",
                     height,
                     print_money(b.reward),
@@ -1735,7 +1727,7 @@ bool Blockchain::validate_block_rewards(
 
     if (!b.miner_tx) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Invalid block: HF {} blocks must have a miner tx",
                 static_cast<int>(b.major_version));
         return false;
@@ -1744,7 +1736,7 @@ bool Blockchain::validate_block_rewards(
     // validate reward
     uint64_t const money_in_use = get_outs_money_amount(b.miner_tx);
     if (b.miner_tx && b.miner_tx->vout.size() == 0 && b.major_version < hf::hf19_reward_batching) {
-        log::error(log::Cat("verify"), "miner tx has no outputs");
+        log::error(logverify, "miner tx has no outputs");
         return false;
     }
 
@@ -1761,7 +1753,7 @@ bool Blockchain::validate_block_rewards(
     block_reward_context.fee = fee;
     block_reward_context.height = height;
     if (!calc_batched_governance_reward(height, block_reward_context.batched_governance)) {
-        log::error(log::Cat("verify"), "Failed to calculate batched governance reward");
+        log::error(logverify, "Failed to calculate batched governance reward");
         return false;
     }
 
@@ -1802,7 +1794,7 @@ bool Blockchain::validate_block_rewards(
         version < hf::hf19_reward_batching) {
         if (version >= hf::hf10_bulletproofs && reward_parts.governance_paid == 0) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Governance reward should not be 0 after hardfork v10 if this height has a "
                     "governance output because it is the batched payout height");
             return false;
@@ -1810,7 +1802,7 @@ bool Blockchain::validate_block_rewards(
 
         if (b.miner_tx->vout.back().amount != reward_parts.governance_paid) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Governance reward amount incorrect.  Should be: {}, is: {}",
                     print_money(reward_parts.governance_paid),
                     print_money(b.miner_tx->vout.back().amount));
@@ -1823,7 +1815,7 @@ bool Blockchain::validate_block_rewards(
                     b.miner_tx->vout.size() - 1,
                     std::get<txout_to_key>(b.miner_tx->vout.back().target).key,
                     m_nettype)) {
-            log::error(log::Cat("verify"), "Governance reward public key incorrect.");
+            log::error(logverify, "Governance reward public key incorrect.");
             return false;
         }
     }
@@ -1847,7 +1839,7 @@ bool Blockchain::validate_block_rewards(
 
     if (money_in_use > max_money_in_use) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "coinbase transaction spends too much money ({}). Maximum block reward is {} (= {} "
                 "base + {} fees)",
                 print_money(money_in_use),
@@ -1865,7 +1857,7 @@ bool Blockchain::validate_block_rewards(
     } else {  // HF19-20
         if (b.reward != reward_parts.miner_fee + reward_parts.service_node_total) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "block reward for batching is incorrect: {} != {} ({} SN + {} tx fees)",
                     print_money(b.reward),
                     print_money(reward_parts.miner_fee + reward_parts.service_node_total),
@@ -2478,7 +2470,7 @@ bool Blockchain::handle_alternative_block(
     if (!(parent_in_main || parent_in_alt)) {
         bvc.m_marked_as_orphaned = true;
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Block recognized as orphaned and rejected, id = {}, height {}, parent in alt {}, "
                 "parent in main {} (parent {}, current top {}, chain height {})",
                 id,
@@ -2518,7 +2510,7 @@ bool Blockchain::handle_alternative_block(
     // (not earlier than the median of the last X blocks in the built alt chain)
     if (!check_block_timestamp(std::move(timestamps), b)) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Block with id: {} for alternative chain, has invalid timestamp: {}",
                 id,
                 b.timestamp);
@@ -2582,7 +2574,7 @@ bool Blockchain::handle_alternative_block(
                 cryptonote::transaction tx;
                 if (!cryptonote::parse_and_validate_tx_base_from_blob(blob, tx)) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Block with id: {} (as alternative) refers to unparsable transaction "
                             "hash {}.",
                             id,
@@ -2654,7 +2646,7 @@ bool Blockchain::handle_alternative_block(
             std::string blob;
             if (!tx_pool.get_transaction(missed_tx, blob)) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Alternative block references unknown TX, rejected alt block {} {}",
                         blk_height,
                         id);
@@ -2664,7 +2656,7 @@ bool Blockchain::handle_alternative_block(
             transaction tx;
             if (!parse_and_validate_tx_from_blob(blob, tx)) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Failed to parse block blob from tx pool when querying the missed "
                         "transactions in block {} {}",
                         blk_height,
@@ -3902,9 +3894,7 @@ bool Blockchain::get_tx_outputs_gindexs(
     uint64_t tx_index;
     if (!m_db->tx_exists(tx_id, tx_index)) {
         log::error(
-                log::Cat("verify"),
-                "get_tx_outputs_gindexs failed to find transaction with id = {}",
-                tx_id);
+                logverify, "get_tx_outputs_gindexs failed to find transaction with id = {}", tx_id);
         return false;
     }
     indexs = m_db->get_tx_amount_output_indices(tx_index, n_txes);
@@ -3920,9 +3910,7 @@ bool Blockchain::get_tx_outputs_gindexs(
     uint64_t tx_index;
     if (!m_db->tx_exists(tx_id, tx_index)) {
         log::error(
-                log::Cat("verify"),
-                "get_tx_outputs_gindexs failed to find transaction with id = {}",
-                tx_id);
+                logverify, "get_tx_outputs_gindexs failed to find transaction with id = {}", tx_id);
         return false;
     }
     std::vector<std::vector<uint64_t>> indices = m_db->get_tx_amount_output_indices(tx_index, 1);
@@ -4045,7 +4033,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
     if (hf_version < hf::hf10_bulletproofs) {
         const bool bulletproof = rct::is_rct_bulletproof(tx.rct_signatures.type);
         if (bulletproof || !tx.rct_signatures.p.bulletproofs.empty()) {
-            log::error(log::Cat("verify"), "Bulletproofs are not allowed before v10");
+            log::error(logverify, "Bulletproofs are not allowed before v10");
             tvc.m_invalid_output = true;
             return false;
         }
@@ -4055,7 +4043,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
         // here:
         if (auto hf10_height = hard_fork_begins(m_nettype, hf::hf10_bulletproofs);
             hf10_height && height > *hf10_height) {
-            log::error(log::Cat("verify"), "Borromean range proofs are not allowed after v10");
+            log::error(logverify, "Borromean range proofs are not allowed after v10");
             tvc.m_invalid_output = true;
             return false;
         }
@@ -4064,7 +4052,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
     if (hf_version < feature::SMALLER_BP) {
         if (tx.rct_signatures.type == rct::RCTType::Bulletproof2) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Ringct type {} is not allowed before v{}",
                     (unsigned)rct::RCTType::Bulletproof2,
                     static_cast<int>(feature::SMALLER_BP));
@@ -4077,7 +4065,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
         if (tx.version >= txversion::v4_tx_types && tx.is_transfer()) {
             if (tx.rct_signatures.type == rct::RCTType::Bulletproof) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Ringct type {} is not allowed after v{}",
                         (unsigned)rct::RCTType::Bulletproof,
                         static_cast<int>(feature::SMALLER_BP));
@@ -4092,7 +4080,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
         if (tx.version >= txversion::v4_tx_types && tx.is_transfer()) {
             if (tx.rct_signatures.type == rct::RCTType::CLSAG) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Ringct type {} is not allowed before v{}",
                         (unsigned)rct::RCTType::CLSAG,
                         static_cast<int>(feature::CLSAG));
@@ -4110,7 +4098,7 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
         (hf_version > feature::CLSAG ||
          height >= 10 + *hard_fork_begins(m_nettype, feature::CLSAG))) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Ringct type {} is not allowed from v{}",
                 (unsigned)tx.rct_signatures.type,
                 static_cast<int>(feature::CLSAG));
@@ -4244,7 +4232,7 @@ bool Blockchain::check_tx_inputs(
         if (tvc.m_invalid_version || tvc.m_invalid_type) {
             if (tvc.m_invalid_version)
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "TX Invalid version: {} for hardfork: {} min/max version: {}/{}",
                         tx.version,
                         (int)hf_version,
@@ -4252,7 +4240,7 @@ bool Blockchain::check_tx_inputs(
                         max_version);
             if (tvc.m_invalid_type)
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "TX Invalid type: {} for hardfork: {} max type: {}",
                         tx.type,
                         (int)hf_version,
@@ -4273,7 +4261,7 @@ bool Blockchain::check_tx_inputs(
         if (tx.type != txtype::oxen_name_system && !std::holds_alternative<txin_gen>(tx.vin[0]) &&
             hf_version >= feature::MIN_2_OUTPUTS && tx.vout.size() < 2) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Tx {} has fewer than two outputs, which is not allowed as of hardfork {}",
                     get_transaction_hash(tx),
                     static_cast<int>(feature::MIN_2_OUTPUTS));
@@ -4309,7 +4297,7 @@ bool Blockchain::check_tx_inputs(
                 // Mixin Check, from hard fork 7, we require mixin at least 9, always.
                 if (in_to_key.key_offsets.size() - 1 != cryptonote::TX_OUTPUT_DECOYS) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Tx {} has incorrect ring size: {} expected: {}",
                             get_transaction_hash(tx),
                             in_to_key.key_offsets.size() - 1,
@@ -4322,7 +4310,7 @@ bool Blockchain::check_tx_inputs(
                 {
                     if (last_key_image &&
                         memcmp(&in_to_key.k_image, last_key_image, sizeof(*last_key_image)) >= 0) {
-                        log::error(log::Cat("verify"), "transaction has unsorted inputs");
+                        log::error(logverify, "transaction has unsorted inputs");
                         tvc.m_verifivation_failed = true;
                         return false;
                     }
@@ -4331,7 +4319,7 @@ bool Blockchain::check_tx_inputs(
 
                 if (have_tx_keyimg_as_spent(in_to_key.k_image)) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Key image already spent in blockchain: {}",
                             in_to_key.k_image);
                     if (key_image_conflicts)
@@ -4350,7 +4338,7 @@ bool Blockchain::check_tx_inputs(
                             pubkeys[sig_index],
                             pmax_used_block_height)) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Failed to check ring signature for tx {} vin key with k_image: {} "
                             "sig_index: {}",
                             get_transaction_hash(tx),
@@ -4360,7 +4348,7 @@ bool Blockchain::check_tx_inputs(
                                                  // Blockchain::handle_block_to_main_chain()
                     {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "  *pmax_used_block_height: {}",
                                 *pmax_used_block_height);
                     }
@@ -4379,7 +4367,7 @@ bool Blockchain::check_tx_inputs(
                         entry.key_image)  // Check if key image is on the blacklist
                     {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Key image: {} is blacklisted by the service node network",
                                 entry.key_image);
                         tvc.m_key_image_blacklisted = true;
@@ -4391,7 +4379,7 @@ bool Blockchain::check_tx_inputs(
                     uint64_t unlock_height = 0;
                     if (service_node_list.is_key_image_locked(in_to_key.k_image, &unlock_height)) {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Key image: {} is locked in a stake until height: {}",
                                 in_to_key.k_image,
                                 unlock_height);
@@ -4410,7 +4398,7 @@ bool Blockchain::check_tx_inputs(
         }
 
         if (!expand_transaction_2(tx, tx_prefix_hash, pubkeys)) {
-            log::error(log::Cat("verify"), "Failed to expand rct signatures!");
+            log::error(logverify, "Failed to expand rct signatures!");
             return false;
         }
 
@@ -4422,7 +4410,7 @@ bool Blockchain::check_tx_inputs(
             case rct::RCTType::Null: {
                 // we only accept no signatures for coinbase txes
                 if (!tx.is_miner_tx()) {
-                    log::error(log::Cat("verify"), "Null rct signature on non-coinbase tx");
+                    log::error(logverify, "Null rct signature on non-coinbase tx");
                     return false;
                 }
                 break;
@@ -4435,7 +4423,7 @@ bool Blockchain::check_tx_inputs(
                 {
                     if (pubkeys.size() != rv.mixRing.size()) {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Failed to check ringct signatures: mismatched pubkeys/mixRing "
                                 "size");
                         return false;
@@ -4443,7 +4431,7 @@ bool Blockchain::check_tx_inputs(
                     for (size_t i = 0; i < pubkeys.size(); ++i) {
                         if (pubkeys[i].size() != rv.mixRing[i].size()) {
                             log::error(
-                                    log::Cat("verify"),
+                                    logverify,
                                     "Failed to check ringct signatures: mismatched pubkeys/mixRing "
                                     "size");
                             return false;
@@ -4454,7 +4442,7 @@ bool Blockchain::check_tx_inputs(
                         for (size_t m = 0; m < pubkeys[n].size(); ++m) {
                             if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[n][m].dest)) {
                                 log::error(
-                                        log::Cat("verify"),
+                                        logverify,
                                         "Failed to check ringct signatures: mismatched pubkey at "
                                         "vin {}, index {}",
                                         n,
@@ -4463,7 +4451,7 @@ bool Blockchain::check_tx_inputs(
                             }
                             if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[n][m].mask)) {
                                 log::error(
-                                        log::Cat("verify"),
+                                        logverify,
                                         "Failed to check ringct signatures: mismatched commitment "
                                         "at vin {}, index {}",
                                         n,
@@ -4478,7 +4466,7 @@ bool Blockchain::check_tx_inputs(
                         rv.type == rct::RCTType::CLSAG ? rv.p.CLSAGs.size() : rv.p.MGs.size();
                 if (n_sigs != tx.vin.size()) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Failed to check ringct signatures: mismatched MGs/vin sizes");
                     return false;
                 }
@@ -4494,14 +4482,14 @@ bool Blockchain::check_tx_inputs(
                                        32);
                     if (error) {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Failed to check ringct signatures: mismatched key image");
                         return false;
                     }
                 }
 
                 if (!rct::verRctNonSemanticsSimple(rv)) {
-                    log::error(log::Cat("verify"), "Failed to check ringct signatures!");
+                    log::error(logverify, "Failed to check ringct signatures!");
                     return false;
                 }
                 break;
@@ -4516,7 +4504,7 @@ bool Blockchain::check_tx_inputs(
                         size_matches &= pubkeys.size() == rv.mixRing[i].size();
                     if (!size_matches) {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Failed to check ringct signatures: mismatched pubkeys/mixRing "
                                 "size");
                         return false;
@@ -4526,7 +4514,7 @@ bool Blockchain::check_tx_inputs(
                         for (size_t m = 0; m < pubkeys[n].size(); ++m) {
                             if (pubkeys[n][m].dest != rct::rct2pk(rv.mixRing[m][n].dest)) {
                                 log::error(
-                                        log::Cat("verify"),
+                                        logverify,
                                         "Failed to check ringct signatures: mismatched pubkey at "
                                         "vin {}, index {}",
                                         n,
@@ -4535,7 +4523,7 @@ bool Blockchain::check_tx_inputs(
                             }
                             if (pubkeys[n][m].mask != rct::rct2pk(rv.mixRing[m][n].mask)) {
                                 log::error(
-                                        log::Cat("verify"),
+                                        logverify,
                                         "Failed to check ringct signatures: mismatched commitment "
                                         "at vin {}, index {}",
                                         n,
@@ -4547,34 +4535,32 @@ bool Blockchain::check_tx_inputs(
                 }
 
                 if (rv.p.MGs.size() != 1) {
-                    log::error(
-                            log::Cat("verify"), "Failed to check ringct signatures: Bad MGs size");
+                    log::error(logverify, "Failed to check ringct signatures: Bad MGs size");
                     return false;
                 }
                 if (rv.p.MGs.empty() || rv.p.MGs[0].II.size() != tx.vin.size()) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Failed to check ringct signatures: mismatched II/vin sizes");
                     return false;
                 }
                 for (size_t n = 0; n < tx.vin.size(); ++n) {
                     if (memcmp(&std::get<txin_to_key>(tx.vin[n]).k_image, &rv.p.MGs[0].II[n], 32)) {
                         log::error(
-                                log::Cat("verify"),
+                                logverify,
                                 "Failed to check ringct signatures: mismatched II/vin sizes");
                         return false;
                     }
                 }
 
                 if (!rct::verRct(rv, false)) {
-                    log::error(log::Cat("verify"), "Failed to check ringct signatures!");
+                    log::error(logverify, "Failed to check ringct signatures!");
                     return false;
                 }
                 break;
             }
             default:
-                log::error(
-                        log::Cat("verify"), "{}: Unsupported rct type: {}", __func__, (int)rv.type);
+                log::error(logverify, "{}: Unsupported rct type: {}", __func__, (int)rv.type);
                 return false;
         }
 
@@ -4582,8 +4568,7 @@ bool Blockchain::check_tx_inputs(
         if (rct::is_rct_bulletproof(rv.type) && hf_version < hf::hf10_bulletproofs) {
             for (const rct::Bulletproof& proof : rv.p.bulletproofs) {
                 if (proof.V.size() > 1 && !hack::test_suite_permissive_txes) {
-                    log::error(
-                            log::Cat("verify"), "Multi output bulletproofs are invalid before v10");
+                    log::error(logverify, "Multi output bulletproofs are invalid before v10");
                     return false;
                 }
             }
@@ -4594,7 +4579,7 @@ bool Blockchain::check_tx_inputs(
             std::string fail_reason;
             if (!m_ons_db.validate_ons_tx(
                         hf_version, get_current_blockchain_height(), tx, data, &fail_reason)) {
-                log::error(log::Cat("verify"), "Failed to validate ONS TX reason: {}", fail_reason);
+                log::error(logverify, "Failed to validate ONS TX reason: {}", fail_reason);
                 tvc.m_verbose_error = std::move(fail_reason);
                 return false;
             }
@@ -4611,25 +4596,19 @@ bool Blockchain::check_tx_inputs(
         if (tx.rct_signatures.txnFee != 0) {
             tvc.m_invalid_input = true;
             tvc.m_verifivation_failed = true;
-            log::error(log::Cat("verify"), "TX type: {} should have 0 fee!", tx.type);
+            log::error(logverify, "TX type: {} should have 0 fee!", tx.type);
             return false;
         }
 
         if (is_l2_event_tx(tx.type)) {
             if (!eth::validate_event_tx(tx.type, hf_version, tx, &tvc.m_verbose_error)) {
-                log::error(
-                        log::Cat("verify"),
-                        "Failed to validate {} TX: {}",
-                        tx.type,
-                        tvc.m_verbose_error);
+                log::error(logverify, "Failed to validate {} TX: {}", tx.type, tvc.m_verbose_error);
                 return false;
             }
         } else if (tx.type == txtype::state_change) {
             tx_extra_service_node_state_change state_change;
             if (!get_service_node_state_change_from_tx_extra(tx.extra, state_change, hf_version)) {
-                log::error(
-                        log::Cat("verify"),
-                        "TX did not have the state change metadata in the tx_extra");
+                log::error(logverify, "TX did not have the state change metadata in the tx_extra");
                 return false;
             }
 
@@ -4637,8 +4616,7 @@ bool Blockchain::check_tx_inputs(
                     service_nodes::quorum_type::obligations, state_change.block_height);
             if (!quorum) {
                 log::error(
-                        log::Cat("verify"),
-                        "could not get obligations quorum for recent state change tx");
+                        logverify, "could not get obligations quorum for recent state change tx");
                 return false;
             }
 
@@ -4648,7 +4626,7 @@ bool Blockchain::check_tx_inputs(
                 // less serious ones like state change heights slightly outside of allowed bounds:
                 // tvc.m_verifivation_failed = true;
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "tx: {}, state change tx could not be completely verified reason: {}",
                         get_transaction_hash(tx),
                         print_vote_verification_context(tvc.m_vote_ctx));
@@ -4666,7 +4644,7 @@ bool Blockchain::check_tx_inputs(
                             {state_change_service_node_pubkey});
             if (service_node_array.empty()) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Service Node no longer exists on the network, state change can be "
                         "ignored");
                 return hf_version < hf::hf12_checkpointing;  // NOTE: Used to be allowed pre HF12.
@@ -4676,7 +4654,7 @@ bool Blockchain::check_tx_inputs(
             if (!service_node_info.can_transition_to_state(
                         hf_version, state_change.block_height, state_change.state)) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "State change trying to vote Service Node into the same state is invalid "
                         "(expired, already applied, or impossible)");
                 tvc.m_double_spend = true;
@@ -4694,7 +4672,7 @@ bool Blockchain::check_tx_inputs(
             if (!service_node_list.is_key_image_locked(
                         unlock.key_image, &unlock_height, &contribution)) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Requested key image: {} to unlock is not locked",
                         unlock.key_image);
                 tvc.m_invalid_input = true;
@@ -4720,7 +4698,7 @@ bool Blockchain::check_tx_inputs(
             }
         } else {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Unhandled tx type: {} rejecting tx: {}",
                     tx.type,
                     get_transaction_hash(tx));
@@ -4890,7 +4868,7 @@ bool Blockchain::check_fee(
 
     if (fee < needed_fee) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "transaction fee is not enough: {}, minimum fee: {}",
                 print_money(fee),
                 print_money(needed_fee));
@@ -4901,7 +4879,7 @@ bool Blockchain::check_fee(
         uint64_t need_burned = opts.burn_fixed + base_miner_fee * opts.burn_percent / 100;
         if (burned < need_burned) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "transaction burned fee is not enough: {}, minimum fee: {}",
                     print_money(burned),
                     print_money(need_burned));
@@ -4998,7 +4976,7 @@ bool Blockchain::check_tx_input(
             // check tx unlock time
             if (!m_bch.is_output_spendtime_unlocked(unlock_time)) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "One of outputs for one of inputs has wrong tx.unlock_time = {}",
                         unlock_time);
                 return false;
@@ -5020,7 +4998,7 @@ bool Blockchain::check_tx_input(
     outputs_visitor vi(output_keys, *this);
     if (!scan_outputkeys_for_indexes(txin, vi, tx_prefix_hash, pmax_related_block_height)) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Failed to get output keys for tx with amount = {} and count indixes {}",
                 print_money(txin.amount),
                 txin.key_offsets.size());
@@ -5029,7 +5007,7 @@ bool Blockchain::check_tx_input(
 
     if (txin.key_offsets.size() != output_keys.size()) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Output keys for tx with amount = {} and count indexes {} returned wrong keys "
                 "count {}",
                 txin.amount,
@@ -5056,7 +5034,7 @@ bool Blockchain::check_block_timestamp(
 
     if (b.timestamp < median_ts) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Timestamp of block with id: {}, {}, less than median of last {} blocks, {}",
                 get_block_hash(b),
                 b.timestamp,
@@ -5080,7 +5058,7 @@ bool Blockchain::check_block_timestamp(const block& b, uint64_t& median_ts) cons
     uint64_t cryptonote_block_future_time_limit = old::BLOCK_FUTURE_TIME_LIMIT_V2;
     if (b.timestamp > get_adjusted_time() + cryptonote_block_future_time_limit) {
         log::error(
-                log::Cat("verify"),
+                logverify,
                 "Timestamp of block with id: {}, {}, bigger than adjusted time + 2 hours",
                 get_block_hash(b),
                 b.timestamp);
@@ -5202,7 +5180,7 @@ Blockchain::block_pow_verified Blockchain::verify_block_pow(
             if (expected_hash) {
                 if (blk_hash != expected_hash) {
                     log::error(
-                            log::Cat("verify"),
+                            logverify,
                             "Block with id is INVALID: {}, expected {}",
                             blk_hash,
                             expected_hash);
@@ -5213,7 +5191,7 @@ Blockchain::block_pow_verified Blockchain::verify_block_pow(
                 result.per_block_checkpointed = true;
             } else {
                 log::info(
-                        log::Cat("verify"),
+                        logverify,
                         "No pre-validated hash at height {}, verifying fully",
                         chain_height);
             }
@@ -5261,7 +5239,7 @@ bool Blockchain::basic_block_checks(cryptonote::block const& blk, bool alt_block
     if (alt_block) {
         if (blk.get_height() == 0) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Block with id: {} (as alternative), but miner tx says height is 0.",
                     blk_hash);
             return false;
@@ -5269,7 +5247,7 @@ bool Blockchain::basic_block_checks(cryptonote::block const& blk, bool alt_block
 
         if (!m_checkpoints.is_alternative_block_allowed(chain_height, blk_height, nullptr)) {
             log::error(
-                    log::Cat("verify"),
+                    logverify,
                     "Block with id: {} can't be accepted for alternative chain, block height: {}, "
                     "chain height: {}",
                     blk_hash,
@@ -5581,7 +5559,7 @@ bool Blockchain::handle_block_to_main_chain(
                         tx_index,
                         m_blocks_txs_check.size());
                 for (const auto& h : m_blocks_txs_check)
-                    log::error(log::Cat("verify"), "  {}", h);
+                    log::error(logverify, "  {}", h);
                 return false;
             }
         }
@@ -5592,14 +5570,14 @@ bool Blockchain::handle_block_to_main_chain(
             if (tx_index >= m_blocks_txs_check.size() ||
                 memcmp(&m_blocks_txs_check[tx_index++], &tx_id, sizeof(tx_id)) != 0) {
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Block with id: {} has at least one transaction (id: {}) with wrong "
                         "inputs.",
                         id,
                         tx_id);
                 add_block_as_invalid(bl);
                 log::error(
-                        log::Cat("verify"),
+                        logverify,
                         "Block with id {} added as invalid because of wrong inputs in transactions",
                         id);
                 return false;
@@ -6488,7 +6466,7 @@ bool Blockchain::prepare_handle_incoming_blocks(
 
         for (const auto& tx_blob : entry.txs) {
             if (tx_index >= txes.size()) {
-                log::error(log::Cat("verify"), "tx_index is out of sync");
+                log::error(logverify, "tx_index is out of sync");
                 m_scan_table.clear();
                 return false;
             }
@@ -6497,24 +6475,20 @@ bool Blockchain::prepare_handle_incoming_blocks(
             ++tx_index;
 
             if (!parse_and_validate_tx_base_from_blob(tx_blob, tx)) {
-                log::error(log::Cat("verify"), "Could not parse tx from incoming blocks");
+                log::error(logverify, "Could not parse tx from incoming blocks");
                 m_scan_table.clear();
                 return false;
             }
             cryptonote::get_transaction_prefix_hash(tx, tx_prefix_hash);
 
-            auto its = m_scan_table.find(tx_prefix_hash);
-            if (its != m_scan_table.end()) {
-                log::error(log::Cat("verify"), "Duplicate tx found from incoming blocks.");
+            auto [its, ins] = m_scan_table.emplace(
+                    tx_prefix_hash,
+                    std::unordered_map<crypto::key_image, std::vector<output_data_t>>{});
+            if (!ins) {
+                log::error(logverify, "Duplicate tx found from incoming blocks.");
                 m_scan_table.clear();
                 return false;
             }
-
-            m_scan_table.emplace(
-                    tx_prefix_hash,
-                    std::unordered_map<crypto::key_image, std::vector<output_data_t>>());
-            its = m_scan_table.find(tx_prefix_hash);
-            assert(its != m_scan_table.end());
 
             // check all tx.vin(s)
             if (!tx.is_miner_tx()) {
@@ -6524,9 +6498,7 @@ bool Blockchain::prepare_handle_incoming_blocks(
                     // check for duplicate
                     auto it = its->second.find(in_to_key.k_image);
                     if (it != its->second.end()) {
-                        log::error(
-                                log::Cat("verify"),
-                                "Duplicate key_image found from incoming blocks.");
+                        log::error(logverify, "Duplicate key_image found from incoming blocks.");
                         m_scan_table.clear();
                         return false;
                     }
@@ -6551,7 +6523,7 @@ bool Blockchain::prepare_handle_incoming_blocks(
         constexpr uint64_t amount{0};
         m_db->get_output_key(epee::span<const uint64_t>(&amount, 1), offsets, txs, true);
     } catch (const std::exception& e) {
-        log::error(log::Cat("verify"), "EXCEPTION: {}", e.what());
+        log::error(logverify, "EXCEPTION: {}", e.what());
     } catch (...) {
     }
 
@@ -6563,17 +6535,15 @@ bool Blockchain::prepare_handle_incoming_blocks(
 
         for (const auto& tx_blob : entry.txs) {
             if (tx_index >= txes.size()) {
-                log::error(log::Cat("verify"), "tx_index is out of sync");
+                log::error(logverify, "tx_index is out of sync");
                 m_scan_table.clear();
                 return false;
             }
-            const transaction& tx = txes[tx_index].first;
-            const crypto::hash& tx_prefix_hash = txes[tx_index].second;
-            ++tx_index;
+            const auto& [tx, tx_prefix_hash] = txes[tx_index++];
 
             auto its = m_scan_table.find(tx_prefix_hash);
             if (its == m_scan_table.end()) {
-                log::error(log::Cat("verify"), "Tx not found on scan table from incoming blocks.");
+                log::error(logverify, "Tx not found on scan table from incoming blocks.");
                 m_scan_table.clear();
                 return false;
             }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1996,7 +1996,8 @@ bool Blockchain::create_block_template_internal(
         difficulty_type& diffic,
         uint64_t& height,
         uint64_t& expected_reward,
-        const std::string& ex_nonce) {
+        const std::string& ex_nonce,
+        std::vector<std::string>* state_change_txes) {
     ZoneScoped;
     log::trace(logcat, "Blockchain::{}", __func__);
     size_t median_weight;
@@ -2083,7 +2084,8 @@ bool Blockchain::create_block_template_internal(
                 expected_reward,
                 b.major_version,
                 height,
-                l2_mempool_max))
+                l2_mempool_max,
+                state_change_txes))
         return false;
 
     pool_cookie = tx_pool.cookie();
@@ -2257,14 +2259,16 @@ bool Blockchain::create_next_pulse_block_template(
         const service_nodes::payout& block_producer,
         uint8_t round,
         uint16_t validator_bitset,
-        uint64_t& height) {
+        uint64_t& height,
+        std::vector<std::string>* supplemental_txes) {
     uint64_t expected_reward = 0;
     block_template_info info = {};
     info.service_node_payout = block_producer;
     uint64_t diffic = 0;
-    std::string nonce = {};
+    std::string nonce;
 
-    bool result = create_block_template_internal(b, info, diffic, height, expected_reward, nonce);
+    bool result = create_block_template_internal(
+            b, info, diffic, height, expected_reward, nonce, supplemental_txes);
     b.pulse.round = round;
     b.pulse.validator_bitset = validator_bitset;
     return result;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -449,7 +449,12 @@ class Blockchain {
      * @param round the current pulse round the block is being generated for
      * @param validator_bitset the bitset indicating which validators in the quorum are
      * participating in constructing the block.
-     * @param ex_nonce extra data to be added to the miner transaction's extra
+     * @param height will be set to the block's height
+     * @param state_change_txes (if provided) will be filled with any state change txes that should
+     * be sent along to the pulse quorum to avoid failures where validators have equivalent but
+     * different versions (i.e. with different signature subsets) of the state change.  Without it
+     * being sent along, any validator with such a different version would be unable to add it to
+     * the chain or broadcast it.
      *
      * @return true if block template filled in successfully, else false
      */
@@ -458,7 +463,8 @@ class Blockchain {
             const service_nodes::payout& block_producer,
             uint8_t round,
             uint16_t validator_bitset,
-            uint64_t& height);
+            uint64_t& height,
+            std::vector<std::string>* state_change_txes = nullptr);
 
     /**
      * @brief checks if a block is known about with a given hash
@@ -1295,7 +1301,8 @@ class Blockchain {
             difficulty_type& di,
             uint64_t& height,
             uint64_t& expected_reward,
-            const std::string& ex_nonce);
+            const std::string& ex_nonce,
+            std::vector<std::string>* state_change_txes = nullptr);
 
     // TODO: evaluate whether or not each of these typedefs are left over from blockchain_storage
     typedef std::unordered_set<crypto::key_image> key_images_container;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -249,7 +249,9 @@ static const command_line::arg_flag arg_disable_ip_check = {
 void (*long_poll_trigger)(tx_memory_pool& pool) = [](tx_memory_pool&) {
     need_core_init("long_poll_trigger"sv);
 };
-quorumnet_new_proc* quorumnet_new = [](core&) -> void* { need_core_init("quorumnet_new"sv); };
+quorumnet_new_proc* quorumnet_new = [](core&, pulse::pulse) -> void* {
+    need_core_init("quorumnet_new"sv);
+};
 quorumnet_init_proc* quorumnet_init = [](core&, void*) { need_core_init("quorumnet_init"sv); };
 quorumnet_delete_proc* quorumnet_delete = [](void*&) { need_core_init("quorumnet_delete"sv); };
 quorumnet_relay_obligation_votes_proc* quorumnet_relay_obligation_votes =
@@ -1331,7 +1333,8 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                     return omq_allow(ip, pk, public_ ? AuthLevel::basic : AuthLevel::none);
                 });
 
-        m_quorumnet_state = quorumnet_new(*this);
+        m_pulse = pulse::pulse{*this};
+        m_quorumnet_state = quorumnet_new(*this, m_pulse);
     }
 
     quorumnet_init(*this, m_quorumnet_state);
@@ -1342,11 +1345,8 @@ void core::start_oxenmq() {
 
     if (m_service_node) {
         m_pulse_thread_id = m_omq->add_tagged_thread("pulse");
-        m_omq->add_timer(
-                [this]() { pulse::main(m_quorumnet_state, *this); },
-                std::chrono::milliseconds(500),
-                false,
-                m_pulse_thread_id);
+        m_pulse.init(m_quorumnet_state);
+        m_omq->add_timer(m_pulse, 500ms, false, m_pulse_thread_id);
         m_omq->add_timer([this]() { check_service_node_time(); }, 5s, false);
         m_omq->add_timer([this]() { check_service_node_ip_address(); }, 15min, false);
     }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2392,17 +2392,22 @@ bool core::relay_service_node_votes() {
 void core::set_service_node_votes_relayed(const std::vector<service_nodes::quorum_vote_t>& votes) {
     m_quorum_cop.set_votes_relayed(votes);
 }
-//-----------------------------------------------------------------------------------------------
+
+// Attempts to build a block_complete_entry containing the block and any referenced transactions in
+// the block.  Transactions are looked up in the mempool.
+//
+// Throws on error (such as failing to parse the block or failing to find a referenced tx).
 block_complete_entry get_block_complete_entry(block& b, tx_memory_pool& pool) {
     block_complete_entry bce = {};
     bce.block = cryptonote::block_to_blob(b);
     for (const auto& tx_hash : b.tx_hashes) {
-        std::string txblob;
-        if (!pool.get_transaction(tx_hash, txblob) || txblob.size() == 0) {
-            oxen::log::error(logcat, "Transaction {} not found in pool", tx_hash);
-            throw oxen::traced<std::runtime_error>("Transaction not found in pool");
+
+        if (std::string txblob; pool.get_transaction(tx_hash, txblob) && !txblob.empty()) {
+            bce.txs.push_back(std::move(txblob));
+            continue;
         }
-        bce.txs.push_back(txblob);
+
+        throw std::runtime_error{"Transaction {} not found in pool"_format(tx_hash)};
     }
     return bce;
 }
@@ -2416,9 +2421,11 @@ bool core::handle_block_found(block& b, block_verification_context& bvc) {
         OXEN_DEFER {
             miner.resume();
         };
+
         try {
             blocks.push_back(get_block_complete_entry(b, mempool));
         } catch (const std::exception& e) {
+            log::error(logcat, "Cannot add block: {}", e.what());
             return false;
         }
         std::vector<block> pblocks;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -68,7 +68,7 @@ extern const command_line::arg_descriptor<size_t> arg_block_download_max_size;
 // has been set up but before it starts listening.  Return an opaque pointer (void *) that gets
 // passed into all the other callbacks below so that the callbacks can recast it into whatever it
 // should be.
-using quorumnet_new_proc = void*(core& core);
+using quorumnet_new_proc = void*(core& core, pulse::pulse pulse);
 // Initializes quorumnet; unlike `quorumnet_new_proc` this needs to be called for all nodes, not
 // just service nodes.  The second argument should be the `quorumnet_new` return value if a
 // service node, nullptr if not.
@@ -925,6 +925,9 @@ class core final {
     // Internal opaque data object managed by cryptonote_protocol/quorumnet.cpp.  void pointer to
     // avoid linking issues (protocol does not link against core).
     void* m_quorumnet_state = nullptr;
+
+    // Internal mostly opaque interface to pulse state.
+    pulse::pulse m_pulse;
 
     /// Stores x25519 -> access level for OMQ authentication.
     /// Not to be modified after the OMQ listener starts.

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -207,9 +207,15 @@ namespace {
                 pulse_wait_stage stage;
             } wait_for_block_template;
 
-            cryptonote::block block;  // The block, received during wait-for-handshake, and
-                                      // updated with validators/signatures as we progress to
-                                      // finalizing it through later stages.
+            // The block, send by the producer after all determining all (initial) participating
+            // validators.  The producer also (starting with Oxen 11.3) also sends any included
+            // state change txes alongside the block template because those can easily have
+            // equivalent but different local txes on the validators if they received quorum
+            // signatures in a different order, and the validators will fail to add the block to the
+            // chain if they don't have the same version of those txes.  (We don't send or allow
+            // other types of txes because we should received those separately).
+            cryptonote::block block;
+            std::unordered_map<crypto::hash, std::string> state_change_txs;
 
             template <typename T, round_state RoundState>
             struct send_and_wait {
@@ -360,10 +366,12 @@ namespace {
             } break;
 
             case message_type::block_template: {
-                const auto& blob = msg.get<message_type::block_template>();
+                const auto& [blob, state_changes] = msg.get<message_type::block_template>();
                 crypto::hash block_hash = blake2b_hash(blob.data(), blob.size());
                 auto buf = tools::memcpy_le(msg.round, block_hash);
                 result = blake2b_hash(buf.data(), buf.size());
+                // blobs in state_changes aren't directly signed, but we parse them and only accept
+                // them if they match txes referenced in the signed block.
             } break;
 
             case message_type::random_value_hash: {
@@ -792,8 +800,8 @@ namespace {
                     return;  // Duplicate copy; nothing to do.
 
                 cryptonote::block block = {};
-                if (!cryptonote::t_serializable_object_from_blob(
-                            block, msg.get<message_type::block_template>())) {
+                auto& [block_blob, state_change_blobs] = msg.get<message_type::block_template>();
+                if (!cryptonote::t_serializable_object_from_blob(block, block_blob)) {
                     log::warning(logcat, "{}Received unparsable pulse block template blob", *this);
                     return;
                 }
@@ -821,7 +829,47 @@ namespace {
                     return;
                 }
 
+                std::unordered_map<crypto::hash, std::string> supp_tx;
+                for (auto& tx_blob : state_change_blobs) {
+                    cryptonote::transaction tx;
+                    if (!parse_and_validate_tx_from_blob(tx_blob, tx)) {
+                        log::warning(logcat, "{}Received unparsable supplemental tx", *this);
+                        return;
+                    }
+
+                    if (tx.type != cryptonote::txtype::state_change) {
+                        log::warning(
+                                logcat,
+                                "{}Received invalid non-state change supplemental tx type: {}",
+                                *this,
+                                tx.type);
+                        return;
+                    }
+
+                    auto hash = get_transaction_hash(tx);
+                    if (std::find(block.tx_hashes.begin(), block.tx_hashes.end(), hash) ==
+                        block.tx_hashes.end()) {
+                        log::warning(
+                                logcat,
+                                "{}Received invalid state change tx {} not referenced by the block "
+                                "template",
+                                *this,
+                                hash);
+                        return;
+                    }
+
+                    supp_tx.emplace(hash, std::move(tx_blob));
+                }
+
+                log::debug(
+                        logcat,
+                        "{}Accepted {}B block template with {} state change txes",
+                        *this,
+                        block_blob.size(),
+                        supp_tx.size());
+
                 transient.block = std::move(block);
+                transient.state_change_txs = std::move(supp_tx);
             } break;
 
             case message_type::random_value_hash: {
@@ -1696,6 +1744,7 @@ namespace {
 
         // Block
         cryptonote::block new_block{};
+        std::vector<std::string> state_change_txes;
         {
             uint64_t height = 0;
             service_nodes::payout block_producer_payouts =
@@ -1707,7 +1756,8 @@ namespace {
                             block_producer_payouts,
                             round.number,
                             transient.wait_for_handshake_bitsets.best_bitset,
-                            height)) {
+                            height,
+                            &state_change_txes)) {
                     log::error(
                             logcat,
                             "{}Failed to generate a block template, waiting until next round",
@@ -1735,8 +1785,9 @@ namespace {
         }
 
         // Message
-        message msg = msg_init<message_type::block_template>(
-                cryptonote::t_serializable_object_to_blob(new_block));
+        message msg = msg_init<message_type::block_template>(message::block_and_txes{
+                cryptonote::t_serializable_object_to_blob(new_block),
+                std::move(state_change_txes)});
         crypto::generate_signature(
                 msg_signature_hash(curr_block.top_hash, msg), key.pub, key.key, msg.signature);
 
@@ -1829,7 +1880,7 @@ namespace {
                     // get rejected during blockchain handling so don't need to be checked here.
                     log::debug(
                             logcat,
-                            "{}Block passed state change validation ({} state changes of {} txs)",
+                            "{}Block passed L2 event validation ({} L2 events of {} txs)",
                             *this,
                             block.tx_eth_count,
                             block.tx_hashes.size());
@@ -2134,7 +2185,7 @@ namespace {
                     break;
             }
             assert(block.signatures.size() == service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES);
-            transient.block.invalidate_hashes();
+            block.invalidate_hashes();
 
             // Propagate Final Block
             if (log::get_level(logcat) <= log::Level::debug)
@@ -2143,6 +2194,20 @@ namespace {
                         "{}Final signed block constructed:\n{}",
                         *this,
                         cryptonote::obj_to_json_str(block));
+
+            // Insert any state change txes into the mempool, because we quite possibly have
+            // *equivalent* ones but those do not have the same hash and will not be found, and we
+            // need to ensure we have the exact one the block producer sent in order for the block
+            // to get admitted to the chain.
+            for (auto& [hash, blob] : transient.state_change_txs) {
+                cryptonote::tx_verification_context tvc{};
+                if (!core.handle_incoming_tx(
+                            blob, tvc, cryptonote::tx_pool_options::from_block()) ||
+                    tvc.m_verifivation_failed) {
+                    log::error(logcat, "Failed to add state change tx {} to mempool", hash);
+                    return goto_preparing_for_next_round();
+                }
+            }
 
             cryptonote::block_verification_context bvc = {};
             if (!core.handle_block_found(block, bvc))

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1,12 +1,14 @@
 #include <array>
 #include <chrono>
+#include <iterator>
+#include <memory>
 
+#include "common/formattable.h"
 #include "common/random.h"
 #include "common/tracy_shim.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_core.h"
-#include "epee/memwipe.h"
-#include "epee/wipeable_string.h"
 #include "ethereum_transactions.h"
 #include "network_config/mocknet.h"
 #include "service_node_list.h"
@@ -45,7 +47,7 @@ namespace {
 
         send_and_wait_for_random_value_hashes,
         send_and_wait_for_random_value,
-        send_and_wait_for_signed_blocks,
+        send_and_wait_for_block_signatures,
     };
 
     constexpr std::string_view round_state_string(round_state state) {
@@ -69,8 +71,8 @@ namespace {
                 return "Send & Wait For Random Value Hash"sv;
             case round_state::send_and_wait_for_random_value:
                 return "Send & Wait For Random Value"sv;
-            case round_state::send_and_wait_for_signed_blocks:
-                return "Send & Wait For Signed Blocks"sv;
+            case round_state::send_and_wait_for_block_signatures:
+                return "Send & Wait For Block Signatures"sv;
         }
 
         return "Invalid2"sv;
@@ -88,6 +90,27 @@ namespace {
         processed,
     };
 
+    struct quorum_printer {
+        const service_nodes::quorum& quorum;
+        const crypto::public_key& me;
+        std::string to_string() const {
+            assert(!quorum.workers.empty());
+            std::string result = "P: {:8.0x}{}; V: "_format(
+                    quorum.workers[0], quorum.workers[0] == me ? "[THIS NODE]" : "");
+            auto append = std::back_inserter(result);
+            for (size_t i = 0; i < quorum.validators.size(); i++)
+                fmt::format_to(
+                        append,
+                        "{}{}:{:8.0x}{}",
+                        i > 0 ? ", " : "",
+                        i,
+                        quorum.validators[i],
+                        quorum.validators[i] == me ? "[THIS NODE]" : "");
+            return result;
+        }
+        static constexpr bool to_string_formattable = true;
+    };
+
     template <typename T>
     using quorum_array = std::array<T, service_nodes::PULSE_QUORUM_NUM_VALIDATORS>;
 
@@ -101,39 +124,44 @@ namespace {
     };
 
     struct pulse_wait_stage {
-        message_queue
-                queue;  // For messages from later stages that arrived before we reached that stage
-        uint16_t bitset;  // Bitset of validators that we received a message from for this stage
+        message_queue queue;  // messages from later stages that arrived ahead of schedule
+        uint16_t bitset;      // Bitset of validators that we received a message from for this stage
         uint16_t msgs_received;  // Number of unique messages received in the stage
-        time_point end_time;     // Time at which the stage ends
+        time_point end_time;     // Time at which the stage ends, determined when the stage begins
     };
 
-    template <typename T>
-    struct pulse_send_stage {
-        T data;     // Data that must be sent to Nodes via Quorumnet
-        bool sent;  // When true, data has been sent via Quorumnet once already.
+    crypto::hash blake2b_hash(void const* data, size_t size) {
+        crypto::hash result;
+        static_assert(sizeof(result) == crypto_generichash_BYTES);
+        crypto_generichash(
+                result.data(),
+                result.size(),
+                reinterpret_cast<unsigned char const*>(data),
+                size,
+                nullptr /*key*/,
+                0 /*key length*/);
+        return result;
+    }
 
-        bool one_time_only() {
-            if (sent)
-                return false;
-            sent = true;
-            return true;
-        }
-    };
+    class pulse_impl {
+      public:
+        explicit pulse_impl(cryptonote::core& core);
 
-    struct round_history {
-        uint64_t height;
-        uint8_t round;
-        crypto::hash top_block_hash;
-        service_nodes::quorum quorum;
-    };
+        // Sets the quorumnet_state pointer and finishes initialization.  Must be called before
+        // check_state or handle_message.
+        void init(void* qnet_state);
 
-    struct round_context {
-        // Store the recent history of quorums in the past to allow validating late
-        // arriving messages and allow printing out the correct response ('error
-        // unknown message origin' or 'ok to ignore').
-        std::array<round_history, 3> quorum_history;
-        size_t quorum_history_index;
+        // Called periodically on a timer, via the public pulse::operator()
+        void check_state();
+
+        // Called externally when a message is received, and internally to process a new message and
+        // to handle previously received messages that arrived early.
+        void handle_message(const message& msg);
+
+      private:
+        cryptonote::core& core;
+        void* quorumnet_state = nullptr;
+        std::optional<uint64_t> hf16, hf21;
 
         struct {
             uint64_t height;  // Current blockchain height that Pulse wants to generate a block for
@@ -141,23 +169,24 @@ namespace {
                                     // date nodes
             time_point round_0_start_time;  // When round 0 should start and subsequent round
                                             // timings are derived from.
-        } wait_for_next_block;
+        } curr_block;
 
         struct {
             bool queue_for_next_round;  // When set to true, invoking prepare_for_round(...) will
                                         // wait for (round + 1)
-            uint8_t round;  // The next round the Pulse ceremony will generate a block for
+            uint8_t number;  // The next round number the Pulse ceremony will generate a block for
             service_nodes::quorum
                     quorum;       // The block producer/validator participating in the next round
             sn_type participant;  // Is this daemon a block producer, validator or non participant.
             size_t my_quorum_position;  // Position in the quorum, 0 if producer or neither, or [0,
                                         // PULSE_QUORUM_NUM_VALIDATORS) if a validator
             std::string node_name;  // Short-hand string for describing the node in logs, i.e. V[0]
-                                    // for validator 0 or W[0] for the producer.
+                                    // for validator 0 or P for the producer.
             time_point start_time;  // When the round starts
-        } prepare_for_round;
+            time_point end_time;    // When the round times out (i.e. when the next round begins)
+        } round;
 
-        struct {
+        struct transient_t {
             struct {
                 bool sent;  // When true, handshake sent and waiting for other handshakes
                 quorum_array<bool> data;  // Received data from messages from Quorumnet
@@ -175,81 +204,136 @@ namespace {
             } wait_for_handshake_bitsets;
 
             struct {
-                cryptonote::block block;  // The block template with the best validator bitset and
-                                          // Pulse round applied to it.
                 pulse_wait_stage stage;
             } wait_for_block_template;
 
-            struct {
-                pulse_send_stage<crypto::hash> send;
+            cryptonote::block block;  // The block, received during wait-for-handshake, and
+                                      // updated with validators/signatures as we progress to
+                                      // finalizing it through later stages.
+
+            template <typename T, round_state RoundState>
+            struct send_and_wait {
+                inline static constexpr auto round_state = RoundState;
+
+                // Data to be sent once to other nodes; cleared when sending, so that data is sent
+                // only once.
+                std::optional<T> to_send;
+
+                // Data from other nodes that we are waiting for:
                 struct {
-                    quorum_array<std::optional<crypto::hash>> data;
+                    quorum_array<std::optional<T>> data;
                     pulse_wait_stage stage;
                 } wait;
-            } random_value_hashes;
 
-            struct {
-                pulse_send_stage<cryptonote::pulse_random_value> send;
+                void clear() {
+                    to_send.reset();
+                    wait.data.fill(std::nullopt);
+                    wait.stage = {};
+                }
+            };
 
-                struct {
-                    quorum_array<std::optional<cryptonote::pulse_random_value>> data;
-                    pulse_wait_stage stage;
-                } wait;
-            } random_value;
+            send_and_wait<crypto::hash, round_state::send_and_wait_for_random_value_hashes>
+                    random_value_hashes;
 
-            struct {
-                pulse_send_stage<crypto::signature> send;
-                cryptonote::block final_block;
+            send_and_wait<
+                    cryptonote::pulse_random_value,
+                    round_state::send_and_wait_for_random_value>
+                    random_value;
 
-                struct {
-                    quorum_array<std::optional<crypto::signature>> data;
-                    pulse_wait_stage stage;
-                } wait;
-            } signed_block;
+            send_and_wait<crypto::signature, round_state::send_and_wait_for_block_signatures>
+                    block_signatures;
+
         } transient;
 
-        round_state state;
+        round_state state = round_state::null_state;
+
+      public:
+        static constexpr bool to_string_formattable = true;
+        std::string to_string() const;
+
+      private:
+        template <message_type mtype, typename... Value>
+        message msg_init(Value&&... val) const;
+
+        std::string msg_source_string(const message& msg) const;
+        bool msg_signature_check(
+                const message& msg,
+                const crypto::hash& top_block_hash,
+                const service_nodes::quorum& quorum) const;
+
+        void handle_messages_received_early_for(pulse_wait_stage& stage);
+        void relay_validator_handshake_bit_or_bitset(bool sending_bitset);
+
+        void generate_random_value();
+
+        void clear_round_data();
+
+        round_state begin_stage_timer(round_state new_state);
+
+        std::optional<bool> reset_for_missing_validators(
+                const pulse_wait_stage& stage, bool timed_out);
+
+        round_state goto_preparing_for_next_round();
+        round_state goto_wait_for_next_block_and_clear_round_data();
+
+        crypto::hash last_wait_log_hash = {}, last_timing_log_hash = {};
+        round_state wait_for_next_block();
+
+        round_state prepare_for_round();
+        round_state wait_for_round();
+
+        round_state send_and_wait_for_handshakes();
+
+        round_state send_handshake_bitsets();
+        round_state wait_for_handshake_bitsets();
+
+        round_state send_block_template();
+        round_state wait_for_block_template();
+
+        // "Late stage": starts after the block template, and can be restarted
+        // with a reduced validator set if one or more don't complete:
+        void reset_late_stages();
+        template <message_type mtype, typename SendAndWait>
+        void start_send(SendAndWait& saw);
+        round_state send_and_wait_for_random_value_hashes();
+        round_state send_and_wait_for_random_value();
+        round_state send_and_wait_for_block_signatures();
     };
 
-    round_context context;
-
-    crypto::hash blake2b_hash(void const* data, size_t size) {
-        crypto::hash result = {};
-        static_assert(sizeof(result) == crypto_generichash_BYTES);
-        crypto_generichash(
-                result.data(),
-                result.size(),
-                reinterpret_cast<unsigned char const*>(data),
-                size,
-                nullptr /*key*/,
-                0 /*key length*/);
-        return result;
-    }
-
-    std::string log_prefix(round_context const& context) {
+    std::string pulse_impl::to_string() const {
         return "Pulse B{} R{}: {}'{}' "_format(
-                context.wait_for_next_block.height,
-                context.state >= round_state::prepare_for_round ? +context.prepare_for_round.round
-                                                                : 0,
-                context.prepare_for_round.node_name.empty()
-                        ? ""
-                        : "{} "_format(context.prepare_for_round.node_name),
-                round_state_string(context.state));
-    }
-
-    constexpr size_t BITSET_VIEW16_SIZE = sizeof(uint16_t) * 8;
-    std::bitset<BITSET_VIEW16_SIZE> bitset_view16(uint16_t val) {
-        std::bitset<BITSET_VIEW16_SIZE> result = val;
-        return result;
+                curr_block.height,
+                state >= round_state::prepare_for_round ? round.number : 0,
+                round.node_name.empty() ? "" : "{} "_format(round.node_name),
+                round_state_string(state));
     }
 
     //
     // NOTE: pulse::message Utiliities
     //
-    message msg_init_from_context(round_context const& context) {
+
+    // msg_init takes the message type as template parameter, and, for message types requiring a
+    // payload, requires exactly 1 argument to be perfect-forward-assigned into the message
+    // `payload` member.
+    template <message_type mtype, typename... Value>
+    message pulse_impl::msg_init(Value&&... val) const {
+        using ValType = message::payload_t<mtype>;
+        static_assert(
+                !std::is_void_v<ValType> || sizeof...(Value) == 0,
+                "msg_init with this message_type requires no argument");
+        static_assert(
+                std::is_void_v<ValType> ||
+                        (sizeof...(Value) == 1 &&
+                         (... && std::same_as<std::remove_cvref_t<Value>, ValType>)),
+                "msg_init with this message_type requires exactly one argument of the appropriate "
+                "payload type");
+
         message result = {};
-        result.quorum_position = context.prepare_for_round.my_quorum_position;
-        result.round = context.prepare_for_round.round;
+        result.quorum_position = round.my_quorum_position;
+        result.round = round.number;
+        result.type = mtype;
+        if constexpr (!std::is_void_v<ValType>)
+            ((result.payload = std::forward<Value>(val)), ...);
         return result;
     }
 
@@ -268,7 +352,7 @@ namespace {
 
             case message_type::handshake_bitset: {
                 auto buf = tools::memcpy_le(
-                        msg.handshakes.validator_bitset,
+                        msg.get<message_type::handshake_bitset>(),
                         top_block_hash,
                         msg.quorum_position,
                         msg.round);
@@ -276,15 +360,18 @@ namespace {
             } break;
 
             case message_type::block_template: {
-                crypto::hash block_hash = blake2b_hash(
-                        msg.block_template.blob.data(), msg.block_template.blob.size());
+                const auto& blob = msg.get<message_type::block_template>();
+                crypto::hash block_hash = blake2b_hash(blob.data(), blob.size());
                 auto buf = tools::memcpy_le(msg.round, block_hash);
                 result = blake2b_hash(buf.data(), buf.size());
             } break;
 
             case message_type::random_value_hash: {
                 auto buf = tools::memcpy_le(
-                        top_block_hash, msg.quorum_position, msg.round, msg.random_value_hash.hash);
+                        top_block_hash,
+                        msg.quorum_position,
+                        msg.round,
+                        msg.get<message_type::random_value_hash>());
                 result = blake2b_hash(buf.data(), buf.size());
             } break;
 
@@ -293,13 +380,12 @@ namespace {
                         top_block_hash,
                         msg.quorum_position,
                         msg.round,
-                        msg.random_value.value.data);
+                        msg.get<message_type::random_value>());
                 result = blake2b_hash(buf.data(), buf.size());
             } break;
 
-            case message_type::signed_block: {
-                crypto::signature const& final_signature =
-                        msg.signed_block.signature_of_final_block_hash;
+            case message_type::block_signature: {
+                const auto& final_signature = msg.get<message_type::block_signature>();
                 auto buf = tools::memcpy_le(
                         top_block_hash, msg.quorum_position, msg.round, final_signature);
                 result = blake2b_hash(buf.data(), buf.size());
@@ -314,47 +400,48 @@ namespace {
     // 6:f9337ffc8bc30baf3fca92a13fa5a3a7ab7c93e69acb7136906e7feae9d3e769
     //   or
     // <Message Type> at round <Round> from <Validator Index>:<Validator Public Key>
-    std::string msg_source_string(round_context const& context, message const& msg) {
-        if (msg.quorum_position >= context.prepare_for_round.quorum.validators.size())
+    std::string pulse_impl::msg_source_string(const message& msg) const {
+        if (msg.quorum_position >= round.quorum.validators.size())
             return "XX";
 
         return "'{}' at round {:d} from {:d}{}"_format(
                 msg.type,
                 msg.round,
                 msg.quorum_position,
-                context.state >= round_state::prepare_for_round &&
-                                msg.quorum_position <
-                                        context.prepare_for_round.quorum.validators.size()
-                        ? ":{}"_format(
-                                  context.prepare_for_round.quorum.validators[msg.quorum_position])
+                state >= round_state::prepare_for_round &&
+                                msg.quorum_position < round.quorum.validators.size()
+                        ? ":{}"_format(round.quorum.validators[msg.quorum_position])
                         : "");
     }
 
-    bool msg_signature_check(
+    bool pulse_impl::msg_signature_check(
             message const& msg,
             crypto::hash const& top_block_hash,
-            service_nodes::quorum const& quorum,
-            std::string* error) {
+            service_nodes::quorum const& quorum) const {
         // Get Service Node Key
         crypto::public_key const* key = nullptr;
         switch (msg.type) {
-            case message_type::invalid: {
+            case message_type::invalid:
                 assert("Invalid Code Path" == nullptr);
-                if (error)
-                    *error = "{}Unhandled message type '{}' can not verify signature."_format(
-                            log_prefix(context), msg.type);
+                log::debug(
+                        logcat,
+                        "{}Unhandled message type '{}' can not verify signature.",
+                        *this,
+                        msg.type);
                 return false;
-            } break;
 
             case message_type::handshake: [[fallthrough]];
             case message_type::handshake_bitset: [[fallthrough]];
             case message_type::random_value_hash: [[fallthrough]];
             case message_type::random_value: [[fallthrough]];
-            case message_type::signed_block: {
-                if (msg.quorum_position >= static_cast<int>(quorum.validators.size())) {
-                    if (error)
-                        *error = "{}Quorum position {} in Pulse message indexes oob"_format(
-                                log_prefix(context), msg.quorum_position);
+            case message_type::block_signature: {
+                if (msg.quorum_position >= quorum.validators.size()) {
+                    log::debug(
+                            logcat,
+                            "{}Invalid quorum position {} in {} message",
+                            *this,
+                            msg.type,
+                            msg.quorum_position);
                     return false;
                 }
 
@@ -363,418 +450,452 @@ namespace {
 
             case message_type::block_template: {
                 if (msg.quorum_position != 0) {
-                    if (error)
-                        *error = "{}Quorum position {} in Pulse message indexes oob"_format(
-                                log_prefix(context), msg.quorum_position);
+                    log::debug(
+                            logcat,
+                            "{}Invalid {} message quorum position {} (expected 0)",
+                            *this,
+                            msg.type,
+                            msg.quorum_position);
                     return false;
                 }
 
-                key = &context.prepare_for_round.quorum.workers[0];
+                key = &round.quorum.workers[0];
             } break;
         }
 
-        if (!crypto::check_signature(
-                    msg_signature_hash(top_block_hash, msg), *key, msg.signature)) {
-            if (error)
-                *error = "{}Signature for {} at height {} is invalid"_format(
-                        log_prefix(context),
-                        msg_source_string(context, msg),
-                        context.wait_for_next_block.height);
-            return false;
-        }
+        if (crypto::check_signature(msg_signature_hash(top_block_hash, msg), *key, msg.signature))
+            return true;
 
-        return true;
+        log::debug(
+                logcat,
+                "{}Signature for {} is invalid for block {}",
+                *this,
+                msg_source_string(msg),
+                curr_block.height);
+        return false;
     }
 
     //
-    // NOTE: round_context Utilities
+    // NOTE: pulse_impl Utilities
     //
+
     // Construct a pulse::message for sending the handshake bit or bitset.
-    void relay_validator_handshake_bit_or_bitset(
-            round_context const& context,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key,
-            bool sending_bitset) {
-        assert(context.prepare_for_round.participant == sn_type::validator);
+    void pulse_impl::relay_validator_handshake_bit_or_bitset(bool sending_bitset) {
+        assert(round.participant == sn_type::validator);
 
         // Message
-        message msg = msg_init_from_context(context);
+        message msg;
         if (sending_bitset) {
-            msg.type = message_type::handshake_bitset;
-
             // Generate the bitset from our received handshakes.
-            auto const& quorum = context.transient.send_and_wait_for_handshakes.data;
+            auto const& quorum = transient.send_and_wait_for_handshakes.data;
+            uint16_t validator_bitset = 0;
             for (size_t quorum_index = 0; quorum_index < quorum.size(); quorum_index++)
-                if (bool received = quorum[quorum_index]; received)
-                    msg.handshakes.validator_bitset |= (1 << quorum_index);
+                if (quorum[quorum_index])
+                    validator_bitset |= (1 << quorum_index);
+            msg = msg_init<message_type::handshake_bitset>(validator_bitset);
         } else {
-            msg.type = message_type::handshake;
+            msg = msg_init<message_type::handshake>();
         }
+        auto& key = core.get_service_keys();
         crypto::generate_signature(
-                msg_signature_hash(context.wait_for_next_block.top_hash, msg),
-                key.pub,
-                key.key,
-                msg.signature);
-        handle_message(quorumnet_state, msg);  // Add our own. We receive our own msg for the first
-                                               // time which also triggers us to relay.
+                msg_signature_hash(curr_block.top_hash, msg), key.pub, key.key, msg.signature);
+        handle_message(msg);  // Add our own. We receive our own msg for the first
+                              // time which also triggers us to relay.
     }
 
     // Check the stage's queue for any messages that we received early and process
     // them if any. Any messages in the queue that we haven't received yet will also
     // be relayed to the quorum.
-    void handle_messages_received_early_for(pulse_wait_stage& stage, void* quorumnet_state) {
+    void pulse_impl::handle_messages_received_early_for(pulse_wait_stage& stage) {
         if (!stage.queue.count)
             return;
 
         for (auto& [msg, queued] : stage.queue.buffer) {
             if (queued == queueing_state::received) {
-                handle_message(quorumnet_state, msg);
+                handle_message(msg);
                 queued = queueing_state::processed;
             }
         }
     }
 
-    // In Pulse, after the block template and validators are locked in, enforce that
-    // all participating validators are doing their job in the stage.
-    bool enforce_validator_participation_and_timeouts(
-            round_context const& context,
-            pulse_wait_stage const& stage,
-            bool timed_out,
-            bool all_received) {
-        assert(context.state > round_state::wait_for_handshake_bitsets);
-        uint16_t const validator_bitset = context.transient.wait_for_handshake_bitsets.best_bitset;
-
-        if (timed_out && !all_received) {
-            log::debug(
-                    logcat,
-                    "{}Stage timed out: insufficient responses. Expected ({}) {} received ({}) {}",
-                    log_prefix(context),
-                    bitset_view16(validator_bitset).count(),
-                    bitset_view16(validator_bitset).to_string(),
-                    bitset_view16(stage.bitset).count(),
-                    bitset_view16(stage.bitset).to_string());
-            return false;
+    // Called when a stage should be considered to begin, to update the stage end_time to current
+    // time + stage timeout.  Does nothing before HF21 (i.e. we keep the initially assigned stage
+    // end_time values).
+    //
+    // Returns `st` for convenience.
+    round_state pulse_impl::begin_stage_timer(round_state st) {
+        pulse_wait_stage* pws = st == round_state::wait_for_handshake_bitsets
+                                      ? &transient.wait_for_handshake_bitsets.stage
+                              : st == round_state::wait_for_block_template
+                                      ? &transient.wait_for_block_template.stage
+                              : st == round_state::send_and_wait_for_random_value_hashes
+                                      ? &transient.random_value_hashes.wait.stage
+                              : st == round_state::send_and_wait_for_random_value
+                                      ? &transient.random_value.wait.stage
+                              : st == round_state::send_and_wait_for_block_signatures
+                                      ? &transient.block_signatures.wait.stage
+                                      : nullptr;
+        assert(pws);
+        if (!pws) {
+            log::error(logcat, "Internal error: begin_stage_timer called with invalid new state!");
+            return st;
         }
+
+        if (core.blockchain.get_network_version(curr_block.height) < cryptonote::hf::hf21_eth)
+            return st;
+
+        auto& conf = core.get_net_config();
+        auto now = clock::now();
+        pws->end_time = std::min(
+                now + conf.PULSE_STAGE_TIMEOUT, round.start_time + conf.PULSE_ROUND_TIMEOUT);
+        using fseconds = std::chrono::duration<float>;
+        log::debug(
+                logcat,
+                "Beginning stage: {}; stage timeout in {:.1f}s",
+                round_state_string(st),
+                fseconds{pws->end_time - now}.count());
+
+        return st;
+    }
+
+    // Check to see that all expected validators provided a response.  Returns:
+    // - std::nullopt if all responses are present (and so we can proceed to the next stage)
+    // - true if missing validators have been removed from the bitset but we still have enough
+    //   remaining validators and time to restart from 'Send & Wait for Value Hash'.  The "best
+    //   bitset" and the block template will have been updated when this is returned, and previous
+    //   state for the hash-value-signature stages will have been cleared.
+    // - false if we can neither continue nor retry, and thus need to revert to waiting for the next
+    //   round.
+    std::optional<bool> pulse_impl::reset_for_missing_validators(
+            const pulse_wait_stage& stage, bool timed_out) {
+        assert(state >= round_state::send_and_wait_for_random_value_hashes);
+
+        auto& participants = transient.block.pulse.validator_bitset;
+        if (stage.bitset == participants)
+            return std::nullopt;
 
         // NOTE: This is not technically meant to hit, internal invariant checking
-        // that should have been triggered earlier. Enforce validator participation is
-        // only called after the stage has ended/timed out.
-        bool unexpected_items = (stage.bitset | validator_bitset) != validator_bitset;
-        if (stage.msgs_received == 0 || unexpected_items) {
+        // that should have been triggered earlier. (This function is only called
+        // after the stage has ended/timed out.)
+        bool unexpected_items = (stage.bitset | participants) != participants;
+        if (unexpected_items) {
             log::error(
                     logcat,
-                    "{}Internal error: expected bitset {}, but accepted and received {}",
-                    log_prefix(context),
-                    bitset_view16(validator_bitset).to_string(),
-                    bitset_view16(stage.bitset).to_string());
+                    "{}Internal error: expected bitset {:011b}, but accepted and received {:011b}",
+                    *this,
+                    participants,
+                    stage.bitset);
             return false;
         }
 
-        return true;
+        if (timed_out && participants != stage.bitset) {
+            log::debug(
+                    logcat,
+                    "{}Stage timed out: missing responses. Expected ({}) {:011b} "
+                    "received ({}) {:011b}",
+                    *this,
+                    std::popcount(participants),
+                    participants,
+                    std::popcount(stage.bitset),
+                    stage.bitset);
+        }
+
+        // TODO: delete the last condition (HF21+) once HF21 has happened, along with the HF21 gate
+        // in begin_stage_timer
+        if (std::popcount(stage.bitset) >= service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES &&
+            clock::now() < round.end_time &&
+            core.blockchain.get_network_version() >= cryptonote::hf::hf21_eth) {
+
+            uint16_t new_participants = stage.bitset;
+            log::debug(
+                    logcat,
+                    "{}Attempting to retry hash/value/signing stages with {} validators: {:011b}",
+                    *this,
+                    std::popcount(new_participants),
+                    new_participants);
+
+            // mutate the block bitset to drop the validators that didn't respond:
+            participants = new_participants;
+
+            reset_late_stages();
+            return true;  // We can continue!
+        }
+        // else we don't have enough potential validators left to retry or we're out of time, so we
+        // have to give up on the round:
+        return false;
     }
 
-}  // anonymous namespace
+    void pulse_impl::handle_message(const message& msg) {
+        if (state < round_state::wait_for_round) {
+            // TODO(doyle): Handle this better.
+            // We are not ready for any messages because we haven't prepared for a round
+            // yet (don't have the necessary information yet to validate the message).
+            return;
+        }
 
-void handle_message(void* quorumnet_state, message const& msg) {
-    if (context.state < round_state::wait_for_round) {
-        // TODO(doyle): Handle this better.
-        // We are not ready for any messages because we haven't prepared for a round
-        // yet (don't have the necessary information yet to validate the message).
-        return;
-    }
+        // TODO(oxen): We don't support messages from future rounds. A round
+        // mismatch will be detected in the signature as the round is included in the
+        // signature hash.
 
-    // TODO(oxen): We don't support messages from future rounds. A round
-    // mismatch will be detected in the signature as the round is included in the
-    // signature hash.
+        if (!msg_signature_check(msg, curr_block.top_hash, round.quorum)) {
+            log::debug(
+                    logcat,
+                    "{}Dropping message with invalid signature: probably a stale message from a "
+                    "previous block/round",
+                    *this);
+            return;
+        }
 
-    if (std::string sig_check_err; !msg_signature_check(
-                msg,
-                context.wait_for_next_block.top_hash,
-                context.prepare_for_round.quorum,
-                &sig_check_err)) {
-        bool print_err = true;
-        size_t iterations = std::min(context.quorum_history.size(), context.quorum_history_index);
-        for (size_t i = 0; i < iterations; i++) {
-            auto const& past_round = context.quorum_history[i];
-            //
-            // NOTE: We can't do any filtering on the quorums to check against
-            // (like comparing the round in the message with the past_round's round)
-            // because the intermediary relayers of this message might have modified
-            // it maliciously before propagating it.
-            //
-            // Hence we check it against all the quorums in history. So keep the
-            // number of quorums stored in history very small to keep this fast!
-            //
+        pulse_wait_stage* stage = nullptr;
+        switch (msg.type) {
+            case message_type::invalid: {
+                log::debug(logcat, "{}Received invalid message type, dropped", *this);
+                return;
+            }
 
-            if (msg_signature_check(
-                        msg, past_round.top_block_hash, past_round.quorum, nullptr /*error msg*/)) {
-                // NOTE: This is ok, we detected a round failed earlier than someone else
-                // and lingering messages are still going around on Quorumnet from
-                // a round in the past.
-                //
-                // i.e. You were the block producer and have submitted the block template,
-                // in which case your role in the ceremony is done and you sleep until
-                // the next round/block. Old lingering messages for the block producer
-                // (you) might still being propagated, and that is ok, and should not be
-                // marked an error, just ignored.
-
-                print_err = false;
-                log::trace(
-                        logcat,
-                        "{}Received valid message from the past (round {}), ignoring",
-                        log_prefix(context),
-                        +msg.round);
+            case message_type::handshake:
+                stage = &transient.send_and_wait_for_handshakes.stage;
                 break;
-            }  // else: Message has unknown origins, it is not something we know how to validate.
+            case message_type::handshake_bitset:
+                stage = &transient.wait_for_handshake_bitsets.stage;
+                break;
+            case message_type::block_template:
+                stage = &transient.wait_for_block_template.stage;
+                break;
+            case message_type::random_value_hash:
+                stage = &transient.random_value_hashes.wait.stage;
+                break;
+            case message_type::random_value: stage = &transient.random_value.wait.stage; break;
+            case message_type::block_signature:
+                stage = &transient.block_signatures.wait.stage;
+                break;
         }
 
-        if (print_err)
-            log::error(logcat, "{}", sig_check_err);
+        bool msg_received_early = false;
+        switch (msg.type) {
+            case message_type::invalid: assert("Invalid Code Path" != nullptr); return;
+            case message_type::handshake:
+                msg_received_early = state < round_state::send_and_wait_for_handshakes;
+                break;
+            case message_type::handshake_bitset:
+                msg_received_early = state < round_state::wait_for_handshake_bitsets;
+                break;
+            case message_type::block_template:
+                msg_received_early = state < round_state::wait_for_block_template;
+                break;
+            case message_type::random_value_hash:
+                msg_received_early = state < round_state::send_and_wait_for_random_value_hashes;
+                break;
+            case message_type::random_value:
+                msg_received_early = state < round_state::send_and_wait_for_random_value;
+                break;
+            case message_type::block_signature:
+                msg_received_early = state < round_state::send_and_wait_for_block_signatures;
+                break;
+        }
 
-        return;
-    }
-
-    pulse_wait_stage* stage = nullptr;
-    switch (msg.type) {
-        case message_type::invalid: {
-            log::trace(logcat, "{}Received invalid message type, dropped", log_prefix(context));
+        if (msg.quorum_position >= service_nodes::PULSE_QUORUM_NUM_VALIDATORS) {
+            log::debug(
+                    logcat,
+                    "{}Dropping {}: invalid message quorum position",
+                    *this,
+                    msg_source_string(msg));
             return;
         }
 
-        case message_type::handshake:
-            stage = &context.transient.send_and_wait_for_handshakes.stage;
-            break;
-        case message_type::handshake_bitset:
-            stage = &context.transient.wait_for_handshake_bitsets.stage;
-            break;
-        case message_type::block_template:
-            stage = &context.transient.wait_for_block_template.stage;
-            break;
-        case message_type::random_value_hash:
-            stage = &context.transient.random_value_hashes.wait.stage;
-            break;
-        case message_type::random_value: stage = &context.transient.random_value.wait.stage; break;
-        case message_type::signed_block: stage = &context.transient.signed_block.wait.stage; break;
-    }
-
-    bool msg_received_early = false;
-    switch (msg.type) {
-        case message_type::invalid: assert("Invalid Code Path" != nullptr); return;
-        case message_type::handshake:
-            msg_received_early = (context.state < round_state::send_and_wait_for_handshakes);
-            break;
-        case message_type::handshake_bitset:
-            msg_received_early = (context.state < round_state::wait_for_handshake_bitsets);
-            break;
-        case message_type::block_template:
-            msg_received_early = (context.state < round_state::wait_for_block_template);
-            break;
-        case message_type::random_value_hash:
-            msg_received_early =
-                    (context.state < round_state::send_and_wait_for_random_value_hashes);
-            break;
-        case message_type::random_value:
-            msg_received_early = (context.state < round_state::send_and_wait_for_random_value);
-            break;
-        case message_type::signed_block:
-            msg_received_early = (context.state < round_state::send_and_wait_for_signed_blocks);
-            break;
-    }
-
-    if (msg_received_early)  // Enqueue the message until we're ready to process it
-    {
-        auto& [entry, queued] = stage->queue.buffer[msg.quorum_position];
-        if (queued == queueing_state::empty) {
-            log::trace(
-                    logcat,
-                    "{}Message received early {}, queueing until we're ready.",
-                    log_prefix(context),
-                    msg_source_string(context, msg));
-            stage->queue.count++;
-            entry = std::move(msg);
-            queued = queueing_state::received;
-        }
-
-        return;
-    }
-
-    uint16_t const validator_bit = (1 << msg.quorum_position);
-    if (context.state > round_state::wait_for_handshake_bitsets &&
-        msg.type > message_type::handshake_bitset) {
-        // After the validator bitset has been set, the participating validators are
-        // locked in. Any stray messages from other validators are rejected.
-        if ((validator_bit & context.transient.wait_for_handshake_bitsets.best_bitset) == 0) {
-            auto bitset_view =
-                    bitset_view16(context.transient.wait_for_handshake_bitsets.best_bitset)
-                            .to_string();
-            log::trace(
-                    logcat,
-                    "{}Dropping {}. Not a locked in participant, bitset is {}",
-                    log_prefix(context),
-                    msg_source_string(context, msg),
-                    bitset_view);
-            return;
-        }
-    }
-
-    if (msg.quorum_position >= service_nodes::PULSE_QUORUM_NUM_VALIDATORS) {
-        log::trace(
-                logcat,
-                "{}Dropping {}. Message quorum position indexes oob",
-                log_prefix(context),
-                msg_source_string(context, msg));
-        return;
-    }
-
-    //
-    // Add Message Data to Pulse Stage
-    //
-    switch (msg.type) {
-        case message_type::invalid: assert("Invalid Code Path" != nullptr); return;
-
-        case message_type::handshake: {
-            auto& quorum = context.transient.send_and_wait_for_handshakes.data;
-            if (quorum[msg.quorum_position])
-                return;
-            quorum[msg.quorum_position] = true;
-            log::trace(
-                    logcat,
-                    "{}Received handshake with quorum position bit ({}) {} saved to bitset {}",
-                    log_prefix(context),
-                    msg.quorum_position,
-                    bitset_view16(validator_bit).to_string(),
-                    bitset_view16(stage->bitset).to_string());
-        } break;
-
-        case message_type::handshake_bitset: {
-            auto& quorum = context.transient.wait_for_handshake_bitsets.data;
-            auto& bitset = quorum[msg.quorum_position];
-            if (bitset)
-                return;
-            bitset = msg.handshakes.validator_bitset;
-        } break;
-
-        case message_type::block_template: {
-            if (stage->msgs_received == 1)
-                return;
-
-            cryptonote::block block = {};
-            if (!cryptonote::t_serializable_object_from_blob(block, msg.block_template.blob)) {
-                log::trace(
-                        logcat,
-                        "{}Received unparsable pulse block template blob",
-                        log_prefix(context));
-                return;
-            }
-
-            if (block.pulse.round != context.prepare_for_round.round) {
-                log::trace(
-                        logcat,
-                        "{}Received pulse block template specifying different round {}, expected "
-                        "{}",
-                        log_prefix(context),
-                        +block.pulse.round,
-                        +context.prepare_for_round.round);
-                return;
-            }
-
-            if (block.pulse.validator_bitset !=
-                context.transient.wait_for_handshake_bitsets.best_bitset) {
-                auto block_bitset = bitset_view16(block.pulse.validator_bitset);
-                auto our_bitset =
-                        bitset_view16(context.transient.wait_for_handshake_bitsets.best_bitset);
-                log::trace(
-                        logcat,
-                        "{}Received pulse block template specifying different validator handshake "
-                        "bitsets {}, expected {}",
-                        log_prefix(context),
-                        block_bitset.to_string(),
-                        our_bitset.to_string());
-                return;
-            }
-
-            context.transient.wait_for_block_template.block = std::move(block);
-        } break;
-
-        case message_type::random_value_hash: {
-            auto& quorum = context.transient.random_value_hashes.wait.data;
-            auto& value = quorum[msg.quorum_position];
-            if (value)
-                return;
-            value = msg.random_value_hash.hash;
-        } break;
-
-        case message_type::random_value: {
-            auto& quorum = context.transient.random_value.wait.data;
-            auto& value = quorum[msg.quorum_position];
-            if (value)
-                return;
-
-            if (auto const& hash =
-                        context.transient.random_value_hashes.wait.data[msg.quorum_position];
-                hash) {
-                auto derived = blake2b_hash(
-                        msg.random_value.value.data, sizeof(msg.random_value.value.data));
-                if (derived != *hash) {
-                    log::trace(
+        if (msg_received_early)  // Enqueue the message until we're ready to process it
+        {
+            auto& [entry, queued] = stage->queue.buffer[msg.quorum_position];
+            if (queued == queueing_state::empty) {
+                if (state <= round_state::wait_for_round &&
+                    msg.type == message_type::block_signature) {
+                    // Because we advance the the next stage immediately upon achieving a full set
+                    // of signatures, we very often end up with a few more copies of signatures
+                    // coming in shortly after we start waiting for the next block, so if we're
+                    // waiting then just drop them: even if we are slow and they are valid for the
+                    // upcoming round, in order to produce a signature, the quorum must have already
+                    // gone ahead without us and so there isn't anything we can do with it.
+                    log::debug(
+                            logcat, "{}Ignoring block sig from last round; probably a dupe", *this);
+                } else {
+                    log::debug(
                             logcat,
-                            "{}Dropping {}. Rederived random value hash {} does not match original "
-                            "hash {}",
-                            log_prefix(context),
-                            msg_source_string(context, msg),
-                            derived,
-                            *hash);
-                    return;
+                            "{}Message received early {}, queueing until we're ready.",
+                            *this,
+                            msg_source_string(msg));
+                    stage->queue.count++;
+                    entry = std::move(msg);
+                    queued = queueing_state::received;
                 }
             }
 
-            value = msg.random_value.value;
-        } break;
+            return;
+        }
 
-        case message_type::signed_block: {
-            // NOTE: The block template with the final random value inserted but no
-            // Service Node signatures. (Service Node signatures are added in one shot
-            // after this stage has timed out and all signatures are collected).
-            cryptonote::block const& final_block_no_signatures =
-                    context.transient.signed_block.final_block;
-            crypto::hash const final_block_hash =
-                    cryptonote::get_block_hash(final_block_no_signatures);
-
-            assert(msg.quorum_position < context.prepare_for_round.quorum.validators.size());
-            crypto::public_key const& validator_key =
-                    context.prepare_for_round.quorum.validators[msg.quorum_position];
-            if (!crypto::check_signature(
-                        final_block_hash,
-                        validator_key,
-                        msg.signed_block.signature_of_final_block_hash)) {
-                log::trace(
+        uint16_t const validator_bit = (1 << msg.quorum_position);
+        if (state > round_state::wait_for_block_template &&
+            msg.type > message_type::block_template) {
+            // Receiving the block template locks in the validator superset: validators can still be
+            // removed, but never added, and so we can discard anything we receive that isn't in
+            // that validator set anymore.
+            const auto participants = transient.block.pulse.validator_bitset;
+            if (!(participants & validator_bit)) {
+                log::debug(
                         logcat,
-                        "{}Dropping {}. Signature signing final block hash {} does not validate "
-                        "with the Service Node",
-                        log_prefix(context),
-                        msg_source_string(context, msg),
-                        msg.signed_block.signature_of_final_block_hash);
+                        "{}Dropping {}: validator has been dropped from the round; "
+                        "current bitset is {:011b}",
+                        *this,
+                        msg_source_string(msg),
+                        participants);
                 return;
             }
+        }
 
-            auto& quorum = context.transient.signed_block.wait.data;
-            auto& signature = quorum[msg.quorum_position];
-            if (signature)
-                return;
-            signature = msg.signed_block.signature_of_final_block_hash;
-        } break;
+        //
+        // Add Message Data to Pulse Stage
+        //
+        switch (msg.type) {
+            case message_type::invalid: assert("Invalid Code Path" != nullptr); return;
+
+            case message_type::handshake: {
+                auto& quorum = transient.send_and_wait_for_handshakes.data;
+                if (quorum[msg.quorum_position])
+                    return;
+                quorum[msg.quorum_position] = true;
+                log::debug(
+                        logcat,
+                        "{}Received handshake with quorum position bit ({}) {:011b} adding to "
+                        "bitset {:011b}",
+                        *this,
+                        msg.quorum_position,
+                        validator_bit,
+                        stage->bitset);
+            } break;
+
+            case message_type::handshake_bitset: {
+                auto& quorum = transient.wait_for_handshake_bitsets.data;
+                auto& bitset = quorum[msg.quorum_position];
+                if (bitset)
+                    return;  // This message is a duplicate, nothing to do.
+                bitset = msg.get<message_type::handshake_bitset>();
+
+                log::debug(
+                        logcat,
+                        "{}Received proposed bitset {:011b} from V[{}]",
+                        *this,
+                        *bitset,
+                        msg.quorum_position);
+            } break;
+
+            case message_type::block_template: {
+                if (stage->msgs_received == 1)
+                    return;  // Duplicate copy; nothing to do.
+
+                cryptonote::block block = {};
+                if (!cryptonote::t_serializable_object_from_blob(
+                            block, msg.get<message_type::block_template>())) {
+                    log::warning(logcat, "{}Received unparsable pulse block template blob", *this);
+                    return;
+                }
+
+                if (block.pulse.round != round.number) {
+                    log::debug(
+                            logcat,
+                            "{}Received pulse block template specifying different round {}, "
+                            "expected {}",
+                            *this,
+                            block.pulse.round,
+                            round.number);
+                    return;
+                }
+
+                if (block.pulse.validator_bitset !=
+                    transient.wait_for_handshake_bitsets.best_bitset) {
+                    log::debug(
+                            logcat,
+                            "{}Received pulse block template specifying different validator "
+                            "handshake bitsets {:011b}, expected {:011b}",
+                            *this,
+                            block.pulse.validator_bitset,
+                            transient.wait_for_handshake_bitsets.best_bitset);
+                    return;
+                }
+
+                transient.block = std::move(block);
+            } break;
+
+            case message_type::random_value_hash: {
+                auto& quorum = transient.random_value_hashes.wait.data;
+                auto& value = quorum[msg.quorum_position];
+                if (value)
+                    return;  // Duplicate message, nothing to do
+                value = msg.get<message_type::random_value_hash>();
+            } break;
+
+            case message_type::random_value: {
+                auto& quorum = transient.random_value.wait.data;
+                auto& value = quorum[msg.quorum_position];
+                if (value)
+                    return;  // Duplicate message, nothing to do
+
+                const auto& msg_rv = msg.get<message_type::random_value>();
+                if (const auto& hash =
+                            transient.random_value_hashes.wait.data[msg.quorum_position]) {
+                    if (auto derived = blake2b_hash(msg_rv.data, sizeof(msg_rv.data));
+                        derived != *hash) {
+                        log::debug(
+                                logcat,
+                                "{}Dropping {}. Rederived random value hash {} does not match "
+                                "original hash {}",
+                                *this,
+                                msg_source_string(msg),
+                                derived,
+                                *hash);
+                        return;
+                    }
+                }
+
+                value = msg_rv;
+            } break;
+
+            case message_type::block_signature: {
+                auto& quorum = transient.block_signatures.wait.data;
+                auto& signature = quorum[msg.quorum_position];
+                if (signature)
+                    return;  // Duplicate message, ignore it.
+
+                // NOTE: The block template with the final random value inserted but no
+                // Service Node signatures. (Service Node signatures are added in one shot
+                // after this stage has ended with all signatures are collected).
+                const auto final_block_hash = cryptonote::get_block_hash(transient.block);
+
+                assert(msg.quorum_position < round.quorum.validators.size());
+                const auto& validator_key = round.quorum.validators[msg.quorum_position];
+                if (auto& sig = msg.get<message_type::block_signature>();
+                    crypto::check_signature(final_block_hash, validator_key, sig))
+                    signature = sig;
+                else {
+                    log::debug(
+                            logcat,
+                            "{}Dropping {}. Signature signing final block hash {} does not "
+                            "validate with the Service Node",
+                            *this,
+                            msg_source_string(msg),
+                            sig);
+                    return;
+                }
+            } break;
+        }
+
+        stage->bitset |= validator_bit;
+        stage->msgs_received++;
+
+        if (quorumnet_state)
+            cryptonote::quorumnet_pulse_relay_message_to_quorum(
+                    quorumnet_state, msg, round.quorum, round.participant == sn_type::producer);
     }
 
-    stage->bitset |= validator_bit;
-    stage->msgs_received++;
-
-    if (quorumnet_state)
-        cryptonote::quorumnet_pulse_relay_message_to_quorum(
-                quorumnet_state,
-                msg,
-                context.prepare_for_round.quorum,
-                context.prepare_for_round.participant == sn_type::producer);
-}
+}  // anonymous namespace
 
 // TODO(doyle): Update pulse::perpare_for_round with this function after the hard fork and sanity
 // check it on testnet.
@@ -790,35 +911,31 @@ bool convert_time_to_round(
     return result_usize <= 255;
 }
 
-bool get_round_timings(
-        cryptonote::Blockchain const& blockchain,
-        uint64_t block_height,
-        uint64_t prev_timestamp,
-        timings& times) {
-    times = {};
+std::optional<timings> get_round_timings(
+        cryptonote::Blockchain const& blockchain, uint64_t block_height, uint64_t prev_timestamp) {
     auto& conf = get_config(blockchain.nettype());
     auto hf16 = hard_fork_begins(conf.NETWORK_TYPE, cryptonote::hf::hf16_pulse);
     if (!hf16 || blockchain.get_current_blockchain_height() < *hf16)
-        return false;
+        return std::nullopt;
 
     cryptonote::block genesis_block;
     if (!blockchain.get_block_by_height(*hf16 - 1, genesis_block))
-        return false;
+        return std::nullopt;
 
+    auto times = std::make_optional<timings>();
     uint64_t const delta_height = block_height - genesis_block.get_height();
-    times.genesis_timestamp = time_point(std::chrono::seconds(genesis_block.timestamp));
+    times->genesis_timestamp = clock::from_time_t(genesis_block.timestamp);
 
-    times.prev_timestamp = time_point(std::chrono::seconds(prev_timestamp));
-    times.ideal_timestamp =
-            time_point(times.genesis_timestamp + conf.TARGET_BLOCK_TIME * delta_height);
+    times->prev_timestamp = clock::from_time_t(prev_timestamp);
+    times->ideal_timestamp = times->genesis_timestamp + conf.TARGET_BLOCK_TIME * delta_height;
 
-    times.r0_timestamp = std::clamp(
-            times.ideal_timestamp,
-            times.prev_timestamp + conf.TARGET_BLOCK_TIME - conf.PULSE_MAX_START_ADJUSTMENT,
-            times.prev_timestamp + conf.TARGET_BLOCK_TIME + conf.PULSE_MAX_START_ADJUSTMENT);
+    times->r0_timestamp = std::clamp(
+            times->ideal_timestamp,
+            times->prev_timestamp + conf.TARGET_BLOCK_TIME - conf.PULSE_MAX_START_ADJUSTMENT,
+            times->prev_timestamp + conf.TARGET_BLOCK_TIME + conf.PULSE_MAX_START_ADJUSTMENT);
 
-    times.miner_fallback_timestamp = times.r0_timestamp + (conf.PULSE_ROUND_TIMEOUT * 255);
-    return true;
+    times->miner_fallback_timestamp = times->r0_timestamp + (conf.PULSE_ROUND_TIMEOUT * 255);
+    return times;
 }
 
 namespace {
@@ -828,7 +945,7 @@ namespace {
       to 1 dedicated Pulse thread, started by OMQ.
 
       Iterating the state-machine is done by a periodic invocation of
-      pulse::main(...) and messages received via Quorumnet for Pulse, which are
+      operator() on the pulse wrapper and messages received via Quorumnet for Pulse, which are
       queued in the thread's job queue.
 
       Using 1 dedicated thread via OMQ avoids any synchronization required in the
@@ -837,104 +954,123 @@ namespace {
       Skip control flow graph for textual description of stages.
 
               +---------------------+
-              | Wait For Next Block |<--------+-------+
+              | Wait For Next Block |<--------<-------<
               +---------------------+         |       |
                |                              |       |
-               +-[Blocks for round acquired]--+ No    |
+              [Blocks for round acquired]-----^ No    |
                |                              |       |
                | Yes                          |       |
-               |                              |       |
+               v                              |       |
               +---------------------+         |       |
-        +---->| Prepare For Round   |         |       |
+        >---->| Prepare For Round   |         |       |
         |     +---------------------+         |       |
         |      |                              |       |
-        |     [Enough SN's for Pulse]---------+ No    |
+        |     [Enough SNs for Pulse? ]--------^ No    |
         |      |                                      |
-        |     Yes                                     |
-        |      |                                      |
+        |      | Yes                                  |
+        |      v                                      |
         |     +---------------------+                 |
         |     | Wait For Round      |                 |
         |     +---------------------+                 |
         |      |                                      |
-        |     [Block Height Changed?]-----------------+ Yes
+        |     [Block Height Changed?]-----------------^ Yes
         |      |
         |      | No
-        |      |
-     No +-----[Participating in Quorum?]
+        |      v
+     No ^-----[Participating in Quorum?]
         |      |
         |      | Yes
-        |      |
-        |      |
-        |     [Validator?]------------------------------------+ No (We are Block Producer)
+        |      v
+        |     [Validator?]------------------------------------v No (We are Block Producer)
         |      |                                              |
         |      | Yes                                          |
+        |      v                                              |
+        |     +------------------------------+                |
+        |     | Send And Wait For Handshakes |                |
+        |     +------------------------------+                |
         |      |                                              |
-        |     +-----------------------------+                 |
-        |     | Send And Wait For Handshakes|                 |
-        |     +-----------------------------+                 |
-        |      |                                              |
-    Yes +-----[Quorumnet Comm Failure]                        |
+    Yes ^-----[Quorumnet Comm Failure?]                       |
         |      |                                              |
         |      | No                                           |
-        |      |                                              |
+        |      v                                              |
         |     +-----------------------+                       |
         |     | Send Handshake Bitset |                       |
         |     +-----------------------+                       |
         |      |                                              |
-    Yes +-----[Quorumnet Comm Failure]                        |
+    Yes ^-----[Quorumnet Comm Failure?]                       |
         |      |                                              |
         |      | No                                           |
-        |      |                                              |
+        |      v                                              |
         |     +----------------------------+                  |
-        |     | Wait For Handshake Bitsets |<-----------------+
+        |     | Wait For Handshake Bitsets |<-----------------<
         |     +----------------------------+
         |      |
-    Yes +-----[Insufficient Bitsets]
+     No ^-----[Bitset reached consensus?]
         |      |
-        |      | No
-        |      |
-        |     [Block Producer?]-------------------------------+ No (We are a Validator)
+        |      | Yes
+        |      v
+        |     [Block Producer?]-------------------------------v No (We are a Validator)
         |      |                                              |
         |      | Yes                                          |
-        |      |                                              |
+        |      v                                              |
         |     +---------------------+                         |
         |     | Send Block Template |                         |
         |     +---------------------+                         |
         |      |                                              |
-        +------+ (Block Producer's role is finished)          |
-        |                                                     |
+        ^------< (Block Producer's role is finished)          |
         |                                                     |
         |     +-------------------------+                     |
-        |     | Wait For Block Template |<--------------------+
+        |     | Wait For Block Template |<--------------------<
         |     +-------------------------+
         |      |
-    Yes +-----[Timed Out Waiting for Template]
+    Yes ^-----[Timed Out Waiting for Template?]
         |      |
         |      | No
-        |      |
+        |      v
         |     +---------------------------------------+
-        |     | Send And Wait For Random Value Hashes |
-        |     +---------------------------------------+
+        |     | Send And Wait For Random Value Hashes |<------<
+        |     +---------------------------------------+       |
+        |      |                                              |
+        |      |                    +-----------------------------------------------+
+        |      |                    | update bitset to exclude missing value nodes; |
+        |      |                    | make new random value                         |
+        |      |                    +-----------------------------------------------+
+        |      |                                                               ^
+        ^----- | -----------------------------------------------------<        |
+        |      v                                                      | Yes    | No
+     No ^-----[Received sufficient Hashes?]                           |        |
+        |      |            |                               [Overall pulse round timed out?]
+        |      |            |                                               |
+        |      | All        |      (7 <= NumHashes < All) && HF21+          |
+        |      |            >-----------------------------------------------^
+        |      v                                                            |
+        |     +---------------------------------+                           |
+        |     | Send And Wait For Random Values |                           |
+        |     +---------------------------------+                           |
+        |      |                                                            |
+     No ^-----[Received sufficient Values?]                                 |
+        |      |            |                                               |
+        |      | All        |      (7 <= NumValues < All) && HF21+          |
+        |      |            >-----------------------------------------------^
+        |      v                                                            |
+        |     +--------------------------------------------+                |
+        |     | - update block template with random values |                |
+        |     | Send And Wait For Block Signatures         |                |
+        |     +--------------------------------------------+                |
+        |      |                                                            |
+     No ^-----[Received and verified sufficient Signatures?]                |
+        |      |            |                                               |
+        |      | All        |      (7 <= NumSigs < All) && HF21+            |
+        |      |            >-----------------------------------------------^
+        |      v
+        |     +---------------------------------------------------------+
+        |     | - add first 7 Signatures (by validator index) to Block; |
+        |     | - add completed Block to blockchain                     |
+        |     +---------------------------------------------------------+
         |      |
-    Yes +-----[Insufficient Hashes]
-        |      |
-        |      | No
-        |      |
-        |     +--------------------------------+
-        |     | Send And Wait For Random Value |
-        |     +--------------------------------+
-        |      |
-    Yes +-----[Insufficient Values]
-        |      |
-        |      | No
-        |      |
-        |     +---------------------------------+
-        |     | Send And Wait For Signed Blocks |
-        |     +---------------------------------+
-        |      |
-    Yes +-----[Block can not be added to blockchain]
+     No ^-----[Block added successfully to blockchain?]
                |
-               | No
+               | Yes
                |
                + (Finished, state machine resets)
 
@@ -997,8 +1133,8 @@ namespace {
 
       Wait For Handshake Bitsets (Block Producer & Validator)
         - Upon receipt, the most common agreed upon bitset is used to lock in
-          participation for the round. The round proceeds if more than 60% of the
-          validators are participating, the round fails otherwise and reverts to
+          participation for the round. The round proceeds if at least 7 of the
+          11 validators are participating, the round fails otherwise and reverts to
           'Prepare For Round'.
 
         - If we are a validator      we go to 'Wait For Block Template'
@@ -1019,169 +1155,176 @@ namespace {
           random value and proceed to the next stage.
 
       Send And Wait For Random Value Hashes (Validator)
-        - On first invcation, send the hash of our random value prepared in the
+        - On first invocation, send the hash of our random value prepared in the
           'Wait For Block Template' stage, followed by waiting for the other random
           value hashes from validators.
 
-        - If not all hashes are received according to the locked in validator bitset
-          in the block, we revert to 'Prepare For Round'.
+        - If not all hashes are received according to the validator bitset in the
+          block, but a retry is possible, then we retry (see Late Stages Retry
+          below).
 
-      Send And Wait For Random Value (Validator)
+        - If we couldn't retry and didn't receive all value hashes then we revert to
+          'Prepare For Round'.
+
+      Send And Wait For Random Values (Validator)
         - On first invcation, send the random value prepared in the 'Wait For Block
           Template' stage, followed by waiting for the other random values from
           validators.
 
-        - If not all values are received according to the locked in validator bitset
-          in the block, we revert to 'Prepare For Round'.
+        - If not all values are received according to the validator bitset in the
+          block, but a retry is possible, then we retry (see Late Stages Retry
+          below).
 
-      Send And Wait For Signed Block (Validator)
+        - If we couldn't retry and didn't receive all values then we revert to
+          'Prepare For Round'.
+
+      Send And Wait For Block Signatures (Validator)
         - On first invcation, send our signature, signing the block template with
           all the random values combined into 1 to other validators and await for
           the other signatures to arrive.
 
-        - Ensure the signature signs the same block template we received at the
-          beginning from the Block Producer.
+        - Ensure the signature signs the same block template we have on hand, which
+          might the original one we received from the Block Producer, or might have
+          bitset modifications (see below).
 
-        - If not all values are received according to the locked in validator bitset
-          in the block, we revert to 'Prepare For Round'.
+        - If not all values are received according to the validator bitset
+          in the block, but a retry is possible, then we retry (see Late Stages
+          Retry below).
 
-        - Add the block to the blockchain and on success, that will automatically
-          begin propagating the block via P2P. The signatures in the block are added
-          in any order, as soon as the first N signatures arrive the block can be
-          P2P-ed.
+        - If we couldn't retry and didn't receive all (valid) signatures then we
+          revert to 'Prepare For Round'.
+
+        - Add the first 7 signatures (ordered by validator index) to the block, and
+          add the block to the blockchain.  This will automatically begin
+          propagation of the block via P2P.
+
+        - If block addition fails, revert to 'Prepare For Round'
+
+      Late Stages Retry
+
+        If any of the "Send And Wait" stages for Random Value Hashes, Random Values,
+        or Block Signatures fails to accumulate all required values then a retry is
+        considered where we adjust the bitset to exclude nodes that failed to
+        contribute a value and restart the hash-value-signature sequence.
+
+        Specifically it must be the case that:
+        - we are on HF21+
+        - there is still time left in the overall pulse round
+        - after clearing the bits of the validators that did not send a valid value
+          we still have at least 7 validators in the bitset that did.
+
+        There is no guarantee that a retry will succeed, but it catches a common
+        case where some validator timed out or dropped out in the middle of the
+        pulse quorum by allowing the remaining validators to nevertheless recover
+        and push out a block without that faulty node.
+
+        (Before the introduction of this retry, such failures would simply result in
+        no block being produced at all, which could not lead to network penalties
+        against the faulty node because the pulse quorum consensus is only ever
+        published via the blocks themselves, which would simply fail to be
+        produced).
+
+        If the retry conditions are met, then each node:
+        - updates the bitset to clear the bits of nodes that failed to respond
+        - chooses a new random value
+        - returns to Send And Wait For Random Value Hashes
+
+        Multiple retries are possible, so long as there is sufficient time remaining
+        in the pulse round.
     */
 
-    round_state goto_preparing_for_next_round(round_context& context) {
-        context.prepare_for_round.queue_for_next_round = true;
+    round_state pulse_impl::goto_preparing_for_next_round() {
+        round.queue_for_next_round = true;
         return round_state::prepare_for_round;
     }
 
-    void clear_round_data(round_context& context) {
-        if (service_nodes::verify_pulse_quorum_sizes(context.prepare_for_round.quorum)) {
-            // NOTE: Store the quorum into history before deleting it from memory.
-            // This way we can verify late arriving messages when we may have progressed
-            // already into a new round/block.
-
-            bool store = true;
-            size_t iterations =
-                    std::min(context.quorum_history.size(), context.quorum_history_index);
-            for (size_t i = 0; i < iterations; i++) {
-                auto& quorum = context.quorum_history[i];
-                if (quorum.height == context.wait_for_next_block.height &&
-                    quorum.round == context.prepare_for_round.round) {
-                    store = false;  // Already stored quorum
-                    break;
-                }
-            }
-
-            if (store) {
-                size_t real_quorum_history_index =
-                        context.quorum_history_index % context.quorum_history.size();
-                context.quorum_history_index++;
-
-                round_history& entry = context.quorum_history[real_quorum_history_index];
-                entry = {};
-
-                entry.top_block_hash = context.wait_for_next_block.top_hash;
-                entry.height = context.wait_for_next_block.height;
-                entry.round = context.prepare_for_round.round;
-                entry.quorum = std::move(context.prepare_for_round.quorum);
-            }
-        }
-
-        context.transient = {};
-        cryptonote::pulse_random_value& old_random_value = context.transient.random_value.send.data;
-        auto& old_random_values_array = context.transient.random_value.wait.data;
-        memwipe(old_random_value.data, sizeof(old_random_value));
-        memwipe(old_random_values_array.data(),
-                old_random_values_array.size() * sizeof(old_random_values_array[0]));
-        context.prepare_for_round = {};
+    void pulse_impl::clear_round_data() {
+        transient = {};
+        round = {};
     }
 
-    round_state goto_wait_for_next_block_and_clear_round_data(round_context& context) {
-        clear_round_data(context);
+    round_state pulse_impl::goto_wait_for_next_block_and_clear_round_data() {
+        clear_round_data();
         return round_state::wait_for_next_block;
     }
 
-    round_state wait_for_next_block(
-            round_context& context, cryptonote::Blockchain const& blockchain) {
+    round_state pulse_impl::wait_for_next_block() {
         ZoneScoped;
         //
-        // NOTE: If the top hash stored in the pulse context is the same as the top block's hash
-        // then we've already attempted Pulse with the current state of the blockchain and
-        // encountered a failure.
+        // NOTE: If the top hash we have stored is the same as the top block's hash then we've
+        // already attempted Pulse with the current state of the blockchain and encountered a
+        // failure.
         //
-        cryptonote::block top_block = blockchain.db().get_top_block();
-        crypto::hash top_hash = cryptonote::get_block_hash(top_block);
+        cryptonote::block top_block = core.blockchain.db().get_top_block();
+        const auto top_hash = cryptonote::get_block_hash(top_block);
         uint64_t chain_height = top_block.get_height() + 1;
-        if (context.wait_for_next_block.top_hash == top_hash) {
-            for (static crypto::hash last_hash = {}; last_hash != top_hash; last_hash = top_hash)
+        if (curr_block.top_hash == top_hash) {
+            if (last_wait_log_hash != top_hash) {
+                last_wait_log_hash = top_hash;
                 log::debug(
                         logcat,
                         "{}Network is currently producing block {} (w/ parent {}), "
                         "waiting until next block",
-                        log_prefix(context),
+                        *this,
                         chain_height,
                         top_hash);
+            }
             return round_state::wait_for_next_block;
         }
 
-        timings times = {};
-        if (!get_round_timings(blockchain, chain_height, top_block.timestamp, times)) {
-            for (static crypto::hash last_hash = {}; last_hash != top_hash; last_hash = top_hash)
-                log::error(
-                        logcat,
-                        "{}Failed to query the block data for Pulse timings",
-                        log_prefix(context));
+        auto times = get_round_timings(core.blockchain, chain_height, top_block.timestamp);
+        if (!times) {
+            if (last_timing_log_hash != top_hash) {
+                last_timing_log_hash = top_hash;
+                log::error(logcat, "{}Failed to query the block data for Pulse timings", *this);
+            }
             return round_state::wait_for_next_block;
         }
 
-        context.wait_for_next_block.round_0_start_time = times.r0_timestamp;
-        context.wait_for_next_block.height = chain_height;
-        context.wait_for_next_block.top_hash = top_hash;
-        context.prepare_for_round = {};
+        curr_block.round_0_start_time = times->r0_timestamp;
+        curr_block.height = chain_height;
+        curr_block.top_hash = top_hash;
+        round = {};
 
         return round_state::prepare_for_round;
     }
 
-    round_state prepare_for_round(
-            round_context& context,
-            service_nodes::service_node_keys const& key,
-            cryptonote::Blockchain const& blockchain) {
-        auto& conf = get_config(blockchain.nettype());
+    round_state pulse_impl::prepare_for_round() {
+        auto& blockchain = core.blockchain;
+        auto& conf = core.get_net_config();
         //
         // NOTE: Clear Round Data
         //
         {
             // Store values
-            uint8_t round = context.prepare_for_round.round;
-            bool queue_for_next_round = context.prepare_for_round.queue_for_next_round;
+            uint8_t round_no = round.number;
+            bool queue_for_next_round = round.queue_for_next_round;
 
-            clear_round_data(context);
+            clear_round_data();
 
             // Restore values
-            context.prepare_for_round.round = round;
-            context.prepare_for_round.queue_for_next_round = queue_for_next_round;
+            round.number = round_no;
+            round.queue_for_next_round = queue_for_next_round;
         }
 
-        if (context.prepare_for_round.queue_for_next_round) {
-            if (context.prepare_for_round.round >= 255) {
+        if (round.queue_for_next_round) {
+            if (round.number >= 255) {
                 // If the next round overflows, we consider the network stalled. Wait for
                 // the next block and allow PoW to return.
-                return goto_wait_for_next_block_and_clear_round_data(context);
+                return goto_wait_for_next_block_and_clear_round_data();
             }
 
             // Also check if the blockchain has changed, in which case we stop and
             // restart Pulse stages.
             std::pair<uint64_t, crypto::hash> tail = blockchain.get_tail_id();
             const crypto::hash& top_hash = tail.second;
-            if (context.wait_for_next_block.top_hash != top_hash)
-                return goto_wait_for_next_block_and_clear_round_data(context);
+            if (curr_block.top_hash != top_hash)
+                return goto_wait_for_next_block_and_clear_round_data();
 
             // 'queue_for_next_round' is set when an intermediate Pulse stage has failed
             // and the caller requests us to wait until the next round to occur.
-            context.prepare_for_round.queue_for_next_round = false;
-            context.prepare_for_round.round++;
+            round.queue_for_next_round = false;
+            round.number++;
         }
 
         //
@@ -1190,104 +1333,100 @@ namespace {
         {
             auto now = clock::now();
             auto const time_since_block =
-                    now <= context.wait_for_next_block.round_0_start_time
-                            ? std::chrono::seconds(0)
-                            : (now - context.wait_for_next_block.round_0_start_time);
+                    now <= curr_block.round_0_start_time ? 0s : now - curr_block.round_0_start_time;
             size_t round_usize = time_since_block / conf.PULSE_ROUND_TIMEOUT;
 
             if (round_usize > 255) {  // Network stalled
                 log::info(
                         logcat,
                         "{}Pulse has timed out, reverting to accepting miner blocks only.",
-                        log_prefix(context));
-                return goto_wait_for_next_block_and_clear_round_data(context);
+                        *this);
+                return goto_wait_for_next_block_and_clear_round_data();
             }
 
             auto curr_round = static_cast<uint8_t>(round_usize);
-            if (curr_round > context.prepare_for_round.round)
-                context.prepare_for_round.round = curr_round;
+            if (curr_round > round.number)
+                round.number = curr_round;
         }
 
+        round.start_time =
+                curr_block.round_0_start_time + (round.number * conf.PULSE_ROUND_TIMEOUT);
+        round.end_time = round.start_time + conf.PULSE_ROUND_TIMEOUT;
+
+        // We initially set all these timeouts to fixed increments from the round start, which is
+        // how everything worked in HF20 and earlier, but starting in HF21 we will update these end
+        // times when we begin each stage from wait_for_bitsets onwards to the current time +
+        // PULSE_STAGE_TIMEOUT, thus ensuring that each stage only gets PULSE_STAGE_TIMEOUT, rather
+        // than each stage getting PULSE_STAGE_TIMEOUT + all unused time from previous stages; that,
+        // in turn, gives us more opportunity to retry late stages in the case of a dropped
+        // validator.
         {
-            using namespace service_nodes;
-            context.prepare_for_round.start_time =
-                    context.wait_for_next_block.round_0_start_time +
-                    (context.prepare_for_round.round * conf.PULSE_ROUND_TIMEOUT);
-            context.transient.send_and_wait_for_handshakes.stage.end_time =
-                    context.prepare_for_round.start_time + conf.PULSE_STAGE_TIMEOUT;
-            context.transient.wait_for_handshake_bitsets.stage.end_time =
-                    context.transient.send_and_wait_for_handshakes.stage.end_time +
-                    conf.PULSE_STAGE_TIMEOUT;
-            context.transient.wait_for_block_template.stage.end_time =
-                    context.transient.wait_for_handshake_bitsets.stage.end_time +
-                    conf.PULSE_STAGE_TIMEOUT;
-            context.transient.random_value_hashes.wait.stage.end_time =
-                    context.transient.wait_for_block_template.stage.end_time +
-                    conf.PULSE_STAGE_TIMEOUT;
-            context.transient.random_value.wait.stage.end_time =
-                    context.transient.random_value_hashes.wait.stage.end_time +
-                    conf.PULSE_STAGE_TIMEOUT;
-            context.transient.signed_block.wait.stage.end_time =
-                    context.transient.random_value.wait.stage.end_time + conf.PULSE_STAGE_TIMEOUT;
+            auto t = round.start_time;
+            for (auto* stage :
+                 {&transient.send_and_wait_for_handshakes.stage,
+                  &transient.wait_for_handshake_bitsets.stage,
+                  &transient.wait_for_block_template.stage,
+                  &transient.random_value_hashes.wait.stage,
+                  &transient.random_value.wait.stage,
+                  &transient.block_signatures.wait.stage}) {
+                stage->end_time = (t += conf.PULSE_STAGE_TIMEOUT);
+            }
         }
 
         std::vector<crypto::hash> const entropy = service_nodes::get_pulse_entropy_for_next_block(
-                blockchain.db(),
-                context.wait_for_next_block.top_hash,
-                context.prepare_for_round.round);
+                blockchain.db(), curr_block.top_hash, round.number);
         auto const active_node_list = blockchain.service_node_list.active_service_nodes_infos();
-        auto hf_version = blockchain.get_network_version();
         crypto::public_key const& block_leader =
                 blockchain.service_node_list.get_next_block_leader().key;
 
-        context.prepare_for_round.quorum = service_nodes::generate_pulse_quorum(
+        auto hf_version = blockchain.get_network_version();
+        round.quorum = service_nodes::generate_pulse_quorum(
                 blockchain.nettype(),
                 block_leader,
                 hf_version,
                 active_node_list,
                 entropy,
-                context.prepare_for_round.round,
-                context.wait_for_next_block.height);
+                round.number,
+                curr_block.height);
 
-        if (!service_nodes::verify_pulse_quorum_sizes(context.prepare_for_round.quorum)) {
+        if (!service_nodes::verify_pulse_quorum_sizes(round.quorum)) {
             log::info(
                     logcat,
                     "{}There are not enough nodes to execute Pulse for height {}. PoW block is "
-                    "required. Sleeping until next block.\n  Workers: {} (required 1)\n  "
-                    "Validators: {} (required {})",
-                    log_prefix(context),
-                    context.wait_for_next_block.height,
-                    context.prepare_for_round.quorum.workers.size(),
-                    context.prepare_for_round.quorum.validators.size(),
+                    "required. Sleeping until next block.\n"
+                    "  Producers: {} (required 1), Validators: {} (required {})",
+                    *this,
+                    curr_block.height,
+                    round.quorum.workers.size(),
+                    round.quorum.validators.size(),
                     service_nodes::PULSE_QUORUM_NUM_VALIDATORS);
-            return goto_wait_for_next_block_and_clear_round_data(context);
+            return goto_wait_for_next_block_and_clear_round_data();
         }
+
+        auto& key = core.get_service_keys();
 
         log::debug(
                 logcat,
-                "{}Generate Pulse quorum: {}",
-                log_prefix(context),
-                context.prepare_for_round.quorum);
+                "{}Generate Pulse quorum:\n    {}",
+                *this,
+                quorum_printer{round.quorum, key.pub});
 
         //
         // NOTE: Quorum participation
         //
-        if (key.pub == context.prepare_for_round.quorum.workers[0]) {
+        if (key.pub == round.quorum.workers[0]) {
             // NOTE: Producer doesn't send handshakes, they only collect the
             // handshake bitsets from the other validators to determine who to
             // lock in for this round in the block template.
-            context.prepare_for_round.participant = sn_type::producer;
-            context.prepare_for_round.node_name = "W[0]";
+            round.participant = sn_type::producer;
+            round.node_name = "Prod";
         } else {
-            for (size_t index = 0; index < context.prepare_for_round.quorum.validators.size();
-                 index++) {
-                auto const& validator_key = context.prepare_for_round.quorum.validators[index];
+            for (size_t index = 0; index < round.quorum.validators.size(); index++) {
+                auto const& validator_key = round.quorum.validators[index];
                 if (validator_key == key.pub) {
-                    context.prepare_for_round.participant = sn_type::validator;
-                    context.prepare_for_round.my_quorum_position = index;
-                    context.prepare_for_round.node_name =
-                            "V[" + std::to_string(context.prepare_for_round.my_quorum_position) +
-                            "]";
+                    round.participant = sn_type::validator;
+                    round.my_quorum_position = index;
+                    round.node_name = "V[{}]"_format(round.my_quorum_position);
                     break;
                 }
             }
@@ -1296,30 +1435,29 @@ namespace {
         return round_state::wait_for_round;
     }
 
-    round_state wait_for_round(round_context& context, cryptonote::Blockchain const& blockchain) {
-        std::pair<uint64_t, crypto::hash> tail = blockchain.get_tail_id();
-        const crypto::hash& top_hash = tail.second;
-        if (context.wait_for_next_block.top_hash != top_hash) {
+    round_state pulse_impl::wait_for_round() {
+        const auto [height, top_hash] = core.blockchain.get_tail_id();
+        if (curr_block.top_hash != top_hash) {
             log::debug(
                     logcat,
                     "{}Top block changed (from {} to {}) whilst waiting for round {}, "
                     "restarting Pulse stages",
-                    log_prefix(context),
-                    context.wait_for_next_block.top_hash,
+                    *this,
+                    curr_block.top_hash,
                     top_hash,
-                    +context.prepare_for_round.round);
-            return goto_wait_for_next_block_and_clear_round_data(context);
+                    round.number);
+            return goto_wait_for_next_block_and_clear_round_data();
         }
 
-        auto start_time = context.prepare_for_round.start_time;
+        auto start_time = round.start_time;
         if (auto now = clock::now(); now < start_time) {
-            for (static uint64_t last_height = 0; last_height != context.wait_for_next_block.height;
-                 last_height = context.wait_for_next_block.height)
+            for (static uint64_t last_height = 0; last_height != curr_block.height;
+                 last_height = curr_block.height)
                 log::info(
                         logcat,
                         "{}Waiting for round {} to start in {}",
-                        log_prefix(context),
-                        +context.prepare_for_round.round,
+                        *this,
+                        round.number,
                         tools::friendly_duration(start_time - now));
             return round_state::wait_for_round;
         }
@@ -1331,8 +1469,8 @@ namespace {
         if (curr_height % 20 >= 10) {
             size_t faulty_chance = tools::uniform_distribution_portable(tools::rng, 100);
             if (faulty_chance < 10) {
-                log::debug(logcat, "{}FAULTY NODE ACTIVATED", log_prefix(context));
-                return goto_preparing_for_next_round(context);
+                log::debug(logcat, "{}FAULTY NODE ACTIVATED", *this);
+                return goto_preparing_for_next_round();
             }
 
             size_t sleep_chance = tools::uniform_distribution_portable(tools::rng, 100);
@@ -1341,148 +1479,136 @@ namespace {
                         std::chrono::seconds(tools::uniform_distribution_portable(tools::rng, 20));
                 std::this_thread::sleep_for(sleep_time);
                 log::debug(
-                        logcat,
-                        "{}SLEEP TIME ACTIVATED {}s",
-                        log_prefix(context),
-                        tools::to_seconds(sleep_time));
+                        logcat, "{}SLEEP TIME ACTIVATED {}s", *this, tools::to_seconds(sleep_time));
             }
         }
 #endif
 
-        if (context.prepare_for_round.participant == sn_type::validator) {
+        if (round.participant == sn_type::validator) {
             log::info(
                     logcat,
                     "{}We are a pulse validator, sending handshake bit and collecting other "
                     "handshakes.",
-                    log_prefix(context));
+                    *this);
             return round_state::send_and_wait_for_handshakes;
-        } else if (context.prepare_for_round.participant == sn_type::producer) {
+        } else if (round.participant == sn_type::producer) {
             log::info(
                     logcat,
                     "{}We are the block producer for height {} in round {}, awaiting handshake "
                     "bitsets.",
-                    log_prefix(context),
-                    context.wait_for_next_block.height,
-                    +context.prepare_for_round.round);
+                    *this,
+                    curr_block.height,
+                    round.number);
             return round_state::wait_for_handshake_bitsets;
         } else {
             log::debug(
-                    logcat,
-                    "{}Non-participant for round, waiting on next round or block.",
-                    log_prefix(context));
-            return goto_preparing_for_next_round(context);
+                    logcat, "{}Non-participant for round, waiting on next round or block.", *this);
+            return goto_preparing_for_next_round();
         }
     }
 
-    round_state send_and_wait_for_handshakes(
-            round_context& context,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key) {
+    round_state pulse_impl::send_and_wait_for_handshakes() {
         ZoneScoped;
         //
         // NOTE: Send
         //
-        assert(context.prepare_for_round.participant == sn_type::validator);
-        if (!context.transient.send_and_wait_for_handshakes.sent) {
-            context.transient.send_and_wait_for_handshakes.sent = true;
+        assert(round.participant == sn_type::validator);
+        if (!transient.send_and_wait_for_handshakes.sent) {
+            transient.send_and_wait_for_handshakes.sent = true;
             try {
-                relay_validator_handshake_bit_or_bitset(
-                        context, quorumnet_state, key, false /*sending_bitset*/);
+                relay_validator_handshake_bit_or_bitset(false /*sending_bitset*/);
             } catch (std::exception const& e) {
                 log::error(
                         logcat,
                         "{}Attempting to invoke and send a Pulse participation handshake "
                         "unexpectedly failed. {}",
-                        log_prefix(context),
+                        *this,
                         e.what());
-                return goto_preparing_for_next_round(context);
+                return goto_preparing_for_next_round();
             }
         }
 
         //
         // NOTE: Wait
         //
-        handle_messages_received_early_for(
-                context.transient.send_and_wait_for_handshakes.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.send_and_wait_for_handshakes.stage;
+        handle_messages_received_early_for(transient.send_and_wait_for_handshakes.stage);
+        pulse_wait_stage const& stage = transient.send_and_wait_for_handshakes.stage;
 
-        auto const& quorum = context.transient.send_and_wait_for_handshakes.data;
+        auto const& quorum = transient.send_and_wait_for_handshakes.data;
         bool const timed_out = clock::now() >= stage.end_time;
         bool const all_handshakes = stage.msgs_received == quorum.size();
 
-        assert(context.prepare_for_round.participant == sn_type::validator);
-        assert(context.prepare_for_round.my_quorum_position < quorum.size());
+        assert(round.participant == sn_type::validator);
+        assert(round.my_quorum_position < quorum.size());
 
         if (all_handshakes || timed_out) {
             bool missing_handshakes = timed_out && !all_handshakes;
             log::info(
                     logcat,
-                    "{}Collected validator handshakes {}{}Sending handshake bitset and collecting "
-                    "other validator bitsets.",
-                    log_prefix(context),
-                    bitset_view16(stage.bitset).to_string(),
-                    (missing_handshakes ? ", we timed out and some handshakes were not seen! "
-                                        : ". "));
+                    "{}Collected validator handshakes {:011b}{} Sending handshake bitset and "
+                    "collecting other validator bitsets.",
+                    *this,
+                    stage.bitset,
+                    missing_handshakes ? ", we timed out and some handshakes were not seen!" : ".");
             return round_state::send_handshake_bitsets;
         } else {
             return round_state::send_and_wait_for_handshakes;
         }
     }
 
-    round_state send_handshake_bitsets(
-            round_context& context,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key) {
+    round_state pulse_impl::send_handshake_bitsets() {
         try {
-            relay_validator_handshake_bit_or_bitset(
-                    context, quorumnet_state, key, true /*sending_bitset*/);
-            return round_state::wait_for_handshake_bitsets;
+            relay_validator_handshake_bit_or_bitset(true /*sending_bitset*/);
+            return begin_stage_timer(round_state::wait_for_handshake_bitsets);
         } catch (std::exception const& e) {
             log::error(
                     logcat,
                     "{}Attempting to invoke and send a Pulse validator bitset unexpectedly failed. "
                     "{}",
-                    log_prefix(context),
+                    *this,
                     e.what());
-            return goto_preparing_for_next_round(context);
+            return goto_preparing_for_next_round();
         }
     }
 
-    round_state wait_for_handshake_bitsets(round_context& context, void* quorumnet_state) {
+    round_state pulse_impl::wait_for_handshake_bitsets() {
         ZoneScoped;
-        handle_messages_received_early_for(
-                context.transient.wait_for_handshake_bitsets.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.wait_for_handshake_bitsets.stage;
+        handle_messages_received_early_for(transient.wait_for_handshake_bitsets.stage);
+        pulse_wait_stage const& stage = transient.wait_for_handshake_bitsets.stage;
 
-        auto const& quorum = context.transient.wait_for_handshake_bitsets.data;
+        auto const& quorum = transient.wait_for_handshake_bitsets.data;
         bool const timed_out = clock::now() >= stage.end_time;
         bool const all_bitsets = stage.msgs_received == quorum.size();
 
         if (timed_out || all_bitsets) {
-            std::map<uint16_t, int> most_common_bitset;
+            std::map<uint16_t, int> bitset_count;
             uint16_t best_bitset = 0;
             size_t count = 0;
             for (size_t quorum_index = 0; quorum_index < quorum.size(); quorum_index++) {
                 auto& bitset = quorum[quorum_index];
                 if (bitset) {
-                    uint16_t num = ++most_common_bitset[*bitset];
+                    uint16_t num = ++bitset_count[*bitset];
                     if (num > count) {
                         best_bitset = *bitset;
                         count = num;
                     }
-                    log::trace(
-                            logcat,
-                            "{}Collected from V[{}], handshake bitset {}",
-                            log_prefix(context),
-                            quorum_index,
-                            bitset_view16(*bitset).to_string());
                 }
+            }
+            if (log::get_level(logcat) <= log::Level::debug) {
+                std::vector<std::string> received;
+                for (const auto& [bitset, count] : bitset_count)
+                    received.push_back("{:011b} (x{})"_format(bitset, count));
+                log::debug(
+                        logcat,
+                        "{}Most common bitset {:011b}, from received bitsets: {}",
+                        *this,
+                        best_bitset,
+                        fmt::join(received, ", "));
             }
 
             bool i_am_not_participating = false;
-            if (best_bitset != 0 && context.prepare_for_round.participant == sn_type::validator)
-                i_am_not_participating =
-                        ((best_bitset & (1 << context.prepare_for_round.my_quorum_position)) == 0);
+            if (best_bitset != 0 && round.participant == sn_type::validator)
+                i_am_not_participating = ((best_bitset & (1 << round.my_quorum_position)) == 0);
 
             if (count < service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES || best_bitset == 0 ||
                 i_am_not_participating) {
@@ -1491,67 +1617,63 @@ namespace {
                     // which validators are online, we wait until the next round.
                     log::debug(
                             logcat,
-                            "{}{}/{} \
-                         validators did not send any handshake bitset or sent an empty handshake \
-                         bitset and have failed to come to agreement. Waiting until next round.",
-                            log_prefix(context),
+                            "{}{}/{} validators did not send any handshake bitset or sent an empty "
+                            "handshake bitset and have failed to come to agreement. Waiting until "
+                            "next round.",
+                            *this,
                             count,
                             quorum.size());
                 } else if (i_am_not_participating) {
                     log::debug(
                             logcat,
-                            "{}The participating validator bitset {} does not include us (quorum "
-                            "index {}). Waiting until next round.",
-                            log_prefix(context),
-                            bitset_view16(best_bitset).to_string(),
-                            context.prepare_for_round.my_quorum_position);
+                            "{}The participating validator bitset {:011b} does not include us "
+                            "(quorum index {}). Waiting until next round.",
+                            *this,
+                            best_bitset,
+                            round.my_quorum_position);
                 } else {
                     // Can't come to agreement, see threshold comment above
                     log::debug(
                             logcat,
                             "{}We heard back from less than {} of the validators ({}/{}). Waiting "
                             "until next round.",
-                            log_prefix(context),
+                            *this,
                             service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES,
                             count,
                             quorum.size());
                 }
 
-                return goto_preparing_for_next_round(context);
+                return goto_preparing_for_next_round();
             }
 
-            context.transient.wait_for_handshake_bitsets.best_bitset = best_bitset;
-            context.transient.wait_for_handshake_bitsets.best_count = count;
+            transient.wait_for_handshake_bitsets.best_bitset = best_bitset;
+            transient.wait_for_handshake_bitsets.best_count = count;
             log::info(
                     logcat,
-                    "{}{}/{} validators agreed on the participating nodes in the quorum {}{}",
-                    log_prefix(context),
+                    "{}{}/{} validators agreed on the participating nodes in the quorum {:011b}{}",
+                    *this,
                     count,
                     quorum.size(),
-                    bitset_view16(best_bitset).to_string(),
-                    (context.prepare_for_round.participant == sn_type::producer ? ""
-                                                                                : ". Awaiting "
-                                                                                  "block template "
-                                                                                  "from block "
-                                                                                  "producer"));
-            if (context.prepare_for_round.participant == sn_type::producer)
+                    best_bitset,
+                    round.participant == sn_type::producer  //
+                            ? ""
+                            : ". Awaiting block template from block producer");
+
+            if (round.participant == sn_type::producer)
                 return round_state::send_block_template;
             else
-                return round_state::wait_for_block_template;
+                return begin_stage_timer(round_state::wait_for_block_template);
         }
 
         return round_state::wait_for_handshake_bitsets;
     }
 
-    round_state send_block_template(
-            round_context& context,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key,
-            cryptonote::Blockchain& blockchain) {
+    round_state pulse_impl::send_block_template() {
         ZoneScoped;
-        assert(context.prepare_for_round.participant == sn_type::producer);
+        assert(round.participant == sn_type::producer);
+        auto& key = core.get_service_keys();
         std::vector<service_nodes::service_node_pubkey_info> list_state =
-                blockchain.service_node_list.get_service_node_list_state({key.pub});
+                core.blockchain.service_node_list.get_service_node_list_state({key.pub});
 
         // Invariants
         if (list_state.empty()) {
@@ -1559,8 +1681,8 @@ namespace {
                     logcat,
                     "{}Block producer (us) is not available on the service node list, waiting "
                     "until next round",
-                    log_prefix(context));
-            return goto_preparing_for_next_round(context);
+                    *this);
+            return goto_preparing_for_next_round();
         }
 
         std::shared_ptr<const service_nodes::service_node_info> info = list_state[0].info;
@@ -1568,88 +1690,79 @@ namespace {
             log::warning(
                     logcat,
                     "{}Block producer (us) is not an active service node, waiting until next round",
-                    log_prefix(context));
-            return goto_preparing_for_next_round(context);
+                    *this);
+            return goto_preparing_for_next_round();
         }
 
         // Block
-        cryptonote::block block = {};
+        cryptonote::block new_block{};
         {
             uint64_t height = 0;
             service_nodes::payout block_producer_payouts =
                     service_nodes::service_node_payout_portions(key.pub, *info);
 
             try {
-                if (!blockchain.create_next_pulse_block_template(
-                            block,
+                if (!core.blockchain.create_next_pulse_block_template(
+                            new_block,
                             block_producer_payouts,
-                            context.prepare_for_round.round,
-                            context.transient.wait_for_handshake_bitsets.best_bitset,
+                            round.number,
+                            transient.wait_for_handshake_bitsets.best_bitset,
                             height)) {
                     log::error(
                             logcat,
                             "{}Failed to generate a block template, waiting until next round",
-                            log_prefix(context));
-                    return goto_preparing_for_next_round(context);
+                            *this);
+                    return goto_preparing_for_next_round();
                 }
             } catch (const std::exception& e) {
                 log::error(
                         logcat,
                         "{}Failed to generate a block template, waiting until next round: {}",
-                        log_prefix(context),
+                        *this,
                         e.what());
-                return goto_preparing_for_next_round(context);
+                return goto_preparing_for_next_round();
             }
 
-            if (context.wait_for_next_block.height != height) {
+            if (curr_block.height != height) {
                 log::debug(
                         logcat,
                         "{}Block height changed whilst preparing block template for round {}, "
                         "restarting Pulse stages",
-                        log_prefix(context),
-                        +context.prepare_for_round.round);
-                return goto_wait_for_next_block_and_clear_round_data(context);
+                        *this,
+                        round.number);
+                return goto_wait_for_next_block_and_clear_round_data();
             }
         }
 
         // Message
-        message msg = msg_init_from_context(context);
-        msg.type = message_type::block_template;
-        msg.block_template.blob = cryptonote::t_serializable_object_to_blob(block);
+        message msg = msg_init<message_type::block_template>(
+                cryptonote::t_serializable_object_to_blob(new_block));
         crypto::generate_signature(
-                msg_signature_hash(context.wait_for_next_block.top_hash, msg),
-                key.pub,
-                key.key,
-                msg.signature);
+                msg_signature_hash(curr_block.top_hash, msg), key.pub, key.key, msg.signature);
 
         // Send
         log::info(
                 logcat,
                 "{}Validators are handshaken and ready, sending block template from producer (us) "
                 "to validators.\n{}",
-                log_prefix(context),
-                cryptonote::obj_to_json_str(block));
+                *this,
+                cryptonote::obj_to_json_str(new_block));
         cryptonote::quorumnet_pulse_relay_message_to_quorum(
-                quorumnet_state, msg, context.prepare_for_round.quorum, true /*block_producer*/);
-        return goto_preparing_for_next_round(context);
+                quorumnet_state, msg, round.quorum, true /*block_producer*/);
+        return goto_preparing_for_next_round();
     }
 
-    round_state wait_for_block_template(
-            round_context& context,
-            service_nodes::service_node_list& node_list,
-            void* quorumnet_state) {
+    round_state pulse_impl::wait_for_block_template() {
         ZoneScoped;
-        handle_messages_received_early_for(
-                context.transient.wait_for_block_template.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.wait_for_block_template.stage;
+        handle_messages_received_early_for(transient.wait_for_block_template.stage);
+        const auto& stage = transient.wait_for_block_template.stage;
 
-        assert(context.prepare_for_round.participant == sn_type::validator);
+        assert(round.participant == sn_type::validator);
         bool timed_out = clock::now() >= stage.end_time;
         bool received = stage.msgs_received == 1;
         if (timed_out || received) {
-            const auto prefix = log_prefix(context);
             if (received) {
-                cryptonote::block& block = context.transient.wait_for_block_template.block;
+                auto& block = transient.block;
 
                 // Before we sign off on the block make sure that we support the inclusion of any
                 // eth state change transactions by making sure we have them in our pool *and* that
@@ -1660,55 +1773,54 @@ namespace {
                                 logcat,
                                 "{}Invalid block from producer: block claims eth L2 state change "
                                 "txs {} > tx count {}",
-                                prefix,
+                                *this,
                                 block.tx_eth_count,
                                 block.tx_hashes.size());
-                        return goto_preparing_for_next_round(context);
+                        return goto_preparing_for_next_round();
                     }
-                    auto mempool_txs =
-                            node_list.blockchain.tx_pool.load_transactions(block.tx_hashes);
+                    auto mempool_txs = core.blockchain.tx_pool.load_transactions(block.tx_hashes);
                     for (size_t i = 0; i < block.tx_eth_count; i++) {
                         if (!mempool_txs[i]) {
-                            log::info(
+                            log::warning(
                                     logcat,
                                     "{}Rejecting block: eth state change tx {} is not in our "
                                     "mempool",
-                                    prefix,
+                                    *this,
                                     block.tx_hashes[i]);
-                            return goto_preparing_for_next_round(context);
+                            return goto_preparing_for_next_round();
                         }
                         auto& tx = *mempool_txs[i];
                         if (!is_l2_event_tx(tx.type)) {
-                            log::info(
+                            log::warning(
                                     logcat,
                                     "{}Rejecting block: claimed state change tx {} is not a state "
                                     "change tx",
-                                    prefix,
+                                    *this,
                                     block.tx_hashes[i]);
-                            return goto_preparing_for_next_round(context);
+                            return goto_preparing_for_next_round();
                         }
                         std::string fail;
                         auto event = eth::extract_event(tx, &fail);
                         if (std::holds_alternative<std::monostate>(event)) {
-                            log::info(
+                            log::warning(
                                     logcat,
                                     "{}Rejecting block: failed to extract event from {}: {}",
-                                    prefix,
+                                    *this,
                                     tx,
                                     fail);
-                            return goto_preparing_for_next_round(context);
+                            return goto_preparing_for_next_round();
                         }
                         if (!std::visit(
-                                    [&l2 = node_list.blockchain.l2_tracker()](const auto& e) {
+                                    [&l2 = core.blockchain.l2_tracker()](const auto& e) {
                                         return l2.get_vote_for(e);
                                     },
                                     event)) {
-                            log::info(
+                            log::warning(
                                     logcat,
                                     "{}Rejecting block: event not found in L2Tracker for tx {}",
-                                    prefix,
+                                    *this,
                                     tx);
-                            return goto_preparing_for_next_round(context);
+                            return goto_preparing_for_next_round();
                         }
                     }
                     // NOTE: We only concern ourselves with the claimed [0, tx_eth_count)
@@ -1718,154 +1830,174 @@ namespace {
                     log::debug(
                             logcat,
                             "{}Block passed state change validation ({} state changes of {} txs)",
-                            prefix,
+                            *this,
                             block.tx_eth_count,
                             block.tx_hashes.size());
                 }
 
-#ifdef NDEBUG
-                log::info(logcat, "{}Valid block received", prefix);
-#else
-                log::info(
-                        logcat,
-                        "{}Valid block received: {}",
-                        prefix,
-                        cryptonote::obj_to_json_str(block));
+                if (!block.signatures.empty()) {
+                    log::warning(
+                            logcat,
+                            "{}Rejecting block: block template has {} pre-filled signatures",
+                            *this,
+                            block.signatures.size());
+                    return goto_preparing_for_next_round();
+                }
+
+                log::info(logcat, "{}Valid block received", *this);
+#ifndef NDEBUG
+                log::trace(logcat, "{}Block data: {}", *this, cryptonote::obj_to_json_str(block));
 #endif
 
                 // Generate my random value and its hash
-                crypto::generate_random_bytes_thread_safe(
-                        sizeof(context.transient.random_value.send.data),
-                        context.transient.random_value.send.data.data);
-                context.transient.random_value_hashes.send.data = blake2b_hash(
-                        &context.transient.random_value.send.data,
-                        sizeof(context.transient.random_value.send.data));
+                generate_random_value();
+
                 return round_state::send_and_wait_for_random_value_hashes;
             } else {
-                log::info(logcat, "{}Timed out, block template was not received", prefix);
-                return goto_preparing_for_next_round(context);
+                log::info(logcat, "{}Timed out, block template was not received", *this);
+                return goto_preparing_for_next_round();
             }
         }
 
         return round_state::wait_for_block_template;
     }
 
-    round_state send_and_wait_for_random_value_hashes(
-            round_context& context,
-            service_nodes::service_node_list& node_list,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key) {
+    // (Re-)Generate my random value and its hash
+    void pulse_impl::generate_random_value() {
+        auto& rv = transient.random_value.to_send.emplace().data;
+        crypto::generate_random_bytes_thread_safe(sizeof(rv), rv);
+        transient.random_value_hashes.to_send = blake2b_hash(rv, sizeof(rv));
+    }
+
+    // Resets the "late stage" states, that is, everything after wait_for_block_template.  This is
+    // used when a validator fails to complete one of the late stages, which ejects the failing
+    // validator and attempts to restart from random_value_hashes.  (We restart to there, regardless
+    // of where the failure is, so that a validator cannot influence the block random value by
+    // observing all the actual random values and then being able to pick the final random value
+    // between the two alternatives or staying in or sitting out).
+    void pulse_impl::reset_late_stages() {
+        transient.random_value_hashes.clear();
+        transient.random_value.clear();
+        transient.block_signatures.clear();
+        generate_random_value();
+    }
+
+    // Common code for late stage send-and-wait functions: if the type's value is not yet sent, this
+    // builds a message, loads it, signs it, and starts distributing it, and starts the stage timer
+    // (defining when we time out the stage).  If the value is already sent, this method does
+    // nothing.
+    template <message_type mtype, typename SendAndWait>
+    void pulse_impl::start_send(SendAndWait& saw) {
+        if (!saw.to_send)
+            return;  // already sent
+        begin_stage_timer(SendAndWait::round_state);
+        // Message
+        message msg = msg_init<mtype>(*saw.to_send);
+        saw.to_send.reset();  // Send only once
+        auto& key = core.get_service_keys();
+        crypto::generate_signature(
+                msg_signature_hash(curr_block.top_hash, msg), key.pub, key.key, msg.signature);
+        handle_message(msg);  // Add our own. We receive our own msg for the
+                              // first time which also triggers us to relay.
+    }
+
+    round_state pulse_impl::send_and_wait_for_random_value_hashes() {
         ZoneScoped;
-        assert(context.prepare_for_round.participant == sn_type::validator);
+        assert(round.participant == sn_type::validator);
 
         //
-        // NOTE: Send
+        // NOTE: Send, and kick off the stage timer
         //
-        if (context.transient.random_value_hashes.send.one_time_only()) {
-            // Message
-            message msg = msg_init_from_context(context);
-            msg.type = message_type::random_value_hash;
-            msg.random_value_hash.hash = context.transient.random_value_hashes.send.data;
-            crypto::generate_signature(
-                    msg_signature_hash(context.wait_for_next_block.top_hash, msg),
-                    key.pub,
-                    key.key,
-                    msg.signature);
-            handle_message(quorumnet_state, msg);  // Add our own. We receive our own msg for the
-                                                   // first time which also triggers us to relay.
-        }
+        start_send<message_type::random_value_hash>(transient.random_value_hashes);
 
         //
         // NOTE: Wait
         //
-        handle_messages_received_early_for(
-                context.transient.random_value_hashes.wait.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.random_value_hashes.wait.stage;
+        handle_messages_received_early_for(transient.random_value_hashes.wait.stage);
+        pulse_wait_stage const& stage = transient.random_value_hashes.wait.stage;
 
         bool const timed_out = clock::now() >= stage.end_time;
-        bool const all_hashes =
-                stage.bitset == context.transient.wait_for_handshake_bitsets.best_bitset;
+        bool const all_hashes = stage.bitset == transient.block.pulse.validator_bitset;
 
         if (timed_out || all_hashes) {
-            auto stage_count = bitset_view16(stage.bitset).count();
-            if (!enforce_validator_participation_and_timeouts(
-                        context, stage, timed_out, all_hashes)) {
-                if (stage_count < service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES) {
-                    log::info(
-                            logcat,
-                            "{} Unable to continue, only have {} of {} required random value "
-                            "hashes",
-                            log_prefix(context),
-                            stage_count,
-                            service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES);
-                    return goto_preparing_for_next_round(context);
-                }
-                auto expected_count =
-                        bitset_view16(context.transient.wait_for_handshake_bitsets.best_bitset)
-                                .count();
-                log::info(
-                        logcat,
-                        "{} continuing with {} validators (expected {}).",
-                        log_prefix(context),
-                        stage_count,
-                        expected_count);
-            }
-
             log::info(
                     logcat,
-                    "{}Received {} random value hashes from {}{}",
-                    log_prefix(context),
-                    stage_count,
-                    bitset_view16(stage.bitset).to_string(),
-                    (timed_out ? ". We timed out and some hashes are missing" : ""));
+                    "{}Received {} random value hashes from {:011b}{}",
+                    *this,
+                    std::popcount(stage.bitset),
+                    stage.bitset,
+                    timed_out ? ". We timed out and some hashes are missing" : "");
+
+            if (!all_hashes && (!hf21 || core.blockchain.get_current_blockchain_height() < *hf21)) {
+                // HF20 workaround to allow pulse to proceed even if a validator fails to send a
+                // random value hash in type.  This can be deleted once we are on HF21 (when the
+                // more robust version via reset_for_missing_validators takes over).
+                if (std::popcount(stage.bitset) < service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES)
+                    return goto_preparing_for_next_round();
+                log::info(logcat, "{}Attempting to continue with HF20 workaround handling", *this);
+            } else if (auto missing = reset_for_missing_validators(stage, timed_out)) {
+                bool retry = *missing;
+                if (retry)
+                    // Missing validators have been removed, but there are enough left to retry
+                    return round_state::send_and_wait_for_random_value_hashes;
+                else
+                    // Missing too many (or took to long) to be able to make a block
+                    return goto_preparing_for_next_round();
+            }
+
             return round_state::send_and_wait_for_random_value;
         }
 
         return round_state::send_and_wait_for_random_value_hashes;
     }
 
-    round_state send_and_wait_for_random_value(
-            round_context& context,
-            service_nodes::service_node_list& node_list,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key) {
+    round_state pulse_impl::send_and_wait_for_random_value() {
         ZoneScoped;
         //
-        // NOTE: Send
+        // NOTE: Send, and kick off the stage timer
         //
-        assert(context.prepare_for_round.participant == sn_type::validator);
-        if (context.transient.random_value.send.one_time_only()) {
-            // Message
-            message msg = msg_init_from_context(context);
-            msg.type = message_type::random_value;
-            msg.random_value.value = context.transient.random_value.send.data;
-            crypto::generate_signature(
-                    msg_signature_hash(context.wait_for_next_block.top_hash, msg),
-                    key.pub,
-                    key.key,
-                    msg.signature);
-            handle_message(quorumnet_state, msg);  // Add our own. We receive our own msg for the
-                                                   // first time which also triggers us to relay.
-        }
+        assert(round.participant == sn_type::validator);
+        start_send<message_type::random_value>(transient.random_value);
 
         //
         // NOTE: Wait
         //
-        handle_messages_received_early_for(
-                context.transient.random_value.wait.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.random_value.wait.stage;
+        handle_messages_received_early_for(transient.random_value.wait.stage);
+        pulse_wait_stage const& stage = transient.random_value.wait.stage;
 
-        auto const& quorum = context.transient.random_value.wait.data;
+        auto const& quorum = transient.random_value.wait.data;
         bool const timed_out = clock::now() >= stage.end_time;
-        auto& prev_stage_bitset = context.transient.random_value_hashes.wait.stage.bitset;
-        bool const all_values = stage.bitset == prev_stage_bitset;
+        bool all_values;
+        // HF20 "maybe keep going" workaround code:
+        const bool hf20_compat_mode =
+                !hf21 || core.blockchain.get_current_blockchain_height() < *hf21;
+        if (hf20_compat_mode)
+            all_values = stage.bitset == transient.random_value_hashes.wait.stage.bitset;
+        else
+            all_values = stage.bitset == transient.block.pulse.validator_bitset;
 
         if (timed_out || all_values) {
-            bool enough_values = bitset_view16(stage.bitset).count() >=
-                                 service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES;
-            if (!enforce_validator_participation_and_timeouts(
-                        context, stage, timed_out, enough_values))
-                return goto_preparing_for_next_round(context);
+            if (!all_values && hf20_compat_mode) {
+                auto num_validators = std::popcount(stage.bitset);
+                if (num_validators < service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES)
+                    return goto_preparing_for_next_round();
+                log::debug(
+                        logcat,
+                        "{}Attempting to continue with HF20 workaround handling with {}/{} "
+                        "validators",
+                        *this,
+                        num_validators,
+                        std::popcount(transient.random_value_hashes.wait.stage.bitset));
+            } else if (auto missing = reset_for_missing_validators(stage, timed_out)) {
+                bool retry = *missing;
+                if (retry)
+                    // Missing validators have been removed, but there are enough left to restart
+                    // from just after the block template was received.
+                    return round_state::send_and_wait_for_random_value_hashes;
+                else
+                    // Missing too many (or took to long) to be able to make a block
+                    return goto_preparing_for_next_round();
+            }
 
             // Generate Final Random Value
             crypto::hash final_hash = {};
@@ -1875,24 +2007,17 @@ namespace {
                 crypto_generichash_init(&state, key, sizeof(key), sizeof(final_hash));
 
                 for (size_t index = 0; index < quorum.size(); index++) {
-                    if (auto& random_value = quorum[index]; random_value) {
-                        epee::wipeable_string string = tools::hex_guts(random_value->data);
-
-#if defined(NDEBUG)
-                        // Mask the random value generated incase someone is snooping logs
-                        // trying to derive the Service Node rng seed.
-                        for (int i = 2; i < static_cast<int>(string.size()) - 2; i++)
-                            string.data()[i] = '.';
-#endif
+                    if (auto& random_value = quorum[index]) {
+                        crypto_generichash_update(
+                                &state, random_value->data, sizeof(random_value->data));
 
                         log::debug(
                                 logcat,
-                                "{}Final random value seeding with V[{}] {}",
-                                log_prefix(context),
+                                "{}Final random value seeding with V[{}] value: {:02x}...{:02x}",
+                                *this,
                                 index,
-                                string.view());
-                        crypto_generichash_update(
-                                &state, random_value->data, sizeof(random_value->data));
+                                *std::begin(random_value->data),
+                                *std::rbegin(random_value->data));
                     }
                 }
 
@@ -1900,23 +2025,31 @@ namespace {
             }
 
             // Add final random value to the block
-            context.transient.signed_block.final_block =
-                    std::move(context.transient.wait_for_block_template.block);
-            cryptonote::block& final_block = context.transient.signed_block.final_block;
-            static_assert(sizeof(final_hash) >= sizeof(final_block.pulse.random_value.data));
-            std::memcpy(
-                    final_block.pulse.random_value.data,
-                    final_hash.data(),
-                    sizeof(final_block.pulse.random_value.data));
+            auto& block_rv = transient.block.pulse.random_value.data;
+            static_assert(sizeof(final_hash) >= sizeof(block_rv));
+            std::memcpy(block_rv, final_hash.data(), sizeof(block_rv));
+            transient.block.invalidate_hashes();
 
-            if (final_block.pulse.validator_bitset != prev_stage_bitset) {
-                log::info(
-                        logcat,
-                        "{} Using subset of ideal bitset as some validators dropped out of the "
-                        "process; updating block validator bitset.",
-                        log_prefix(context));
-                final_block.pulse.validator_bitset = prev_stage_bitset;
-                final_block.invalidate_hashes();
+            if (hf20_compat_mode) {
+                const auto& rv_validators = transient.random_value_hashes.wait.stage.bitset;
+                // We mutate the bitset in the block with the random_value_hashes stage bitset
+                // (rather than this random_value bitset) because 11.2.0 nodes without this
+                // workaround will drop out after the random_value_hashes stage because they didn't
+                // get all the rv hashes, and don't have this "keep trying" workaround, but we don't
+                // want to penalize them, so if someone provided rv hashes we give them
+                // participation credit in the final block even if they didn't make it to the end.
+                //
+                // Observed problematic (apparently massively overloaded) nodes during the 11.2.0
+                // release generally failed to make it to the random value hash phase, so this
+                // effectively pruned them out with pulse participation failures properly assigned.
+                if (transient.block.pulse.validator_bitset != rv_validators) {
+                    transient.block.pulse.validator_bitset = rv_validators;
+                    log::info(
+                            logcat,
+                            "{}Using subset of ideal bitset as some validators dropped out of the "
+                            "process; updating block validator bitset.",
+                            *this);
+                }
             }
 
             // Generate the signature of the final block (without any of the other
@@ -1924,203 +2057,195 @@ namespace {
             // 'PULSE_BLOCK_REQUIRED_SIGNATURES' that arrive to be added. These can be
             // inconsistent between syncing clients, as long as the signature itself is
             // valid against the quorum Service Nodes).
-            crypto::hash const& final_block_hash = cryptonote::get_block_hash(final_block);
+            auto& key = core.get_service_keys();
             crypto::generate_signature(
-                    final_block_hash, key.pub, key.key, context.transient.signed_block.send.data);
+                    cryptonote::get_block_hash(transient.block),
+                    key.pub,
+                    key.key,
+                    transient.block_signatures.to_send.emplace());
 
             log::info(
                     logcat,
-                    "{}Block final random value {} generated from validators {}",
-                    log_prefix(context),
-                    tools::hex_guts(final_block.pulse.random_value.data),
-                    bitset_view16(stage.bitset).to_string());
-            return round_state::send_and_wait_for_signed_blocks;
+                    "{}Block final random value {} generated from validators {:011b}",
+                    *this,
+                    tools::hex_guts(block_rv),
+                    stage.bitset);
+            return round_state::send_and_wait_for_block_signatures;
         }
 
         return round_state::send_and_wait_for_random_value;
     }
 
-    round_state send_and_wait_for_signed_blocks(
-            round_context& context,
-            service_nodes::service_node_list& node_list,
-            void* quorumnet_state,
-            service_nodes::service_node_keys const& key,
-            cryptonote::core& core) {
+    round_state pulse_impl::send_and_wait_for_block_signatures() {
         ZoneScoped;
-        assert(context.prepare_for_round.participant == sn_type::validator);
+        assert(round.participant == sn_type::validator);
 
         //
-        // NOTE: Send
+        // NOTE: Send, and kick off the stage timer
         //
-        if (context.transient.signed_block.send.one_time_only()) {
-            // Message
-            message msg = msg_init_from_context(context);
-            msg.type = message_type::signed_block;
-            msg.signed_block.signature_of_final_block_hash =
-                    context.transient.signed_block.send.data;
-            crypto::generate_signature(
-                    msg_signature_hash(context.wait_for_next_block.top_hash, msg),
-                    key.pub,
-                    key.key,
-                    msg.signature);
-            handle_message(quorumnet_state, msg);  // Add our own. We receive our own msg for the
-                                                   // first time which also triggers us to relay.
-        }
+        start_send<message_type::block_signature>(transient.block_signatures);
 
         //
         // NOTE: Wait
         //
-        handle_messages_received_early_for(
-                context.transient.signed_block.wait.stage, quorumnet_state);
-        pulse_wait_stage const& stage = context.transient.signed_block.wait.stage;
+        auto& wait = transient.block_signatures.wait;
+        handle_messages_received_early_for(wait.stage);
+        pulse_wait_stage const& stage = wait.stage;
 
-        auto const& quorum = context.transient.signed_block.wait.data;
+        auto const& quorum = wait.data;
         bool const timed_out = clock::now() >= stage.end_time;
-        bool const enough = stage.bitset >= context.transient.random_value.wait.stage.bitset;
 
-        if (timed_out || enough) {
-            if (!enforce_validator_participation_and_timeouts(context, stage, timed_out, enough))
-                return goto_preparing_for_next_round(context);
+        // HF20 "maybe keep going" workaround code:
+        const bool hf20_compat_mode =
+                !hf21 || core.blockchain.get_current_blockchain_height() < *hf21;
+        auto& block = transient.block;
+        const bool all_sigs =
+                stage.bitset == (hf20_compat_mode ? transient.random_value.wait.stage.bitset
+                                                  : block.pulse.validator_bitset);
 
-            // Select signatures randomly so we don't always just take the first N required
-            // signatures. Then sort just the first N required signatures, so signatures are added
-            // to the block in sorted order, but were chosen randomly.
-            std::array<size_t, service_nodes::PULSE_QUORUM_NUM_VALIDATORS> indices = {};
-            size_t indices_count = 0;
+        if (timed_out || all_sigs) {
+            if (auto missing = reset_for_missing_validators(stage, timed_out)) {
+                bool retry = *missing;
+                if (retry)
+                    // Missing validators have been removed, but there are enough left to restarting
+                    // from just after the block template was received.
+                    return round_state::send_and_wait_for_random_value_hashes;
+                else
+                    // Missing too many (or took to long) to be able to make a block
+                    return goto_preparing_for_next_round();
+            }
 
-            // Pull out indices where we've received a signature
-            for (size_t index = 0; index < quorum.size(); index++)
-                if (quorum[index])
-                    indices[indices_count++] = index;
+            assert(std::popcount(stage.bitset) >= service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES);
 
-            // Random select from first 'N' PULSE_BLOCK_REQUIRED_SIGNATURES from indices_count
-            // entries.
-            assert(indices_count >= service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES);
-            std::array<size_t, service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES> selected = {};
-            std::sample(
-                    indices.begin(),
-                    indices.begin() + indices_count,
-                    selected.begin(),
-                    selected.size(),
-                    tools::rng);
-
-            // Add Signatures
-            cryptonote::block& final_block = context.transient.signed_block.final_block;
-            for (size_t index = 0; index < service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES;
-                 index++) {
-                uint16_t validator_index = indices[index];
-                auto const& signature = quorum[validator_index];
-                assert(signature);
+            // Add first PULSE_BLOCK_REQUIRED_SIGNATURES signatures
+            for (uint16_t validator_index = 0; validator_index < quorum.size(); validator_index++) {
+                const auto& signature = quorum[validator_index];
+                if (!signature)
+                    continue;
                 log::debug(
                         logcat,
                         "{}Signature added: {}:{}, {}",
-                        log_prefix(context),
+                        *this,
                         validator_index,
-                        context.prepare_for_round.quorum.validators[validator_index],
+                        round.quorum.validators[validator_index],
                         *signature);
-                final_block.signatures.emplace_back(validator_index, *signature);
+                block.signatures.emplace_back(validator_index, *signature);
+                if (block.signatures.size() == service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES)
+                    break;
             }
+            assert(block.signatures.size() == service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES);
+            transient.block.invalidate_hashes();
 
             // Propagate Final Block
-            log::debug(
-                    logcat,
-                    "{}Final signed block constructed\n{}",
-                    log_prefix(context),
-                    cryptonote::obj_to_json_str(final_block));
-            cryptonote::block_verification_context bvc = {};
-            if (!core.handle_block_found(final_block, bvc))
-                return goto_preparing_for_next_round(context);
+            if (log::get_level(logcat) <= log::Level::debug)
+                log::debug(
+                        logcat,
+                        "{}Final signed block constructed:\n{}",
+                        *this,
+                        cryptonote::obj_to_json_str(block));
 
-            return goto_wait_for_next_block_and_clear_round_data(context);
+            cryptonote::block_verification_context bvc = {};
+            if (!core.handle_block_found(block, bvc))
+                return goto_preparing_for_next_round();
+
+            return goto_wait_for_next_block_and_clear_round_data();
         }
 
-        return round_state::send_and_wait_for_signed_blocks;
+        return round_state::send_and_wait_for_block_signatures;
     }
 
-}  // anonymous namespace
+    pulse_impl::pulse_impl(cryptonote::core& core) : core{core} {}
 
-void main(void* quorumnet_state, cryptonote::core& core) {
-    cryptonote::Blockchain& blockchain = core.blockchain;
-    service_nodes::service_node_keys const& key = core.get_service_keys();
+    void pulse_impl::init(void* qnet_state) {
+        assert(!quorumnet_state);
+        quorumnet_state = qnet_state;
+        hf16 = hard_fork_begins(core.get_nettype(), cryptonote::hf::hf16_pulse);
+        hf21 = hard_fork_begins(core.get_nettype(), cryptonote::hf::hf21_eth);
 
-    //
-    // NOTE: Early exit if too early
-    //
-    auto hf16 = hard_fork_begins(core.get_nettype(), cryptonote::hf::hf16_pulse);
-    if (!hf16) {
-        for (static bool once = true; once; once = !once)
-            log::error(logcat, "Pulse: HF16 is not defined, pulse worker waiting");
-        return;
-    }
-
-    if (uint64_t height = blockchain.get_current_blockchain_height(); height < *hf16) {
-        for (static bool once = true; once; once = !once)
+        if (!hf16)
+            log::error(logcat, "Pulse: HF16 is not defined; pulse disabled");
+        else if (uint64_t height = core.blockchain.get_current_blockchain_height();
+                 height < *hf16) {
             log::debug(
                     logcat,
                     "Pulse: Network at block {} is not ready for Pulse until block {}, waiting",
                     height,
                     *hf16);
+        }
+    }
+
+    void pulse_impl::check_state() {
+        //
+        // NOTE: Early exit if too early
+        //
+        if (!hf16)
+            return;
+
+        if (state <= round_state::wait_for_next_block &&
+            core.blockchain.get_current_blockchain_height() < *hf16)
+            return;
+
+        auto last_state = round_state::null_state;
+        do {
+            ZoneScoped;
+            last_state = state;
+            switch (state) {
+                case round_state::null_state: state = round_state::wait_for_next_block; break;
+
+                case round_state::wait_for_next_block: state = wait_for_next_block(); break;
+
+                case round_state::prepare_for_round: state = prepare_for_round(); break;
+
+                case round_state::wait_for_round: state = wait_for_round(); break;
+
+                case round_state::send_and_wait_for_handshakes:
+                    state = send_and_wait_for_handshakes();
+                    break;
+
+                case round_state::send_handshake_bitsets: state = send_handshake_bitsets(); break;
+
+                case round_state::wait_for_handshake_bitsets:
+                    state = wait_for_handshake_bitsets();
+                    break;
+
+                case round_state::wait_for_block_template: state = wait_for_block_template(); break;
+
+                case round_state::send_block_template: state = send_block_template(); break;
+
+                case round_state::send_and_wait_for_random_value_hashes:
+                    state = send_and_wait_for_random_value_hashes();
+                    break;
+
+                case round_state::send_and_wait_for_random_value:
+                    state = send_and_wait_for_random_value();
+                    break;
+
+                case round_state::send_and_wait_for_block_signatures:
+                    state = send_and_wait_for_block_signatures();
+                    break;
+            }
+
+            mocknet_push_mock_pulse_block(core);
+        } while (last_state != state);
+    }
+
+}  // anonymous namespace
+
+pulse::pulse(cryptonote::core& core) : impl{std::make_shared<pulse_impl>(core)} {}
+
+void pulse::init(void* quorumnet_state) {
+    static_cast<pulse_impl*>(impl.get())->init(quorumnet_state);
+}
+
+void pulse::operator()(const message* msg) const {
+    auto* pimpl = static_cast<pulse_impl*>(impl.get());
+    if (!pimpl) {
+        log::error(logcat, "Pulse state update attempted without initialized pulse state!");
         return;
     }
-
-    auto& node_list = core.service_node_list;
-    for (auto last_state = round_state::null_state;
-         last_state != context.state || last_state == round_state::null_state;) {
-        ZoneScoped;
-        last_state = context.state;
-        switch (context.state) {
-            case round_state::null_state: context.state = round_state::wait_for_next_block; break;
-
-            case round_state::wait_for_next_block:
-                context.state = wait_for_next_block(context, blockchain);
-                break;
-
-            case round_state::prepare_for_round:
-                context.state = prepare_for_round(context, key, blockchain);
-                break;
-
-            case round_state::wait_for_round:
-                context.state = wait_for_round(context, blockchain);
-                break;
-
-            case round_state::send_and_wait_for_handshakes:
-                context.state = send_and_wait_for_handshakes(context, quorumnet_state, key);
-                break;
-
-            case round_state::send_handshake_bitsets:
-                context.state = send_handshake_bitsets(context, quorumnet_state, key);
-                break;
-
-            case round_state::wait_for_handshake_bitsets:
-                context.state = wait_for_handshake_bitsets(context, quorumnet_state);
-                break;
-
-            case round_state::wait_for_block_template:
-                context.state = wait_for_block_template(context, node_list, quorumnet_state);
-                break;
-
-            case round_state::send_block_template:
-                context.state = send_block_template(context, quorumnet_state, key, blockchain);
-                break;
-
-            case round_state::send_and_wait_for_random_value_hashes:
-                context.state = send_and_wait_for_random_value_hashes(
-                        context, node_list, quorumnet_state, key);
-                break;
-
-            case round_state::send_and_wait_for_random_value:
-                context.state =
-                        send_and_wait_for_random_value(context, node_list, quorumnet_state, key);
-                break;
-
-            case round_state::send_and_wait_for_signed_blocks:
-                context.state = send_and_wait_for_signed_blocks(
-                        context, node_list, quorumnet_state, key, core);
-                break;
-        }
-
-        mocknet_push_mock_pulse_block(core);
-    }
+    if (msg)
+        pimpl->handle_message(*msg);
+    pimpl->check_state();
 }
 
 }  // namespace pulse

--- a/src/cryptonote_core/pulse.h
+++ b/src/cryptonote_core/pulse.h
@@ -24,7 +24,7 @@ enum struct message_type : uint8_t {
     block_template,
     random_value_hash,
     random_value,
-    signed_block,
+    block_signature,
 };
 
 constexpr std::string_view to_string(message_type type) {
@@ -36,7 +36,7 @@ constexpr std::string_view to_string(message_type type) {
         case message_type::block_template: return "Block Template"sv;
         case message_type::random_value_hash: return "Random Value Hash"sv;
         case message_type::random_value: return "Random Value"sv;
-        case message_type::signed_block: return "Signed Block"sv;
+        case message_type::block_signature: return "Block Signature"sv;
     }
     return "Invalid2"sv;
 }
@@ -48,25 +48,31 @@ struct message {
     crypto::signature signature;  // Signs the contents of the message, proving it came from the
                                   // node at quorum_position
 
-    struct {
-        uint16_t validator_bitset;  // Set if type is handshake_bitset, otherwise 0.
-    } handshakes;
+    std::variant<
+            std::monostate,
+            uint16_t,
+            std::string,
+            crypto::hash,
+            cryptonote::pulse_random_value,
+            crypto::signature>
+            payload;  // Contained type dependent on `type`
 
-    struct {
-        std::string blob;
-    } block_template;
+    // clang-format off
+    template <message_type Type>
+    using payload_t =
+        std::conditional_t<Type == message_type::handshake_bitset, uint16_t,
+        std::conditional_t<Type == message_type::block_template, std::string,
+        std::conditional_t<Type == message_type::random_value_hash, crypto::hash,
+        std::conditional_t<Type == message_type::random_value, cryptonote::pulse_random_value,
+        std::conditional_t<Type == message_type::block_signature, crypto::signature, void>>>>>;
+    // clang-format on
 
-    struct {
-        crypto::hash hash;
-    } random_value_hash;
-
-    struct {
-        cryptonote::pulse_random_value value;
-    } random_value;
-
-    struct {
-        crypto::signature signature_of_final_block_hash;
-    } signed_block;
+    template <message_type Type>
+    auto& get() const {
+        static_assert(
+                !std::is_void_v<payload_t<Type>>, "message_type does not have a payload value");
+        return std::get<payload_t<Type>>(payload);
+    }
 };
 
 struct timings {
@@ -78,8 +84,28 @@ struct timings {
     time_point miner_fallback_timestamp;
 };
 
-void main(void* quorumnet_state, cryptonote::core& core);
-void handle_message(void* quorumnet_state, message const& msg);
+// Opaque holder class for the private internal implementation; an external pulse caller constructs
+// this, then calls it like a function (i.e. `operator()`) to deliver new messages, and periodically
+// to trigger stage/round advancement.  The holder is essentially a shared_ptr and so can be copied
+// without duplicating the underlying pulse state.
+class pulse {
+  private:
+    std::shared_ptr<void> impl;
+
+  public:
+    pulse() = default;
+    explicit pulse(cryptonote::core& core);
+
+    // Finishes initialization, taking the quorumnet_state pointer (because quorumnet itself depends
+    // on a pulse object).
+    void init(void* quorumnet_state);
+
+    // The pulse object should be called periodically to check for pulse state advancement (i.e.
+    // from timeouts, next rounds etc.).  It can also be invoked to deliver a message when incoming,
+    // external messages arrive: if `msg` is not nullptr, then the message will be processed before
+    // the state is rechecked (so that incoming messages can immediately trigger state changes).
+    void operator()(const message* msg = nullptr) const;
+};
 
 // Calculate the current Pulse round active depending on the 'time' elapsed since round 0 started
 // for a block. r0_timestamp: The timestamp that round 0 starts at for the desired block (this
@@ -92,11 +118,8 @@ bool convert_time_to_round(
         const time_point& time,
         const time_point& r0_timestamp,
         uint8_t* round);
-bool get_round_timings(
-        const cryptonote::Blockchain& blockchain,
-        uint64_t height,
-        uint64_t prev_timestamp,
-        timings& times);
+std::optional<timings> get_round_timings(
+        const cryptonote::Blockchain& blockchain, uint64_t height, uint64_t prev_timestamp);
 
 }  // namespace pulse
 

--- a/src/cryptonote_core/pulse.h
+++ b/src/cryptonote_core/pulse.h
@@ -48,10 +48,11 @@ struct message {
     crypto::signature signature;  // Signs the contents of the message, proving it came from the
                                   // node at quorum_position
 
+    using block_and_txes = std::pair<std::string, std::vector<std::string>>;
     std::variant<
             std::monostate,
             uint16_t,
-            std::string,
+            block_and_txes,
             crypto::hash,
             cryptonote::pulse_random_value,
             crypto::signature>
@@ -61,16 +62,20 @@ struct message {
     template <message_type Type>
     using payload_t =
         std::conditional_t<Type == message_type::handshake_bitset, uint16_t,
-        std::conditional_t<Type == message_type::block_template, std::string,
+        std::conditional_t<Type == message_type::block_template, block_and_txes,
         std::conditional_t<Type == message_type::random_value_hash, crypto::hash,
         std::conditional_t<Type == message_type::random_value, cryptonote::pulse_random_value,
         std::conditional_t<Type == message_type::block_signature, crypto::signature, void>>>>>;
     // clang-format on
 
     template <message_type Type>
+        requires(!std::is_void_v<payload_t<Type>>)
     auto& get() const {
-        static_assert(
-                !std::is_void_v<payload_t<Type>>, "message_type does not have a payload value");
+        return std::get<payload_t<Type>>(payload);
+    }
+    template <message_type Type>
+        requires(!std::is_void_v<payload_t<Type>>)
+    auto& get() {
         return std::get<payload_t<Type>>(payload);
     }
 };

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3019,7 +3019,9 @@ void service_node_list::verify_block(
             prev_timestamp = blockchain.db().get_block_timestamp(prev_height);
         }
 
-        if (!pulse::get_round_timings(blockchain, height, prev_timestamp, timings))
+        if (auto t = pulse::get_round_timings(blockchain, height, prev_timestamp))
+            timings = std::move(*t);
+        else
             throw oxen::traced<std::runtime_error>{
                     "Failed to query the block data for Pulse timings to validate incoming {} at height {}"_format(
                             block_type, height)};

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -17,9 +17,9 @@ inline constexpr size_t PULSE_QUORUM_ENTROPY_LAG =
         21;  // How many blocks back from the tip of the Blockchain to source entropy for the Pulse
              // quorums.
 
-inline constexpr size_t PULSE_QUORUM_NUM_VALIDATORS = 11;
-inline constexpr size_t PULSE_QUORUM_SIZE = PULSE_QUORUM_NUM_VALIDATORS + 1 /*Leader*/;
-inline constexpr size_t PULSE_BLOCK_REQUIRED_SIGNATURES =
+inline constexpr int PULSE_QUORUM_NUM_VALIDATORS = 11;
+inline constexpr int PULSE_QUORUM_SIZE = PULSE_QUORUM_NUM_VALIDATORS + 1 /*Leader*/;
+inline constexpr int PULSE_BLOCK_REQUIRED_SIGNATURES =
         7;  // A block must have exactly N signatures to be considered properly
 
 static_assert(PULSE_QUORUM_NUM_VALIDATORS >= PULSE_BLOCK_REQUIRED_SIGNATURES);
@@ -31,8 +31,7 @@ static_assert(
 
 constexpr uint16_t pulse_validator_bit_mask() {
     uint16_t result = 0;
-    for (size_t validator_index = 0; validator_index < PULSE_QUORUM_NUM_VALIDATORS;
-         validator_index++)
+    for (int validator_index = 0; validator_index < PULSE_QUORUM_NUM_VALIDATORS; validator_index++)
         result |= 1 << validator_index;
     return result;
 }

--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -255,7 +255,7 @@ bool verify_quorum_signatures(
         const cryptonote::block* block) {
     bool enforce_vote_ordering = true;
     constexpr size_t MAX_QUORUM_SIZE =
-            std::max(CHECKPOINT_QUORUM_SIZE, PULSE_QUORUM_NUM_VALIDATORS);
+            std::max<size_t>(CHECKPOINT_QUORUM_SIZE, PULSE_QUORUM_NUM_VALIDATORS);
     std::array<size_t, MAX_QUORUM_SIZE> unique_vote_set = {};
 
     switch (type) {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1867,7 +1867,8 @@ bool tx_memory_pool::fill_block_template(
         uint64_t& expected_reward,
         hf version,
         uint64_t height,
-        std::optional<uint64_t> l2_max) {
+        std::optional<uint64_t> l2_max,
+        std::vector<std::string>* state_change_txes) {
     auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     total_weight = 0;
@@ -1923,6 +1924,8 @@ bool tx_memory_pool::fill_block_template(
     uint64_t next_reward = 0;
     uint64_t net_fee = 0;
     bl.tx_eth_count = 0;
+    if (state_change_txes)
+        state_change_txes->clear();
 
     for (const auto& pooltx : m_txs_by_priority) {
         const auto& txid = std::get<crypto::hash>(pooltx);
@@ -2036,6 +2039,8 @@ bool tx_memory_pool::fill_block_template(
         bl.tx_hashes.push_back(txid);
         if (meta.l2_height > 0)
             bl.tx_eth_count++;
+        if (tx.type == txtype::state_change && state_change_txes)
+            state_change_txes->push_back(txblob);
         total_weight += meta.weight;
         raw_fee += meta.fee;
         net_fee = next_reward_parts.miner_fee;

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -466,7 +466,8 @@ class tx_memory_pool {
             uint64_t& expected_reward,
             hf version,
             uint64_t height,
-            std::optional<uint64_t> l2_max = std::nullopt);
+            std::optional<uint64_t> l2_max = std::nullopt,
+            std::vector<std::string>* state_change_txes = nullptr);
 
     /**
      * @brief get a list of all transactions in the pool

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -1798,6 +1798,7 @@ namespace {
 
     // Extra fields are intentionally given tags after the common header fields.
     const std::string PULSE_TAG_BLOCK_TEMPLATE = "t";
+    const std::string PULSE_TAG_BLOCK_SUPPLEMENTAL = "tx";
     const std::string PULSE_TAG_VALIDATOR_BITSET = "u";
     const std::string PULSE_TAG_RANDOM_VALUE = "v";
     const std::string PULSE_TAG_RANDOM_VALUE_HASH = "x";
@@ -1853,7 +1854,10 @@ namespace {
 
             case message_type::block_template: {
                 command = PULSE_CMD_SEND_BLOCK_TEMPLATE;
-                data.append(PULSE_TAG_BLOCK_TEMPLATE, msg.get<message_type::block_template>());
+                const auto& [block, supplemental] = msg.get<message_type::block_template>();
+                data.append(PULSE_TAG_BLOCK_TEMPLATE, block);
+                if (!supplemental.empty())
+                    data.append_list(PULSE_TAG_BLOCK_SUPPLEMENTAL, supplemental);
             } break;
 
             case message_type::handshake: command = PULSE_CMD_SEND_VALIDATOR_BIT; [[fallthrough]];
@@ -1971,10 +1975,15 @@ namespace {
         pulse::message msg = pulse_parse_msg_header_fields(
                 pulse::message_type::block_template, data, INVALID_ARG_PREFIX);
 
+        auto& [block_blob, supplemental] = msg.payload.emplace<pulse::message::block_and_txes>();
         if (auto const& tag = PULSE_TAG_BLOCK_TEMPLATE; data.skip_until(tag))
-            msg.payload = data.consume_string();
+            block_blob = data.consume_string();
         else
             throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
+
+        if (data.skip_until(PULSE_TAG_BLOCK_SUPPLEMENTAL))
+            data.consume_list(supplemental);
+        // else missing is fine: it is not sent if empty, or by Oxen nodes older than 11.3
 
         qnet.omq.job(
                 [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());

--- a/src/cryptonote_protocol/quorumnet.cpp
+++ b/src/cryptonote_protocol/quorumnet.cpp
@@ -28,15 +28,18 @@
 
 #include "quorumnet.h"
 
+#include <oxenc/bt_producer.h>
 #include <oxenc/hex.h>
 #include <oxenmq/oxenmq.h>
 #include <time.h>
 
 #include <iterator>
 #include <shared_mutex>
+#include <vector>
 
 #include "common/exception.h"
 #include "common/random.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_core.h"
@@ -86,6 +89,7 @@ namespace {
 
     struct QnetState {
         cryptonote::core& core;
+        pulse::pulse pulse;
         oxenmq::OxenMQ& omq{core.omq()};
 
         // Track submitted blink txes here; unlike the blinks stored in the mempool we store these
@@ -110,11 +114,12 @@ namespace {
         std::condition_variable pulse_message_queue_cv;
         std::queue<pulse::message> pulse_message_queue;
 
-        QnetState(cryptonote::core& core) : core{core} {}
+        QnetState(cryptonote::core& core, pulse::pulse pulse) :
+                core{core}, pulse{std::move(pulse)} {}
 
         static QnetState& from(void* obj) {
             assert(obj);
-            return *reinterpret_cast<QnetState*>(obj);
+            return *static_cast<QnetState*>(obj);
         }
     };
 
@@ -133,8 +138,8 @@ namespace {
 
     void setup_endpoints(cryptonote::core& core, void* obj);
 
-    void* new_qnetstate(cryptonote::core& core) {
-        return new QnetState(core);
+    void* new_qnetstate(cryptonote::core& core, pulse::pulse pulse) {
+        return new QnetState{core, std::move(pulse)};
     }
 
     void delete_qnetstate(void*& obj) {
@@ -240,11 +245,10 @@ namespace {
             cryptonote::core& core,
             std::vector<prepared_relay_destinations> const& destinations,
             std::string_view command,
-            std::string&& data) {
+            std::string_view data) {
         for (auto const& [x25519_string, connect_string] : destinations) {
             log::info(logcat, "Relaying data to {} @ {}", to_hex(x25519_string), connect_string);
-            core.omq().send(
-                    x25519_string, command, std::move(data), send_option::hint{connect_string});
+            core.omq().send(x25519_string, command, data, send_option::hint{connect_string});
         }
     }
 
@@ -372,12 +376,25 @@ namespace {
 
         /// Relays a command and any number of serialized data to everyone we're supposed to relay
         /// to
-        template <typename... T>
-        void relay_to_peers(const std::string_view& cmd, const T&... data) {
-            relay_to_peers_impl(
-                    cmd,
-                    std::array<std::string, sizeof...(T)>{bt_serialize(data)...},
-                    std::make_index_sequence<sizeof...(T)>{});
+        void relay_to_peers(std::string_view cmd, const bt_dict& data) {
+            relay_to_peers(cmd, bt_serialize(data));
+        }
+        void relay_to_peers(std::string_view cmd, const bt_dict_producer& data) {
+            relay_to_peers(cmd, data.view());
+        }
+        void relay_to_peers(std::string_view cmd, std::string_view serialized_data) {
+            for (auto& peer : peers) {
+                log::trace(
+                        logcat,
+                        "Relaying {} to peer {}{}",
+                        cmd,
+                        to_hex(peer.first),
+                        (peer.second.empty() ? " (if connected)"s : " @ " + peer.second));
+                if (peer.second.empty())
+                    omq.send(peer.first, cmd, serialized_data, send_option::optional{});
+                else
+                    omq.send(peer.first, cmd, serialized_data, send_option::hint{peer.second});
+            }
         }
 
       private:
@@ -535,26 +552,6 @@ namespace {
                             my_position[i - 1],
                             my_position[i]);
                 }
-            }
-        }
-
-        /// Relays a command and pre-serialized data to everyone we're supposed to relay to
-        template <size_t N, size_t... I>
-        void relay_to_peers_impl(
-                const std::string_view& cmd,
-                std::array<std::string, N> relay_data,
-                std::index_sequence<I...>) {
-            for (auto& peer : peers) {
-                log::trace(
-                        logcat,
-                        "Relaying {} to peer {}{}",
-                        cmd,
-                        to_hex(peer.first),
-                        (peer.second.empty() ? " (if connected)"s : " @ " + peer.second));
-                if (peer.second.empty())
-                    omq.send(peer.first, cmd, relay_data[I]..., send_option::optional{});
-                else
-                    omq.send(peer.first, cmd, relay_data[I]..., send_option::hint{peer.second});
             }
         }
     };
@@ -1812,7 +1809,7 @@ namespace {
     const std::string PULSE_CMD_BLOCK_TEMPLATE = "block_template";
     const std::string PULSE_CMD_RANDOM_VALUE_HASH = "random_value_hash";
     const std::string PULSE_CMD_RANDOM_VALUE = "random_value";
-    const std::string PULSE_CMD_SIGNED_BLOCK = "signed_block";
+    const std::string PULSE_CMD_BLOCK_SIGNATURE = "signed_block";
     const std::string PULSE_CMD_SEND_VALIDATOR_BITSET =
             PULSE_CMD_CATEGORY + "." + PULSE_CMD_VALIDATOR_BITSET;
     const std::string PULSE_CMD_SEND_VALIDATOR_BIT =
@@ -1823,8 +1820,8 @@ namespace {
             PULSE_CMD_CATEGORY + "." + PULSE_CMD_RANDOM_VALUE_HASH;
     const std::string PULSE_CMD_SEND_RANDOM_VALUE =
             PULSE_CMD_CATEGORY + "." + PULSE_CMD_RANDOM_VALUE;
-    const std::string PULSE_CMD_SEND_SIGNED_BLOCK =
-            PULSE_CMD_CATEGORY + "." + PULSE_CMD_SIGNED_BLOCK;
+    const std::string PULSE_CMD_SEND_BLOCK_SIGNATURE =
+            PULSE_CMD_CATEGORY + "." + PULSE_CMD_BLOCK_SIGNATURE;
 
     void pulse_relay_message_to_quorum(
             void* self,
@@ -1834,56 +1831,58 @@ namespace {
         peer_info::exclude_set relay_exclude;
 
         bool include_block_producer = false;
-        std::string_view command = {};
+        std::string_view command;
 
-        bt_dict data = {};
-        data[PULSE_TAG_SIGNATURE] = tools::view_guts(msg.signature);
-        data[PULSE_TAG_BLOCK_ROUND] = msg.round;
+        using namespace pulse;
 
-        if (msg.type == pulse::message_type::block_template) {
-            command = PULSE_CMD_SEND_BLOCK_TEMPLATE;
-            data[PULSE_TAG_BLOCK_TEMPLATE] = msg.block_template.blob;
-        } else {
-            data[PULSE_TAG_QUORUM_POSITION] = msg.quorum_position;
+        bt_dict_producer data;
+        if (msg.type != message_type::block_template)
+            data.append(PULSE_TAG_QUORUM_POSITION, msg.quorum_position);
+        data.append(PULSE_TAG_BLOCK_ROUND, msg.round);
+        data.append(PULSE_TAG_SIGNATURE, tools::view_guts(msg.signature));
 
-            switch (msg.type) {
-                case pulse::message_type::invalid: assert("Invalid Code Path" == nullptr); break;
+        switch (msg.type) {
+            case message_type::invalid: assert("Invalid Code Path" == nullptr); break;
 
-                case pulse::message_type::signed_block: {
-                    command = PULSE_CMD_SEND_SIGNED_BLOCK;
-                    data[PULSE_TAG_FINAL_BLOCK_SIGNATURE] =
-                            tools::view_guts(msg.signed_block.signature_of_final_block_hash);
-                } break;
+            case message_type::block_signature: {
+                command = PULSE_CMD_SEND_BLOCK_SIGNATURE;
+                data.append(
+                        PULSE_TAG_FINAL_BLOCK_SIGNATURE,
+                        tools::view_guts(msg.get<message_type::block_signature>()));
+            } break;
 
-                case pulse::message_type::block_template: break;
+            case message_type::block_template: {
+                command = PULSE_CMD_SEND_BLOCK_TEMPLATE;
+                data.append(PULSE_TAG_BLOCK_TEMPLATE, msg.get<message_type::block_template>());
+            } break;
 
-                case pulse::message_type::handshake: /* FALLTHRU */
-                case pulse::message_type::handshake_bitset: {
-                    assert(msg.quorum_position < quorum.validators.size());
+            case message_type::handshake: command = PULSE_CMD_SEND_VALIDATOR_BIT; [[fallthrough]];
+            case message_type::handshake_bitset: {
+                assert(msg.quorum_position < quorum.validators.size());
 
-                    include_block_producer = msg.type == pulse::message_type::handshake_bitset;
-                    relay_exclude.insert(quorum.validators[msg.quorum_position]);
+                include_block_producer = msg.type == message_type::handshake_bitset;
+                relay_exclude.insert(quorum.validators[msg.quorum_position]);
 
-                    if (msg.type == pulse::message_type::handshake) {
-                        command = PULSE_CMD_SEND_VALIDATOR_BIT;
-                    } else {
-                        assert(msg.type == pulse::message_type::handshake_bitset);
-                        command = PULSE_CMD_SEND_VALIDATOR_BITSET;
-                        data[PULSE_TAG_VALIDATOR_BITSET] = msg.handshakes.validator_bitset;
-                    }
-                } break;
+                if (msg.type == message_type::handshake_bitset) {
+                    command = PULSE_CMD_SEND_VALIDATOR_BITSET;
+                    data.append(
+                            PULSE_TAG_VALIDATOR_BITSET, msg.get<message_type::handshake_bitset>());
+                }
+            } break;
 
-                case pulse::message_type::random_value_hash: {
-                    command = PULSE_CMD_SEND_RANDOM_VALUE_HASH;
-                    data[PULSE_TAG_RANDOM_VALUE_HASH] =
-                            tools::view_guts(msg.random_value_hash.hash);
-                } break;
+            case message_type::random_value_hash: {
+                command = PULSE_CMD_SEND_RANDOM_VALUE_HASH;
+                data.append(
+                        PULSE_TAG_RANDOM_VALUE_HASH,
+                        tools::view_guts(msg.get<message_type::random_value_hash>()));
+            } break;
 
-                case pulse::message_type::random_value: {
-                    command = PULSE_CMD_SEND_RANDOM_VALUE;
-                    data[PULSE_TAG_RANDOM_VALUE] = tools::view_guts(msg.random_value.value);
-                } break;
-            }
+            case message_type::random_value: {
+                command = PULSE_CMD_SEND_RANDOM_VALUE;
+                data.append(
+                        PULSE_TAG_RANDOM_VALUE,
+                        tools::view_guts(msg.get<message_type::random_value>()));
+            } break;
         }
 
         auto& qnet = QnetState::from(self);
@@ -1891,8 +1890,7 @@ namespace {
             service_nodes::quorum const* quorum_ptr = &quorum;
             auto destinations = peer_prepare_relay_to_quorum_subset(
                     qnet.core, &quorum_ptr, &quorum_ptr + 1, 4 /*num_peers*/);
-            peer_relay_to_prepared_destinations(
-                    qnet.core, destinations, command, bt_serialize(data));
+            peer_relay_to_prepared_destinations(qnet.core, destinations, command, data.view());
         } else {
             peer_info peer_list{
                     qnet,
@@ -1952,14 +1950,13 @@ namespace {
 
         if (bitset) {
             if (auto const& tag = PULSE_TAG_VALIDATOR_BITSET; data.skip_until(tag))
-                msg.handshakes.validator_bitset = data.consume_integer<uint16_t>();
+                msg.payload = data.consume_integer<uint16_t>();
             else
                 throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
-                [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
-                qnet.core.pulse_thread_id());
+                [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());
     }
 
     void handle_pulse_block_template(Message& m, QnetState& qnet) {
@@ -1975,13 +1972,12 @@ namespace {
                 pulse::message_type::block_template, data, INVALID_ARG_PREFIX);
 
         if (auto const& tag = PULSE_TAG_BLOCK_TEMPLATE; data.skip_until(tag))
-            msg.block_template.blob = data.consume_string_view();
+            msg.payload = data.consume_string();
         else
             throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
 
         qnet.omq.job(
-                [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
-                qnet.core.pulse_thread_id());
+                [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());
     }
 
     void handle_pulse_random_value_hash(Message& m, QnetState& qnet) {
@@ -1998,19 +1994,13 @@ namespace {
                 pulse::message_type::random_value_hash, data, INVALID_ARG_PREFIX);
 
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE_HASH; data.skip_until(tag)) {
-            auto str = data.consume_string_view();
-            if (str.size() != sizeof(msg.random_value_hash.hash))
-                throw oxen::traced<std::invalid_argument>(
-                        "Invalid hash data size: " + std::to_string(str.size()));
-
-            std::memcpy(msg.random_value_hash.hash.data(), str.data(), str.size());
+            msg.payload = tools::make_from_guts<crypto::hash>(data.consume_string_view());
         } else {
             throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
-                [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
-                qnet.core.pulse_thread_id());
+                [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());
     }
 
     void handle_pulse_random_value(Message& m, QnetState& qnet) {
@@ -2026,21 +2016,17 @@ namespace {
         pulse::message msg = pulse_parse_msg_header_fields(
                 pulse::message_type::random_value, data, INVALID_ARG_PREFIX);
         if (auto const& tag = PULSE_TAG_RANDOM_VALUE; data.skip_until(tag)) {
-            auto str = data.consume_string_view();
-            if (str.size() != sizeof(msg.random_value.value.data))
-                throw oxen::traced<std::invalid_argument>(
-                        "Invalid data size: " + std::to_string(str.size()));
-            std::memcpy(msg.random_value.value.data, str.data(), str.size());
+            msg.payload = tools::make_from_guts<cryptonote::pulse_random_value>(
+                    data.consume_string_view());
         } else {
             throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
-                [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
-                qnet.core.pulse_thread_id());
+                [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());
     }
 
-    void handle_pulse_signed_block(Message& m, QnetState& qnet) {
+    void handle_pulse_block_signature(Message& m, QnetState& qnet) {
         if (m.data.size() != 1)
             throw oxen::traced<std::runtime_error>{
                     "Rejecting pulse signed block expected one data entry not {}"_format(
@@ -2050,19 +2036,17 @@ namespace {
                 "Invalid pulse signed block: missing required field '"sv;
         bt_dict_consumer data{m.data[0]};
         pulse::message msg = pulse_parse_msg_header_fields(
-                pulse::message_type::signed_block, data, INVALID_ARG_PREFIX);
+                pulse::message_type::block_signature, data, INVALID_ARG_PREFIX);
 
         if (auto const& tag = PULSE_TAG_FINAL_BLOCK_SIGNATURE; data.skip_until(tag)) {
             auto sig_str = data.consume_string_view();
-            msg.signed_block.signature_of_final_block_hash =
-                    convert_string_view_bytes_to_signature(sig_str);
+            msg.payload = convert_string_view_bytes_to_signature(sig_str);
         } else {
             throw oxen::traced<std::invalid_argument>{"{}{}'"_format(INVALID_ARG_PREFIX, tag)};
         }
 
         qnet.omq.job(
-                [&qnet, data = std::move(msg)]() { pulse::handle_message(&qnet, data); },
-                qnet.core.pulse_thread_id());
+                [&qnet, msg = std::move(msg)] { qnet.pulse(&msg); }, qnet.core.pulse_thread_id());
     }
 
 }  // namespace
@@ -2133,8 +2117,8 @@ namespace {
                     .add_command(
                             PULSE_CMD_RANDOM_VALUE,
                             [&qnet](Message& m) { handle_pulse_random_value(m, qnet); })
-                    .add_command(PULSE_CMD_SIGNED_BLOCK, [&qnet](Message& m) {
-                        handle_pulse_signed_block(m, qnet);
+                    .add_command(PULSE_CMD_BLOCK_SIGNATURE, [&qnet](Message& m) {
+                        handle_pulse_block_signature(m, qnet);
                     });
         }
 

--- a/src/cryptonote_protocol/quorumnet.h
+++ b/src/cryptonote_protocol/quorumnet.h
@@ -30,8 +30,6 @@
 
 // This file (plus .cpp) contains the glue layer between cryptonote_core and oxen-mq.
 
-#include <vector>
-
 namespace service_nodes {
 struct quorum_vote_t;
 };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -342,7 +342,7 @@ bool daemon::run(bool interactive) {
         while (!stop_sig)
             std::this_thread::sleep_for(100ms);
         if (shutdown) {
-            log::error(logcat, "Signal received; shutting down...");
+            log::warning(logcat, "Signal received; shutting down...");
             stop();
         }
     }};

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1620,20 +1620,35 @@ void core_rpc_server::invoke(GET_BLOCK_HEADER_BY_HASH& gbh, rpc_context context)
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
         GET_BLOCK_HEADERS_RANGE& get_block_headers_range, rpc_context context) {
-    const uint64_t bc_height = m_core.blockchain.get_current_blockchain_height();
-    uint64_t start_height = get_block_headers_range.request.start_height;
-    uint64_t end_height = get_block_headers_range.request.end_height;
-    if (start_height >= bc_height)
+    const int64_t bc_height =
+            static_cast<int64_t>(m_core.blockchain.get_current_blockchain_height());
+    const auto& req = get_block_headers_range.request;
+    int64_t start_height = req.start_height;
+    int64_t end_height = req.end_height;
+    if (start_height >= bc_height || -start_height > bc_height)
         throw rpc_error{
                 ERROR_TOO_BIG_HEIGHT,
                 "Invalid start_height: {} exceeds top block height {}"_format(
                         start_height, bc_height - 1)};
-    if (end_height >= bc_height)
+    if (start_height < 0)
+        start_height = bc_height + start_height;
+    if (end_height >= bc_height || -end_height > bc_height)
         throw rpc_error{
                 ERROR_TOO_BIG_HEIGHT,
                 "Invalid end_height: {} exceeds top block height {}"_format(
                         end_height, bc_height - 1)};
-    for (uint64_t h = start_height; h <= end_height; ++h) {
+    if (end_height < 0)
+        end_height = bc_height + end_height;
+    if (start_height > end_height)
+        throw rpc_error{
+                ERROR_TOO_BIG_HEIGHT,
+                "Invalid start/end heights: end_height cannot be less than start_height."};
+    if (end_height - start_height >= GET_BLOCK_HEADERS_RANGE::MAX_COUNT)
+        throw rpc_error{
+                ERROR_TOO_BIG_HEIGHT,
+                "Invalid start/end heights: requested range of {} blocks exceeds limit {}"_format(
+                        end_height - start_height + 1, GET_BLOCK_HEADERS_RANGE::MAX_COUNT)};
+    for (int64_t h = start_height; h <= end_height; ++h) {
         block blk;
         size_t block_size;
         bool have_block = m_core.blockchain.get_block_by_height(h, blk, &block_size);
@@ -1647,8 +1662,8 @@ void core_rpc_server::invoke(
                 false,
                 std::nullopt,
                 get_block_hash(blk),
-                get_block_headers_range.request.fill_pow_hash && context.admin,
-                get_block_headers_range.request.get_tx_hashes,
+                req.fill_pow_hash && context.admin,
+                req.get_tx_hashes,
                 get_block_headers_range.response["headers"].emplace_back(),
                 get_block_headers_range.is_bt(),
                 m_core);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -234,12 +234,12 @@ void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
     info.response["hard_fork"] = m_core.blockchain.get_network_version();
 
     bool next_block_is_pulse = false;
-    if (pulse::timings t; pulse::get_round_timings(bs, height, top_block.timestamp, t)) {
+    if (auto t = pulse::get_round_timings(bs, height, top_block.timestamp)) {
         info.response["pulse_ideal_timestamp"] =
-                tools::to_seconds(t.ideal_timestamp.time_since_epoch());
+                tools::to_seconds(t->ideal_timestamp.time_since_epoch());
         info.response["pulse_target_timestamp"] =
-                tools::to_seconds(t.r0_timestamp.time_since_epoch());
-        next_block_is_pulse = pulse::clock::now() < t.miner_fallback_timestamp;
+                tools::to_seconds(t->r0_timestamp.time_since_epoch());
+        next_block_is_pulse = pulse::clock::now() < t->miner_fallback_timestamp;
     }
 
     if (cryptonote::checkpoint_t checkpoint; db.get_immutable_checkpoint(&checkpoint, top_height)) {
@@ -2438,11 +2438,12 @@ void core_rpc_server::invoke(GET_QUORUM_STATE& get_quorum_state, rpc_context con
         const auto& blockchain = m_core.blockchain;
         const auto& top_header = blockchain.db().get_block_header_from_height(curr_height - 1);
 
-        pulse::timings next_timings{};
         uint8_t pulse_round = 0;
-        if (pulse::get_round_timings(blockchain, curr_height, top_header.timestamp, next_timings) &&
+        if (auto next_timings =
+                    pulse::get_round_timings(blockchain, curr_height, top_header.timestamp);
+            next_timings &&
             pulse::convert_time_to_round(
-                    nettype(), pulse::clock::now(), next_timings.r0_timestamp, &pulse_round)) {
+                    nettype(), pulse::clock::now(), next_timings->r0_timestamp, &pulse_round)) {
             auto entropy =
                     service_nodes::get_pulse_entropy_for_next_block(blockchain.db(), pulse_round);
             auto& sn_list = m_core.service_node_list;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3105,7 +3105,7 @@ void core_rpc_server::fill_sn_response_entry(
             } else
                 c["address"] = cryptonote::get_account_address_as_str(
                         m_core.get_nettype(), false /*subaddress*/, contributor.address);
-            if (contributor.reserved != contributor.amount)
+            if (contributor.reserved && contributor.reserved != contributor.amount)
                 c["reserved"] = contributor.reserved;
             if (want_locked_c) {
                 auto& locked = (c["locked_contributions"] = json::array());

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1491,27 +1491,27 @@ static void fill_block_header_response(
         std::optional<uint64_t> maybe_height,
         const crypto::hash& hash,
         bool fill_pow_hash,
-        bool get_tx_hashes,
+        bool tx_hashes_and_sigs,
         nlohmann::json& response,
         bool is_bt,
         cryptonote::core& core) {
 
     auto& db = core.blockchain.db();
 
-    tools::json_binary_proxy response_hex{
-            response,
-            is_bt ? tools::json_binary_proxy::fmt::bt : tools::json_binary_proxy::fmt::hex};
+    auto binfmt = is_bt ? tools::json_binary_proxy::fmt::bt : tools::json_binary_proxy::fmt::hex;
+
+    serialization::json_archiver ar{binfmt};
+    serialize(ar, const_cast<block&>(blk));
+    response = std::move(ar).json();
+    tools::json_binary_proxy response_hex{response, binfmt};
 
     uint64_t height = maybe_height ? *maybe_height : blk.get_height();
-
-    response["major_version"] = static_cast<uint8_t>(blk.major_version);
-    response["minor_version"] = static_cast<uint8_t>(blk.minor_version);
-    response["timestamp"] = blk.timestamp;
-    response_hex["prev_hash"] = blk.prev_id;
-    response["nonce"] = blk.nonce;
-    response["orphan_status"] = orphan_status;
-    response["height"] = height;
+    if (!response.count("height"))
+        response["height"] = height;
     response["depth"] = core.blockchain.get_current_blockchain_height() - height - 1;
+    response["prev_hash"] = std::move(response["prev_id"]);
+    response.erase("prev_id");
+    response["orphan_status"] = orphan_status;
     response_hex["hash"] = hash;
     response["difficulty"] = core.blockchain.block_difficulty(height);
     response["cumulative_difficulty"] = db.get_block_cumulative_difficulty(height);
@@ -1519,9 +1519,10 @@ static void fill_block_header_response(
     response["block_weight"] = weight;
     response["block_size"] = block_size + weight;
     auto coinbase = get_block_coinbase_payouts(blk);
-    response["coinbase_payouts"] = coinbase;
-    response["reward"] =
-            blk.major_version >= cryptonote::hf::hf19_reward_batching ? blk.reward : coinbase;
+    if (blk.major_version < cryptonote::hf::hf21_eth)
+        response["coinbase_payouts"] = coinbase;
+    if (blk.major_version < cryptonote::hf::hf19_reward_batching)
+        response["reward"] = coinbase;
     response["num_txes"] = blk.tx_hashes.size();
     if (fill_pow_hash)
         response_hex["pow_hash"] = get_block_longhash_w_blockchain(
@@ -1530,20 +1531,19 @@ static void fill_block_header_response(
     if (blk.major_version < feature::ETH_BLS)
         response_hex["service_node_winner"] =
                 cryptonote::get_service_node_winner_from_tx_extra(blk.miner_tx.value().extra);
-    else
-        response_hex["service_node_winner_tail"] = blk.sn_winner_tail;
-    if (blk.major_version >= cryptonote::feature::ETH_BLS) {
-        response["l2_height"] = blk.l2_height;
-        response["l2_reward"] = blk.l2_reward;
-        response["l2_votes"] = blk.l2_votes;
+    else {
+        response["service_node_winner_tail"] = std::move(response["sn_winner_tail"]);
+        response.erase("sn_winner_tail");
     }
+    response.erase("miner_tx");
     if (blk.miner_tx) {
         response_hex["miner_tx_hash"] = cryptonote::get_transaction_hash(*blk.miner_tx);
         response["miner_tx_outs"] = blk.miner_tx->vout.size();
     }
-    if (get_tx_hashes)
-        for (const auto& tx_hash : blk.tx_hashes)
-            response_hex["tx_hashes"].push_back(tx_hash);
+    if (!tx_hashes_and_sigs) {
+        response.erase("tx_hashes");
+        response.erase("signatures");
+    }
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(GET_LAST_BLOCK_HEADER& get_last_block_header, rpc_context context) {
@@ -1752,11 +1752,12 @@ void core_rpc_server::invoke(GET_BLOCK& get_block, rpc_context context) {
             block_height,
             block_hash,
             get_block.request.fill_pow_hash && context.admin,
-            false /*tx hashes*/,
+            true /*tx hashes*/,
             get_block.response["block_header"],
             get_block.is_bt(),
             m_core);
-    get_block.response_hex["tx_hashes"] = blk.tx_hashes;
+    get_block.response["tx_hashes"] = std::move(get_block.response["block_header"]["tx_hashes"]);
+    get_block.response["block_header"].erase("tx_hashes");
     get_block.response_hex["blob"] = t_serializable_object_to_blob(blk);
     get_block.response["json"] = obj_to_json_str(blk);
     get_block.response["status"] = STATUS_OK;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -684,12 +684,18 @@ namespace {
         auto& _state_change(const T& x) {
             // Common loading code for nearly-identical state_change and deregister_old variables:
             auto voters = json::array();
-            for (auto& v : x.votes)
+            auto sigs = json::array();
+            json_binary_proxy sigs_hex{sigs, format};
+
+            for (auto& v : x.votes) {
                 voters.push_back(v.validator_index);
+                sigs_hex.push_back(v.signature);
+            }
 
             json sc{{"height", x.block_height},
                     {"index", x.service_node_index},
-                    {"voters", std::move(voters)}};
+                    {"voters", std::move(voters)},
+                    {"signatures", std::move(sigs)}};
             return set("sn_state_change", std::move(sc));
         }
         void operator()(const tx_extra_service_node_deregister_old& x) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1623,8 +1623,16 @@ void core_rpc_server::invoke(
     const uint64_t bc_height = m_core.blockchain.get_current_blockchain_height();
     uint64_t start_height = get_block_headers_range.request.start_height;
     uint64_t end_height = get_block_headers_range.request.end_height;
-    if (start_height >= bc_height || end_height >= bc_height || start_height > end_height)
-        throw rpc_error{ERROR_TOO_BIG_HEIGHT, "Invalid start/end heights."};
+    if (start_height >= bc_height)
+        throw rpc_error{
+                ERROR_TOO_BIG_HEIGHT,
+                "Invalid start_height: {} exceeds top block height {}"_format(
+                        start_height, bc_height - 1)};
+    if (end_height >= bc_height)
+        throw rpc_error{
+                ERROR_TOO_BIG_HEIGHT,
+                "Invalid end_height: {} exceeds top block height {}"_format(
+                        end_height, bc_height - 1)};
     for (uint64_t h = start_height; h <= end_height; ++h) {
         block blk;
         size_t block_size;
@@ -1705,21 +1713,20 @@ void core_rpc_server::invoke(GET_BLOCK& get_block, rpc_context context) {
                             get_block.request.hash)};
         if (!m_core.blockchain.get_block_by_hash(block_hash, blk, &block_size, &orphan))
             throw rpc_error{
-                    ERROR_INTERNAL,
-                    "Internal error: can't get block by hash. Hash = {}."_format(
-                            get_block.request.hash)};
+                    ERROR_ID_NOT_FOUND,
+                    "Requested block hash: {} not found"_format(get_block.request.hash)};
     } else {
+        auto req_height = get_block.request.height.value();
         if (auto curr_height = m_core.blockchain.get_current_blockchain_height();
-            get_block.request.height >= curr_height)
+            req_height >= curr_height)
             throw rpc_error{
                     ERROR_TOO_BIG_HEIGHT,
                     "Requested block height: {} greater than current top block height: {}"_format(
-                            get_block.request.height, curr_height - 1)};
-        if (!m_core.blockchain.get_block_by_height(get_block.request.height, blk, &block_size))
+                            req_height, curr_height - 1)};
+        if (!m_core.blockchain.get_block_by_height(*get_block.request.height, blk, &block_size))
             throw rpc_error{
                     ERROR_INTERNAL,
-                    "Internal error: can't get block by height. Height = {}."_format(
-                            get_block.request.height)};
+                    "Internal error: can't get block by height. Height = {}."_format(req_height)};
         block_hash = get_block_hash(blk);
         block_height = get_block.request.height;
     }

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -229,7 +229,7 @@ void parse_request(SUBMIT_TRANSACTION& tx, rpc_input in) {
 }
 
 void parse_request(GET_BLOCK_HASH& bh, rpc_input in) {
-    get_values(in, "heights", bh.request.heights);
+    get_values(in, "heights", required{bh.request.heights});
 
     if (bh.request.heights.size() > bh.MAX_HEIGHTS)
         throw std::domain_error{"Error: too many block heights requested at once"};
@@ -365,6 +365,13 @@ void parse_request(GET_BLOCK_HEADER_BY_HASH& get_block_header_by_hash, rpc_input
             get_block_header_by_hash.request.hash,
             "hashes",
             get_block_header_by_hash.request.hashes);
+
+    if (get_block_header_by_hash.request.hash.empty() &&
+        get_block_header_by_hash.request.hashes.empty())
+        throw std::invalid_argument{"Error: No hash/hashes parameter given"};
+    if (get_block_header_by_hash.request.hashes.size() > GET_BLOCK_HEADERS_RANGE::MAX_COUNT)
+        throw std::invalid_argument{
+                "Error: no more than 1000 block headers may be requested at once"};
 }
 
 void parse_request(SET_BANS& set_bans, rpc_input in) {
@@ -378,17 +385,23 @@ void parse_request(SET_BANS& set_bans, rpc_input in) {
             required{set_bans.request.seconds});
 }
 
-void parse_request(GET_BLOCK_HEADERS_RANGE& get_block_headers_range, rpc_input in) {
+void parse_request(GET_BLOCK_HEADERS_RANGE& gbhr, rpc_input in) {
     get_values(
             in,
             "end_height",
-            get_block_headers_range.request.end_height,
+            required{gbhr.request.end_height},
             "fill_pow_hash",
-            get_block_headers_range.request.fill_pow_hash,
+            gbhr.request.fill_pow_hash,
             "get_tx_hashes",
-            get_block_headers_range.request.get_tx_hashes,
+            gbhr.request.get_tx_hashes,
             "start_height",
-            get_block_headers_range.request.start_height);
+            required{gbhr.request.start_height});
+
+    if (gbhr.request.end_height >= gbhr.request.start_height + gbhr.MAX_HEIGHTS)
+        throw std::invalid_argument{
+                "Error: no more than 1000 block headers may be requested at once"};
+    if (gbhr.request.end_height < gbhr.request.start_height)
+        throw std::invalid_argument{"Error: end_height cannot be less than start_height"};
 }
 
 void parse_request(GET_BLOCK_HEADER_BY_HEIGHT& get_block_header_by_height, rpc_input in) {
@@ -402,6 +415,14 @@ void parse_request(GET_BLOCK_HEADER_BY_HEIGHT& get_block_header_by_height, rpc_i
             get_block_header_by_height.request.height,
             "heights",
             get_block_header_by_height.request.heights);
+
+    if (!get_block_header_by_height.request.height &&
+        get_block_header_by_height.request.heights.empty())
+        throw std::invalid_argument{
+                "Error: Either height or heights parameter must be given but are missing"};
+    if (get_block_header_by_height.request.heights.size() > GET_BLOCK_HEADERS_RANGE::MAX_COUNT)
+        throw std::invalid_argument{
+                "Error: no more than 1000 block headers may be requested at once"};
 }
 
 void parse_request(GET_BLOCK& get_block, rpc_input in) {
@@ -413,6 +434,8 @@ void parse_request(GET_BLOCK& get_block, rpc_input in) {
             get_block.request.hash,
             "height",
             get_block.request.height);
+    if (!get_block.request.hash.empty() == get_block.request.height.has_value())
+        throw std::invalid_argument{"Error: Exactly one of hash or height must be specified"};
 }
 
 void parse_request(GET_OUTPUT_HISTOGRAM& get_output_histogram, rpc_input in) {

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -396,12 +396,6 @@ void parse_request(GET_BLOCK_HEADERS_RANGE& gbhr, rpc_input in) {
             gbhr.request.get_tx_hashes,
             "start_height",
             required{gbhr.request.start_height});
-
-    if (gbhr.request.end_height >= gbhr.request.start_height + gbhr.MAX_HEIGHTS)
-        throw std::invalid_argument{
-                "Error: no more than 1000 block headers may be requested at once"};
-    if (gbhr.request.end_height < gbhr.request.start_height)
-        throw std::invalid_argument{"Error: end_height cannot be less than start_height"};
 }
 
 void parse_request(GET_BLOCK_HEADER_BY_HEIGHT& get_block_header_by_height, rpc_input in) {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1059,8 +1059,11 @@ struct GET_CONNECTIONS : NO_ARGS {
 ///
 /// Inputs:
 ///
-/// - `start_height` -- The starting block's height.
+/// - `start_height` -- The starting block's height.  If negative then the value means relative to
+///   the current chain height (e.g. "start_height": -10, "end_height": -1 would request the last 10
+///   blocks).
 /// - `end_height` -- The ending block's height (inclusive).  Must be less than start_height + 1000.
+///   Negative values are relative to the current chain height.
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
 /// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
 ///   transactions
@@ -1083,11 +1086,11 @@ struct GET_BLOCK_HEADERS_RANGE : PUBLIC {
     }
 
     // Used for this endpoint as well as the by_hash/by_height versions.
-    static constexpr size_t MAX_COUNT = 1000;
+    static constexpr int64_t MAX_COUNT = 1000;
 
     struct request_parameters {
-        uint64_t start_height;
-        uint64_t end_height;
+        int64_t start_height;
+        int64_t end_height;
         bool fill_pow_hash;
         bool get_tx_hashes;
     } request;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -664,8 +664,8 @@ struct GET_BLOCK_HASH : PUBLIC {
 ///
 /// Inputs:
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
-/// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
-///   transactions
+/// - `get_tx_hashes` -- If true (default false) then include some extra info: hashes of
+///   non-coinbase transactions, and pulse quorum block signatures.
 ///
 /// Outputs:
 ///
@@ -724,8 +724,8 @@ struct GET_LAST_BLOCK_HEADER : PUBLIC {
 /// - `hash` -- The block's hash.
 /// - `hashes` -- Request multiple blocks via an array of hashes
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
-/// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
-///   transactions
+/// - `get_tx_hashes` -- If true (default false) then include some extra info: hashes of
+///   non-coinbase transactions, and pulse quorum block signatures.
 ///
 /// Outputs:
 ///
@@ -755,8 +755,8 @@ struct GET_BLOCK_HEADER_BY_HASH : PUBLIC {
 /// - `height` -- A block height to look up; returned in `block_header`
 /// - `heights` -- Block heights to retrieve; returned in `block_headers`
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
-/// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
-///   transactions
+/// - `get_tx_hashes` -- If true (default false) then include some extra info: hashes of
+///   non-coinbase transactions, and pulse quorum block signatures.
 ///
 /// Outputs:
 ///
@@ -1065,8 +1065,8 @@ struct GET_CONNECTIONS : NO_ARGS {
 /// - `end_height` -- The ending block's height (inclusive).  Must be less than start_height + 1000.
 ///   Negative values are relative to the current chain height.
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
-/// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
-///   transactions
+/// - `get_tx_hashes` -- If true (default false) then include some extra info: hashes of
+///   non-coinbase transactions, and pulse quorum block signatures.
 ///
 /// Outputs:
 ///

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -809,7 +809,7 @@ struct GET_BLOCK : PUBLIC {
 
     struct request_parameters {
         std::string hash;
-        uint64_t height;
+        std::optional<uint64_t> height;
         bool fill_pow_hash;
     } request;
 };
@@ -1060,7 +1060,7 @@ struct GET_CONNECTIONS : NO_ARGS {
 /// Inputs:
 ///
 /// - `start_height` -- The starting block's height.
-/// - `end_height` -- The ending block's height.
+/// - `end_height` -- The ending block's height (inclusive).  Must be less than start_height + 1000.
 /// - `fill_pow_hash` -- Tell the daemon if it should fill out pow_hash field.
 /// - `get_tx_hashes` -- If true (default false) then include the hashes of non-coinbase
 ///   transactions
@@ -1081,6 +1081,9 @@ struct GET_BLOCK_HEADERS_RANGE : PUBLIC {
     static constexpr auto names() {
         return NAMES("get_block_headers_range", "getblockheadersrange");
     }
+
+    // Used for this endpoint as well as the by_hash/by_height versions.
+    static constexpr size_t MAX_COUNT = 1000;
 
     struct request_parameters {
         uint64_t start_height;

--- a/src/rpc/core_rpc_server_error_codes.h
+++ b/src/rpc/core_rpc_server_error_codes.h
@@ -40,6 +40,6 @@ constexpr int16_t ERROR_WRONG_PARAM = -1, ERROR_TOO_BIG_HEIGHT = -2,
                   ERROR_CORE_BUSY = -9, ERROR_WRONG_BLOCKBLOB_SIZE = -10,
                   ERROR_UNSUPPORTED_RPC = -11, ERROR_MINING_TO_SUBADDRESS = -12,
                   ERROR_REGTEST_REQUIRED = -13, ERROR_BLS_SIG = -14, ERROR_NO_L2_TRACKER = -15,
-                  ERROR_NOT_A_SERVICE_NODE = -16;
+                  ERROR_NOT_A_SERVICE_NODE = -16, ERROR_ID_NOT_FOUND = -17;
 
 }  // namespace cryptonote::rpc


### PR DESCRIPTION
This PR takes a deep dive into pulse to improve the late stage handling that caused significant blockchain stalls around the HF20 hard fork, and is a more robust version of the workaround added in #1834.

Full details are in the commit messages.

In a nutshell, this allows the pulse "late stage" (that is: everything after receiving the block template) to restart, potentially multiple times, if one or more validators doesn't complete the stage.

This necessitated changing the pulse stage timing, and so does not activate until HF21.

It also reworks various bits of the internal pulse code to make the code easier to work with.

This PR also speeds up pulse by allowing pulse to wake up whenever a pulse message is received, while previously it only checked for messages every 500ms (and so as a result, *each stage* even an all-good quorum, adds typical delays of nearly 3s to the overall process because of the need to wait for the last validator's 500ms timer to fire in each stage before everything propagates).

This branch has been running well on testnet for several days, including on a different version of the branch that deliberately induces random drop outs of some nodes during diffferent parts of the late stage; the dropout is now handled gracefully, attributing a missed pulse bit to the node in question, without falling back to backup rounds due to quorum failures.  This branch is also successfully running on mainnet nodes, with verified successful participation and signing of pulse blocks.

While testing this, we still found some occasional pulse quorum backup rounds uncovered a more serious (and long standing) bug in pulse where a pulse validator would fail to add the block to its own chain (and thus also fail to propagate it) when the block references state change txes (decomms, recomms, etc.) for which it received votes in a different order than the producer.  What happens is the validators producing an error at the very end of the pulse ceremony of:

    [txpool:error|cryptonote_core/tx_pool.cpp:XXXX] Failed to find tx in txpool

because, indeed, that validator does not have the  tx referenced in the block in its mempool: instead it has an equivalent tx with a different set of first-received signatures, and thus with a different hash.  Because pulse block template transmission does not include any transactions (unless regular p2p block propagation), this meant that such a validator would neither add nor propagate the block, and if *none* of the validators got votes in the same order as the block producer, the round would fail because no one propagates the block.

The fixes the issue by adding any state change txes alongside the block template message, and having validators add those to their mempool immediately before adding the block.

While testing all of this I also ran into various related small issues and annoyances and fixed them as well.