### PR TITLE
Oxen 11.3 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 11.3.0
+    VERSION 11.3.1
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Landing")
 # Version update notes:

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -61,6 +61,7 @@
 #include "cryptonote_core/service_node_rules.h"
 #include "epee/int-util.h"
 #include "epee/string_tools.h"
+#include "networks.h"
 #include "oxen_economy.h"
 #include "rpc/core_rpc_server_commands_defs.h"
 
@@ -2845,16 +2846,16 @@ bool rpc_command_executor::prepare_eth_registration(
                 ed_sig.substr(0, 64),
                 ed_sig.substr(64));
     } else {
+        auto nettype =
+                cryptonote::network_type_from_string(info["nettype"].get<std::string_view>());
         if (url.empty())
-            url = get_config(cryptonote::network_type_from_string(
-                                     info["nettype"].get<std::string_view>()))
-                          .DEFAULT_STAKING_URL;
+            url = get_config(nettype).DEFAULT_STAKING_URL;
 
         if (url.empty()) {
             tools::fail_msg_writer(
                     "Unable to submit L2 staking information: '{}' network has no default staking "
                     "URL",
-                    info["nettype"].get<std::string_view>());
+                    cryptonote::network_type_to_string(nettype));
             return false;
         }
 
@@ -2869,6 +2870,7 @@ bool rpc_command_executor::prepare_eth_registration(
         tools::msg_writer("Submitting L2 staking information to {} ...", url);
 
         auto msg = cpr::Multipart{
+                {"network"s, std::string{cryptonote::network_type_to_string(nettype)}},
                 {"sig_ed25519"s, ed_sig},
                 {"pubkey_bls"s, bls_pubkey},
                 {"sig_bls"s, bls_sig},

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -602,6 +602,11 @@ void L2Tracker::generate_purge_transactions() {
         return;
     }
 
+    if (purge_state.in_contract.empty()) {
+        log::debug(logcat, "Skipping purge tx creation: service node list is entirely empty");
+        return;
+    }
+
     // We only add nodes in the mempool here, on a fresh fetch of data.  It's possible that
     // conditions change that make it purgeable before our next fetch, but if so that's okay: it'll
     // get to live slightly longer to next update but we'll catch it then.
@@ -695,6 +700,7 @@ void L2Tracker::update_purge_list(bool curr_height_fallback) {
 
                     auto result_hex = maybe_result->get<std::string_view>();
                     std::vector<std::pair<uint64_t, bls_public_key>> result;
+                    bool failed = false;
                     try {
                         result = RewardsContract::parse_all_service_node_ids(result_hex);
                     } catch (const std::exception& e) {
@@ -704,9 +710,10 @@ void L2Tracker::update_purge_list(bool curr_height_fallback) {
                                 "{}: {}",
                                 purge_height,
                                 e.what());
+                        failed = true;
                     }
 
-                    if (!result.empty()) {
+                    if (!failed) {
                         purge_state.in_contract.clear();
                         for (const auto& [id, blspk] : result)
                             purge_state.in_contract.insert(blspk);

--- a/src/network_config/stagenet.h
+++ b/src/network_config/stagenet.h
@@ -84,8 +84,6 @@ inline constexpr network_config config{
         .L2_TRACKER_SAFE_BLOCKS = mainnet::config.L2_TRACKER_SAFE_BLOCKS,
         .L2_NODE_LIST_PURGE_BLOCKS = testnet::config.L2_NODE_LIST_PURGE_BLOCKS,
         .L2_NODE_LIST_PURGE_MIN_OXEN_AGE = testnet::config.L2_NODE_LIST_PURGE_MIN_OXEN_AGE,
-        // FIXME: once mainnet is close to launching this will move to an alternative
-        // stagenet-specific URL and stake.getsession.org will be used for mainnet staking:
-        .DEFAULT_STAKING_URL = "https://stake.getsession.org"sv,
+        .DEFAULT_STAKING_URL = "https://testnet.stake.getsession.org"sv,
 };
 }  // namespace cryptonote::config::stagenet


### PR DESCRIPTION
- fix a verbose warning caused by the contracts being empty
- update the stagenet staking website URL, and pass along the network type so the backend can figure it out