### PR TITLE
Fix block rewards failing to be inserted on archival heights; fixup DBs affected by this

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -791,8 +791,9 @@ void BlockchainSQLite::blockchain_detached(
         prepared_exec(
                 "INSERT INTO delayed_payments ({delayed_fields})"
                 " SELECT {delayed_fields} FROM delayed_payments_{suffix}"
-                " WHERE ? BETWEEN height AND payout_height"_format(
+                " WHERE ? >= height AND ? < payout_height"_format(
                         "delayed_fields"_a = DELAYED_PAYMENTS_COLS, "suffix"_a = suffix),
+                static_cast<int64_t>(new_height),
                 static_cast<int64_t>(new_height));
     }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -1727,4 +1727,92 @@ bool BlockchainSQLite::save_payments(
     }
     return true;
 }
+
+std::optional<uint64_t> BlockchainSQLite::apply_fixups()
+{
+    std::optional<uint64_t> result;
+    if (nettype == cryptonote::network_type::MAINNET) {
+        struct fixup_record {
+            uint64_t height;
+            uint64_t value;
+            cryptonote::hf hf;
+        } constexpr RECORDS[] = {
+                {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
+                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
+                {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
+        };
+
+        int64_t version = prepared_get<int64_t>("PRAGMA user_version");
+        uint64_t earliest_height = (std::end(RECORDS) - 1)->height;
+        if (version == 0 && height >= earliest_height) {
+            // This DB that has synced past the ETH transition and is still on V0 may be affected by
+            // the delayed payments issue that incorrectly rejected rewards payments in blocks
+            // sitting on the archiving interval (due to duplicate delayed payment rows to be
+            // archived) at 1'870'000 and/or 1'880'000
+            //
+            // We verify that here with known correct values on those heights for an arbitrary
+            // address.
+            //
+            // TODO: This is temporary code to migrate all the old DBs to V1 and to ensure everyone
+            // has the correct rewards value. Once a release has been put out with this code, we can
+            // immediately remove this from the codebase.
+            //
+            // The only thing that needs to move is the DB pragma to set the version to 1. This
+            // should be moved into the SQL DB constructor.
+            eth::address addr = tools::make_from_hex_guts<eth::address>(
+                    "0x26b0227617159797b9301a8EA6FB264f17d37Cb4"sv);
+
+            fmt::memory_buffer buf;
+            for (const auto& record : RECORDS) {
+                std::optional<int64_t> amount_db = prepared_maybe_get<int64_t>(
+                        "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
+                        "height = ?",
+                        db::blob_binder{addr},
+                        static_cast<int64_t>(record.height));
+
+                if (amount_db) {
+                    auto read = reward_money::from_db_amount(*amount_db, record.hf);
+                    auto expected =
+                            cryptonote::reward_money::from_db_amount(record.value, record.hf);
+                    if (read != expected) {
+                        fmt::format_to(
+                                std::back_inserter(buf),
+                                "{}  - Incorrect rewards in archive at blk {}, read: {}, "
+                                "expected: {}",
+                                buf.size() ? "\n" : "",
+                                record.height,
+                                cryptonote::print_money(read.to_coin()),
+                                cryptonote::print_money(expected.to_coin()));
+                        if (!result)
+                            result = record.height;
+                    }
+                }
+            }
+
+            // If there's no rewind height set, it means this node's DB is up to date. But inbetween
+            // this patch being released and it being run on a node, there could be many more 10k
+            // intervals that has elapsed since the hardcoded heights. At any one of those future
+            // 10k intervals the rewards value can potentially diverge so we enforce a rescan
+            // always. Again once you have a v1 database, that signifies you're running a version of
+            // the code that is not affected by this bug and so this code branch can be eliminated.
+            if (result) {
+                log::info(
+                        globallogcat,
+                        "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
+                        "closest snapshot from blk {} and recalculating\n{}",
+                        *result - 1,
+                        fmt::to_string(buf));
+            } else {
+                result = RECORDS[0].height;
+                log::info(
+                        globallogcat,
+                        "Re-orging to the closest snapshot from blk {} and recalculating "
+                        "rewards",
+                        *result - 1);
+            }
+        }
+        db.exec("PRAGMA user_version = 1");
+    }
+    return result;
+}
 }  // namespace cryptonote

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -798,9 +798,8 @@ void BlockchainSQLite::blockchain_detached(
         prepared_exec(
                 "INSERT INTO delayed_payments ({delayed_fields})"
                 " SELECT {delayed_fields} FROM delayed_payments_{suffix}"
-                " WHERE ? >= height AND ? < payout_height"_format(
+                " WHERE ?1 >= height AND ?1 < payout_height"_format(
                         "delayed_fields"_a = DELAYED_PAYMENTS_COLS, "suffix"_a = suffix),
-                static_cast<int64_t>(new_height),
                 static_cast<int64_t>(new_height));
     }
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -652,6 +652,12 @@ void BlockchainSQLite::upgrade_schema() {
         --
         -- When pruning we floor to the closest interval to make the SQL table match the equivalent
         -- pruning math ('cull_height') in the SNL at 'process_block()'.
+        --
+        -- It's possible and expected to have conflicts when archiving delayed_payments. For example
+        -- on mainnet, we archive every 10k blocks and a deregistration delayed payment row lasts
+        -- for 21.6k blocks (30 days). If we archive a deregistration, on the next 10k interval,
+        -- it's possible the deregistration is still present in the table and will be attempted to
+        -- be re-archived. We ignore those conflicts as it's expected behaviour.
         DROP   TRIGGER IF EXISTS make_archive;
         CREATE TRIGGER           make_archive AFTER UPDATE ON batch_db_info
         FOR EACH ROW WHEN (NEW.height % {archive_interval}) = 0 AND NEW.height > OLD.height BEGIN
@@ -665,7 +671,7 @@ void BlockchainSQLite::upgrade_schema() {
                 WHERE height < (NEW.height - {archive_keep});
 
             -- Delayed payments
-            INSERT INTO delayed_payments_archive ({delayed_fields})
+            INSERT OR IGNORE INTO delayed_payments_archive ({delayed_fields})
                 SELECT {delayed_fields} FROM delayed_payments;
             DELETE FROM delayed_payments_archive WHERE height < (NEW.height - {archive_keep});
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -1728,23 +1728,25 @@ bool BlockchainSQLite::save_payments(
     return true;
 }
 
-std::optional<uint64_t> BlockchainSQLite::apply_fixups()
+BlockchainSQLite::NeedsFixupResult BlockchainSQLite::needs_fixup(bool dry_run)
 {
-    std::optional<uint64_t> result;
+    NeedsFixupResult result = {};
+    result.prev_db_version = prepared_get<int64_t>("PRAGMA user_version");
+
     if (nettype == cryptonote::network_type::MAINNET) {
         struct fixup_record {
             uint64_t height;
             uint64_t value;
             cryptonote::hf hf;
         } constexpr RECORDS[] = {
-                {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
-                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
                 {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
+                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
+                {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
         };
 
-        int64_t version = prepared_get<int64_t>("PRAGMA user_version");
-        uint64_t earliest_height = (std::end(RECORDS) - 1)->height;
-        if (version == 0 && height >= earliest_height) {
+        uint64_t earliest_height = RECORDS[0].height;
+        bool do_checks = dry_run || result.prev_db_version == 0;
+        if (do_checks && height >= earliest_height) {
             // This DB that has synced past the ETH transition and is still on V0 may be affected by
             // the delayed payments issue that incorrectly rejected rewards payments in blocks
             // sitting on the archiving interval (due to duplicate delayed payment rows to be
@@ -1783,8 +1785,8 @@ std::optional<uint64_t> BlockchainSQLite::apply_fixups()
                                 record.height,
                                 cryptonote::print_money(read.to_coin()),
                                 cryptonote::print_money(expected.to_coin()));
-                        if (!result)
-                            result = record.height;
+                        if (!result.detach_height)
+                            result.detach_height = (record.height - 1);
                     }
                 }
             }
@@ -1795,23 +1797,27 @@ std::optional<uint64_t> BlockchainSQLite::apply_fixups()
             // 10k intervals the rewards value can potentially diverge so we enforce a rescan
             // always. Again once you have a v1 database, that signifies you're running a version of
             // the code that is not affected by this bug and so this code branch can be eliminated.
-            if (result) {
+            if (result.detach_height) {
                 log::info(
                         globallogcat,
                         "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
                         "closest snapshot from blk {} and recalculating\n{}",
-                        *result - 1,
+                        *result.detach_height,
                         fmt::to_string(buf));
             } else {
-                result = RECORDS[0].height;
-                log::info(
-                        globallogcat,
-                        "Re-orging to the closest snapshot from blk {} and recalculating "
-                        "rewards",
-                        *result - 1);
+                if (!dry_run) {
+                    result.detach_height = (std::end(RECORDS) - 1)->height - 1;
+                    log::info(
+                            globallogcat,
+                            "Re-orging to the closest snapshot from blk {} and recalculating "
+                            "rewards",
+                            *result.detach_height);
+                }
             }
         }
-        db.exec("PRAGMA user_version = 1");
+
+        if (!dry_run)
+            db.exec("PRAGMA user_version = 1");
     }
     return result;
 }

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -671,8 +671,9 @@ void BlockchainSQLite::upgrade_schema() {
                 WHERE height < (NEW.height - {archive_keep});
 
             -- Delayed payments
-            INSERT OR IGNORE INTO delayed_payments_archive ({delayed_fields})
-                SELECT {delayed_fields} FROM delayed_payments;
+            INSERT INTO delayed_payments_archive ({delayed_fields})
+                SELECT {delayed_fields} FROM delayed_payments
+                ON CONFLICT (block_height, block_tx_index, contributor_index) DO NOTHING;
             DELETE FROM delayed_payments_archive WHERE height < (NEW.height - {archive_keep});
 
         END;

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -672,7 +672,7 @@ void BlockchainSQLite::upgrade_schema() {
 
             -- Delayed payments
             INSERT INTO delayed_payments_archive ({delayed_fields})
-                SELECT {delayed_fields} FROM delayed_payments
+                SELECT {delayed_fields} FROM delayed_payments WHERE true
                 ON CONFLICT (block_height, block_tx_index, contributor_index) DO NOTHING;
             DELETE FROM delayed_payments_archive WHERE height < (NEW.height - {archive_keep});
 

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -262,6 +262,8 @@ class BlockchainSQLite : public db::Database {
     // (for HF21 and earlier blocks) into atomics (expected for HF22+ blocks).
     void convert_hf22();
 
+    std::optional<uint64_t> apply_fixups();
+
     uint64_t height;
     const cryptonote::network_type nettype;
 };

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -262,7 +262,13 @@ class BlockchainSQLite : public db::Database {
     // (for HF21 and earlier blocks) into atomics (expected for HF22+ blocks).
     void convert_hf22();
 
-    std::optional<uint64_t> apply_fixups();
+    struct NeedsFixupResult
+    {
+        int prev_db_version;
+        std::optional<uint64_t> detach_height;
+    };
+
+    NeedsFixupResult needs_fixup(bool dry_run);
 
     uint64_t height;
     const cryptonote::network_type nettype;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -963,6 +963,10 @@ bool Blockchain::init(
             detach_height = std::max(detach_height, static_cast<uint64_t>(1));
         }
 
+        BlockchainSQLite::NeedsFixupResult fixup_result = m_sqlite_db->needs_fixup(/*dry_run=*/false);
+        if (fixup_result.detach_height)
+            detach_height = std::min(detach_height, *fixup_result.detach_height);
+
         if (!exec_detach_hooks(
                     *this,
                     detach_height,
@@ -973,20 +977,19 @@ bool Blockchain::init(
                     /*use_threaded_load*/ true)) {
             return false;
         }
-    }
 
-    if (std::optional<uint64_t> rewind_to_height = m_sqlite_db->apply_fixups(); rewind_to_height) {
-        if (!exec_detach_hooks(
-                    *this,
-                    (*rewind_to_height - 1),
-                    m_blockchain_detached_hooks,
-                    /*by_pop_blocks*/ false,
-                    /*load_missing_blocks_into_oxen_subsystems*/ true,
-                    abort,
-                    /*use_threaded_load*/ true)) {
-            return false;
+        // Only check the rewards values are correct, just once afterwards, on the initial migration
+        if (fixup_result.prev_db_version == 0) {
+            bool still_wrong = m_sqlite_db->needs_fixup(/*dry_run=*/true).detach_height.has_value();
+            if (still_wrong) {
+                log::warning(
+                        logcat,
+                        "Invalid rewards were detected. A re-org was attempted but the incorrect "
+                        "values are still present. Please notify the developers");
+            }
         }
     }
+
     return true;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -975,6 +975,118 @@ bool Blockchain::init(
         }
     }
 
+    {
+        int64_t version = m_sqlite_db->prepared_get<int64_t>("PRAGMA user_version");
+        uint64_t check_height_1 = 1'870'000;
+        uint64_t check_height_2 = 1'880'000;
+
+        if (version == 0 && m_sqlite_db->height >= check_height_1 && nettype == cryptonote::network_type::MAINNET) {
+            // This DB that has synced past the ETH transition and is still on V0 may be affected by
+            // the delayed payments issue that incorrectly rejected rewards payments in blocks
+            // sitting on the archiving interval (due to duplicate delayed payment rows to be
+            // archived) at 1'870'000 and/or 1'880'000
+            //
+            // We verify that here with known correct values on those heights for an arbitrary
+            // address.
+            //
+            // TODO: This is temporary code to migrate all the old DBs to V1 and to ensure everyone
+            // has the correct rewards value. Once a release has been put out with this code, we can
+            // immediately remove this from the codebase.
+            //
+            // The only thing that needs to move is the DB pragma to set the version to 1. This
+            // should be moved into the SQL DB constructor.
+            eth::address addr = tools::make_from_hex_guts<eth::address>(
+                    "0x26b0227617159797b9301a8EA6FB264f17d37Cb4"sv);
+            std::optional<int64_t> amount_at_1870k_db = m_sqlite_db->prepared_maybe_get<int64_t>(
+                    "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
+                    "height = ?",
+                    db::blob_binder{addr},
+                    static_cast<int64_t>(check_height_1));
+            std::optional<int64_t> amount_at_1880k_db = m_sqlite_db->prepared_maybe_get<int64_t>(
+                    "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
+                    "height = ?",
+                    db::blob_binder{addr},
+                    static_cast<int64_t>(check_height_2));
+            std::optional<uint64_t> rewind_to_height;
+
+            fmt::memory_buffer buf;
+            if (amount_at_1870k_db) {
+                auto read = reward_money::from_db_amount(*amount_at_1870k_db, hf::hf21_eth);
+                auto expected = cryptonote::reward_money::from_db_amount(
+                        12'342'509'582'265'973, hf::hf21_eth);
+                if (read != expected) {
+                    fmt::format_to(
+                            std::back_inserter(buf),
+                            "  - Incorrect rewards in archive at blk {}, read: {}, "
+                            "expected: {}\n",
+                            check_height_1,
+                            cryptonote::print_money(read.to_coin()),
+                            cryptonote::print_money(expected.to_coin()));
+                    rewind_to_height = check_height_1;
+                }
+            } else {
+                // If we're missing the row for some reason from our archives then we force a rescan
+                // as the DB is in an unexpected state (maybe it got deleted from the filsystem?)
+                rewind_to_height = check_height_1;
+                fmt::format_to(
+                        std::back_inserter(buf),
+                        "  - Missing row archives at blk {}\n",
+                        check_height_1);
+            }
+
+            if (amount_at_1880k_db) {
+                auto read = reward_money::from_db_amount(*amount_at_1880k_db, hf::hf22_eth_fixup);
+                auto expected = cryptonote::reward_money::from_db_amount(
+                        12'576'153'824'838, hf::hf22_eth_fixup);
+                if (read != expected) {
+                    fmt::format_to(
+                            std::back_inserter(buf),
+                            "  - Incorrect rewards in archive at blk {}, read: {}, "
+                            "expected: {}",
+                            check_height_2,
+                            cryptonote::print_money(read.to_coin()),
+                            cryptonote::print_money(expected.to_coin()));
+                    if (!rewind_to_height)
+                        rewind_to_height = check_height_2;
+                }
+            } else {
+                if (!rewind_to_height)
+                    rewind_to_height = check_height_2;  // Missing archive, to be safe we rescan
+                fmt::format_to(
+                        std::back_inserter(buf),
+                        "  - Missing row archives at blk {}",
+                        check_height_2);
+            }
+
+            // If there's no rewind height set, it means this node's DB is up to date. But inbetween
+            // this patch being released and it being run on a node, there could be many more 10k
+            // intervals that has elapsed since the hardcoded heights. At any one of those future
+            // 10k intervals the rewards value can potentially diverge so we enforce a rescan
+            // always. Again once you have a v1 database, that signifies you're running a version of
+            // the code that is not affected by this bug and so this code branch can be eliminated.
+            if (!rewind_to_height)
+                rewind_to_height = check_height_2;
+
+            log::info(
+                    globallogcat,
+                    "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
+                    "closest snapshot from blk {} and recalculating\n{}",
+                    *rewind_to_height - 1,
+                    fmt::to_string(buf));
+            if (!exec_detach_hooks(
+                        *this,
+                        (*rewind_to_height - 1),
+                        m_blockchain_detached_hooks,
+                        /*by_pop_blocks*/ false,
+                        /*load_missing_blocks_into_oxen_subsystems*/ true,
+                        abort,
+                        /*use_threaded_load*/ true)) {
+                return false;
+            }
+        }
+        m_sqlite_db->db.exec("PRAGMA user_version = 1");
+    }
+
     return true;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -975,12 +975,19 @@ bool Blockchain::init(
         }
     }
 
-    {
-        int64_t version = m_sqlite_db->prepared_get<int64_t>("PRAGMA user_version");
-        uint64_t check_height_1 = 1'870'000;
-        uint64_t check_height_2 = 1'880'000;
+    if (nettype == cryptonote::network_type::MAINNET) {
+        struct fixup_record {
+            uint64_t height;
+            uint64_t value;
+            cryptonote::hf hf;
+        } constexpr RECORDS[] = {
+                {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
+                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
+                {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
+        };
 
-        if (version == 0 && m_sqlite_db->height >= check_height_1 && nettype == cryptonote::network_type::MAINNET) {
+        int64_t version = m_sqlite_db->prepared_get<int64_t>("PRAGMA user_version");
+        if (version == 0 && m_sqlite_db->height >= RECORDS[0].height) {
             // This DB that has synced past the ETH transition and is still on V0 may be affected by
             // the delayed payments issue that incorrectly rejected rewards payments in blocks
             // sitting on the archiving interval (due to duplicate delayed payment rows to be
@@ -997,65 +1004,33 @@ bool Blockchain::init(
             // should be moved into the SQL DB constructor.
             eth::address addr = tools::make_from_hex_guts<eth::address>(
                     "0x26b0227617159797b9301a8EA6FB264f17d37Cb4"sv);
-            std::optional<int64_t> amount_at_1870k_db = m_sqlite_db->prepared_maybe_get<int64_t>(
-                    "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
-                    "height = ?",
-                    db::blob_binder{addr},
-                    static_cast<int64_t>(check_height_1));
-            std::optional<int64_t> amount_at_1880k_db = m_sqlite_db->prepared_maybe_get<int64_t>(
-                    "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
-                    "height = ?",
-                    db::blob_binder{addr},
-                    static_cast<int64_t>(check_height_2));
+
             std::optional<uint64_t> rewind_to_height;
-
             fmt::memory_buffer buf;
-            if (amount_at_1870k_db) {
-                auto read = reward_money::from_db_amount(*amount_at_1870k_db, hf::hf21_eth);
-                auto expected = cryptonote::reward_money::from_db_amount(
-                        12'342'509'582'265'973, hf::hf21_eth);
-                if (read != expected) {
-                    fmt::format_to(
-                            std::back_inserter(buf),
-                            "  - Incorrect rewards in archive at blk {}, read: {}, "
-                            "expected: {}\n",
-                            check_height_1,
-                            cryptonote::print_money(read.to_coin()),
-                            cryptonote::print_money(expected.to_coin()));
-                    rewind_to_height = check_height_1;
-                }
-            } else {
-                // If we're missing the row for some reason from our archives then we force a rescan
-                // as the DB is in an unexpected state (maybe it got deleted from the filsystem?)
-                rewind_to_height = check_height_1;
-                fmt::format_to(
-                        std::back_inserter(buf),
-                        "  - Missing row archives at blk {}\n",
-                        check_height_1);
-            }
+            for (const auto& record : RECORDS) {
+                std::optional<int64_t> amount_db = m_sqlite_db->prepared_maybe_get<int64_t>(
+                        "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
+                        "height = ?",
+                        db::blob_binder{addr},
+                        static_cast<int64_t>(record.height));
 
-            if (amount_at_1880k_db) {
-                auto read = reward_money::from_db_amount(*amount_at_1880k_db, hf::hf22_eth_fixup);
-                auto expected = cryptonote::reward_money::from_db_amount(
-                        12'576'153'824'838, hf::hf22_eth_fixup);
-                if (read != expected) {
-                    fmt::format_to(
-                            std::back_inserter(buf),
-                            "  - Incorrect rewards in archive at blk {}, read: {}, "
-                            "expected: {}",
-                            check_height_2,
-                            cryptonote::print_money(read.to_coin()),
-                            cryptonote::print_money(expected.to_coin()));
-                    if (!rewind_to_height)
-                        rewind_to_height = check_height_2;
+                if (amount_db) {
+                    auto read = reward_money::from_db_amount(*amount_db, record.hf);
+                    auto expected =
+                            cryptonote::reward_money::from_db_amount(record.value, record.hf);
+                    if (read != expected) {
+                        fmt::format_to(
+                                std::back_inserter(buf),
+                                "{}  - Incorrect rewards in archive at blk {}, read: {}, "
+                                "expected: {}",
+                                buf.size() ? "\n" : "",
+                                record.height,
+                                cryptonote::print_money(read.to_coin()),
+                                cryptonote::print_money(expected.to_coin()));
+                        if (!rewind_to_height)
+                            rewind_to_height = record.height;
+                    }
                 }
-            } else {
-                if (!rewind_to_height)
-                    rewind_to_height = check_height_2;  // Missing archive, to be safe we rescan
-                fmt::format_to(
-                        std::back_inserter(buf),
-                        "  - Missing row archives at blk {}",
-                        check_height_2);
             }
 
             // If there's no rewind height set, it means this node's DB is up to date. But inbetween
@@ -1064,15 +1039,22 @@ bool Blockchain::init(
             // 10k intervals the rewards value can potentially diverge so we enforce a rescan
             // always. Again once you have a v1 database, that signifies you're running a version of
             // the code that is not affected by this bug and so this code branch can be eliminated.
-            if (!rewind_to_height)
-                rewind_to_height = check_height_2;
+            if (rewind_to_height) {
+                log::info(
+                        globallogcat,
+                        "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
+                        "closest snapshot from blk {} and recalculating\n{}",
+                        *rewind_to_height - 1,
+                        fmt::to_string(buf));
+            } else {
+                rewind_to_height = (std::end(RECORDS) - 1)->height;
+                log::info(
+                        globallogcat,
+                        "Re-orging to the closest snapshot from blk {} and recalculating "
+                        "rewards",
+                        *rewind_to_height - 1);
+            }
 
-            log::info(
-                    globallogcat,
-                    "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
-                    "closest snapshot from blk {} and recalculating\n{}",
-                    *rewind_to_height - 1,
-                    fmt::to_string(buf));
             if (!exec_detach_hooks(
                         *this,
                         (*rewind_to_height - 1),

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -975,101 +975,18 @@ bool Blockchain::init(
         }
     }
 
-    if (nettype == cryptonote::network_type::MAINNET) {
-        struct fixup_record {
-            uint64_t height;
-            uint64_t value;
-            cryptonote::hf hf;
-        } constexpr RECORDS[] = {
-                {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
-                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
-                {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
-        };
-
-        int64_t version = m_sqlite_db->prepared_get<int64_t>("PRAGMA user_version");
-        uint64_t earliest_height = (std::end(RECORDS) - 1)->height;
-        if (version == 0 && m_sqlite_db->height >= earliest_height) {
-            // This DB that has synced past the ETH transition and is still on V0 may be affected by
-            // the delayed payments issue that incorrectly rejected rewards payments in blocks
-            // sitting on the archiving interval (due to duplicate delayed payment rows to be
-            // archived) at 1'870'000 and/or 1'880'000
-            //
-            // We verify that here with known correct values on those heights for an arbitrary
-            // address.
-            //
-            // TODO: This is temporary code to migrate all the old DBs to V1 and to ensure everyone
-            // has the correct rewards value. Once a release has been put out with this code, we can
-            // immediately remove this from the codebase.
-            //
-            // The only thing that needs to move is the DB pragma to set the version to 1. This
-            // should be moved into the SQL DB constructor.
-            eth::address addr = tools::make_from_hex_guts<eth::address>(
-                    "0x26b0227617159797b9301a8EA6FB264f17d37Cb4"sv);
-
-            std::optional<uint64_t> rewind_to_height;
-            fmt::memory_buffer buf;
-            for (const auto& record : RECORDS) {
-                std::optional<int64_t> amount_db = m_sqlite_db->prepared_maybe_get<int64_t>(
-                        "SELECT amount FROM batched_payments_accrued_archive WHERE address = ? AND "
-                        "height = ?",
-                        db::blob_binder{addr},
-                        static_cast<int64_t>(record.height));
-
-                if (amount_db) {
-                    auto read = reward_money::from_db_amount(*amount_db, record.hf);
-                    auto expected =
-                            cryptonote::reward_money::from_db_amount(record.value, record.hf);
-                    if (read != expected) {
-                        fmt::format_to(
-                                std::back_inserter(buf),
-                                "{}  - Incorrect rewards in archive at blk {}, read: {}, "
-                                "expected: {}",
-                                buf.size() ? "\n" : "",
-                                record.height,
-                                cryptonote::print_money(read.to_coin()),
-                                cryptonote::print_money(expected.to_coin()));
-                        if (!rewind_to_height)
-                            rewind_to_height = record.height;
-                    }
-                }
-            }
-
-            // If there's no rewind height set, it means this node's DB is up to date. But inbetween
-            // this patch being released and it being run on a node, there could be many more 10k
-            // intervals that has elapsed since the hardcoded heights. At any one of those future
-            // 10k intervals the rewards value can potentially diverge so we enforce a rescan
-            // always. Again once you have a v1 database, that signifies you're running a version of
-            // the code that is not affected by this bug and so this code branch can be eliminated.
-            if (rewind_to_height) {
-                log::info(
-                        globallogcat,
-                        "Incorrect rewards detected in SQL DB will be fixed, re-orging to the "
-                        "closest snapshot from blk {} and recalculating\n{}",
-                        *rewind_to_height - 1,
-                        fmt::to_string(buf));
-            } else {
-                rewind_to_height = RECORDS[0].height;
-                log::info(
-                        globallogcat,
-                        "Re-orging to the closest snapshot from blk {} and recalculating "
-                        "rewards",
-                        *rewind_to_height - 1);
-            }
-
-            if (!exec_detach_hooks(
-                        *this,
-                        (*rewind_to_height - 1),
-                        m_blockchain_detached_hooks,
-                        /*by_pop_blocks*/ false,
-                        /*load_missing_blocks_into_oxen_subsystems*/ true,
-                        abort,
-                        /*use_threaded_load*/ true)) {
-                return false;
-            }
+    if (std::optional<uint64_t> rewind_to_height = m_sqlite_db->apply_fixups(); rewind_to_height) {
+        if (!exec_detach_hooks(
+                    *this,
+                    (*rewind_to_height - 1),
+                    m_blockchain_detached_hooks,
+                    /*by_pop_blocks*/ false,
+                    /*load_missing_blocks_into_oxen_subsystems*/ true,
+                    abort,
+                    /*use_threaded_load*/ true)) {
+            return false;
         }
-        m_sqlite_db->db.exec("PRAGMA user_version = 1");
     }
-
     return true;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -981,13 +981,14 @@ bool Blockchain::init(
             uint64_t value;
             cryptonote::hf hf;
         } constexpr RECORDS[] = {
-                {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
-                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
                 {1'890'000, 12'826'639'569'804, hf::hf22_eth_fixup},
+                {1'880'000, 12'576'153'824'838, hf::hf22_eth_fixup},
+                {1'870'000, 12'342'509'582'265'973, hf::hf21_eth},
         };
 
         int64_t version = m_sqlite_db->prepared_get<int64_t>("PRAGMA user_version");
-        if (version == 0 && m_sqlite_db->height >= RECORDS[0].height) {
+        uint64_t earliest_height = (std::end(RECORDS) - 1)->height;
+        if (version == 0 && m_sqlite_db->height >= earliest_height) {
             // This DB that has synced past the ETH transition and is still on V0 may be affected by
             // the delayed payments issue that incorrectly rejected rewards payments in blocks
             // sitting on the archiving interval (due to duplicate delayed payment rows to be
@@ -1047,7 +1048,7 @@ bool Blockchain::init(
                         *rewind_to_height - 1,
                         fmt::to_string(buf));
             } else {
-                rewind_to_height = (std::end(RECORDS) - 1)->height;
+                rewind_to_height = RECORDS[0].height;
                 log::info(
                         globallogcat,
                         "Re-orging to the closest snapshot from blk {} and recalculating "


### PR DESCRIPTION
It's possible for there to be duplicate rows on insertion when we populate the archival delayed payment rows. If we have a deregistration which lasts for 21k blocks which elapses over two consecutive 10k intervals, then, it will already exist in the archive.

Since we have a UNIQUE constraint on the `(block, tx_index, contrib_index)` and the row already exists, the insertion fails and the rewards are not correctly recorded. The fix here is to allow duplicates so we update the `INSERT INTO` command to `INSERT OR IGNORE INTO` to handle this situation.

We do however now have a network that cannot come to consensus on the correct amount of rewards to sign off on for claiming. The solution I've come up with is to hardcode the expected rewards value of an address that was affected in the 1'870'000th and 1'880'000th block. If the node's DB does not have those values, we know they are out of sync and issue a rescan by detach the blockchain to the next closest archive.

As of current with the fix applied on a DB that was affected by the failure on block 1'870'000, I was able to rederive the rewards value for the hardcoded address that other nodes that weren't affected by this which currently constitutes around~20% of the network. The other 80% are witnessing a version of the network which experienced a failure at 1'870'000 and/or 1'880'000. 

The majority of the network is currently then underpaying the designated Ethereum address's stake and so by fixing it we should be correctly paying out the right amount of SESH to those users.