### PR TITLE
Add --debug-max-sync-height

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5246,11 +5246,35 @@ Blockchain::block_pow_verified Blockchain::verify_block_pow(
     return result;
 }
 
+void Blockchain::max_sync_height(uint64_t max_height) {
+    m_max_sync_height = max_height;
+    if (m_max_sync_height > 0)
+        log::warning(
+                logcat,
+                "Blockchain max sync height enabled; oxend will not sync beyond height {}",
+                m_max_sync_height);
+}
+
 bool Blockchain::basic_block_checks(cryptonote::block const& blk, bool alt_block) {
     const crypto::hash blk_hash = cryptonote::get_block_hash(blk);
     const uint64_t blk_height = blk.get_height();
     const uint64_t chain_height = get_current_blockchain_height();
     const auto hf_version = get_network_version();
+
+    if (m_max_sync_height && blk_height >= m_max_sync_height) {
+        auto lvl = log::Level::debug;
+        if (auto now = std::chrono::steady_clock::now(); m_max_sync_last_log < now - 10min) {
+            lvl = log::Level::critical;
+            m_max_sync_last_log = now;
+        }
+        log::log(
+                logverify,
+                lvl,
+                "--debug-max-sync-height={} was used, so refusing block with height {}",
+                m_max_sync_height,
+                blk_height);
+        return false;
+    }
 
     if (alt_block) {
         if (blk.get_height() == 0) {

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1268,6 +1268,11 @@ class Blockchain {
     bool load_missing_blocks_into_oxen_subsystems(
             const std::atomic<bool>* abort = nullptr, bool use_threaded_load = false);
 
+    /** DEBUG.  Sets a max sync height; the blockchain object will reject any incoming blocks with a
+     *   sync height above the given value.  0 disables.
+     */
+    void max_sync_height(uint64_t max_height);
+
 #ifndef IN_UNIT_TESTS
   private:
 #endif
@@ -1345,6 +1350,8 @@ class Blockchain {
     std::chrono::nanoseconds m_fake_scan_time;
     uint64_t m_sync_counter;
     uint64_t m_bytes_to_sync;
+    uint64_t m_max_sync_height = 0;
+    std::chrono::steady_clock::time_point m_max_sync_last_log = std::chrono::steady_clock::now() - 1h;
 
     uint64_t m_long_term_block_weights_window;
     uint64_t m_long_term_effective_median_block_weight;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -112,6 +112,10 @@ static const command_line::arg_descriptor<uint64_t> arg_test_drop_download_heigh
         "test-drop-download-height",
         "Like test-drop-download but discards only after around certain height",
         0};
+static const command_line::arg_descriptor<uint64_t> arg_max_sync_height = {
+        "debug-max-sync-height",
+        "DEBUG option: rejects any incoming blocks with heights >= the given value",
+        0};
 static const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {
         "fast-block-sync", "Sync up most of the way by using embedded, known block hashes.", 1};
 static const command_line::arg_descriptor<uint64_t> arg_prep_blocks_threads = {
@@ -337,6 +341,7 @@ void core::init_options(boost::program_options::options_description& desc) {
 
     command_line::add_arg(desc, arg_test_drop_download);
     command_line::add_arg(desc, arg_test_drop_download_height);
+    command_line::add_arg(desc, arg_max_sync_height);
     command_line::add_network_args(desc);
     command_line::add_arg(desc, arg_keep_fakechain);
     command_line::add_arg(desc, arg_fixed_difficulty);
@@ -389,6 +394,7 @@ bool core::handle_command_line(const boost::program_options::variables_map& vm) 
     m_config_folder = tools::utf8_path(command_line::get_arg(vm, arg_data_dir));
 
     test_drop_download_height(command_line::get_arg(vm, arg_test_drop_download_height));
+    blockchain.max_sync_height(get_arg(vm, arg_max_sync_height));
     m_pad_transactions = get_arg(vm, arg_pad_transactions);
     m_offline = get_arg(vm, arg_offline);
     m_has_ip_check_disabled = get_arg(vm, arg_disable_ip_check);


### PR DESCRIPTION
I often find myself wanting to sync up to block N, and usually add a hack somewhere in the blockchain acceptance and rebuild to make that happen.

This add a new option to make that possible any time.