### PR TITLE
Fix exception-unsafe prepare_handle_incoming_block and various LMDB cleanup/fixes

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3718,14 +3718,9 @@ void BlockchainLMDB::batch_stop() {
     check_open();
     log::trace(logcat, "batch transaction: committing...");
     auto time1 = std::chrono::steady_clock::now();
-    try {
-        m_write_txn->commit();
-        time_commit1 += std::chrono::steady_clock::now() - time1;
-        cleanup_batch();
-    } catch (const std::exception& e) {
-        cleanup_batch();
-        throw;
-    }
+    auto on_exit = oxen::defer([&] { cleanup_batch(); });
+    m_write_txn->commit();
+    time_commit1 += std::chrono::steady_clock::now() - time1;
     log::trace(logcat, "batch transaction: end");
 }
 
@@ -3740,15 +3735,8 @@ void BlockchainLMDB::batch_abort() {
     if (m_writer != boost::this_thread::get_id())
         throw1(DB_ERROR("batch transaction owned by other thread"));
     check_open();
-    // for destruction of batch transaction
-    m_write_txn = nullptr;
-    // explicitly call in case mdb_env_close() (BlockchainLMDB::close()) called before
-    // BlockchainLMDB destructor called.
+    auto on_exit = oxen::defer([&] { cleanup_batch(); });
     m_write_batch_txn->abort();
-    delete m_write_batch_txn;
-    m_write_batch_txn = nullptr;
-    m_batch_active = false;
-    memset(&m_wcursors, 0, sizeof(m_wcursors));
     log::trace(logcat, "batch transaction: aborted");
 }
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -628,9 +628,13 @@ void BlockchainLMDB::do_resize(uint64_t bytes_required) {
     log::trace(logcat, "BlockchainLMDB::{}", __func__);
     std::lock_guard lock{*this};
 
-    bool batch_was_active = m_batch_active;
-    if (batch_was_active)
-        batch_stop();
+    assert(!m_batch_active &&
+           "Do resize is private and _only_ called at the start `batch_start` so m_batch_active "
+           "will always be false because `batch_start` returns early if it's active");
+    if (m_batch_active) {
+        log::error(logcat, "LMDB batch is unexpectedly active during resize, cancelling resize");
+        return;
+    }
 
     // NOTE: Check disk capacity
     uint64_t const add_size = std::max(MIN_GROW_SIZE, bytes_required);
@@ -676,8 +680,6 @@ void BlockchainLMDB::do_resize(uint64_t bytes_required) {
                 old_size_str, new_size_str, mdb_strerror(result))));
 
     log::info(logcat, "LMDB map size increased.  Old: {}, new: {}", old_size_str, new_size_str);
