### PR TITLE
BLS aggregator: do not retry node for signature for 5 mins after a bad signature 

### DIFF
--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -483,8 +483,20 @@ namespace {
                 single_callback{std::move(callback)},
                 final_callback{std::move(final_callback)} {
 
-            core.service_node_list.copy_reachable_service_node_addresses(
-                    std::back_inserter(snodes), core.get_nettype());
+            std::lock_guard lock{bad_signer_mutex};
+            const auto expiry = std::chrono::steady_clock::now() - BAD_SIGNER_TIMEOUT;
+            for (auto it = recent_bad_signers.begin(); it != recent_bad_signers.end();)
+                if (it->second < expiry)
+                    it = recent_bad_signers.erase(it);
+                else
+                    ++it;
+
+            core.service_node_list.for_each_reachable_service_node_address(
+                    [this](service_nodes::service_node_address&& addr) {
+                        if (!recent_bad_signers.contains(addr.bls_pubkey))
+                            snodes.push_back(std::move(addr));
+                    },
+                    core.get_nettype());
         }
 
         cryptonote::core& core;
@@ -517,6 +529,14 @@ namespace {
         // The number of service nodes to which requests have been initiated (i.e. this is the count
         // of reachable nodes at the time the request was initiated).
         size_t snode_count() { return snodes.size(); }
+
+        // Stores the pubkeys of nodes that have given us bad BLS signatures recently, so that we
+        // can skip them if we do another signature.  We retry them if at least 5 mins has passed
+        // since the last time they gave us a bad signature.
+        inline static std::unordered_map<eth::bls_public_key, std::chrono::steady_clock::time_point>
+                recent_bad_signers{};
+        constexpr static auto BAD_SIGNER_TIMEOUT = 5min;
+        inline static std::mutex bad_signer_mutex{};
 
       private:
         void send_requests(
@@ -656,6 +676,11 @@ namespace {
                         sig);
                 agg_sig.subtract(sig);
                 agg_pub.subtract(blspk);
+                {
+                    std::lock_guard lock{nodes_request_data::bad_signer_mutex};
+                    nodes_request_data::recent_bad_signers[blspk] =
+                            std::chrono::steady_clock::now();
+                }
 
                 result.signature = agg_sig.get();
                 result.aggregate_pubkey = agg_pub.get();

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -795,7 +795,7 @@ class service_node_list {
                 continue;
             // If we don't have a proof then we won't know the IP/port, and so this node isn't
             // considered reachable and shouldn't be returned.
-            if (!it->second.proof)
+            if (!it->second.proof || !it->second.proof->public_ip)
                 continue;
             auto& proof = *it->second.proof;
 
@@ -821,7 +821,7 @@ class service_node_list {
 
                 // NOTE: Look for their latest IP/port from an uptime proof
                 auto it = proofs.find(recently_removed_it.service_node_pubkey);
-                if (it != proofs.end() && it->second.proof) {
+                if (it != proofs.end() && it->second.proof && it->second.proof->public_ip) {
                     auto& proof = *it->second.proof;
                     cb(service_node_address{
                             recently_removed_it.service_node_pubkey,

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -776,13 +776,14 @@ class service_node_list {
         }
     }
 
-    /// Copies `service_node_address`es (pubkeys, ip, port) of all current and expired (yet to be
-    /// removed from smart contract) SNs with potentially reachable, known addresses (via a recently
-    /// received valid proof) into the given output iterator.  Service nodes that for which we have
-    /// not yet received/accepted a proof containing IP info are not included.
-    template <std::output_iterator<service_node_address> OutputIt>
-    void copy_reachable_service_node_addresses(
-            OutputIt out, cryptonote::network_type nettype) const {
+    /// Iterates through `service_node_address`es (pubkeys, ip, port) of all current and expired
+    /// (yet to be removed from smart contract) SNs with potentially reachable, known addresses (via
+    /// a recently received valid proof), calling the given callback with the address info.  Service
+    /// nodes that for which we have not yet received/accepted a proof containing IP info are not
+    /// included.
+    template <std::invocable<service_node_address> Callback>
+    void for_each_reachable_service_node_address(
+            Callback&& cb, cryptonote::network_type nettype) const {
         std::lock_guard lock{m_sn_mutex};
         bool sn_pk_is_ed25519_hf = cryptonote::is_hard_fork_at_least(
                 nettype, cryptonote::feature::SN_PK_IS_ED25519, m_state.height);
@@ -806,12 +807,12 @@ class service_node_list {
                                                    // proof
                 pubkey_x25519 = it->second.pubkey_x25519;
             }
-            *out++ = service_node_address{
+            cb(service_node_address{
                     pk_info.first,
                     pk_info.second->bls_public_key,
                     sn_pk_is_ed25519_hf ? snpk_to_xpk(pk_info.first) : it->second.pubkey_x25519,
                     proof.public_ip,
-                    proof.qnet_port};
+                    proof.qnet_port});
         }
 
         if (sn_pk_is_ed25519_hf) {
@@ -822,24 +823,24 @@ class service_node_list {
                 auto it = proofs.find(recently_removed_it.service_node_pubkey);
                 if (it != proofs.end() && it->second.proof) {
                     auto& proof = *it->second.proof;
-                    *out++ = service_node_address{
+                    cb(service_node_address{
                             recently_removed_it.service_node_pubkey,
                             recently_removed_it.info.bls_public_key,
                             it->second.pubkey_x25519,
                             proof.public_ip,
-                            proof.qnet_port};
+                            proof.qnet_port});
                     continue;
                 }
 
                 // NOTE: We don't have a proof, we defer to what we last stored for the node.
                 if (recently_removed_it.public_ip == 0 || recently_removed_it.qnet_port == 0)
                     continue;
-                *out++ = service_node_address{
+                cb(service_node_address{
                         recently_removed_it.service_node_pubkey,
                         recently_removed_it.info.bls_public_key,
                         snpk_to_xpk(recently_removed_it.service_node_pubkey),
                         recently_removed_it.public_ip,
-                        recently_removed_it.qnet_port};
+                        recently_removed_it.qnet_port});
             }
         }
     }


### PR DESCRIPTION
A small number of nodes on the network are currently providing consistently bad signatures (I suspect because their key_bls has been regenerated), and as a result every single signature request has to go through the (slow, intensive) process of verifying all signatures independently, which adds several seconds to the aggregation time.

This adds a 5-minute cooldown so that, after receiving such a bad BLS signature, we don't submit BLS signature requests to that node for the next 5 minutes.