### PR TITLE
Add L2 synced checks before proofing, validating or producing blocks

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2123,6 +2123,18 @@ bool Blockchain::create_block_template_internal(
             return false;
         }
 
+        eth::L2Tracker::L2Heights l2_heights = m_l2_tracker->get_l2_heights();
+        if (l2_heights.synced < b.l2_height) {  // Haven't synced the logs for this height yet
+            log::error(
+                    logcat,
+                    "Block template uses L2 height {} which is not synced in the L2 tracker yet. "
+                    "The L2 tracker's current latest/synced height is {}/{}",
+                    b.l2_height,
+                    l2_heights.latest,
+                    l2_heights.synced);
+            return false;
+        }
+
         // Clamp the l2_reward value into the maximum allowed range by the chain (this means sudden
         // pool reward changes will only show up gradually in l2_reward, but prevents abuse by
         // faulty/compromised L2 providers or pulse quorums).

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2114,15 +2114,6 @@ bool Blockchain::create_block_template_internal(
     }
 
     if (hf_version >= cryptonote::feature::ETH_BLS) {
-        auto actual_reward = m_l2_tracker->get_reward_rate(b.l2_height);
-        if (!actual_reward) {
-            log::error(
-                    logcat,
-                    "L2 Tracker failed to retrieve the current block reward; unable to create a "
-                    "block");
-            return false;
-        }
-
         eth::L2Tracker::L2Heights l2_heights = m_l2_tracker->get_l2_heights();
         if (l2_heights.synced < b.l2_height) {  // Haven't synced the logs for this height yet
             log::error(
@@ -2132,6 +2123,15 @@ bool Blockchain::create_block_template_internal(
                     b.l2_height,
                     l2_heights.latest,
                     l2_heights.synced);
+            return false;
+        }
+
+        auto actual_reward = m_l2_tracker->get_reward_rate(b.l2_height);
+        if (!actual_reward) {
+            log::error(
+                    logcat,
+                    "L2 Tracker failed to retrieve the current block reward; unable to create a "
+                    "block");
             return false;
         }
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2673,6 +2673,29 @@ void core::do_uptime_proof_call() {
                                     : "startup");
                     return;
                 }
+
+                eth::L2Tracker::L2Heights l2_heights = l2_tracker().get_l2_heights();
+                assert(l2_heights.latest >= l2_heights.synced);
+                size_t allowed_height_delta = 10s / config::L2_BLOCK_TIME;
+                size_t min_height = l2_heights.latest - allowed_height_delta;
+
+                // Allow some block buffer because these are individual network requests which take
+                // time
+                if (l2_heights.synced < min_height) {
+                    log::error(
+                            globallogcat,
+                            fg(fmt::terminal_color::red) | fmt::emphasis::bold,
+                            "Failed to submit uptime proof: the L2 RPC provider has not synced the "
+                            "logs from Arbitrum to a sufficient height of {:L} to be considered "
+                            "synced. The L2's latest known/synced height is {:L}/{:L}. Check your "
+                            "L2 provider's dashboard for request health or the logs of "
+                            "your local Arbitrum node to ensure the getLogs requests are being "
+                            "handled successfully",
+                            min_height,
+                            l2_heights.latest,
+                            l2_heights.synced);
+                    return;
+                }
             }
 
             submit_uptime_proof();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1180,8 +1180,7 @@ bool core::init_service_keys() {
     if (m_service_node) {
         keys.key = crypto::ed25519_to_monero_secret_key(keys.key_ed25519);
         if (!crypto::secret_key_to_public_key(keys.key, keys.pub))
-            throw oxen::traced<std::runtime_error>{
-                    "Failed to derive primary key from ed25519 key"};
+            throw oxen::traced<std::runtime_error>{"Failed to derive primary key from ed25519 key"};
         if (std::memcmp(keys.pub.data(), keys.pub_ed25519.data(), 32))
             throw oxen::traced<std::runtime_error>{
                     "Internal error: unexpected primary pubkey and ed25519 pubkey mismatch"};

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2685,8 +2685,8 @@ void core::do_uptime_proof_call() {
                             globallogcat,
                             fg(fmt::terminal_color::red) | fmt::emphasis::bold,
                             "Failed to submit uptime proof: the L2 RPC provider has not synced the "
-                            "logs from Arbitrum to a sufficient height of {:L} to be considered "
-                            "synced. The L2's latest known/synced height is {:L}/{:L}. Check your "
+                            "logs from Arbitrum to a sufficient height of {} to be considered "
+                            "synced. The L2's latest known/synced height is {}/{}. Check your "
                             "L2 provider's dashboard for request health or the logs of "
                             "your local Arbitrum node to ensure the getLogs requests are being "
                             "handled successfully",

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1819,6 +1819,20 @@ namespace {
                 // eth state change transactions by making sure we have them in our pool *and* that
                 // we have the indicated state change in our L2 tracker.
                 if (block.major_version >= cryptonote::feature::ETH_BLS) {
+                    eth::L2Tracker::L2Heights l2_heights = core.l2_tracker().get_l2_heights();
+                    if (l2_heights.synced < block.l2_height) {
+                        log::error(
+                                logcat,
+                                "{}Pulse block template uses L2 height {} which is not synced in "
+                                "the L2 tracker yet. The L2 tracker's current latest/synced height "
+                                "is {}/{}",
+                                *this,
+                                block.l2_height,
+                                l2_heights.latest,
+                                l2_heights.synced);
+                        return goto_preparing_for_next_round();
+                    }
+
                     if (block.tx_eth_count > block.tx_hashes.size()) {
                         log::warning(
                                 logcat,

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5461,7 +5461,8 @@ uptime_proof::Proof service_node_list::generate_uptime_proof(
             storage_omq_port,
             ss_version,
             quorumnet_port,
-            hardfork >= feature::ETH_TRANSITION ? blockchain.l2_tracker().get_l2_heights().synced : 0,
+            hardfork >= feature::ETH_TRANSITION ? blockchain.l2_tracker().get_l2_heights().synced
+                                                : 0,
             lokinet_version,
             keys};
 }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5461,7 +5461,7 @@ uptime_proof::Proof service_node_list::generate_uptime_proof(
             storage_omq_port,
             ss_version,
             quorumnet_port,
-            hardfork >= feature::ETH_TRANSITION ? blockchain.l2_tracker().get_latest_height() : 0,
+            hardfork >= feature::ETH_TRANSITION ? blockchain.l2_tracker().get_l2_heights().synced : 0,
             lokinet_version,
             keys};
 }

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -172,7 +172,7 @@ service_node_test_results quorum_cop::check_service_node(
 
     if (check_l2_height) {
         // Checking if the nodes L2 height is too far behind
-        auto l2_min_acceptable_height = m_core.l2_tracker().get_latest_height();
+        auto l2_min_acceptable_height = m_core.l2_tracker().get_l2_heights().synced;
         l2_min_acceptable_height -= std::min(
                 static_cast<uint64_t>(proof_age / cryptonote::config::L2_BLOCK_TIME),
                 l2_min_acceptable_height);

--- a/src/l2_tracker/l2_tracker.cpp
+++ b/src/l2_tracker/l2_tracker.cpp
@@ -930,9 +930,13 @@ std::optional<uint64_t> L2Tracker::get_reward_rate(uint64_t height) const {
     return std::nullopt;
 }
 
-uint64_t L2Tracker::get_latest_height() const {
+L2Tracker::L2Heights L2Tracker::get_l2_heights() const {
     std::shared_lock lock{mutex};
-    return state.latest_height;
+    L2Heights result = {
+            .latest = state.latest_height,
+            .synced = state.synced_height,
+    };
+    return result;
 }
 
 std::optional<std::chrono::nanoseconds> L2Tracker::latest_height_age() const {

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -282,7 +282,12 @@ class L2Tracker {
     std::optional<uint64_t> get_reward_rate(uint64_t height) const;
 
     // Returns the latest L2 height we know about, i.e. from previous provider updates.
-    uint64_t get_latest_height() const;
+    struct L2Heights {
+        uint64_t latest;
+        uint64_t synced;
+    };
+
+    L2Heights get_l2_heights() const;
 
     // Returns the latest L2 height that we have known about for at least 70s
     // (L2_TRACKER_SAFE_BLOCKS); when building a block we use this slight lag so that service nodes

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -226,8 +226,11 @@ void core_rpc_server::invoke(GET_INFO& info, rpc_context context) {
 
     info.response["height"] = height;
     info.response["l2_height"] = top_block.l2_height;
-    if (auto* l2 = bs.maybe_l2_tracker())
-        info.response["l2_tracker_height"] = l2->get_latest_height();
+    if (auto* l2 = bs.maybe_l2_tracker()) {
+        eth::L2Tracker::L2Heights heights = l2->get_l2_heights();
+        info.response["l2_tracker_height"] = heights.latest;
+        info.response["l2_tracker_synced_height"] = heights.synced;
+    }
     info.response_hex["top_block_hash"] = get_block_hash(top_block);
     info.response["target_height"] = m_core.get_target_blockchain_height();
 


### PR DESCRIPTION
`synced_height` in the L2 tracker, tracks the latest height in which getLogs was successful for the node, so this value tracks the absolute latest height that the L2 tracker has completely synced all the information necessary to do consensus related tasks in the workchain correctly.

So the idea here is instead of using `latest_height` (which is the nwest height reported by the L2 provider), we use the `synced_height` to determine if we should proceed with any operation that requires data from the L2 tracker. So 3 code paths have been modified

- The uptime proof will not be submitted if the synced height falls behind the latest height by more than 10s worth of arbitrum blocks
- A pulse validator will not participate in the quorum if it has not synced their L2 tracker to the requested block L2 height
- A pules block producer will fail to generate a block template if their L2 tracker has not synced the L2 height it has determined needs to be witnessed into the block

The latest height and synced height can differ from each other because they are different EVM network requests. Get logs can fail causing synced height to not be updated in lock-step with the get height query.