### PR TITLE
Fix false positive error logs about liquidation mismatch

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -815,7 +815,13 @@ BlockchainSQLite::wallet_info::wallet_info(
         lifetime_unlocked_stakes = reward_money::from_db_atomic(life_unlocked);
         lifetime_liquidated_stakes = reward_money::from_db_atomic(life_liquidated);
         lifetime_rewards = reward_money::from_db_amount(life_rewards, *hf_version);
-        locked_stakes = lifetime_locked_stakes - lifetime_unlocked_stakes;
+        // LOCKED = STAKES_IN - STAKES_OUT, where STAKES_IN are contributions made, and STAKES_OUT
+        // consists of both the amount that got released back to you (lifetime_unlocked_stakes)
+        // *and* any liquidation amounts that got subtracted from your balance in case of a
+        // liquidation (to match the liquidation amount that got transferred into the pool and
+        // liquidator via the SNRewards contract liquidation call).
+        locked_stakes =
+                lifetime_locked_stakes - lifetime_unlocked_stakes - lifetime_liquidated_stakes;
 
         // NOTE: Some of these fields are only enumerated on ETH addresses so gate error
         // checking behind said flag.
@@ -824,8 +830,11 @@ BlockchainSQLite::wallet_info::wallet_info(
             assert(!lifetime_unlocked_stakes.negative());
             assert(!lifetime_rewards.negative());
 
-            auto rederived =
-                    lifetime_unlocked_stakes + lifetime_rewards - lifetime_liquidated_stakes;
+            // Your lifetime claimable amount (`amount`) should equal exactly whatever stakes came
+            // back to you via unlocking, plus whatever rewards you have ever earned.  (But no
+            // liquidated amounts, since those *don't* come back to you and don't enter
+            // `unlocked_stakes`):
+            auto rederived = lifetime_unlocked_stakes + lifetime_rewards;
             if (amount != rederived) {
                 // clang-format off
                 // NOTE: The affected address that we patched up in the fixups in SNL received a
@@ -843,14 +852,15 @@ BlockchainSQLite::wallet_info::wallet_info(
                             logcat,
                             "Internal error: SN contributor {} at height {} lifetime claimable "
                             "mismatch:\n"
-                            "lifetime claimable {} != {} (= {} rewards + {} unlocked - {} "
-                            "liquidated)",
+                            "lifetime claimable {} != {} (= {} rewards + {} unlocked) [lifetime "
+                            "stakes={}, liquidated={}]",
                             log_addr{tools::make_from_guts<eth::address>(addr_bytes)},
                             height,
                             amount,
                             rederived,
                             lifetime_rewards,
                             lifetime_unlocked_stakes,
+                            lifetime_locked_stakes,
                             lifetime_liquidated_stakes);
                     assert(amount == rederived);
                 }


### PR DESCRIPTION
The double-check code here was performing safety checks on the amounts with loud log errors on mismatch, but was subtracting liquidated amounts from the unlocked stakes -- but that double-subtracts the liquidations (because liquidation penalties are subtracted *before* the lifetime unlocked value gets updated in the database).  As a reuslt, when we started having liquidations on chain, we started getting oxend log warnings about the mismatch.  The database values -- which is what gets used for actual signatures and release of funds -- were correct, but the double-check calculation here producing the warnings was not.

Aside from silencing the false positive error, this changed fixes the RPC endpoint `locked_stakes` value returned from RPC, which is currently 50 OXEN too high per liquidation that has ever applied to an account.

For example, before committing this and looking at one address producing such warnings:

    {
        "address": "0xF307378Aa27E17645B0b1242667B94B279e9C62e",
        "amount": 29545.816287621,
        "found": true,
        "lifetime_liquidated_stakes": 50.000000000,
        "lifetime_locked_stakes": 52806.000000000,
        "lifetime_rewards": 1789.816287621,
        "lifetime_unlocked_stakes": 27756.000000000,
        "locked_stakes": 25050.000000000,
        "timelocked_stakes": 0
    }

and with this commit applied:

    {
        "address": "0xF307378Aa27E17645B0b1242667B94B279e9C62e",
        "amount": 29545.965111753,
        "found": true,
        "lifetime_liquidated_stakes": 50.000000000,
        "lifetime_locked_stakes": 52806.000000000,
        "lifetime_rewards": 1789.965111753,
        "lifetime_unlocked_stakes": 27756.000000000,
        "locked_stakes": 25000.000000000,
        "timelocked_stakes": 0
    }

(I added the "."s in the output for readability in this commit message; the actual RPC endpoint returns atomic amounts).