### PR TITLE
Fix get_service_nodes Session compatibility

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2874,9 +2874,11 @@ void core_rpc_server::fill_sn_response_entry(
         const crypto::public_key& sn_pubkey,
         const service_nodes::service_node_info& info,
         uint64_t top_height,
-        const std::unordered_map<eth::bls_public_key, bool>* removable) {
+        const std::unordered_map<eth::bls_public_key, bool>* removable,
+        bool oxen10_compat_fields) {
 
-    auto binary_format = is_bt ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex;
+    auto binary_format = (is_bt && !oxen10_compat_fields) ? json_binary_proxy::fmt::bt
+                                                          : json_binary_proxy::fmt::hex;
     json_binary_proxy binary{entry, binary_format};
 
     set_if_requested(reqed, binary, "service_node_pubkey", sn_pubkey);
@@ -3022,7 +3024,7 @@ void core_rpc_server::fill_sn_response_entry(
                     m_core.get_service_keys().pub_x25519);
             set_if_requested(reqed, binary, "pubkey_bls", m_core.get_service_keys().pub_bls);
         } else {
-            if (proof.proof->public_ip != 0)
+            if (proof.proof->public_ip != 0 || oxen10_compat_fields)
                 set_if_requested(
                         reqed,
                         entry,
@@ -3235,7 +3237,8 @@ void core_rpc_server::invoke(GET_SERVICE_NODES& sns, rpc_context) {
                 pubkey_info.pubkey,
                 *pubkey_info.info,
                 top_height,
-                &removable);
+                &removable,
+                sns.request.oxen10_compat_fields);
 }
 
 void core_rpc_server::invoke(HF21_DRY_RUN& req, rpc_context) {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -248,7 +248,8 @@ class core_rpc_server {
             const crypto::public_key& sn_pubkey,
             const service_nodes::service_node_info& sn_info,
             uint64_t top_height,
-            const std::unordered_map<eth::bls_public_key, bool>* removable);
+            const std::unordered_map<eth::bls_public_key, bool>* removable,
+            bool oxen10_compat_fields = false);
 
     void add_event_sn_info(
             json& entry,

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -49,6 +49,11 @@ void parse_request(GET_SERVICE_NODES& sns, rpc_input in) {
                 !sns.request.fields.count("-locked_contributions") &&
                 sns.request.fields.count("contributors"))
                 sns.request.fields.insert("locked_contributions");
+
+            // Session clients do not handle missing "public_ip", "storage_lmq_port",
+            // "storage_server_version" values, so if the deprecated fields are requested, we
+            // include Oxen 10 compatible "0" values.
+            sns.request.oxen10_compat_fields = true;
         }
     }
     if (!fields_dict) {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2106,6 +2106,7 @@ struct GET_SERVICE_NODES : PUBLIC {
         bool active_only = false;
         int limit = 0;
         crypto::hash poll_block_hash{};
+        bool oxen10_compat_fields = false;
     } request;
 };
 


### PR DESCRIPTION
Current versions of Session making requests to `get_service_nodes` are having trouble with `"public_ip"` and similar being missing when a node doesn't have proof contact info.

This puts them back in with 0 values when a request is still using the "fields" value with a dict of key/true pairs (as Session does) rather than a list of keys, and keeps them omitted otherwise.

Also force keys to hex (even with bt requests) with such a request, because at least one of the Session clients does that and expects pubkey_ed25519 to be hex in response.