### PR TITLE
Switch to oxen-logging category parser

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -44,7 +44,7 @@ if(BUILD_STATIC_DEPS)
 endif()
 
 if(NOT TARGET oxen::logging)
-    system_or_submodule(OXENLOGGING oxen-logging liboxen-logging>=1.1.1 oxen-logging)
+    system_or_submodule(OXENLOGGING oxen-logging liboxen-logging>=1.2.0 oxen-logging)
     if(OXENLOGGING_FOUND)
         # If we load oxen-logging via system lib then we won't necessarily have fmt/spdlog targets,
         # but this script will give us them:

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1283,11 +1283,16 @@ void core::init_oxenmq(const boost::program_options::variables_map& vm) {
                 return service_node_list.remote_lookup(x25519_pk);
             },
             [](LogLevel omqlevel, const char* file, int line, std::string msg) {
-                auto level = *oxen::logging::parse_level(omqlevel);
+                auto level = oxen::logging::parse_level(omqlevel);
                 if (omqlogcat->should_log(level))
                     omqlogcat->log({file, line, "omq"}, level, "{}", msg);
             },
-            oxenmq::LogLevel::trace);
+#ifdef NDEBUG
+            oxenmq::LogLevel::debug
+#else
+            oxenmq::LogLevel::trace
+#endif
+    );
 
     // ping.ping: a simple debugging target for pinging the omq listener
     m_omq->add_category("ping", Access{AuthLevel::none})

--- a/src/logging/oxen_logger.cpp
+++ b/src/logging/oxen_logger.cpp
@@ -15,7 +15,7 @@ using namespace std::literals;
 
 static auto logcat = log::Cat("logging");
 