-    if (batch_was_active)
-        batch_start();
 }
 
 void BlockchainLMDB::add_block(

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3696,31 +3696,6 @@ bool BlockchainLMDB::batch_start(uint64_t bytes_required) {
     return true;
 }
 
-void BlockchainLMDB::batch_commit() {
-    log::trace(logcat, "BlockchainLMDB::{}", __func__);
-    if (!m_batch_transactions)
-        throw0(DB_ERROR("batch transactions not enabled"));
-    if (!m_batch_active)
-        throw1(DB_ERROR("batch transaction not in progress"));
-    if (m_write_batch_txn == nullptr)
-        throw1(DB_ERROR("batch transaction not in progress"));
-    if (m_writer != boost::this_thread::get_id())
-        throw1(DB_ERROR("batch transaction owned by other thread"));
-
-    check_open();
-
-    log::trace(logcat, "batch transaction: committing...");
-    auto time1 = std::chrono::steady_clock::now();
-    m_write_txn->commit();
-    time_commit1 += std::chrono::steady_clock::now() - time1;
-    log::trace(logcat, "batch transaction: committed");
-
-    m_write_txn = nullptr;
-    delete m_write_batch_txn;
-    m_write_batch_txn = nullptr;
-    memset(&m_wcursors, 0, sizeof(m_wcursors));
-}
-
 void BlockchainLMDB::cleanup_batch() {
     // for destruction of batch transaction
     m_write_txn = nullptr;

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -355,7 +355,6 @@ class BlockchainLMDB : public BlockchainDB {
 
     void set_batch_transactions(bool batch_transactions) override;
     bool batch_start(uint64_t bytes_required = 0) override;
-    void batch_commit();
     void batch_stop() override;
     void batch_abort() override;
 

--- a/src/bls/bls_aggregator.cpp
+++ b/src/bls/bls_aggregator.cpp
@@ -47,8 +47,8 @@ static constexpr std::string_view to_string(bls_exit_type type) {
 
 std::string bytes_to_hex_dot_truncate_middle(std::span<const unsigned char> bytes) {
     size_t dot_size = 3;  // How many dots to show in the middle
-    size_t head_hex = 6;  // How many hex characters to preserve from head of string
-    size_t tail_hex = 6;  // How many hex characters to preserve from tail of string
+    size_t head_hex = 3;  // How many hex characters to preserve from head of string
+    size_t tail_hex = 3;  // How many hex characters to preserve from tail of string
 
     std::string hex = oxenc::to_hex(bytes.begin(), bytes.end());
 
@@ -56,7 +56,7 @@ std::string bytes_to_hex_dot_truncate_middle(std::span<const unsigned char> byte
     std::string_view head = tools::string_safe_substr(hex, 0, head_hex);
 
     tail_hex = std::min(tail_hex, head.size());
-    std::string_view tail = tools::string_safe_substr(head, head.size() - tail_hex, tail_hex);
+    std::string_view tail = tools::string_safe_substr(hex, hex.size() - tail_hex, tail_hex);
 
     std::string result = fmt::format("{}{:.>{}}{}", head, "", dot_size, tail);
     return result;
@@ -309,11 +309,22 @@ namespace {
                 continue;
 
             fmt::format_to(
-                    std::back_inserter(buffer), "{} runs:\n", success ? "Successful" : "Failed");
-            for (const auto& item : list) {
+                    std::back_inserter(buffer),
+                    "{} runs ({}):\n",
+                    success ? "Successful" : "Failed",
+                    list.size());
+            for (size_t index = 0; index < list.size(); index++) {
+                const auto& item = list[index];
+
+                const std::array<uint16_t, 3>& ver = item.addr.version;
+                std::string ver_str = ver == std::array<uint16_t, 3>{0, 0, 0}
+                                            ? "Unknown"
+                                            : "{}.{}.{}"_format(ver[0], ver[1], ver[2]);
                 fmt::format_to(
                         std::back_inserter(buffer),
-                        "  - SN {} BLS {} XKEY {} @ {:<21} => {}\n",
+                        "  {:<4d} SN {} {} BLS {} XKEY {} @ {:<21} => {}\n",
+                        index,
+                        ver_str,
                         bytes_to_hex_dot_truncate_middle(item.addr.sn_pubkey),
                         bytes_to_hex_dot_truncate_middle(item.addr.bls_pubkey),
                         bytes_to_hex_dot_truncate_middle(item.addr.x_pubkey),

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1045,10 +1045,20 @@ bool Blockchain::deinit() {
 // It starts a batch and calls private method pop_block_from_db().
 void Blockchain::pop_blocks(uint64_t nblocks) {
     ZoneScoped;
-    uint64_t i = 0;
     auto lock = tools::unique_locks(tx_pool, *this);
-    bool stop_batch = m_db->batch_start();
 
+    bool stop_batch = m_db->batch_start();
+    bool pop_error = false;
+    auto on_exit = oxen::defer([&] {
+        if (stop_batch) {
+            if (pop_error)
+                m_db->batch_abort();
+            else
+                m_db->batch_stop();
+        }
+    });
+
+    uint64_t i = 0;
     try {
         const uint64_t blockchain_height = m_db->height();
         if (blockchain_height > 0)
@@ -1075,14 +1085,11 @@ void Blockchain::pop_blocks(uint64_t nblocks) {
         }
     } catch (const std::exception& e) {
         log::error(logcat, "Error when popping blocks after processing {} blocks: {}", i, e.what());
-        if (stop_batch)
-            m_db->batch_abort();
+        pop_error = true;
         return;
     }
 
     exec_detach_hooks(*this, m_db->height(), m_blockchain_detached_hooks, /*by_pop_blocks=*/true);
-    if (stop_batch)
-        m_db->batch_stop();
 }
 //------------------------------------------------------------------
 // This function tells BlockchainDB to remove the top block from the
@@ -1386,10 +1393,13 @@ bool Blockchain::rollback_blockchain_switching(
 bool Blockchain::blink_rollback(uint64_t rollback_height) {
     auto lock = tools::unique_locks(tx_pool, *this);
     bool stop_batch = m_db->batch_start();
+    auto on_exit = oxen::defer([&] {
+        if (stop_batch)
+            m_db->batch_stop();
+    });
+
     log::debug(logcat, "Rolling back to height {}", rollback_height);
     bool ret = rollback_blockchain_switching({}, rollback_height);
-    if (stop_batch)
-        m_db->batch_stop();
     return ret;
 }
 //------------------------------------------------------------------
@@ -6072,6 +6082,10 @@ bool Blockchain::update_checkpoints_from_json_file(const fs::path& file_path) {
     {
         std::unique_lock lock{*this};
         bool stop_batch = m_db->batch_start();
+        auto on_exit = oxen::defer([&] {
+            if (stop_batch)
+                m_db->batch_stop();
+        });
 
         for (std::vector<height_to_hash>::const_iterator it = first_to_check;
              it != one_past_last_to_check;
@@ -6090,9 +6104,6 @@ bool Blockchain::update_checkpoints_from_json_file(const fs::path& file_path) {
                 result = false;
             }
         }
-
-        if (stop_batch)
-            m_db->batch_stop();
     }
 
     return result;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -6398,267 +6398,283 @@ bool Blockchain::prepare_handle_incoming_blocks(
         total_txs += entry.txs.size();
     }
     m_bytes_to_sync += bytes;
-    while (!m_db->batch_start(bytes)) {
-        unlock();
-        tx_pool.unlock();
-        std::this_thread::sleep_for(100ms);
-        std::lock(tx_pool, *this);
-    }
-    m_batch_success = true;
 
-    const uint64_t height = m_db->height();
-    if ((height + blocks_entry.size()) < m_blocks_hash_check.size())
-        return true;
+    // It's important that any exception thrown here is caught to return false once we have the
+    // lock and attempt to start the batch because we need to call cleanup_handle_incoming_blocks
+    // to ensure we release the locks and do general cleanup (otherwise we deadlock the system).
+    //
+    // We don't expect an exception to be thrown here so we log an error if we do to investigate if
+    // it does.
+    try {
+        while (!m_db->batch_start(bytes)) {
+            unlock();
+            tx_pool.unlock();
+            std::this_thread::sleep_for(100ms);
+            std::lock(tx_pool, *this);
+        }
+        m_batch_success = true;
 
-    bool blocks_exist = false;
-    tools::threadpool& tpool = tools::threadpool::getInstance();
-    unsigned threads = tpool.get_max_concurrency();
-    blocks.resize(blocks_entry.size());
+        const uint64_t height = m_db->height();
+        if ((height + blocks_entry.size()) < m_blocks_hash_check.size())
+            return true;
 
-    {
-        // limit threads, default limit = 4
-        if (threads > m_max_prepare_blocks_threads)
-            threads = m_max_prepare_blocks_threads;
+        bool blocks_exist = false;
+        tools::threadpool& tpool = tools::threadpool::getInstance();
+        unsigned threads = tpool.get_max_concurrency();
+        blocks.resize(blocks_entry.size());
 
-        unsigned int batches = blocks_entry.size() / threads;
-        unsigned int extra = blocks_entry.size() % threads;
-        log::debug(logcat, "block_batches: {}", batches);
-        std::vector<std::unordered_map<crypto::hash, crypto::hash>> maps(threads);
-        auto it = blocks_entry.begin();
-        unsigned blockidx = 0;
+        {
+            // limit threads, default limit = 4
+            if (threads > m_max_prepare_blocks_threads)
+                threads = m_max_prepare_blocks_threads;
 
-        const crypto::hash tophash = m_db->top_block_hash();
-        for (unsigned i = 0; i < threads; i++) {
-            for (unsigned int j = 0; j < batches; j++, ++blockidx) {
+            unsigned int batches = blocks_entry.size() / threads;
+            unsigned int extra = blocks_entry.size() % threads;
+            log::debug(logcat, "block_batches: {}", batches);
+            std::vector<std::unordered_map<crypto::hash, crypto::hash>> maps(threads);
+            auto it = blocks_entry.begin();
+            unsigned blockidx = 0;
+
+            const crypto::hash tophash = m_db->top_block_hash();
+            for (unsigned i = 0; i < threads; i++) {
+                for (unsigned int j = 0; j < batches; j++, ++blockidx) {
+                    block& block = blocks[blockidx];
+                    crypto::hash block_hash;
+
+                    if (!parse_and_validate_block_from_blob(it->block, block, block_hash))
+                        return false;
+
+                    // check first block and skip all blocks if its not chained properly
+                    if (blockidx == 0) {
+                        if (block.prev_id != tophash) {
+                            log::debug(
+                                    logcat,
+                                    "Skipping prepare blocks. New blocks don't belong to "
+                                    "chain.");
+                            blocks.clear();
+                            return true;
+                        }
+                    }
+                    if (have_block(block_hash))
+                        blocks_exist = true;
+
+                    std::advance(it, 1);
+                }
+            }
+
+            for (unsigned i = 0; i < extra && !blocks_exist; i++, blockidx++) {
                 block& block = blocks[blockidx];
                 crypto::hash block_hash;
 
                 if (!parse_and_validate_block_from_blob(it->block, block, block_hash))
                     return false;
 
-                // check first block and skip all blocks if its not chained properly
-                if (blockidx == 0) {
-                    if (block.prev_id != tophash) {
-                        log::debug(
-                                logcat,
-                                "Skipping prepare blocks. New blocks don't belong to chain.");
-                        blocks.clear();
-                        return true;
-                    }
-                }
                 if (have_block(block_hash))
                     blocks_exist = true;
 
                 std::advance(it, 1);
             }
-        }
 
-        for (unsigned i = 0; i < extra && !blocks_exist; i++, blockidx++) {
-            block& block = blocks[blockidx];
-            crypto::hash block_hash;
+            if (!blocks_exist && blocks[0].major_version < feature::PULSE) {
+                // This code multi-threads the pow hash cache (m_blocks_longhash_table), but in
+                // pulse we rarely use those values (and if isn't set all that happens is that
+                // the pow hash gets computed later), so skip this entirely post-pulse.
+                m_blocks_longhash_table.clear();
+                uint64_t thread_height = height;
+                tools::threadpool::waiter waiter;
+                m_prepare_height = height;
+                m_prepare_nblocks = blocks_entry.size();
+                m_prepare_blocks = &blocks;
+                for (unsigned int i = 0; i < threads; i++) {
+                    unsigned nblocks = batches;
+                    if (i < extra)
+                        ++nblocks;
+                    tpool.submit(
+                            &waiter,
+                            [this,
+                             thread_height,
+                             blocks = epee::span<const block>(
+                                     &blocks[thread_height - height], nblocks),
+                             &map = maps[i]] { block_longhash_worker(thread_height, blocks, map); },
+                            true);
+                    thread_height += nblocks;
+                }
 
-            if (!parse_and_validate_block_from_blob(it->block, block, block_hash))
-                return false;
+                waiter.wait(&tpool);
+                m_prepare_height = 0;
 
-            if (have_block(block_hash))
-                blocks_exist = true;
+                if (m_cancel)
+                    return false;
 
-            std::advance(it, 1);
-        }
-
-        if (!blocks_exist && blocks[0].major_version < feature::PULSE) {
-            // This code multi-threads the pow hash cache (m_blocks_longhash_table), but in pulse we
-            // rarely use those values (and if isn't set all that happens is that the pow hash gets
-            // computed later), so skip this entirely post-pulse.
-            m_blocks_longhash_table.clear();
-            uint64_t thread_height = height;
-            tools::threadpool::waiter waiter;
-            m_prepare_height = height;
-            m_prepare_nblocks = blocks_entry.size();
-            m_prepare_blocks = &blocks;
-            for (unsigned int i = 0; i < threads; i++) {
-                unsigned nblocks = batches;
-                if (i < extra)
-                    ++nblocks;
-                tpool.submit(
-                        &waiter,
-                        [this,
-                         thread_height,
-                         blocks = epee::span<const block>(&blocks[thread_height - height], nblocks),
-                         &map = maps[i]] { block_longhash_worker(thread_height, blocks, map); },
-                        true);
-                thread_height += nblocks;
+                for (const auto& map : maps) {
+                    m_blocks_longhash_table.insert(map.begin(), map.end());
+                }
             }
+        }
 
-            waiter.wait(&tpool);
-            m_prepare_height = 0;
+        if (m_cancel)
+            return false;
 
+        if (blocks_exist) {
+            log::debug(logcat, "Skipping remainder of prepare blocks. Blocks exist.");
+            return true;
+        }
+
+        m_fake_scan_time = 0ns;
+        m_fake_pow_calc_time = 0ns;
+
+        m_scan_table.clear();
+
+        auto prepare_elapsed = std::chrono::steady_clock::now() - prepare;
+        m_fake_pow_calc_time = prepare_elapsed / blocks_entry.size();
+
+        if (blocks_entry.size() > 1 && threads > 1 && m_show_time_stats)
+            log::debug(
+                    logcat, "Prepare blocks took: {}", tools::friendly_duration(prepare_elapsed));
+
+        auto scantable = std::chrono::steady_clock::now();
+
+        // [input] stores all absolute_offsets for each amount
+        std::vector<uint64_t> offsets;
+        // [output] stores all output_data_t for each absolute_offset
+        std::vector<output_data_t> txs;
+        std::vector<std::pair<cryptonote::transaction, crypto::hash>> txes(total_txs);
+
+        // generate absolute offsets
+        size_t tx_index = 0;
+        for (const auto& entry : blocks_entry) {
             if (m_cancel)
                 return false;
 
-            for (const auto& map : maps) {
-                m_blocks_longhash_table.insert(map.begin(), map.end());
-            }
-        }
-    }
+            for (const auto& tx_blob : entry.txs) {
+                if (tx_index >= txes.size()) {
+                    log::error(logverify, "tx_index is out of sync");
+                    m_scan_table.clear();
+                    return false;
+                }
+                transaction& tx = txes[tx_index].first;
+                crypto::hash& tx_prefix_hash = txes[tx_index].second;
+                ++tx_index;
 
-    if (m_cancel)
-        return false;
+                if (!parse_and_validate_tx_base_from_blob(tx_blob, tx)) {
+                    log::error(logverify, "Could not parse tx from incoming blocks");
+                    m_scan_table.clear();
+                    return false;
+                }
+                cryptonote::get_transaction_prefix_hash(tx, tx_prefix_hash);
 
-    if (blocks_exist) {
-        log::debug(logcat, "Skipping remainder of prepare blocks. Blocks exist.");
-        return true;
-    }
-
-    m_fake_scan_time = 0ns;
-    m_fake_pow_calc_time = 0ns;
-
-    m_scan_table.clear();
-
-    auto prepare_elapsed = std::chrono::steady_clock::now() - prepare;
-    m_fake_pow_calc_time = prepare_elapsed / blocks_entry.size();
-
-    if (blocks_entry.size() > 1 && threads > 1 && m_show_time_stats)
-        log::debug(logcat, "Prepare blocks took: {}", tools::friendly_duration(prepare_elapsed));
-
-    auto scantable = std::chrono::steady_clock::now();
-
-    // [input] stores all absolute_offsets for each amount
-    std::vector<uint64_t> offsets;
-    // [output] stores all output_data_t for each absolute_offset
-    std::vector<output_data_t> txs;
-    std::vector<std::pair<cryptonote::transaction, crypto::hash>> txes(total_txs);
-
-    // generate absolute offsets
-    size_t tx_index = 0;
-    for (const auto& entry : blocks_entry) {
-        if (m_cancel)
-            return false;
-
-        for (const auto& tx_blob : entry.txs) {
-            if (tx_index >= txes.size()) {
-                log::error(logverify, "tx_index is out of sync");
-                m_scan_table.clear();
-                return false;
-            }
-            transaction& tx = txes[tx_index].first;
-            crypto::hash& tx_prefix_hash = txes[tx_index].second;
-            ++tx_index;
-
-            if (!parse_and_validate_tx_base_from_blob(tx_blob, tx)) {
-                log::error(logverify, "Could not parse tx from incoming blocks");
-                m_scan_table.clear();
-                return false;
-            }
-            cryptonote::get_transaction_prefix_hash(tx, tx_prefix_hash);
-
-            auto [its, ins] = m_scan_table.emplace(
-                    tx_prefix_hash,
-                    std::unordered_map<crypto::key_image, std::vector<output_data_t>>{});
-            if (!ins) {
-                log::error(logverify, "Duplicate tx found from incoming blocks.");
-                m_scan_table.clear();
-                return false;
-            }
-
-            // check all tx.vin(s)
-            if (!tx.is_miner_tx()) {
-                for (const auto& txin : tx.vin) {
-                    const auto& in_to_key = std::get<txin_to_key>(txin);
-
-                    // check for duplicate
-                    auto it = its->second.find(in_to_key.k_image);
-                    if (it != its->second.end()) {
-                        log::error(logverify, "Duplicate key_image found from incoming blocks.");
-                        m_scan_table.clear();
-                        return false;
-                    }
+                auto [its, ins] = m_scan_table.emplace(
+                        tx_prefix_hash,
+                        std::unordered_map<crypto::key_image, std::vector<output_data_t>>{});
+                if (!ins) {
+                    log::error(logverify, "Duplicate tx found from incoming blocks.");
+                    m_scan_table.clear();
+                    return false;
                 }
 
-                // add new absolute offsets to offsets
-                if (!tx.is_miner_tx())
-                    for (const auto& txin : tx.vin)
-                        for (auto off : relative_output_offsets_to_absolute(
-                                     std::get<txin_to_key>(txin).key_offsets))
-                            offsets.push_back(off);
+                // check all tx.vin(s)
+                if (!tx.is_miner_tx()) {
+                    for (const auto& txin : tx.vin) {
+                        const auto& in_to_key = std::get<txin_to_key>(txin);
+
+                        // check for duplicate
+                        auto it = its->second.find(in_to_key.k_image);
+                        if (it != its->second.end()) {
+                            log::error(
+                                    logverify, "Duplicate key_image found from incoming blocks.");
+                            m_scan_table.clear();
+                            return false;
+                        }
+                    }
+
+                    // add new absolute offsets to offsets
+                    if (!tx.is_miner_tx())
+                        for (const auto& txin : tx.vin)
+                            for (auto off : relative_output_offsets_to_absolute(
+                                         std::get<txin_to_key>(txin).key_offsets))
+                                offsets.push_back(off);
+                }
             }
         }
-    }
 
-    // sort and remove duplicate absolute_offsets in offset_map
-    std::sort(offsets.begin(), offsets.end());
-    auto last = std::unique(offsets.begin(), offsets.end());
-    offsets.erase(last, offsets.end());
+        // sort and remove duplicate absolute_offsets in offset_map
+        std::sort(offsets.begin(), offsets.end());
+        auto last = std::unique(offsets.begin(), offsets.end());
+        offsets.erase(last, offsets.end());
 
-    try {
-        constexpr uint64_t amount{0};
-        m_db->get_output_key(epee::span<const uint64_t>(&amount, 1), offsets, txs, true);
-    } catch (const std::exception& e) {
-        log::error(logverify, "EXCEPTION: {}", e.what());
-    } catch (...) {
-    }
+        try {
+            constexpr uint64_t amount{0};
+            m_db->get_output_key(epee::span<const uint64_t>(&amount, 1), offsets, txs, true);
+        } catch (const std::exception& e) {
+            log::error(logverify, "EXCEPTION: {}", e.what());
+        } catch (...) {
+        }
 
-    // now generate a table for each tx_prefix and k_image hashes
-    tx_index = 0;
-    for (const auto& entry : blocks_entry) {
-        if (m_cancel)
-            return false;
-
-        for (const auto& tx_blob : entry.txs) {
-            if (tx_index >= txes.size()) {
-                log::error(logverify, "tx_index is out of sync");
-                m_scan_table.clear();
+        // now generate a table for each tx_prefix and k_image hashes
+        tx_index = 0;
+        for (const auto& entry : blocks_entry) {
+            if (m_cancel)
                 return false;
-            }
-            const auto& [tx, tx_prefix_hash] = txes[tx_index++];
 
-            auto its = m_scan_table.find(tx_prefix_hash);
-            if (its == m_scan_table.end()) {
-                log::error(logverify, "Tx not found on scan table from incoming blocks.");
-                m_scan_table.clear();
-                return false;
-            }
+            for (const auto& tx_blob : entry.txs) {
+                if (tx_index >= txes.size()) {
+                    log::error(logverify, "tx_index is out of sync");
+                    m_scan_table.clear();
+                    return false;
+                }
+                const auto& [tx, tx_prefix_hash] = txes[tx_index++];
 
-            if (!tx.is_miner_tx()) {
-                for (const auto& txin : tx.vin) {
-                    const txin_to_key& in_to_key = std::get<txin_to_key>(txin);
-                    auto needed_offsets =
-                            relative_output_offsets_to_absolute(in_to_key.key_offsets);
+                auto its = m_scan_table.find(tx_prefix_hash);
+                if (its == m_scan_table.end()) {
+                    log::error(logverify, "Tx not found on scan table from incoming blocks.");
+                    m_scan_table.clear();
+                    return false;
+                }
 
-                    std::vector<output_data_t> outputs;
-                    for (const uint64_t& offset_needed : needed_offsets) {
-                        size_t pos = 0;
-                        bool found = false;
+                if (!tx.is_miner_tx()) {
+                    for (const auto& txin : tx.vin) {
+                        const txin_to_key& in_to_key = std::get<txin_to_key>(txin);
+                        auto needed_offsets =
+                                relative_output_offsets_to_absolute(in_to_key.key_offsets);
 
-                        for (const uint64_t& offset_found : offsets) {
-                            if (offset_needed == offset_found) {
-                                found = true;
-                                break;
+                        std::vector<output_data_t> outputs;
+                        for (const uint64_t& offset_needed : needed_offsets) {
+                            size_t pos = 0;
+                            bool found = false;
+
+                            for (const uint64_t& offset_found : offsets) {
+                                if (offset_needed == offset_found) {
+                                    found = true;
+                                    break;
+                                }
+
+                                ++pos;
                             }
 
-                            ++pos;
+                            if (found && pos < txs.size())
+                                outputs.push_back(txs.at(pos));
+                            else
+                                break;
                         }
 
-                        if (found && pos < txs.size())
-                            outputs.push_back(txs.at(pos));
-                        else
-                            break;
+                        its->second.emplace(in_to_key.k_image, outputs);
                     }
-
-                    its->second.emplace(in_to_key.k_image, outputs);
                 }
             }
         }
-    }
 
-    if (total_txs > 0) {
-        auto scantable_elapsed = std::chrono::steady_clock::now() - scantable;
-        m_fake_scan_time = scantable_elapsed / total_txs;
-        if (m_show_time_stats)
-            log::debug(
-                    logcat,
-                    "Prepare scantable took: {}",
-                    tools::friendly_duration(scantable_elapsed));
+        if (total_txs > 0) {
+            auto scantable_elapsed = std::chrono::steady_clock::now() - scantable;
+            m_fake_scan_time = scantable_elapsed / total_txs;
+            if (m_show_time_stats)
+                log::debug(
+                        logcat,
+                        "Prepare scantable took: {}",
+                        tools::friendly_duration(scantable_elapsed));
+        }
+    } catch (const std::exception& e) {
+        log::error(logcat, "Prepare to handle incoming blocks failed: {}", e.what());
+        return false;
     }
 
     return true;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -6454,11 +6454,13 @@ service_nodes_infos_t::iterator service_node_list::state_t::erase_info(
 
             uint32_t public_ip = 0;
             uint16_t qnet_port = 0;
+            std::array<uint16_t, 3> version = {};
             if (sn_list) {
                 auto proof_it = sn_list->proofs.find(snpk);
                 if (proof_it != sn_list->proofs.end()) {
                     const std::unique_ptr<uptime_proof::Proof>& proof = proof_it->second.proof;
                     if (proof) {
+                        version = proof->version;
                         public_ip = proof->public_ip;
                         qnet_port = proof->qnet_port;
                     }
@@ -6476,6 +6478,7 @@ service_nodes_infos_t::iterator service_node_list::state_t::erase_info(
                     .type = exit_type,
                     .public_ip = public_ip,
                     .qnet_port = qnet_port,
+                    .version = version,
                     .service_node_pubkey = snpk,
                     .info = *it->second});
         }

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -425,6 +425,7 @@ struct service_node_address {
     crypto::x25519_public_key x_pubkey;
     uint32_t ip;
     uint16_t port;
+    std::array<uint16_t, 3> version{};
 };
 
 using pubkey_and_sninfo = std::pair<crypto::public_key, std::shared_ptr<const service_node_info>>;
@@ -814,7 +815,8 @@ class service_node_list {
                     pk_info.second->bls_public_key,
                     sn_pk_is_ed25519_hf ? snpk_to_xpk(pk_info.first) : it->second.pubkey_x25519,
                     proof.public_ip,
-                    proof.qnet_port});
+                    proof.qnet_port,
+                    proof.version});
         }
 
         if (sn_pk_is_ed25519_hf) {
@@ -830,7 +832,8 @@ class service_node_list {
                             recently_removed_it.info.bls_public_key,
                             it->second.pubkey_x25519,
                             proof.public_ip,
-                            proof.qnet_port});
+                            proof.qnet_port,
+                            proof.version});
                     continue;
                 }
 
@@ -842,7 +845,8 @@ class service_node_list {
                         recently_removed_it.info.bls_public_key,
                         snpk_to_xpk(recently_removed_it.service_node_pubkey),
                         recently_removed_it.public_ip,
-                        recently_removed_it.qnet_port});
+                        recently_removed_it.qnet_port,
+                        recently_removed_it.version});
             }
         }
     }
@@ -932,17 +936,18 @@ class service_node_list {
             purged,
         };
 
-        uint64_t height;              // Height at which the SN exited/deregistered
-        uint64_t liquidation_height;  // Height at which the SN is eligible for liquidation
-        type_t type;                  // Event that occurred to remove this SN
-        uint32_t public_ip;           // Last known public IP of this SN (may be outdated)
-        uint16_t qnet_port;           // Last known quorumnet port of this SN (may be outdated)
+        uint64_t height;                  // Height at which the SN exited/deregistered
+        uint64_t liquidation_height;      // Height at which the SN is eligible for liquidation
+        type_t type;                      // Event that occurred to remove this SN
+        uint32_t public_ip;               // Last known public IP of this SN (may be outdated)
+        uint16_t qnet_port;               // Last known quorumnet port of this SN (may be outdated)
+        std::array<uint16_t, 3> version;  // Last known version of this SN (may be outdated)
         crypto::public_key service_node_pubkey;  // SN primary ed25519 key
         service_node_info info;  // Info copied from the SNL and frozen at point of exit
 
         template <class Archive>
         void serialize_object(Archive& ar) {
-            uint8_t version = 1;
+            uint8_t version = 2;
             field_varint(ar, "version", version);
             if (version == 0) {  // NOTE: v0 we completely discard and force a full-rescan
                 crypto::public_key pubkey;
@@ -962,6 +967,9 @@ class service_node_list {
             if (version >= 1) {
                 field(ar, "service_node_pubkey", service_node_pubkey);
                 field(ar, "info", info);
+            }
+            if (version >= 2) {
+                field(ar, "version", version);
             }
         }
     };


### PR DESCRIPTION
- `batch_commit` is an unused function the LMDB layer that is now removed, no code as using it.
- `do_resize` was checking for if a batch was active and closing and re-opening it unnecessarily. `do_resize` is a private function that's only called in the implementation file, and, the only place it is called is in the `batch_start` function before the code to start a batch has run. Hence it can never be active during a resize so that code has been removed.
- Use `oxen::defer` to ensure that the LMDB `batch_stop` is called when `batch_start` is executed on scope-exit. Essentially just makes sure that if there's any early return/uncaught thrown exception, on stack unwind the batch will be closed correctly, making sure that the DB remains in a consistent state.
- Guard against a thrown exception in `batch_start` in `prepare_handle_incoming_blocks`  which is the other part of this https://github.com/oxen-io/oxen-core/pull/1868. With the fix, that code path shouldn't throw anymore, but, for future proofing, we add a try-catch block over it to signal very loudly that this function must return to the callee to ensure that cleanup_handling_incoming_blocks is called which correctly releases held locks and closes the batch.
- Fix the BLS debug logs repeating the key prefix when truncating the keys for printing.