### PR TITLE
Rpc & log fixes

### DIFF
--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -1908,7 +1908,7 @@ namespace {
                                 "(this node)",
                                 *this,
                                 fmt::join(block.l2_votes, ","),
-                                fmt::join(block.l2_votes, ","));
+                                fmt::join(my_l2_votes, ","));
                         return goto_preparing_for_next_round();
                     }
                 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -163,14 +163,6 @@ namespace {
     constexpr uint64_t round_up(uint64_t value, uint64_t quantum) {
         return (value + quantum - 1) / quantum * quantum;
     }
-
-    void rename_key(nlohmann::json& obj, std::string_view old_key, std::string_view new_key) {
-        if (auto it = obj.find(old_key); it != obj.end()) {
-            auto val = std::move(*it);
-            obj.erase(it);
-            obj[std::string{new_key}] = std::move(val);
-        }
-    }
 }  // namespace
 
 const std::unordered_map<std::string, std::shared_ptr<const rpc_command>> rpc_commands =
@@ -2708,63 +2700,30 @@ void core_rpc_server::invoke(
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(BLS_EXIT_LIQUIDATION_LIST& rpc, rpc_context) {
-    auto list = nlohmann::json::array();
+    rpc.response = json::array();
     using node_t = service_nodes::service_node_list::recently_removed_node;
-    m_core.service_node_list.for_each_recently_removed_node([&list, is_bt = rpc.is_bt()](
-                                                                    const node_t& elem) {
-        // NOTE: Serialise to JSON
-        serialization::json_archiver ar{
-                is_bt ? json_binary_proxy::fmt::bt : json_binary_proxy::fmt::hex};
-        serialize(ar, const_cast<node_t&>(elem));
-        nlohmann::json serialized = std::move(ar).json();
-        nlohmann::json& sn_info = serialized["info"];
+    const auto removable = m_core.blockchain.get_removable_nodes();
+    m_core.service_node_list.for_each_recently_removed_node(
+            [this, &rpc, &removable](const node_t& elem) {
+                rpc.response.push_back(json{
+                        {"height", elem.height},
+                        {"liquidation_height", elem.liquidation_height},
+                        {"type",
+                         elem.type == node_t::type_t::voluntary_exit ? "exit"
+                         : elem.type == node_t::type_t::deregister   ? "deregister"
+                                                                     : "unknown"},
+                });
+                rpc.response_hex.back()["service_node_pubkey"] = elem.service_node_pubkey;
 
-        // NOTE: Remove implementation details from the contributor JSON
-        for (auto& contrib_it : sn_info["contributors"]) {
-            constexpr std::string_view ERASE_FIELDS_CONTRIBUTOR[] = {
-                    "address",  // Cryptonote address  (not used in L2, use ETH addresses)
-                    "locked_contributions",  // $OXEN contributions (not used in L2, use $SESH)
-            };
-
-            for (const auto& field : ERASE_FIELDS_CONTRIBUTOR) {
-                auto it = contrib_it.find(field);
-                assert(it != contrib_it.end());
-                contrib_it.erase(it);
-            }
-
-            // NOTE: Remove operator cryptonote address and replace with ethereum address
-            rename_key(contrib_it, "ethereum_address", "address");
-        }
-
-        // NOTE: Remove operator cryptonote address and replace with ethereum address
-        rename_key(sn_info, "operator_ethereum_address", "operator_address");
-
-        // NOTE: Remove implementation details from the output JSON
-        constexpr std::string_view ERASE_FIELDS[] = {
-                "public_ip",
-                "qnet_port",
-                "type",
-        };
-
-        for (const auto& field : ERASE_FIELDS) {
-            auto it = serialized.find(field);
-            assert(it != serialized.end());
-            serialized.erase(it);
-        }
-
-        // NOTE: Assign the type
-        switch (elem.type) {
-            case node_t::type_t::voluntary_exit: serialized["type"] = "exit"; break;
-            case node_t::type_t::deregister: serialized["type"] = "deregister"; break;
-            case node_t::type_t::purged:
-                assert(!"Internal error: found invalid purged node in recently_removed_nodes");
-        }
-
-        // NOTE: Store the object into the RPC response array
-        list.push_back(std::move(serialized));
-    });
-
-    rpc.response = std::move(list);
+                fill_sn_response_entry(
+                        rpc.response.back()["info"] = json::object(),
+                        rpc.is_bt(),
+                        rpc.request.fields,
+                        elem.service_node_pubkey,
+                        elem.info,
+                        m_core.blockchain.get_tail_id().first,
+                        &removable);
+            });
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(
@@ -3139,18 +3098,19 @@ void core_rpc_server::fill_sn_response_entry(
             if (contributor.ethereum_address) {
                 c["address"] = "{}"_format(contributor.ethereum_address);
                 c["beneficiary"] = "{}"_format(contributor.ethereum_beneficiary);
-            } else
+            } else {
                 c["address"] = cryptonote::get_account_address_as_str(
                         m_core.get_nettype(), false /*subaddress*/, contributor.address);
-            if (contributor.reserved && contributor.reserved != contributor.amount)
-                c["reserved"] = contributor.reserved;
-            if (want_locked_c) {
-                auto& locked = (c["locked_contributions"] = json::array());
-                for (const auto& src : contributor.locked_contributions) {
-                    auto& lc = locked.emplace_back(json{{"amount", src.amount}});
-                    json_binary_proxy lc_binary{lc, binary_format};
-                    lc_binary["key_image"] = src.key_image;
-                    lc_binary["key_image_pub_key"] = src.key_image_pub_key;
+                if (contributor.reserved && contributor.reserved != contributor.amount)
+                    c["reserved"] = contributor.reserved;
+                if (want_locked_c) {
+                    auto& locked = (c["locked_contributions"] = json::array());
+                    for (const auto& src : contributor.locked_contributions) {
+                        auto& lc = locked.emplace_back(json{{"amount", src.amount}});
+                        json_binary_proxy lc_binary{lc, binary_format};
+                        lc_binary["key_image"] = src.key_image;
+                        lc_binary["key_image_pub_key"] = src.key_image_pub_key;
+                    }
                 }
             }
         }
@@ -3955,9 +3915,16 @@ void core_rpc_server::invoke(ONS_RESOLVE& resolve, rpc_context) {
 
 static nlohmann::json wallet_info_to_json(
         std::string address, const BlockchainSQLite::wallet_info& wallet_info) {
+
+    if (eth::address addr; tools::try_load_from_hex_guts(address, addr))
+        // The database always stores the lower-case 0xabc123... version of eth addresses, but we
+        // want to return the proper checksum-formatted version, which we get by putting it back
+        // into an eth::address and running it through the formatter:
+        address = "{}"_format(addr);
+
     nlohmann::json result = {
             {"found", wallet_info.found},
-            {"address", address},
+            {"address", std::move(address)},
             {"amount", wallet_info.amount.to_coin()},
             {"lifetime_locked_stakes", wallet_info.lifetime_locked_stakes.to_coin()},
             {"lifetime_unlocked_stakes", wallet_info.lifetime_unlocked_stakes.to_coin()},

--- a/src/rpc/core_rpc_server_command_parser.cpp
+++ b/src/rpc/core_rpc_server_command_parser.cpp
@@ -544,6 +544,16 @@ void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in) {
     get_values(in, "address", required{cmd.request.address}, "height", cmd.request.height);
 }
 
+void parse_request(BLS_EXIT_LIQUIDATION_LIST& cmd, rpc_input in) {
+    std::vector<std::string_view> fields;
+    get_values(in, "fields", fields);
+    for (const auto& f : fields)
+        cmd.request.fields.emplace(f);
+    // If the only thing given is "all" then just clear it (as a small optimization):
+    if (cmd.request.fields.size() == 1 && *cmd.request.fields.begin() == "all")
+        cmd.request.fields.clear();
+}
+
 void parse_request(BLS_EXIT_LIQUIDATION_REQUEST& cmd, rpc_input in) {
     crypto::public_key sn_pubkey{};
     eth::bls_public_key bls_pubkey{};

--- a/src/rpc/core_rpc_server_command_parser.h
+++ b/src/rpc/core_rpc_server_command_parser.h
@@ -13,6 +13,7 @@ using rpc_input = std::variant<std::monostate, nlohmann::json, oxenc::bt_dict_co
 inline void parse_request(NO_ARGS&, rpc_input) {}
 
 void parse_request(BANNED& banned, rpc_input in);
+void parse_request(BLS_EXIT_LIQUIDATION_LIST& cmd, rpc_input in);
 void parse_request(BLS_EXIT_LIQUIDATION_REQUEST& cmd, rpc_input in);
 void parse_request(BLS_REWARDS_REQUEST& cmd, rpc_input in);
 void parse_request(CONTRACT_REGISTRATION& reg, rpc_input in);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2419,11 +2419,27 @@ struct GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES : PUBLIC, NO_ARGS {
 /// Get the list of nodes that are eligible to be removed or liquidated from the network using an
 /// aggregated signature. This request can never fail.
 ///
+/// Inputs:
+/// - `fields` -- specifies a list of service node info keys to return (see get_service_nodes).
+///   Note that this only takes an array of keys, not the backwards compatible dict of fields that
+///   older get_service_nodes used.
+///
 /// Outputs:
 ///
-/// - `list` -- The list of nodes that can be removed or liquidated
-struct BLS_EXIT_LIQUIDATION_LIST : PUBLIC, NO_ARGS {
+/// - `list` -- The list of nodes that can be removed or liquidated.  Contains keys:
+///   - `height` -- the height at which this node left the active service node list.
+///   - `liquidation_height` -- the earliest height at which this node may be liquidated.
+///   - `service_node_pubkey` -- the service node pubkey of the node
+///   - `type` -- string indicating how this node left the service node list: `"exit"` if it
+///     successfully completed an unlock gracefully, or `"deregister"` if the node was deregistered.
+///   - `info` -- the service node details; this is the same data that would be returned in the
+///     get_service_nodes call for this node.
+struct BLS_EXIT_LIQUIDATION_LIST : PUBLIC {
     static constexpr auto names() { return NAMES("bls_exit_liquidation_list"); }
+
+    struct request_parameters {
+        std::unordered_set<std::string> fields;
+    } request;
 };
 
 /// RPC: service_node/bls_rewards_request


### PR DESCRIPTION
While testing changes for 11.4.0, I found a log statement bug and some inconsistencies in RPC commands:
- When a l2 vote mismatch appears, the block votes were being printed twice instead of block votes and local votes.
- RPC: `get_accrued_rewards`: properly format ETH addresses
- RPC: `bls_exit_liquidation_list`: refactored it to use existing SN info serialization code, which fixes a bunch of inconsistencies and issues (see commit message).  Also made it take a "fields" parameter which is already handled by the existing generic SN info code and so nearly free to implement.
- SN info serialization code was including an empty "locked_contribution" list, but that list should only be included for pre-ETH HF contributions.