-void set_additional_log_categories(log::Level& log_level) {
+void set_additional_log_categories(log::Level log_level) {
     switch (log_level) {
         case log::Level::critical: break;
         case log::Level::err: break;
@@ -54,69 +54,42 @@ void set_additional_log_categories(log::Level& log_level) {
     }
 }
 
-LogCats extract_categories(std::string_view categories) {
-    LogCats result;
-    for (auto cat : tools::split_any(categories, " ,;", true)) {
-        auto pieces = tools::split_any(cat, ":=", true);
-        if (pieces.size() < 1 || pieces.size() > 2) {
-            log::error(
-                    logcat,
-                    "Invalid or unparseable log category/level '{}'; expected 'level' or "
-                    "'category=level'",
-                    cat);
-            continue;
-        }
-        auto lvl = parse_level(pieces.back());
-        if (!lvl) {
-            log::error(logcat, "Invalid log level '{}' in log input '{}'", pieces.back(), cat);
-            continue;
-        }
-        auto cat_name = pieces.size() == 1 ? "*"sv : pieces.front();
+using strlvl = std::pair<std::string_view, log::Level>;
+static constexpr std::array extra_levels = {
+        strlvl{"4"sv, log::Level::trace},
+        strlvl{"3"sv, log::Level::trace},
+        strlvl{"2"sv, log::Level::debug},
+        strlvl{"1"sv, log::Level::info},
+        strlvl{"0"sv, log::Level::warn},
+        strlvl{"trc"sv, log::Level::trace},
+        strlvl{"dbg"sv, log::Level::debug},
+        strlvl{"inf"sv, log::Level::info},
+        strlvl{"wrn"sv, log::Level::warn},
+        strlvl{"crt"sv, log::Level::critical},
+};
 
-        if (cat_name == "*") {
-            result.default_level = *lvl;
-            result.cat_levels.clear();
-        } else {
-            result.cat_levels[std::string{pieces.front()}] = *lvl;
-        }
-    }
-
-    return result;
+static int add_compat_levels() {
+    for (auto& [s, l] : extra_levels)
+        log::add_level_compat_string(std::string{s}, l);
+    return 42;  // Dummy value just to have a return value for static initialization
 }
+static int compat_levels = add_compat_levels();
 
 void apply_categories_string(std::string_view categories) {
-    extract_categories(categories).apply();
-}
-
-std::list<std::string> LogCats::apply() {
-    std::list<std::string> applied;
-    if (default_level) {
-        log::reset_level(*default_level);
-        set_additional_log_categories(*default_level);
-        applied.push_back("*={}"_format(log::to_string(*default_level)));
-    }
-
-    for (const auto& [cat, lvl] : cat_levels) {
-        log::set_level(cat, lvl);
-        applied.push_back("{}={}"_format(cat, log::to_string(lvl)));
-    }
-
-    if (!applied.empty())
-        log::info(logcat, "Applied log categories: {}", fmt::join(applied, ", "));
-
-    return applied;
+    log::extract_categories(categories).apply(set_additional_log_categories);
 }
 
 void init(const std::string& log_location, std::string_view log_levels, bool log_to_stdout) {
-    auto cats = extract_categories(log_levels);
+    auto cats = log::extract_categories(log_levels);
     if (cats.empty() && !log_levels.empty()) {
-        std::cerr << "Incorrect log level string: " << log_levels << std::endl;
-        throw std::runtime_error{"Invalid log level or log categories"};
+        std::cerr << "Invalid log level string: " << log_levels << std::endl;
+        throw std::runtime_error{
+                "Invalid log level or log categories string: {}"_format(log_levels)};
     }
     if (!cats.default_level)
         cats.default_level = log::Level::warn;
 
-    cats.apply();
+    cats.apply(set_additional_log_categories);
     if (log_to_stdout)
         log::add_sink(log::Type::Print, "stdout");
     if (!log_location.empty())
@@ -147,59 +120,25 @@ void set_file_sink(const std::string& log_location) {
     log::info(logcat, "Writing logs to {}", log_location);
 }
 
-using namespace std::literals;
-
-using strlvl = std::pair<std::string_view, log::Level>;
-static constexpr std::array logLevels = {
-        strlvl{""sv, log::Level::warn},         strlvl{"4"sv, log::Level::trace},
-        strlvl{"3"sv, log::Level::trace},       strlvl{"2"sv, log::Level::debug},
-        strlvl{"1"sv, log::Level::info},        strlvl{"0"sv, log::Level::warn},
-        strlvl{"trace"sv, log::Level::trace},   strlvl{"trc"sv, log::Level::trace},
-        strlvl{"debug"sv, log::Level::debug},   strlvl{"dbg"sv, log::Level::debug},
-        strlvl{"info"sv, log::Level::info},     strlvl{"inf"sv, log::Level::info},
-        strlvl{"warning"sv, log::Level::warn},  strlvl{"warn"sv, log::Level::warn},
-        strlvl{"wrn"sv, log::Level::warn},      strlvl{"error"sv, log::Level::err},
-        strlvl{"err"sv, log::Level::err},       strlvl{"critical"sv, log::Level::critical},
-        strlvl{"crit"sv, log::Level::critical}, strlvl{"crt"sv, log::Level::critical},
-};
-
-std::optional<spdlog::level::level_enum> parse_level(std::string_view input) {
-
-    auto in = tools::lowercase_ascii_string(input);
-    for (const auto& [str, lvl] : logLevels)
-        if (str == in)
-            return lvl;
-
-    return std::nullopt;
+log::Level parse_level(uint8_t input) {
+    switch (input) {
+        case 0: return log::Level::warn;
+        case 1: return log::Level::info;
+        case 2: return log::Level::debug;
+        default: return log::Level::trace;
+    }
 }
 
-static constexpr std::array<std::pair<uint8_t, log::Level>, 5> intLogLevels = {
-        {{4, log::Level::trace},
-         {3, log::Level::trace},
-         {2, log::Level::debug},
-         {1, log::Level::info},
-         {0, log::Level::warn}}};
-
-std::optional<spdlog::level::level_enum> parse_level(uint8_t input) {
-    for (const auto& [str, lvl] : intLogLevels)
-        if (str == input)
-            return lvl;
-    return std::nullopt;
-}
-
-static constexpr std::array<std::pair<oxenmq::LogLevel, log::Level>, 6> omqLogLevels = {
-        {{oxenmq::LogLevel::trace, log::Level::trace},
-         {oxenmq::LogLevel::debug, log::Level::debug},
-         {oxenmq::LogLevel::info, log::Level::info},
-         {oxenmq::LogLevel::warn, log::Level::warn},
-         {oxenmq::LogLevel::error, log::Level::err},
-         {oxenmq::LogLevel::fatal, log::Level::critical}}};
-
-std::optional<spdlog::level::level_enum> parse_level(oxenmq::LogLevel input) {
-    for (const auto& [str, lvl] : omqLogLevels)
-        if (str == input)
-            return lvl;
-    return std::nullopt;
+log::Level parse_level(oxenmq::LogLevel input) {
+    switch (input) {
+        case oxenmq::LogLevel::trace: return log::Level::trace;
+        case oxenmq::LogLevel::debug: return log::Level::debug;
+        case oxenmq::LogLevel::info: return log::Level::info;
+        case oxenmq::LogLevel::warn: return log::Level::warn;
+        case oxenmq::LogLevel::error: return log::Level::err;
+        case oxenmq::LogLevel::fatal: return log::Level::critical;
+    }
+    return log::Level::trace;
 }
 
 }  // namespace oxen::logging

--- a/src/logging/oxen_logger.h
+++ b/src/logging/oxen_logger.h
@@ -34,44 +34,13 @@ extern oxen::log::CategoryLogger globallogcat;
 namespace oxen::logging {
 void init(const std::string& log_location, std::string_view log_level, bool log_to_stdout = true);
 void set_file_sink(const std::string& log_location);
-void set_additional_log_categories(const log::Level& log_level);
-// Takes a string such as "warning, abc=info, quic=debug" and applies it to the logger.  String
-// rules:
-//
-// - Categories can be separated with spaces, commas, or semicolons
-// - The category name and the level can be separated with `=` or `:`
-// - A bare level can be specified and is equivalent to `*=level`
-// - A single `*` as the category resets all existing categories to the given level (and so means
-//   that anything before the *, such as 'abc=info, *=warning', has no effect).
-// - anything else sets the level of a single category.  (Note that `foo*=debug` is not special: it
-//   just sets a literal category 'foo*' to a level of debug, which probably doesn't do anything).
-//
-// TODO: this would probably be usefully adapted into oxen-logging itself.
+void set_additional_log_categories(log::Level log_level);
+
+// Takes a string such as "warning, abc=info, quic=debug" and applies it to the logger.  See
+// oxen::logger for the exact rules of how this works.
 void apply_categories_string(std::string_view categories);
 
-// The return value of `extract_categories`: this contains the (possible) default as well as any
-// individual log categories specified by a category string.
-struct LogCats {
-    std::optional<log::Level> default_level;
-    std::unordered_map<std::string, log::Level> cat_levels;
-
-    // True if this object contains no parsed levels (either neither a default nor any category
-    // levels)
-    bool empty() const { return !default_level && cat_levels.empty(); }
-
-    // Applies the settings in the object to the global logger.  Returns the actual setting applied
-    // (i.e. not including redundant or unparseable settings).
-    std::list<std::string> apply();
-};
-
-/// Given a log level string this extracts the default and individual category levels applied by the
-/// string, returning them in a LogCats struct.  Only final settings are included (i.e. settings
-/// overridden by a later default, or same category occuring again later, are omitted).  This is
-/// used internally by apply_categories_string but can also be used directly.
-[[nodiscard]] LogCats extract_categories(std::string_view categories);
-
-std::optional<log::Level> parse_level(std::string_view input);
-std::optional<log::Level> parse_level(uint8_t input);
-std::optional<log::Level> parse_level(oxenmq::LogLevel input);
+log::Level parse_level(uint8_t input);
+log::Level parse_level(oxenmq::LogLevel input);
 
 }  // namespace oxen::logging

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1374,7 +1374,7 @@ void core_rpc_server::invoke(GET_PEER_LIST& pl, rpc_context) {
 }
 //------------------------------------------------------------------------------------------------------------------------------
 void core_rpc_server::invoke(SET_LOG_LEVEL& set_log_level, rpc_context) {
-    auto cats = oxen::logging::extract_categories(set_log_level.request.categories);
+    auto cats = oxen::log::extract_categories(set_log_level.request.categories);
     if (cats.empty()) {
         log::error(
                 logcat,
@@ -1384,7 +1384,7 @@ void core_rpc_server::invoke(SET_LOG_LEVEL& set_log_level, rpc_context) {
         return;
     }
 
-    auto applied = cats.apply();
+    auto applied = cats.apply(oxen::logging::set_additional_log_categories);
 
     set_log_level.response["applied"] = std::move(applied);
     set_log_level.response["status"] = STATUS_OK;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3340,14 +3340,8 @@ bool simple_wallet::set_log(const std::vector<std::string>& args) {
         PRINT_USAGE(USAGE_SET_LOG);
         return true;
     }
-    if (!args.empty()) {
-        auto log_level = oxen::logging::parse_level(args[0]);
-        if (log_level.has_value())
-            log::reset_level(*log_level);
-        else {
-            oxen::logging::apply_categories_string(args[0]);
-        }
-    }
+    if (!args.empty())
+        oxen::logging::apply_categories_string(args[0]);
 
     success_msg_writer() << "Log categories updated";
     return true;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -283,9 +283,7 @@ WalletManagerBase* WalletManagerFactory::getWalletManager() {
 
 EXPORT
 void WalletManagerFactory::setLogLevel(int level) {
-    auto log_level = oxen::logging::parse_level(level);
-    if (log_level.has_value())
-        log::reset_level(*log_level);
+    log::reset_level(oxen::logging::parse_level(level));
 }
 
 EXPORT

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3102,9 +3102,7 @@ SET_DAEMON::response wallet_rpc_server::invoke(SET_DAEMON::request&& req) {
 SET_LOG_LEVEL::response wallet_rpc_server::invoke(SET_LOG_LEVEL::request&& req) {
     if (req.level < 0 || req.level > 4)
         throw wallet_rpc_error{error_code::INVALID_LOG_LEVEL, "Error: log level not valid"};
-    auto log_level = oxen::logging::parse_level(req.level);
-    if (log_level.has_value())
-        log::reset_level(*log_level);
+    log::reset_level(oxen::logging::parse_level(req.level));
     return {};
 }
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet3/wallet.cpp
+++ b/src/wallet3/wallet.cpp
@@ -81,7 +81,7 @@ Wallet::Wallet(
 void Wallet::init() {
     keys->expand_subaddresses(
             {config.general.subaddress_lookahead_major, config.general.subaddress_lookahead_minor});
-    oxen::log::reset_level(*oxen::logging::parse_level(config.logging.level));
+    oxen::logging::apply_categories_string(config.logging.level);
     fs::path log_location = "";
     if (config.logging.save_logs_in_subdirectory)
         log_location /= config.logging.logdir;


### PR DESCRIPTION
oxen-logging 1.2.0 (https://github.com/oxen-io/oxen-logging/pull/19) extracted the log category string parser from oxen-core so that we can use it elsewhere; this commit updates oxen-core to drop its parsing in favour of the new version from oxen-logging.

The new code should work identically to existing code, with some small improvements:

- glob matching of categories, e.g. `net*=debug` matches net, net.p2p.msg, and anything else starting with net.
- ability to disable logging for a category entirely with `cat=off` (or aliases `cat=disable` or `cat=none`).