### PR TITLE
Fix issue with only tracking last purge in a block for SQL rewards metadata

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -932,7 +932,7 @@ static BlockchainSQLite::wallet_info get_accrued_rewards_at_impl(
             "SELECT"
             " {}"
             " FROM "
-            " batched_payments_accrued"
+            " batched_payments_accrued_recent"
             " WHERE address = ? AND height = ?"_format(WALLET_METADATA_FIELDS),
             address,
             static_cast<int64_t>(at_height));

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -368,16 +368,17 @@ static void verify_rewards_db_values(
                         cryptonote::print_money(history.total),
                         cryptonote::print_money(wallet_info.locked_stakes.to_coin()));
 
-                for (const auto& stake : history.stakes) {
+                for (size_t index = 0; index < history.stakes.size(); index++) {
+                    const auto& stake = history.stakes[index];
                     fmt::format_to(
                             std::back_inserter(buffer),
-                            "\n  SN {} => {} SESH",
+                            "\n  {:02d} SN {} => {} SESH",
+                            index,
                             stake.pubkey,
                             cryptonote::print_money(stake.stake));
                 }
 
                 log::error(logcat, "{}", fmt::to_string(buffer));
-                assert(wallet_info.locked_stakes.to_coin() == history.total);
             }
         }
     }
@@ -4087,8 +4088,12 @@ block_add_result service_node_list::state_t::update_from_block(
                     }
                 }
 
-                if (std::holds_alternative<eth::event::ServiceNodePurge>(event))
-                    result.purged_stakes = conf_result.exit_stakes;
+                if (std::holds_alternative<eth::event::ServiceNodePurge>(event)) {
+                    result.purged_stakes.insert(
+                            result.purged_stakes.end(),
+                            conf_result.exit_stakes.begin(),
+                            conf_result.exit_stakes.end());
+                }
             }
 
             // NOTE: Post-amble, advance iterator

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -789,6 +789,8 @@ class service_node_list {
 
         // NOTE: Add nodes from the SNL (active & decomm)
         for (const auto& pk_info : m_state.service_nodes_infos) {
+            if (pk_info.second->staking_requirement == 0)
+                continue;
             auto it = proofs.find(pk_info.first);
             if (it == proofs.end())
                 continue;

--- a/src/cryptonote_core/sesh_transition/sesh_transition.cpp
+++ b/src/cryptonote_core/sesh_transition/sesh_transition.cpp
@@ -293,8 +293,9 @@ static void dump_transition_outcome_csv(
 
             // NOTE: Write the CSV line
             file.print(
-                    "redacted_{:04d},{},{},{},{},{},{}\n",
-                    index++,
+                    "{}_{:04d},{},{},{},{},{},{}\n",
+                    sorted_it.addr,
+                    index,
                     sorted_it.oxen_sn_count,
                     sorted_it.sesh_sn_count,
                     cryptonote::print_money(bonus_tokens),
@@ -374,18 +375,18 @@ static void dump_transition_outcome_csv(
         for (const node_transition& it : node_list) {
             bool transitioned = it.tokens_allocated >= context.staking_requirement;
             file.print(
-                    "{:06d},"           // registration_height
-                    "redacted_{:04d},"  // pkey
-                    "{},"               // tokens_allocated
-                    "{},"               // transitioned
-                    "{},"               // missing_ed25519_key
-                    "{},"               // missing_bls_key
-                    "{},"               // partially_funded
-                    "{},"               // contributor_not_registered_for_swap
-                    "{},"               // insufficient_sesh
+                    "{:06d}," // registration_height
+                    "{},"     // pkey
+                    "{},"     // tokens_allocated
+                    "{},"     // transitioned
+                    "{},"     // missing_ed25519_key
+                    "{},"     // missing_bls_key
+                    "{},"     // partially_funded
+                    "{},"     // contributor_not_registered_for_swap
+                    "{},"     // insufficient_sesh
                     "\n",
                     it.sn_info->registration_height,
-                    count++,
+                    it.pkey,
                     cryptonote::print_money(it.tokens_allocated),
                     transitioned,
                     it.missing_ed25519_key,

--- a/src/cryptonote_core/sesh_transition/sesh_transition.cpp
+++ b/src/cryptonote_core/sesh_transition/sesh_transition.cpp
@@ -375,15 +375,15 @@ static void dump_transition_outcome_csv(
         for (const node_transition& it : node_list) {
             bool transitioned = it.tokens_allocated >= context.staking_requirement;
             file.print(
-                    "{:06d}," // registration_height
-                    "{},"     // pkey
-                    "{},"     // tokens_allocated
-                    "{},"     // transitioned
-                    "{},"     // missing_ed25519_key
-                    "{},"     // missing_bls_key
-                    "{},"     // partially_funded
-                    "{},"     // contributor_not_registered_for_swap
-                    "{},"     // insufficient_sesh
+                    "{:06d},"  // registration_height
+                    "{},"      // pkey
+                    "{},"      // tokens_allocated
+                    "{},"      // transitioned
+                    "{},"      // missing_ed25519_key
+                    "{},"      // missing_bls_key
+                    "{},"      // partially_funded
+                    "{},"      // contributor_not_registered_for_swap
+                    "{},"      // insufficient_sesh
                     "\n",
                     it.sn_info->registration_height,
                     it.pkey,


### PR DESCRIPTION
- When there are multiple purge transactions in a block, only the last one was stored into the post-block update struct. This meant the metadata tracking how much stakes the network has locked went out of sync.
- Remove the redacting of information from the CSV reports produced on the ETH transition as this information is now public.
- When a height is specified for retrieving the accrued rewards for an address, it was using the `batched_payments_accrued` which does not have a `height` column. It must use `batched_payments_accrued_recent` which stores a short history of the rewards owed to an address. This fixes the accrued rewards failing spuriously around the block boundary.
- Avoid zombie nodes in the BLS aggregation step which was messing with the ability to validate with the contract's aggregate public key