### PR TITLE
Add optional cooldown to L2 tracker update logs

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -87,6 +87,9 @@ inline constexpr auto ETH_L2_DEFAULT_REQUEST_TIMEOUT = 5s;
 // used to retrieve the logs.  Can be adjusted at runtime using the --l2-max-logs command
 // line/config file setting.
 inline constexpr auto ETH_L2_DEFAULT_MAX_LOGS = 1000;
+// The default value for the minimum time between ethereum log update requests.  Can be adjusted
+// at runtime using the --l2-update-cooldown command line/config file setting.
+inline constexpr auto ETH_L2_DEFAULT_UPDATE_COOLDOWN = 0s;
 // When refreshing, this controls how often we get heights from *all* configured L2 providers
 // (instead of just the primary one) to check whether L2 providers are in sync.  (This only applies
 // when multiple L2 providers are in use).

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -175,6 +175,10 @@ static const command_line::arg_descriptor<int> arg_l2_max_logs = {
         "Specify the maximum number of logs we will request at once in a single request to the L2 "
         "provider.  If more logs are needed than this at once then multiple requests will be used.",
         ETH_L2_DEFAULT_MAX_LOGS};
+static const command_line::arg_descriptor<double> arg_l2_update_cooldown = {
+        "l2-update-cooldown",
+        "Specify the minimum time between log update requests to the L2 provider.",
+        dseconds{ETH_L2_DEFAULT_UPDATE_COOLDOWN}.count()};
 static const command_line::arg_descriptor<double> arg_l2_check_interval = {
         "l2-check-interval",
         "When multiple L2 providers are specified, this specifies how often (in seconds) all of "
@@ -190,11 +194,6 @@ static const command_line::arg_flag arg_l2_skip_chainid = {
         "l2-skip-chainid",
         "Skips the oxend startup chainId check that ensures the configured L2 provider(s) are "
         "providing data for the the correct L2 chain."};
-static const command_line::arg_flag arg_l2_skip_proof_check = {
-        "l2-skip-proof-check",
-        "Skips the requirement in HF20 that we have heard from the L2 provider recently before "
-        "sending an uptime proof.  This is a temporary option that will be removed after the HF20 "
-        "transition period."};
 static const command_line::arg_descriptor<std::string> arg_l2_proxy = {
         "l2-proxy",
         "Enables this node to act as an L2 state proxy.  This option takes a filename containing "
@@ -358,7 +357,6 @@ void core::init_options(boost::program_options::options_description& desc) {
     command_line::add_arg(desc, arg_l2_check_interval);
     command_line::add_arg(desc, arg_l2_check_threshold);
     command_line::add_arg(desc, arg_l2_skip_chainid);
-    command_line::add_arg(desc, arg_l2_skip_proof_check);
     command_line::add_arg(desc, arg_l2_proxy);
     command_line::add_arg(desc, arg_l2_oxend);
     command_line::add_arg(desc, arg_storage_server_port);
@@ -750,7 +748,11 @@ bool core::init(
             l2_refresh = as_duration<std::chrono::milliseconds>(
                     command_line::get_arg(vm, arg_l2_refresh));
 
-        m_l2_tracker = std::make_unique<eth::L2Tracker>(*this, l2_refresh);
+        m_l2_tracker = std::make_unique<eth::L2Tracker>(
+                *this,
+                l2_refresh,
+                as_duration<std::chrono::milliseconds>(
+                        command_line::get_arg(vm, arg_l2_update_cooldown)));
 
         m_l2_tracker->provider->setTimeout(as_duration<std::chrono::milliseconds>(
                 1000 * command_line::get_arg(vm, arg_l2_timeout)));
@@ -866,9 +868,6 @@ bool core::init(
     // it being configured correctly
     if (m_nettype == network_type::FAKECHAIN && !m_l2_tracker)
         m_l2_tracker = std::make_unique<eth::L2Tracker>(*this);
-
-    // TODO: remove this after HF21
-    m_skip_proof_l2_check = command_line::get_arg(vm, arg_l2_skip_proof_check);
 
     r = blockchain.init(
             std::move(db),

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -356,6 +356,7 @@ void core::init_options(boost::program_options::options_description& desc) {
     command_line::add_arg(desc, arg_l2_max_logs);
     command_line::add_arg(desc, arg_l2_check_interval);
     command_line::add_arg(desc, arg_l2_check_threshold);
+    command_line::add_arg(desc, arg_l2_update_cooldown);
     command_line::add_arg(desc, arg_l2_skip_chainid);
     command_line::add_arg(desc, arg_l2_proxy);
     command_line::add_arg(desc, arg_l2_oxend);

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -69,22 +69,29 @@ L2Tracker::L2Tracker(
                   }} {
     if (update_cooldown > 0s) {
         update_logs_cooldown = update_cooldown;
-        update_logs_thread = std::thread{[this]() {
+        update_logs_thread = std::thread{[this] {
             std::chrono::steady_clock::time_point last_update{};
-            while (running) {
-                update_logs_wakeup.wait(false);
-                bool wake = update_logs_wakeup.exchange(false);
-                if (wake && running) {
-                    auto now = std::chrono::steady_clock::now();
-                    auto delta = now - last_update;
-                    if (delta < update_logs_cooldown) {
-                        std::this_thread::sleep_for(update_logs_cooldown - delta);
-                        if (!running)
-                            break;
-                    }
-                    update_logs_internal();
-                    last_update = std::chrono::steady_clock::now();
+            std::unique_lock lock{update_logs_mutex};
+            while (update_logs_running) {
+                update_logs_cv.wait(lock, [this] { return update_logs_wakeup; });
+                if (!update_logs_running)
+                    break;
+                update_logs_wakeup = false;
+
+                auto now = std::chrono::steady_clock::now();
+                auto delta = now - last_update;
+
+                if (now < last_update + update_logs_cooldown) {
+                    update_logs_cv.wait_until(lock, last_update + update_logs_cooldown, [this] {
+                        return !update_logs_running;
+                    });
+                    if (!update_logs_running)
+                        break;
                 }
+                lock.unlock();
+                update_logs_internal();
+                last_update = std::chrono::steady_clock::now();
+                lock.lock();
             }
         }};
     }
@@ -130,9 +137,15 @@ L2Tracker::L2Tracker(
 }
 
 L2Tracker::~L2Tracker() {
-    running = false;
-    update_logs_wakeup = true;
-    update_logs_wakeup.notify_one();
+    if (update_logs_thread.joinable()) {
+        {
+            std::lock_guard lock{update_logs_mutex};
+            update_logs_running = false;
+            update_logs_wakeup = true;
+        }
+        update_logs_cv.notify_one();
+        update_logs_thread.join();
+    }
 }
 
 // For any given l2 height, we calculate the reward using the last height (inclusive) that was
@@ -467,8 +480,11 @@ void L2Tracker::update_logs() {
     if (!update_logs_thread.joinable())
         update_logs_internal();
     else {
-        update_logs_wakeup = true;
-        update_logs_wakeup.notify_one();
+        {
+            std::lock_guard lock{update_logs_mutex};
+            update_logs_wakeup = true;
+        }
+        update_logs_cv.notify_one();
     }
 }
 

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -67,23 +67,26 @@ L2Tracker::L2Tracker(
                               /*squelch*/ true,
                               update_thread_id);
                   }} {
-    if (update_cooldown != 0s) {
+    if (update_cooldown > 0s) {
         update_logs_cooldown = update_cooldown;
-        update_logs_thread = std::make_unique<std::thread>([this]() {
-            auto last_update = std::chrono::steady_clock::now();
+        update_logs_thread = std::thread{[this]() {
+            std::chrono::steady_clock::time_point last_update{};
             while (running) {
                 update_logs_wakeup.wait(false);
+                update_logs_wakeup = false;
                 if (running) {
                     auto now = std::chrono::steady_clock::now();
                     auto delta = now - last_update;
-                    if (delta < update_logs_cooldown)
+                    if (delta < update_logs_cooldown) {
                         std::this_thread::sleep_for(update_logs_cooldown - delta);
+                        if (!running)
+                            break;
+                    }
                     update_logs_internal();
                     last_update = std::chrono::steady_clock::now();
                 }
-                update_logs_wakeup = false;
             }
-        });
+        }};
     }
 }
 
@@ -461,7 +464,7 @@ void L2Tracker::update_rewards(std::optional<std::forward_list<uint64_t>> more) 
 
 void L2Tracker::update_logs() {
     // if no cooldown set, no update thread, just call it
-    if (!update_logs_thread)
+    if (!update_logs_thread.joinable())
         update_logs_internal();
     else {
         update_logs_wakeup = true;

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -73,8 +73,8 @@ L2Tracker::L2Tracker(
             std::chrono::steady_clock::time_point last_update{};
             while (running) {
                 update_logs_wakeup.wait(false);
-                update_logs_wakeup = false;
-                if (running) {
+                bool wake = update_logs_wakeup.exchange(false);
+                if (wake && running) {
                     auto now = std::chrono::steady_clock::now();
                     auto delta = now - last_update;
                     if (delta < update_logs_cooldown) {

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -55,7 +55,10 @@ L2Tracker::L2Tracker(
     });
 }
 
-L2Tracker::L2Tracker(cryptonote::core& core_, std::chrono::milliseconds update_interval) :
+L2Tracker::L2Tracker(
+        cryptonote::core& core_,
+        std::chrono::milliseconds update_interval,
+        std::chrono::milliseconds update_cooldown) :
         L2Tracker{core_, ethyl::Provider::make_provider(), [this, update_interval] {
                       update_state();
                       core.omq().add_timer(
@@ -63,7 +66,26 @@ L2Tracker::L2Tracker(cryptonote::core& core_, std::chrono::milliseconds update_i
                               update_interval,
                               /*squelch*/ true,
                               update_thread_id);
-                  }} {}
+                  }} {
+    if (update_cooldown != 0s) {
+        update_logs_cooldown = update_cooldown;
+        update_logs_thread = std::make_unique<std::thread>([this]() {
+            auto last_update = std::chrono::steady_clock::now();
+            while (running) {
+                update_logs_wakeup.wait(false);
+                if (running) {
+                    auto now = std::chrono::steady_clock::now();
+                    auto delta = now - last_update;
+                    if (delta < update_logs_cooldown)
+                        std::this_thread::sleep_for(update_logs_cooldown - delta);
+                    update_logs_internal();
+                    last_update = std::chrono::steady_clock::now();
+                }
+                update_logs_wakeup = false;
+            }
+        });
+    }
+}
 
 L2Tracker::L2Tracker(
         cryptonote::core& core_,
@@ -104,7 +126,11 @@ L2Tracker::L2Tracker(
             .add_command("purge_state", [this](auto& msg) { l2_notify_state(msg, true); });
 }
 
-L2Tracker::~L2Tracker() = default;
+L2Tracker::~L2Tracker() {
+    running = false;
+    update_logs_wakeup = true;
+    update_logs_wakeup.notify_one();
+}
 
 // For any given l2 height, we calculate the reward using the last height (inclusive) that was
 // divisible by (netconfig).L2_REWARD_POOL_UPDATE_BLOCKS:
@@ -434,6 +460,16 @@ void L2Tracker::update_rewards(std::optional<std::forward_list<uint64_t>> more) 
 }
 
 void L2Tracker::update_logs() {
+    // if no cooldown set, no update thread, just call it
+    if (!update_logs_thread)
+        update_logs_internal();
+    else {
+        update_logs_wakeup = true;
+        update_logs_wakeup.notify_one();
+    }
+}
+
+void L2Tracker::update_logs_internal() {
     assert(provider);
     std::shared_lock lock{mutex};
 

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -200,7 +200,13 @@ class L2Tracker {
     // defines how many requests we make to the L2 provider: each (this period) we need to make one
     // request to get the current block height, and then at least one more to fetch any logs since
     // the previous block height we knew about.
-    explicit L2Tracker(cryptonote::core& core, std::chrono::milliseconds update_frequency = 10s);
+    // `update_cooldown` governs how frequently we will make repeated eth_getLogs calls, as some
+    // providers have rate limits which would otherwise be hit, default is no cooldown/delay
+    // between requests.
+    explicit L2Tracker(
+            cryptonote::core& core,
+            std::chrono::milliseconds update_frequency = 10s,
+            std::chrono::milliseconds update_cooldown = 0s);
 
     // Constructs an L2Tracker in L2 proxy mode, where we rely on one or more external oxends to
     // provide us with L2 state data.
@@ -368,6 +374,13 @@ class L2Tracker {
     // This is the meat of get_vote_for ServiceNodePurge, but is also used internally when deciding
     // whether to put things in the mempool.
     bool is_node_purgeable(const bls_public_key& bls_pubkey) const;
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> update_logs_wakeup{false};
+    std::chrono::milliseconds update_logs_cooldown{0s};
+    std::unique_ptr<std::thread> update_logs_thread;
+
+    void update_logs_internal();
 };
 
 }  // namespace eth

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -4,6 +4,7 @@
 #include <oxenmq/oxenmq.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <ethyl/provider.hpp>
 #include <forward_list>
 #include <ranges>
@@ -375,8 +376,9 @@ class L2Tracker {
     // whether to put things in the mempool.
     bool is_node_purgeable(const bls_public_key& bls_pubkey) const;
 
-    std::atomic<bool> running{true};
-    std::atomic<bool> update_logs_wakeup{false};
+    std::mutex update_logs_mutex;
+    std::condition_variable update_logs_cv;
+    bool update_logs_running = true, update_logs_wakeup = false;
     std::chrono::milliseconds update_logs_cooldown{0s};
     std::thread update_logs_thread;
 

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -378,7 +378,7 @@ class L2Tracker {
     std::atomic<bool> running{true};
     std::atomic<bool> update_logs_wakeup{false};
     std::chrono::milliseconds update_logs_cooldown{0s};
-    std::unique_ptr<std::thread> update_logs_thread;
+    std::thread update_logs_thread;
 
     void update_logs_internal();
 };


### PR DESCRIPTION
Some L2 providers rate limit based on some amount of requests or "points" per second; for those it seems good to be able to rate limit ourselves rather than just ignore it and have log spam.

Also included: removed now-deprecated cli/config option, and updated some log levels in ethyl