### PR TITLE
Fix deadlock after 6-7 days from SNL+Blockchain opening conflicting write TXNs

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -5547,7 +5547,11 @@ bool service_node_list::store(uint64_t state_height) {
         return true;
 
     // NOTE: Convert the runtime SNL data into a format suitable for serialization into the DB
-    std::lock_guard lock(m_sn_mutex);
+    // NOTE: Must lock blockchain to prevent other threads from opening a batch whilst we have a
+    // db_wtxn_guard open which breaks LMDB.
+    // TODO: db_wtxn_guard looks like it could be replaced with an RAII class that does
+    // batch_start and batch_stop, consider repurposing LockedTXN and or merging them all into one.
+    auto locks = tools::unique_locks(m_sn_mutex, blockchain);
 
     std::vector<std::string> archive_blob_list;
     std::vector<std::string> history_blob_list;


### PR DESCRIPTION
After 6-7 days, a timer activates that periodically calls SNL::store() to backup the current SNL state to disk. During this process if the daemon receives a Pulse block, that will also initiate a write to the DB.

These 2 processes conflict with each other, the SNL opens a single-write TXN whereas the Blockchain opens a batch-write TXN which are incompatible with each other. Opening a TXN in that sequence causes a deadlock because the blockchain thread handling the receipt of a block throws an exception without releasing the lock (opening it in the opposite TXN does not deadlock because the periodic timer instead throws the exception but is exception safe).

This fixes it by ensuring that the SNL locks the Blockchain thread so when the periodic timer gets invoked if we receive a block, the block handling thread will not proceed until the store is done thereby preventing the exception from handling.

This commit only addresses this individual issue. The other fixes to make Blockchain exception safe on block handled (e.g.: ensuring that the locks it held are released when the stack unwinds) is in another PR.