### PR TITLE
Tweak L2 defaults

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -86,10 +86,10 @@ inline constexpr auto ETH_L2_DEFAULT_REQUEST_TIMEOUT = 5s;
 // contract state in a single request.  If more than this are required multiple requests will be
 // used to retrieve the logs.  Can be adjusted at runtime using the --l2-max-logs command
 // line/config file setting.
-inline constexpr auto ETH_L2_DEFAULT_MAX_LOGS = 1000;
+inline constexpr auto ETH_L2_DEFAULT_MAX_LOGS = 500;
 // The default value for the minimum time between ethereum log update requests.  Can be adjusted
 // at runtime using the --l2-update-cooldown command line/config file setting.
-inline constexpr auto ETH_L2_DEFAULT_UPDATE_COOLDOWN = 0s;
+inline constexpr auto ETH_L2_DEFAULT_UPDATE_COOLDOWN = 1250ms;
 // When refreshing, this controls how often we get heights from *all* configured L2 providers
 // (instead of just the primary one) to check whether L2 providers are in sync.  (This only applies
 // when multiple L2 providers are in use).


### PR DESCRIPTION
- Default the cooldown to enabled with a 1.25s cooldown to reduce the likelihood of of rate limiting by keeping subsequent getLogs requests less than 1/s.
- Reduce default block range to 500 as a couple free tier providers have this as the max range and it causes problems for some nodes.